### PR TITLE
Clean up usage module

### DIFF
--- a/library/Backends/Michelson/test/Test/Michelson.hs
+++ b/library/Backends/Michelson/test/Test/Michelson.hs
@@ -10,7 +10,7 @@ import Juvix.Backends.Michelson.Optimisation
 import qualified Juvix.Core.Erased.Ann as J
 import Juvix.Library hiding (Type, show)
 import qualified Juvix.Library.NameSymbol as NameSymbol
-import Juvix.Library.Usage
+import qualified Juvix.Library.Usage as Usage
 import Michelson.Untyped as M hiding (Type)
 import qualified Michelson.Untyped as M
 import qualified Test.Tasty as T
@@ -448,7 +448,7 @@ intPair x y =
 
 intPairs1 :: RawTerm
 intPairs1 =
-  Ann (SNat 2) (primTy (Untyped.pair pairInt pairInt)) $
+  Ann (Usage.SNat 2) (primTy (Untyped.pair pairInt pairInt)) $
     J.AppM
       ( Ann one t $
           J.Prim $
@@ -504,14 +504,14 @@ addPairs name =
           [car int int xLook, cdr int int xLook]
   where
     t = primTy int
-    t' = J.Pi (SNat 2) (primTy pairInt) t
+    t' = J.Pi (Usage.SNat 2) (primTy pairInt) t
     xLook = Ann one (primTy pairInt) (J.Var name)
 
 addDoublePairs :: RawTerm
 addDoublePairs =
   Ann one t $
     J.AppM
-      ( Ann one (J.Pi (SNat 2) (primTy (Untyped.pair pairInt pairInt)) t) $
+      ( Ann one (J.Pi (Usage.SNat 2) (primTy (Untyped.pair pairInt pairInt)) t) $
           J.LamM [] ["y"] $
             Ann one t $
               J.AppM
@@ -542,7 +542,7 @@ xtwice =
       ( Ann
           one
           ( J.Pi mempty (primTy int) $
-              J.Pi (SNat 2) (primTy int) $
+              J.Pi (Usage.SNat 2) (primTy int) $
                 J.Pi mempty (primTy int) $
                   primTy int
           )
@@ -562,7 +562,7 @@ xtwice =
                   Ann one (primTy int) (J.Var "x")
                 ]
       )
-      [push1Int 2, pushInt (SNat 2) 3, push1Int 4]
+      [push1Int 2, pushInt (Usage.SNat 2) 3, push1Int 4]
 
 oddApp :: RawTerm
 oddApp =
@@ -571,7 +571,7 @@ oddApp =
       ( Ann
           one
           ( J.Pi mempty (primTy int) $
-              J.Pi (SNat 2) (primTy int) $
+              J.Pi (Usage.SNat 2) (primTy int) $
                 J.Pi mempty (primTy int) $
                   primTy int
           )
@@ -1073,13 +1073,13 @@ annIntOne :: Integer -> RawTerm
 annIntOne i =
   Ann one (primTy Untyped.int) (J.Prim (Constant (M.ValueInt i)))
 
-pushInt :: Usage -> Integer -> AnnTerm PrimTy RawPrimVal
+pushInt :: Usage.T -> Integer -> AnnTerm PrimTy RawPrimVal
 pushInt usage i = pushUsage usage (M.ValueInt i) Untyped.int
 
 push1Int :: Integer -> AnnTerm PrimTy RawPrimVal
 push1Int i = push1 (M.ValueInt i) Untyped.int
 
-pushUsage :: Usage -> M.Value' Op -> M.Ty -> AnnTerm PrimTy RawPrimVal
+pushUsage :: Usage.T -> M.Value' Op -> M.Ty -> AnnTerm PrimTy RawPrimVal
 pushUsage usage const ty =
   Ann
     usage

--- a/library/Core/src/Juvix/Core/Base/Types/Base.hs
+++ b/library/Core/src/Juvix/Core/Base/Types/Base.hs
@@ -7,7 +7,7 @@ import Data.Kind (Constraint)
 import Extensible (extensible)
 import Juvix.Library hiding (Pos)
 import qualified Juvix.Library.NameSymbol as NameSymbol
-import Juvix.Library.Usage (Usage)
+import qualified Juvix.Library.Usage as Usage
 
 type Universe = Natural
 
@@ -45,17 +45,17 @@ extensible
         Prim primVal
       | -- | formation rule of the dependent function type PI.
         -- the Usage(π) tracks how many times x is used.
-        Pi Usage (Term primTy primVal) (Term primTy primVal)
+        Pi Usage.T (Term primTy primVal) (Term primTy primVal)
       | -- | LAM Introduction rule of PI.
         -- The abstracted variables usage is tracked with the Usage(π).
         Lam (Term primTy primVal)
       | -- | Dependent pair (Σ) type, with each half having its own usage
-        Sig Usage (Term primTy primVal) (Term primTy primVal)
+        Sig Usage.T (Term primTy primVal) (Term primTy primVal)
       | -- | Pair value
         Pair (Term primTy primVal) (Term primTy primVal)
       | -- | Let binder.
         -- the local definition is bound to de Bruijn index 0.
-        Let Usage (Elim primTy primVal) (Term primTy primVal)
+        Let Usage.T (Elim primTy primVal) (Term primTy primVal)
       | -- | Unit type.
         UnitTy
       | -- | Unit Value
@@ -74,16 +74,16 @@ extensible
       | -- | elimination rule of PI (APP).
         App (Elim primTy primVal) (Term primTy primVal)
       | -- | Annotation with usage.
-        Ann Usage (Term primTy primVal) (Term primTy primVal) Universe
+        Ann Usage.T (Term primTy primVal) (Term primTy primVal) Universe
       deriving (Eq, Show, Generic, Data, NFData)
 
     -- Values/types
     data Value primTy primVal
       = VStar Universe
       | VPrimTy primTy
-      | VPi Usage (Value primTy primVal) (Value primTy primVal)
+      | VPi Usage.T (Value primTy primVal) (Value primTy primVal)
       | VLam (Value primTy primVal)
-      | VSig Usage (Value primTy primVal) (Value primTy primVal)
+      | VSig Usage.T (Value primTy primVal) (Value primTy primVal)
       | VPair (Value primTy primVal) (Value primTy primVal)
       | VUnitTy
       | VUnit

--- a/library/Core/src/Juvix/Core/Base/Types/Globals.hs
+++ b/library/Core/src/Juvix/Core/Base/Types/Globals.hs
@@ -7,7 +7,7 @@ import Data.Kind (Constraint)
 import Juvix.Core.Base.Types.Base
 import Juvix.Library hiding (Pos)
 import Juvix.Library.HashMap (HashMap)
-import Juvix.Library.Usage (Usage)
+import qualified Juvix.Library.Usage as Usage
 
 type RawGlobalAll (c :: Type -> Constraint) ext primTy primVal =
   ( c primTy,
@@ -92,7 +92,7 @@ deriving instance
 
 data RawDataArg' ext primTy primVal = RawDataArg
   { rawArgName :: GlobalName,
-    rawArgUsage :: Usage,
+    rawArgUsage :: Usage.T,
     rawArgType :: Term' ext primTy primVal
   }
   deriving (Generic)
@@ -115,7 +115,7 @@ deriving instance
 
 data DataArg' ext primTy primVal = DataArg
   { argName :: GlobalName,
-    argUsage :: Usage,
+    argUsage :: Usage.T,
     argType :: Value' ext primTy primVal
   }
   deriving (Generic)
@@ -349,7 +349,7 @@ type Globals' extV extT primTy primVal =
 
 data RawTeleEle' ext primTy primVal = RawTeleEle
   { rawName :: GlobalName,
-    rawUsage :: Usage,
+    rawUsage :: Usage.T,
     rawTy :: Term' ext primTy primVal,
     rawExtension :: XPi ext primTy primVal
   }
@@ -376,7 +376,7 @@ type RawTelescope ext primTy primVal =
 
 data TeleEle' extV extT primTy primVal = TeleEle
   { name :: GlobalName,
-    usage :: Usage,
+    usage :: Usage.T,
     ty :: Value' extV primTy primVal,
     extension :: XPi extT primTy primVal
   }

--- a/library/Core/src/Juvix/Core/Erased/Algorithm.hs
+++ b/library/Core/src/Juvix/Core/Erased/Algorithm.hs
@@ -129,8 +129,8 @@ erasePrimVal p = do
 
 erasePatterns ::
   ErasureM primTy1 primTy2 primVal1 primVal2 m =>
-  ([pat], ([(Usage.Usage, arg)], ret)) ->
-  m ([pat], ([(Usage.Usage, arg)], ret))
+  ([pat], ([(Usage.T, arg)], ret)) ->
+  m ([pat], ([(Usage.T, arg)], ret))
 erasePatterns ([], ([], ret)) = pure ([], ([], ret))
 erasePatterns (_ : ps, ((Usage.SNat 0, _) : args, ret)) = erasePatterns (ps, (args, ret))
 erasePatterns (p : ps, (arg : args, ret)) = do
@@ -140,7 +140,7 @@ erasePatterns _ = throw @"erasureError" (Erasure.InternalError "invalid type & p
 
 piTypeToList ::
   IR.Term primTy primVal ->
-  ([(Usage.Usage, IR.Term primTy primVal)], IR.Term primTy primVal)
+  ([(Usage.T, IR.Term primTy primVal)], IR.Term primTy primVal)
 piTypeToList ty =
   case ty of
     IR.Pi usage arg ret ->

--- a/library/Core/src/Juvix/Core/Erased/Algorithm/Types.hs
+++ b/library/Core/src/Juvix/Core/Erased/Algorithm/Types.hs
@@ -30,7 +30,7 @@ import qualified Juvix.Core.Translate as Translate
 import Juvix.Library hiding (Datatype, Type, empty)
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Juvix.Library.PrettyPrint as PP
-import Juvix.Library.Usage (Usage)
+import qualified Juvix.Library.Usage as Usage
 
 type MapPrim p1 p2 ty val =
   [NameSymbol.T] -> p1 -> Either (Error ty val) p2
@@ -182,7 +182,7 @@ data Datatype primTy primVal = Datatype
 
 data DataArg primTy = DataArg
   { argName :: GlobalName,
-    argUsage :: Usage,
+    argUsage :: Usage.T,
     argType :: Type primTy
   }
 

--- a/library/StandardLibrary/src/Juvix/Library/Usage.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Usage.hs
@@ -51,9 +51,8 @@ instance PP.PrettySyntax T where
   pretty' (SNat π) = pure $ PP.show π
   pretty' Omega = pure "ω"
 
-pred :: T -> T
-pred (SNat x) = SNat (x - 1)
-pred Omega = Omega
+pred :: T -> Maybe T
+pred π = π `minus` SNat 1
 
 minus :: T -> T -> Maybe T
 minus Omega _ = Just Omega

--- a/library/StandardLibrary/src/Juvix/Library/Usage.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Usage.hs
@@ -39,6 +39,8 @@ instance Monoid T where
 instance Semiring T where
   one = SNat 1
 
+  SNat 0 <.> _ = SNat 0
+  _ <.> SNat 0 = SNat 0
   SNat π <.> SNat ρ = SNat (π * ρ)
   Omega <.> _ = Omega
   _ <.> Omega = Omega

--- a/library/StandardLibrary/src/Juvix/Library/Usage.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Usage.hs
@@ -3,11 +3,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 
 module Juvix.Library.Usage
-  ( Usage,
-    NatAndw (..),
-    T,
+  ( T (..),
     numToNat,
-    allowsUsageOf,
     allows,
     pred,
     minus,
@@ -17,69 +14,64 @@ where
 import Juvix.Library hiding (pred, show)
 import qualified Juvix.Library.PrettyPrint as PP
 
--- | Usage is an alias for the semiring representation
-type T = NatAndw
-
-type Usage = NatAndw
-
--- | NatAndw is the choice of the semiring for ({ℕ, ω}, (+), 0, (*), 1)
-data NatAndw
-  = -- | semiring of (Nat,w) for usage annotation
-    -- 0, 1, or n usage
+-- | Each binder and local context element in Juvix is annotated with a
+-- /usage/, which tracks how many times it is needed in a runtime-relevant way.
+-- In our case, a usage is either a natural number specifying an exact usage
+-- (i.e., not an upper bound), or 𝛚, meaning that usage is not tracked for that
+-- variable and any number of usages is allowed.
+data T
+  = -- | Definite usage.
     SNat Natural
-  | -- | unspecified usage
+  | -- | Any number of usages allowed.
     Omega
   deriving (Eq, Show, Read, Generic, Data, NFData)
 
--- Addition is the semi-Ring/Monoid instance
-instance Semigroup NatAndw where
-  SNat x <> SNat y = SNat (x + y)
+-- | Addition
+instance Semigroup T where
+  SNat π <> SNat ρ = SNat (π + ρ)
   Omega <> _ = Omega
   _ <> Omega = Omega
 
-instance Monoid NatAndw where
+instance Monoid T where
   mempty = SNat 0
 
--- Semiring instance is thus multiplication
-instance Semiring NatAndw where
+-- | Multiplication
+instance Semiring T where
   one = SNat 1
 
-  SNat x <.> SNat y = SNat (x * y)
+  SNat π <.> SNat ρ = SNat (π * ρ)
   Omega <.> _ = Omega
   _ <.> Omega = Omega
 
-type instance PP.Ann NatAndw = ()
+type instance PP.Ann T = ()
 
-instance PP.PrettySyntax NatAndw where
+instance PP.PrettySyntax T where
   pretty' (SNat π) = pure $ PP.show π
   pretty' Omega = pure "ω"
 
-pred :: NatAndw -> NatAndw
+pred :: T -> T
 pred (SNat x) = SNat (x - 1)
 pred Omega = Omega
 
-minus :: Usage -> Usage -> Maybe Usage
+minus :: T -> T -> Maybe T
 minus Omega _ = Just Omega
-minus (SNat i) (SNat j) | i >= j = Just $ SNat $ i - j
+minus (SNat π) (SNat ρ) | π >= ρ = Just $ SNat $ π - ρ
 minus _ _ = Nothing
 
 infixl 6 `minus` -- same as -
 
--- | numToNat is a helper function that converts an integer to NatAndW
-numToNat :: Integer -> NatAndw
+-- | Converts an integer to a usage.
+numToNat :: Integer -> T
 numToNat = SNat . fromInteger
 
 -- variables annotated with n can be used n times.
 -- variables annotated with Omega can be used any times.
 
--- | allowsUsageOf is the function that checks usage compatibility
-allowsUsageOf :: Usage -> Usage -> Bool
-allowsUsageOf (SNat x) (SNat y) = x == y
-allowsUsageOf Omega (SNat _) = True
-allowsUsageOf Omega Omega = True
-allowsUsageOf (SNat _) Omega = False
+-- | allows is the function that checks usage compatibility
+allows :: T -> T -> Bool
+allows (SNat x) (SNat y) = x == y
+allows Omega (SNat _) = True
+allows Omega Omega = True
+allows (SNat _) Omega = False
 
-allows :: Usage -> Usage -> Bool
-allows = allowsUsageOf
-
-infix 4 `allowsUsageOf`, `allows` -- same as <=
+infix 4 `allows` -- same as <=


### PR DESCRIPTION
- [x] `Usage.T` now has one name, not three
- [x] fix bug in multiplication (0 × ω should be 0 not ω)
- [ ] come up with a test that actually fails for 0×ω=ω
- [x] make `pred` partial (what is `pred (SNat 0)`? ⊥ currently!!!) and fix uses in michelson backend
  - edit: "make it partial" as in change the return type to `Maybe T` instead of it being the _bad_ kind of partial like now