### PR TITLE
Typecheck more Michelson instructions

### DIFF
--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -193,6 +193,12 @@ Module that implements the backend parameters for the Michelson backend.
   + [[Library]]
   + [[NameSymbol]]
   + [[Library/Usage]]
+***** Parameterisation <<Test/Parameterisation>>
+- _Relies on_
+  + [[Compilation/Types]]
+  + [[Untyped]]
+  + [[Michelson/Parameterisation]]
+  + [[Core/Parameterisation]]
 ***** Pipeline <<Test/Pipeline>>
 - _Relies on_
   + [[Backends/Michelson]]

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Parameterisation.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Parameterisation.hs
@@ -75,6 +75,7 @@ hasType' CompareMutez ty = P.checkFirst2AndLast ty isBool
 hasType' CompareHash ty = P.checkFirst2AndLast ty isBool
 -- Hacks make more exact later
 hasType' EDivI (x :| [y, _]) = P.check2Equal (x :| [y])
+hasType' EDivI ty = False
 hasType' (Inst M.TRANSFER_TOKENS {}) (_ :| [_, _, _]) = True
 hasType' (Inst M.UNIT {}) (_ :| []) = True
 hasType' (Inst M.BALANCE {}) (_ :| []) = True
@@ -95,6 +96,16 @@ hasType' (Constant _v) ty
   | length ty == 1 = True
   | otherwise = False
 hasType' _ ((Application List _) :| []) = True
+hasType' (Inst (M.LSL _)) ((PrimTy (M.Ty M.TNat _)) :| [PrimTy (M.Ty M.TNat _), PrimTy (M.Ty M.TNat _)]) = True
+hasType' (Inst (M.LSL _)) _ = False
+hasType' (Inst (M.SHA256 _)) ((PrimTy (M.Ty M.TBytes _)) :| [PrimTy (M.Ty M.TBytes _)]) = True
+hasType' (Inst (M.SHA256 _)) _ = False
+hasType' (Inst (M.SHA512 _)) ((PrimTy (M.Ty M.TBytes _)) :| [PrimTy (M.Ty M.TBytes _)]) = True
+hasType' (Inst (M.SHA512 _)) _ = False
+hasType' (Inst (M.NOW _)) (PrimTy (M.Ty M.TTimestamp _) :| []) = True
+hasType' (Inst (M.NOW _)) _ = False
+hasType' (Inst (M.SET_DELEGATE _)) ((Application Types.Option (PrimTy (M.Ty M.TKeyHash _) :| [])) :| [PrimTy (M.Ty M.TOperation _)]) = True
+hasType' (Inst (M.SET_DELEGATE _)) _ = False
 -- do something nicer here
 hasType' x ty = Prelude.error ("unsupported: " <> Juvix.Library.show x <> " :: " <> Juvix.Library.show ty)
 

--- a/library/Backends/Michelson/test/Main.hs
+++ b/library/Backends/Michelson/test/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import Juvix.Library
 import qualified Test.Golden as Golden
 import qualified Test.Michelson as Michelson
+import qualified Test.Parameterisation as Parameterisation
 import qualified Test.Pipeline as Pipeline
 import qualified Test.Tasty as T
 import qualified Test.VStack as VStack
@@ -13,7 +14,7 @@ allCheckedTests = do
   pure $
     T.testGroup
       "All tests that are checked"
-      [Michelson.top, VStack.top, Pipeline.top, goldenTests]
+      [Michelson.top, VStack.top, Parameterisation.top, Pipeline.top, goldenTests]
 
 main :: IO ()
 main = allCheckedTests >>= T.defaultMain

