### PR TITLE
Support type application in core

### DIFF
--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fdefer-type-errors #-}
 -- |
 -- - Entrypoints into compilation from core terms to Michelson terms & contracts.
 module Juvix.Backends.Michelson.Compilation where

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Pretty.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Pretty.hs
@@ -31,7 +31,7 @@ type TyAnn = Last TyAnn'
 
 type TDoc = PP.Doc TyAnn
 
-type instance PP.Ann PrimTy = TyAnn
+type instance PP.Ann RawPrimTy = TyAnn
 
 tycon :: TDoc -> TDoc
 tycon = PP.annotate' TAPrimTy
@@ -42,7 +42,7 @@ ptycon = pure . tycon
 appT :: (PP.PrecReader m, Foldable t) => m TDoc -> t (m TDoc) -> m TDoc
 appT = PP.app' TAPunct
 
-instance PP.PrettySyntax PrimTy where
+instance PP.PrettySyntax RawPrimTy where
   pretty' = \case
     PrimTy ty -> PP.pretty' ty
     Pair -> ptycon "pair"

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Compilation/Types.hs
@@ -1,14 +1,17 @@
 -- |
 -- - Types used internally by the Michelson backend.
 module Juvix.Backends.Michelson.Compilation.Types
-  ( PrimTy (..),
+  ( RawPrimTy (..),
+    PrimTy',
+    PrimTyIR,
+    PrimTyHR,
     RawPrimVal (..),
-    Return',
-    Take,
-    Arg',
     PrimVal',
     PrimValIR,
     PrimValHR,
+    Return',
+    Take,
+    Arg',
     RawTerm,
     Term,
     Value,
@@ -33,7 +36,7 @@ import qualified Michelson.Typed as MT
 import qualified Michelson.Untyped as M
 import qualified Michelson.Untyped.Instr as Instr
 
-data PrimTy
+data RawPrimTy
   = PrimTy M.Ty
   | -- extra types that need arguments
     Pair
@@ -44,7 +47,8 @@ data PrimTy
   | List
   | Set
   | ContractT
-  | Application PrimTy (NonEmpty PrimTy)
+    -- FIXME is this still needed?
+  | Application RawPrimTy (NonEmpty RawPrimTy)
   deriving (Show, Eq, Generic, Data)
 
 data RawPrimVal
@@ -110,11 +114,11 @@ data RawPrimVal
   | MapOp
   deriving (Show, Eq, Generic, Data)
 
-type Return' ext = App.Return' ext (P.PrimType PrimTy) RawPrimVal
+type Return' ext = App.Return' ext (P.PrimType RawPrimTy) RawPrimVal
 
-type Take = App.Take (P.PrimType PrimTy) RawPrimVal
+type Take = App.Take (P.PrimType RawPrimTy) RawPrimVal
 
-type Arg' ext = App.Arg' ext (P.PrimType PrimTy) RawPrimVal
+type Arg' ext = App.Arg' ext (P.PrimType RawPrimTy) RawPrimVal
 
 type PrimVal' ext = Return' ext
 
@@ -122,11 +126,17 @@ type PrimValIR = PrimVal' IR.T
 
 type PrimValHR = PrimVal' CoreErased.T
 
-type RawTerm = CoreErased.AnnTerm PrimTy RawPrimVal
+type PrimTy' ext = App.Return' ext () RawPrimTy
 
-type Term = CoreErased.AnnTerm PrimTy PrimValHR
+type PrimTyIR = PrimTy' IR.T
 
-type Type = CoreErased.Type PrimTy
+type PrimTyHR = PrimTy' CoreErased.T
+
+type RawTerm = CoreErased.AnnTerm RawPrimTy RawPrimVal
+
+type Term = CoreErased.AnnTerm PrimTyHR PrimValHR
+
+type Type = CoreErased.Type PrimTyHR
 
 type Value = M.Value' M.ExpandedOp
 

--- a/library/Backends/Michelson/src/Juvix/Backends/Michelson/Pipeline.hs
+++ b/library/Backends/Michelson/src/Juvix/Backends/Michelson/Pipeline.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+
 module Juvix.Backends.Michelson.Pipeline (BMichelson (..), compileMichelson) where
 
 import qualified Juvix.Backends.Michelson.Compilation as M
@@ -11,7 +13,7 @@ data BMichelson = BMichelson
   deriving (Eq, Show)
 
 instance HasBackend BMichelson where
-  type Ty BMichelson = Param.PrimTy
+  type Ty BMichelson = Param.RawPrimTy
   type Val BMichelson = Param.RawPrimVal
   type Err BMichelson = Param.CompilationError
 
@@ -29,8 +31,8 @@ instance HasBackend BMichelson where
 compileMichelson ::
   MonadFail f =>
   Param.AnnTerm
-    Param.PrimTy
-    (ErasedAnn.TypedPrim Param.PrimTy Param.RawPrimVal) ->
+    Param.RawPrimTy
+    (ErasedAnn.TypedPrim Param.RawPrimTy Param.RawPrimVal) ->
   f Text
 compileMichelson term = do
   let (res, _logs) = M.compileContract $ ErasedAnn.toRaw term

--- a/library/Backends/Plonk/src/Juvix/Backends/Plonk/Pipeline.hs
+++ b/library/Backends/Plonk/src/Juvix/Backends/Plonk/Pipeline.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+
 {-# LANGUAGE UndecidableInstances #-}
 
 module Juvix.Backends.Plonk.Pipeline

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fdefer-typed-holes #-}
+
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -16,15 +18,17 @@ import qualified Juvix.Core.Parameterisation as Param
 import Juvix.Library
 import qualified LLVM.AST.Type as LLVM
 
-instance Param.CanApply PrimTy where
+instance Param.CanPrimApply () PrimTy where
+  primArity = arityTy
   -- TODO: Needs to implement apply
-  arity = arityTy
+  primApply = _
 
-instance Param.CanApply (PrimVal ext) where
-  -- TODO: Needs to implement apply
-  arity val = case val of
+instance Param.CanPrimApply PrimTy (PrimVal ext) where
+  primArity val = case val of
     App.Cont {} -> App.numLeft val
     App.Return {} -> arityRaw $ App.retTerm val
+  -- TODO: Needs to implement apply
+  primApply = _
 
 -- | Parameters for the LLVM backend.
 llvm :: Param.Parameterisation PrimTy RawPrimVal

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Pipeline.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Pipeline.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+
 -- | The basic connection between the backend and the Juvix pipeline.
 module Juvix.Backends.LLVM.Pipeline
   ( BLLVM (..),

--- a/library/Core/src/Juvix/Core/Application.hs
+++ b/library/Core/src/Juvix/Core/Application.hs
@@ -14,6 +14,8 @@ module Juvix.Core.Application
     Take (..),
     argToReturn,
     takeToReturn,
+    returnToTake,
+    argToTake,
   )
 where
 
@@ -206,6 +208,15 @@ argToReturn _ = empty
 -- | Translate a 'Take' into a 'Return''.
 takeToReturn :: Take ty term -> Return' ext ty term
 takeToReturn (Take {type', term}) = Return {retType = type', retTerm = term}
+
+returnToTake :: Alternative f => Return' ext ty term -> f (Take ty term)
+returnToTake (Cont {}) = empty
+returnToTake (Return {retType, retTerm}) =
+  pure $ Take {type' = retType, term = retTerm, usage = Usage.Omega}
+
+argToTake :: MonadPlus f => Arg' ext ty term -> f (Take ty term)
+argToTake = argToReturn >=> returnToTake
+
 
 data PPAnn' ty term
   = APunct

--- a/library/Core/src/Juvix/Core/Application.hs
+++ b/library/Core/src/Juvix/Core/Application.hs
@@ -212,7 +212,7 @@ takeToReturn (Take {type', term}) = Return {retType = type', retTerm = term}
 returnToTake :: Alternative f => Return' ext ty term -> f (Take ty term)
 returnToTake (Cont {}) = empty
 returnToTake (Return {retType, retTerm}) =
-  pure $ Take {type' = retType, term = retTerm, usage = Usage.Omega}
+  pure $ Take {type' = retType, term = retTerm, usage = Usage.SAny}
 
 argToTake :: MonadPlus f => Arg' ext ty term -> f (Take ty term)
 argToTake = argToReturn >=> returnToTake

--- a/library/Core/src/Juvix/Core/Parameterisations/Naturals.hs
+++ b/library/Core/src/Juvix/Core/Parameterisations/Naturals.hs
@@ -54,36 +54,22 @@ typeOf Mul = P.PrimType $ Ty :| [Ty, Ty]
 hasType :: Val -> P.PrimType Ty -> Bool
 hasType x ty = ty == typeOf x
 
-instance P.CanApply Ty where
-  arity Ty = 0
-  apply f xs = Left $ P.ExtraArguments f xs
+instance P.CanPrimApply () Ty where
+  primArity Ty = 0
+  primApply _ _ = panic "ill typed"
 
-instance P.CanApply Val where
-  arity = pred . fromIntegral . length . typeOf
-  apply f xs = app f $ toList xs
+instance P.CanPrimApply Ty Val where
+  primArity = pred . fromIntegral . length . typeOf
+  primApply f xs = app (App.term f) $ map App.term (toList xs)
     where
+      app n [] = Right (typeOf n, n)
       app Add (Val x : xs) = app (Curried Add x) xs
       app Sub (Val x : xs) = app (Curried Sub x) xs
       app Mul (Val x : xs) = app (Curried Mul x) xs
       app (Curried Add x) (Val y : ys) = app (Val (x + y)) ys
       app (Curried Sub x) (Val y : ys) = app (Val (x - y)) ys
       app (Curried Mul x) (Val y : ys) = app (Val (x * y)) ys
-      app n [] = Right n
-      app f (x : xs) = Left $ P.ExtraArguments f (x :| xs)
-
-instance P.CanApply (P.TypedPrim Ty Val) where
-  arity (App.Cont {numLeft}) = numLeft
-  arity (App.Return {retTerm}) = P.arity retTerm
-
-  -- partial application handled by Val so Cont should never appear
-  apply (App.Return {retTerm = f}) xs'
-    | Just xs <- traverse unReturn xs' =
-      P.mapApplyErr wrap $ P.apply f xs
-    where
-      unReturn (App.Return {retTerm}) = Just retTerm
-      unReturn _ = Nothing
-      wrap x = App.Return {retTerm = x, retType = typeOf x}
-  apply f' xs' = Left $ P.InvalidArguments f' xs'
+      app _ (_ : _) = panic "ill typed"
 
 instance E.HasWeak Ty where weakBy' _ _ ty = ty
 

--- a/library/Core/src/Juvix/Core/Parameterisations/Unit.hs
+++ b/library/Core/src/Juvix/Core/Parameterisations/Unit.hs
@@ -31,17 +31,13 @@ hasType :: Val -> P.PrimType Ty -> Bool
 hasType Val (P.PrimType (Ty :| [])) = True
 hasType _ _ = False
 
-instance P.CanApply Ty where
-  arity _ = 0
-  apply f xs = Left $ P.ExtraArguments f xs
+instance P.CanPrimApply () Ty where
+  primArity _ = 0
+  primApply _ _ = panic "ill typed"
 
-instance P.CanApply Val where
-  arity _ = 0
-  apply f xs = Left $ P.ExtraArguments f xs
-
-instance P.CanApply (P.TypedPrim Ty Val) where
-  arity _ = 0
-  apply f xs = Left $ P.ExtraArguments f xs
+instance P.CanPrimApply Ty Val where
+  primArity _ = 0
+  primApply _ _ = panic "ill typed"
 
 instance E.HasWeak Ty where weakBy' _ _ ty = ty
 

--- a/library/EasyPipeline/src/Easy.hs
+++ b/library/EasyPipeline/src/Easy.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 -- |
@@ -91,7 +93,7 @@ def =
     }
 
 -- @defMichelson@ gives us Michelson prelude
-defMichelson :: Options Michelson.Param.PrimTy Michelson.Param.RawPrimVal
+defMichelson :: Options Michelson.Param.RawPrimTy Michelson.Param.RawPrimVal
 defMichelson =
   def
     { prelude =

--- a/library/Pipeline/src/Juvix/Pipeline.hs
+++ b/library/Pipeline/src/Juvix/Pipeline.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+
 {-# LANGUAGE TypeFamilyDependencies #-}
 
 module Juvix.Pipeline
@@ -61,12 +63,12 @@ type Constraints b =
     Show (Err b),
     Show (Val b),
     Show (Ty b),
-    Show (ApplyErrorExtra (Ty b)),
-    Show (ApplyErrorExtra (TypedPrim (Ty b) (Val b))),
+    Show (Core.PrimApplyError (Ty b)),
+    Show (Core.PrimApplyError (TypedPrim (Ty b) (Val b))),
     Show (Arg (Ty b)),
     Show (Arg (TypedPrim (Ty b) (Val b))),
-    CanApply (Ty b),
-    CanApply (TypedPrim (Ty b) (Val b)),
+    Core.CanPrimApply () (Ty b),
+    Core.CanPrimApply (Ty b) (Val b),
     IR.HasWeak (Val b),
     IR.HasSubstValue IR.T (Ty b) (TypedPrim (Ty b) (Val b)) (Ty b),
     IR.HasPatSubstTerm (OnlyExts.T IR.T) (Ty b) (Val b) (Ty b),
@@ -166,7 +168,7 @@ class HasBackend b where
       --      RawGlobal (Ty b) (Val b)
       -- into RawGlobal (Ty b) (TypedPrim (Ty b) (Val b))
       typedGlobals = map (typePrims ty) globalDefs
-      evaluatedGlobals = HM.map (unsafeEvalGlobal typedGlobals) typedGlobals
+      evaluatedGlobals = _ -- HM.map (unsafeEvalGlobal typedGlobals) typedGlobals
       getMain = case HM.elems $ HM.filter isMain globalDefs of
         [] -> Feedback.fail $ "No main function found in " <> toS (pShowNoColor globalDefs)
         main : _ -> pure main


### PR DESCRIPTION
- Adds support for type-level application by reusing the infrastructure in `J.C.Application` in primitive types too.
- Adds a new typeclass `J.C.Parameterisation.CanPrimApply`, for applying a primitive function to known-well-typed arguments, as well as asking the arity of a function. The former is what Michelson's `applyProper` function did before.
    - Backends provide instances for `CanPrimApply Ty Val`, and `CanApply () Ty` (or, in a hypothetical backend with a kind system, `CanApply Kind Ty` or something........)