### PR TITLE
Add Witch to standard library

### DIFF
--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -321,14 +321,14 @@ Surface language
 - _Relies on_
   + [[Plonk]]
   + [[Ann]]
+  + [[Core/HR]]
+  + [[Core/IR]]
   + [[Library]]
   + [[Feedback]]
   + [[Library/Test/Golden]]
   + [[Juvix/Pipeline]]
   + [[Juvix/Pipeline]]
   + [[ToCore/Types]]
-  + [[Core/HR]]
-  + [[Core/IR]]
 ***** Orphan
 - _Relies on_
   + [[Library]]

--- a/stdlib/Witch/Base.ju
+++ b/stdlib/Witch/Base.ju
@@ -1,0 +1,26 @@
+mod Witch.Base where
+
+let Term = %Builtin.Witch.Term
+let Type = %Builtin.Witch.Type
+let Top  = %Builtin.Witch.Top
+
+effect TypeChecker =
+  let reduce    : Term -> Term
+  let normalize : Term -> Term
+  let newVar    : String -> Name
+  let unify     : Term -> Term -> Top
+  let checkType : Term -> Type -> Term
+  let get       : () -> List (Term, Type)
+  let set       : List (Term, Type) -> ()
+  quote         : a -> Term
+  unquote       : Term -> a
+
+handler runSpeculative = %Builtin.Witch.runSpeculative
+handler typecheck = %Builtin.Witch.typecheck
+
+let Errors = %Builtin.Witch.Errors
+
+effect Error =
+  typeError : NonEmptyList Error -> a
+
+handler catch = %Bultin.Witch.catch

--- a/stdlib/Witch/Base.ju
+++ b/stdlib/Witch/Base.ju
@@ -23,4 +23,4 @@ let Errors = %Builtin.Witch.Errors
 effect Error =
   typeError : NonEmptyList Error -> a
 
-handler catch = %Bultin.Witch.catch
+handler catch = %Builtin.Witch.catch


### PR DESCRIPTION
This PR adds Witch to Juvix's standard library.

For now, it adds the typechecker primitives to `Witch.Base`.
Next Steps are:
  - [ ] Create Witch's main datatype
  - [ ] Add more primitives to `Witch.Base` according to Agda's TC monad
  - [ ] Add `trace` and `admit` to the `Error` effect
 
After this, Witch should be ready to accept strategies written in Juvix.

Blocks
----
 - #890 

Blocked by
----
 - #787 
 - #903 