--- a/library/Backends/Michelson/test/Test/Parameterisation.hs
+++ b/library/Backends/Michelson/test/Test/Parameterisation.hs
@@ -1,0 +1,98 @@
+module Test.Parameterisation (top) where
+
+import GHC.Base
+import Juvix.Backends.Michelson.Compilation.Types (Op, PrimTy (Application, Option, PrimTy), RawPrimVal (EDivI, Inst))
+import Juvix.Backends.Michelson.DSL.Untyped (blank)
+import Juvix.Backends.Michelson.Parameterisation (michelson)
+import Juvix.Core.Parameterisation (PrimType (PrimType), hasType)
+import qualified Michelson.Untyped as MU
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+hasMichelsonType :: RawPrimVal -> NonEmpty PrimTy -> Bool
+hasMichelsonType val ty = hasType michelson val (PrimType ty)
+
+primMichelsonType :: MU.T -> MU.TypeAnn -> PrimTy
+primMichelsonType ty ann = PrimTy (MU.Ty ty ann)
+
+unannotatedType :: MU.T -> PrimTy
+unannotatedType ty = primMichelsonType ty blank
+
+unannotatedInstr :: (MU.VarAnn -> MU.InstrAbstract Op) -> RawPrimVal
+unannotatedInstr instr = Inst (instr blank)
+
+primBool :: PrimTy
+primBool = unannotatedType MU.TBool
+
+primNat :: PrimTy
+primNat = unannotatedType MU.TNat
+
+primInt :: PrimTy
+primInt = unannotatedType MU.TInt
+
+primTimestamp :: PrimTy
+primTimestamp = unannotatedType MU.TTimestamp
+
+primKeyHash :: PrimTy
+primKeyHash = unannotatedType MU.TKeyHash
+
+primOperation :: PrimTy
+primOperation = unannotatedType MU.TOperation
+
+binOp :: PrimTy -> NonEmpty PrimTy
+binOp ty = ty :| [ty, ty]
+
+natBinOp :: NonEmpty PrimTy
+natBinOp = binOp primNat
+
+intBinOp :: NonEmpty PrimTy
+intBinOp = binOp primInt
+
+lslInstr :: RawPrimVal
+lslInstr = Inst (MU.LSL blank)
+
+divInstr :: RawPrimVal
+divInstr = EDivI
+
+nowInstr :: RawPrimVal
+nowInstr = unannotatedInstr MU.NOW
+
+setDelegateInstr :: RawPrimVal
+setDelegateInstr = unannotatedInstr MU.SET_DELEGATE
+
+top :: TestTree
+top = testGroup "Michelson Parameterisation tests" tests
+
+tests :: [TestTree]
+tests =
+  [ typecheckLSL,
+    typecheckDiv,
+    typecheckNow,
+    typecheckSetDelegate
+  ]
+
+typecheckLSL :: TestTree
+typecheckLSL = testCase "Test type-checking of LSL instruction" $ do
+  hasMichelsonType lslInstr natBinOp @?= True
+  hasMichelsonType lslInstr (primNat :| [primNat, primBool]) @?= False
+
+typecheckDiv :: TestTree
+typecheckDiv = testCase "Test type-checking of DIV instruction" $ do
+  hasMichelsonType divInstr natBinOp @?= True
+  hasMichelsonType divInstr intBinOp @?= True
+  hasMichelsonType divInstr (primNat :| [primInt, primInt]) @?= False
+
+-- This would currently fail because typechecking of DIV is too liberal
+-- (https://github.com/heliaxdev/juvix/issues/819).
+-- hasMichelsonType divInstr (primString :| [primString, primMutez]) @?= False
+
+typecheckNow :: TestTree
+typecheckNow = testCase "Test type-checking of NOW instruction" $ do
+  hasMichelsonType nowInstr (primTimestamp :| []) @?= True
+  hasMichelsonType nowInstr (primNat :| []) @?= False
+
+typecheckSetDelegate :: TestTree
+typecheckSetDelegate = testCase "Test type-checking of SET_DELEGATE instruction" $ do
+  hasMichelsonType setDelegateInstr (Application Option (primKeyHash :| []) :| [primOperation]) @?= True
+  hasMichelsonType setDelegateInstr (primKeyHash :| [primOperation]) @?= False
+  hasMichelsonType setDelegateInstr (primTimestamp :| []) @?= False


### PR DESCRIPTION
Typecheck the Michelson LSL, SHA256, SHA512, NOW, and SET_DELEGATE instructions.

Also fail typechecking of EDIV if the type doesn't match the expected pattern (rather than throwing an "unsupported instruction" in that case).

Add tests for the new typechecking.

This addresses #816 as far as `LSL` specifically is concerned, along with a few other instructions, but there remain more Michelson instructions that aren't typechecked yet.