### PR TITLE
LLVM: Sum Types and Monads

### DIFF
--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -396,7 +396,69 @@ Representation of LLVM primitives in Juvix.
   + [[Library]]
 ******* Codegen
 ******** Block
-- Has the code necessary to generate LLVM Code
+- Has the code necessary to generate LLVM Code, and gives a small
+  DSL in order to effectively do so.
+An example of using the library to define an llvm function from
+haskell may look like
+@
+  defineLink :: (Define m, Debug m) => m Operand.Operand
+  defineLink = Block.defineFunction Type.void "link" args $
+    do
+      aux1 <- auxiliary1
+      aux2 <- auxiliary2
+      node1 <- Block.externf "node_1"
+      node2 <- Block.externf "node_1"
+      Types.debugLevelOne $ do
+        _ <- Block.printCString "Executing Link rule \n" []
+        _ <- Block.printCString "Calling Link on \n" []
+        Debug.printNodePort node1 aux1
+        Debug.printNodePort node2 aux2
+      Ops.setPort ("node_1", "port_1") ("node_2", "port_2")
+      Types.debugLevelOne $ do
+        _ <- Block.printCString "Calling Link on \n" []
+        Debug.printNodePort node1 aux2
+        Debug.printNodePort node2 aux1
+      Ops.setPort ("node_2", "port_2") ("node_1", "port_1")
+      Block.retNull
+    where
+      args =
+        [ (nodePointer, "node_1"),
+          (numPortsPointer, "port_1"),
+          (nodePointer, "node_2"),
+          (numPortsPointer, "port_2")
+        ]
+@
+Here we define a function called "link" that takes 4 arguments, and
+generates code that will link two nodes together. Since we are
+writing an llvm function, we have to `Block.externf` the given
+arguments to be able to refer to them in the LLVM code.
+Using the code to compile IR terms coming from some abstract
+machine looks a bit different, we can see it in this example here
+@
+  compileLam ty captures arguments body
+   | length captures == 0 = do
+      let (llvmArgty, llvmRetty) =
+            functionTypeLLVM ty
+          llvmArgNames =
+            fmap (Block.internName . NameSymbol.toSymbol) arguments
+          llvmArguments =
+            zip llvmArgty llvmArgNames
+      -- time to generate unique names
+      lamName <- Block.generateUniqueSymbol "lambda"
+      Block.defineFunction llvmRetty lamName llvmArguments $
+        do
+          bod <- compileTerm body
+          Block.ret bod
+   | otherwise =
+      throw @"err" (Types.UnsupportedOperation "closures are not supported")
+@
+In this example instead of having to `Block.externf` the given
+arguments, we can rely on resolution to properly handle
+that. However, we can see effective use of the library with the
+`Block.generateUniqueSymbol` function and the
+`Block.defineFunction` function. The first gives us an unique to
+compile again, while the latter setups up the environment to
+compile a new top level declaration.
 - _Relies on_
   + [[Codegen/Types]]
   + [[Shared]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -393,6 +393,31 @@ Representation of LLVM primitives in Juvix.
   + [[Application]]
   + [[Core/Parameterisation]]
   + [[Library]]
+******* Codegen
+******** Constants
+Module for predefined constants
+- _Relies on_
+  + [[Library]]
+******** Types <<Codegen/Types>>
+- _Relies on_
+  + [[Shared]]
+  + [[Sum]]
+  + [[Library]]
+  + [[HashMap]]
+********* Shared
+Shared between Types and Sum
+- _Relies on_
+  + [[Library]]
+  + [[HashMap]]
+********* Sum
+Provides a mechanism for defining Sum types
+- Has the code to encode a sum type via what is defined by the user or
+  what is defined to create the interaction net system.
+- _Relies on_
+  + [[Constants]]
+  + [[Shared]]
+  + [[Library]]
+  + [[HashMap]]
 *** test
 **** Main <<llvm/test/Main>>
 - _Relies on_

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -370,7 +370,6 @@ Surface language
   + [[Ann]]
   + [[Library]]
   + [[Feedback]]
-  + [[HashMap]]
   + [[NameSymbol]]
 ******* Parameterization <<LLVM/Parameterization>>
 Parameterization and application of the LLVM backend primitives.

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -364,6 +364,8 @@ Surface language
   + [[Primitive]]
 ******* Compilation <<LLVM/Compilation>>
 - _Relies on_
+  + [[Block]]
+  + [[Codegen/Types]]
   + [[Primitive]]
   + [[Ann]]
   + [[Library]]
@@ -394,6 +396,13 @@ Representation of LLVM primitives in Juvix.
   + [[Core/Parameterisation]]
   + [[Library]]
 ******* Codegen
+******** Block
+- Has the code necessary to generate LLVM Code
+- _Relies on_
+  + [[Codegen/Types]]
+  + [[Shared]]
+  + [[Library]]
+  + [[HashMap]]
 ******** Constants
 Module for predefined constants
 - _Relies on_

--- a/hie.yaml
+++ b/hie.yaml
@@ -21,9 +21,9 @@ cradle:
     - path: ./library/Backends/Michelson/test
       component: "michelson:test:michelson-test"
 
-    - path: ./library/Backends/LLVM/src
+    - path: ./library/Backends/llvm/src
       component: "llvm"
-    - path: ./library/Backends/LLVM/test
+    - path: ./library/Backends/llvm/test
       component: "llvm:test:llvm-test"
 
     - path: ./library/Backends/Plonk/src

--- a/library/Backends/llvm/package.yaml
+++ b/library/Backends/llvm/package.yaml
@@ -20,21 +20,41 @@ extra-source-files:
 description:         LLVM backend for the Juvix programming language.
 
 dependencies:
-- base >= 4.7 && < 5
-- core
-- pipeline
-- llvm-hs-pretty
-- llvm-hs-pure >= 9.0 && < 9.1
-- standard-library
-- unordered-containers >= 0.2.13
+  - base >= 4.7 && < 5
+  - core
+  - pipeline
+  - llvm-hs-pretty
+  - llvm-hs-pure >= 9.0 && < 9.1
+  - standard-library
+  - unordered-containers >= 0.2.13
+  - Cabal
+  - bytestring
 
 default-extensions:
-- TypeSynonymInstances
-- FlexibleInstances
-- NoImplicitPrelude
-- TypeFamilies
-- TypeApplications
-- MultiParamTypeClasses
+  - TypeSynonymInstances
+  - FlexibleInstances
+  - NoImplicitPrelude
+  - TypeFamilies
+  - TypeApplications
+  - MultiParamTypeClasses
+  - OverloadedStrings
+  - DataKinds
+  - DerivingStrategies
+  - DerivingVia
+  - FlexibleContexts
+  - FlexibleInstances
+  - GeneralizedNewtypeDeriving
+  - MultiWayIf
+  - TypeFamilies
+  - NamedFieldPuns
+  - DisambiguateRecordFields
+  - TupleSections
+  - BlockArguments
+  - StandaloneDeriving
+  - QuasiQuotes
+  - TypeOperators
+  - TypeInType
+  - DeriveGeneric
 
 library:
   source-dirs: src

--- a/library/Backends/llvm/package.yaml
+++ b/library/Backends/llvm/package.yaml
@@ -29,6 +29,7 @@ dependencies:
   - unordered-containers >= 0.2.13
   - Cabal
   - bytestring
+  - data-structures
 
 default-extensions:
   - TypeSynonymInstances
@@ -72,4 +73,6 @@ tests:
     - llvm
     - tasty
     - unordered-containers
+    - data-structures
+    - translate
 

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
@@ -1,5 +1,74 @@
 -- |
--- - Has the code necessary to generate LLVM Code
+-- - Has the code necessary to generate LLVM Code, and gives a small
+--   DSL in order to effectively do so.
+--
+-- An example of using the library to define an llvm function from
+-- haskell may look like
+--
+-- @
+--   defineLink :: (Define m, Debug m) => m Operand.Operand
+--   defineLink = Block.defineFunction Type.void "link" args $
+--     do
+--       aux1 <- auxiliary1
+--       aux2 <- auxiliary2
+--       node1 <- Block.externf "node_1"
+--       node2 <- Block.externf "node_1"
+--       Types.debugLevelOne $ do
+--         _ <- Block.printCString "Executing Link rule \n" []
+--         _ <- Block.printCString "Calling Link on \n" []
+--         Debug.printNodePort node1 aux1
+--         Debug.printNodePort node2 aux2
+--       Ops.setPort ("node_1", "port_1") ("node_2", "port_2")
+--       Types.debugLevelOne $ do
+--         _ <- Block.printCString "Calling Link on \n" []
+--         Debug.printNodePort node1 aux2
+--         Debug.printNodePort node2 aux1
+--       Ops.setPort ("node_2", "port_2") ("node_1", "port_1")
+--       Block.retNull
+--     where
+--       args =
+--         [ (nodePointer, "node_1"),
+--           (numPortsPointer, "port_1"),
+--           (nodePointer, "node_2"),
+--           (numPortsPointer, "port_2")
+--         ]
+-- @
+--
+--
+-- Here we define a function called "link" that takes 4 arguments, and
+-- generates code that will link two nodes together. Since we are
+-- writing an llvm function, we have to `Block.externf` the given
+-- arguments to be able to refer to them in the LLVM code.
+--
+-- Using the code to compile IR terms coming from some abstract
+-- machine looks a bit different, we can see it in this example here
+--
+-- @
+--   compileLam ty captures arguments body
+--    | length captures == 0 = do
+--       let (llvmArgty, llvmRetty) =
+--             functionTypeLLVM ty
+--           llvmArgNames =
+--             fmap (Block.internName . NameSymbol.toSymbol) arguments
+--           llvmArguments =
+--             zip llvmArgty llvmArgNames
+--       -- time to generate unique names
+--       lamName <- Block.generateUniqueSymbol "lambda"
+--       Block.defineFunction llvmRetty lamName llvmArguments $
+--         do
+--           bod <- compileTerm body
+--           Block.ret bod
+--    | otherwise =
+--       throw @"err" (Types.UnsupportedOperation "closures are not supported")
+-- @
+--
+-- In this example instead of having to `Block.externf` the given
+-- arguments, we can rely on resolution to properly handle
+-- that. However, we can see effective use of the library with the
+-- `Block.generateUniqueSymbol` function and the
+-- `Block.defineFunction` function. The first gives us an unique to
+-- compile again, while the latter setups up the environment to
+-- compile a new top level declaration.
 module Juvix.Backends.LLVM.Codegen.Block where
 
 import Data.ByteString.Short hiding (length)

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
@@ -1,0 +1,845 @@
+-- |
+-- - Has the code necessary to generate LLVM Code
+module Juvix.Backends.LLVM.Codegen.Block where
+
+import Data.ByteString.Short hiding (length)
+import Juvix.Backends.LLVM.Codegen.Types as Types
+import Juvix.Backends.LLVM.Codegen.Types.Shared
+import Juvix.Library hiding (Type, local)
+import qualified Juvix.Library.HashMap as Map
+import LLVM.AST
+import qualified LLVM.AST as AST
+import qualified LLVM.AST.CallingConvention as CC
+import qualified LLVM.AST.Constant as C
+import qualified LLVM.AST.Global as Global
+import qualified LLVM.AST.IntegerPredicate as IntPred
+import qualified LLVM.AST.Linkage as L
+import qualified LLVM.AST.Name as Name
+import qualified LLVM.AST.Operand as Operand
+import qualified LLVM.AST.ParameterAttribute as ParameterAttribute
+import qualified LLVM.AST.Type as Type
+import Prelude (String)
+
+--------------------------------------------------------------------------------
+-- Codegen Operations
+--------------------------------------------------------------------------------
+
+fresh :: (HasState "count" b m, Enum b) => m b
+fresh = do
+  i <- get @"count"
+  put @"count" (succ i)
+  pure i
+
+resetCount :: (HasState "count" s m, Num s) => m ()
+resetCount = put @"count" 0
+
+emptyBlock :: Int -> BlockState
+emptyBlock i = BlockState i [] Nothing
+
+createBlocks ::
+  ( HasState "blocks" (Map.HashMap Name BlockState) m,
+    HasThrow "err" Errors m
+  ) =>
+  m [BasicBlock]
+createBlocks = do
+  sortedBlocks <- sortBlocks . Map.toList <$> get @"blocks"
+  traverse makeBlock sortedBlocks
+
+makeBlock :: HasThrow "err" Errors f => (Name, BlockState) -> f BasicBlock
+makeBlock (l, BlockState i s t) = maketerm t >>| BasicBlock l (reverse s)
+  where
+    maketerm (Just x) = pure x
+    maketerm Nothing = throw @"err" (BlockLackingTerminator i)
+
+sortBlocks :: [(a, BlockState)] -> [(a, BlockState)]
+sortBlocks = sortBy (compare `on` (idx . snd))
+
+entryBlockName :: IsString p => p
+entryBlockName = "entry"
+
+emptyCodegen :: Types.CodegenState
+emptyCodegen =
+  Types.CodegenState
+    { Types.currentBlock = mkName entryBlockName,
+      Types.blocks = Map.empty,
+      Types.symTab = Map.empty,
+      Types.typTab = Map.empty,
+      Types.varTab = Map.empty,
+      Types.count = 0,
+      Types.names = Map.empty,
+      Types.blockCount = 1,
+      Types.moduleAST = emptyModule "EAC",
+      Types.debug = 0
+    }
+
+execEnvState :: Codegen a -> SymbolTable -> CodegenState
+execEnvState (Types.CodeGen m) a = execState (runExceptT m) (emptyCodegen {Types.symTab = a})
+
+evalEnvState :: Codegen a -> SymbolTable -> Either Errors a
+evalEnvState (Types.CodeGen m) a = evalState (runExceptT m) (emptyCodegen {Types.symTab = a})
+
+--------------------------------------------------------------------------------
+-- Module Level
+--------------------------------------------------------------------------------
+
+emptyModule :: ShortByteString -> Module
+emptyModule label = AST.defaultModule {moduleName = label}
+
+addDefn :: HasState "moduleDefinitions" [Definition] m => Definition -> m ()
+addDefn d = modify @"moduleDefinitions" (<> [d])
+
+addType :: HasState "moduleDefinitions" [Definition] m => Name -> Type -> m ()
+addType name typ =
+  addDefn (TypeDefinition name (Just typ))
+
+defineGen ::
+  HasState "moduleDefinitions" [Definition] m =>
+  Bool ->
+  Type ->
+  Symbol ->
+  [(Type, Name)] ->
+  [BasicBlock] ->
+  m Operand
+defineGen isVarArgs retty label argtys body = do
+  addDefn $
+    GlobalDefinition $
+      functionDefaults
+        { Global.parameters = params,
+          -- Figure out which is best!
+          Global.callingConvention = CC.Fast,
+          Global.returnType = retty,
+          Global.basicBlocks = body,
+          Global.name = internName label
+        }
+  return $
+    ConstantOperand $
+      C.GlobalReference
+        (Types.pointerOf (FunctionType retty (fst <$> argtys) isVarArgs))
+        (internName label)
+  where
+    params = ((\(ty, nm) -> Parameter ty nm []) <$> argtys, isVarArgs)
+
+define,
+  defineVarArgs ::
+    HasState "moduleDefinitions" [Definition] m =>
+    Type ->
+    Symbol ->
+    [(Type, Name)] ->
+    [BasicBlock] ->
+    m Operand
+define = defineGen False
+defineVarArgs = defineGen True
+
+-- | registerFunction is useful for making functions properly recursive
+registerFunction :: HasState "symTab" SymbolTable m => Type -> [(Type, b)] -> Name -> m ()
+registerFunction retty argtys label =
+  assign (nameToSymbol label) $
+    ConstantOperand $
+      C.GlobalReference
+        (Types.pointerOf (FunctionType retty (fst <$> argtys) False))
+        label
+
+makeFunction ::
+  ( HasThrow "err" Errors m,
+    HasState "blockCount" Int m,
+    HasState "blocks" (Map.T Name.Name BlockState) m,
+    HasState "count" Word m,
+    HasState "currentBlock" Name.Name m,
+    HasState "names" Names m,
+    HasState "symTab" Types.SymbolTable m
+  ) =>
+  Symbol ->
+  [(Type.Type, Name.Name)] ->
+  m ()
+makeFunction name args = do
+  entry <- addBlock name
+  _ <- setBlock entry
+  traverse_
+    (\(typ, nam) -> assign (nameToSymbol nam) (local typ nam))
+    args
+
+defineFunctionGen ::
+  Types.Define m => Bool -> Type -> Symbol -> [(Type, Name)] -> m a -> m Operand
+defineFunctionGen bool retty name args body = do
+  oldSymTab <- get @"symTab"
+  -- flush the blocks so we can have clean block for functions
+  put @"blocks" Map.empty
+  resetCount
+  functionOperand <-
+    (makeFunction name args >> registerFunction retty args (internName name) >> body >> createBlocks)
+      >>= defineGen bool retty name args
+  -- TODO ∷ figure out if LLVM functions can leak out of their local scope
+  put @"symTab" oldSymTab
+  -- flush out blocks after functions
+  -- comment for debugging!
+  put @"blocks" Map.empty
+  resetCount
+  assign name functionOperand
+  pure functionOperand
+
+defineFunction,
+  defineFunctionVarArgs ::
+    Define m => Type -> Symbol -> [(Type, Name)] -> m a -> m Operand
+defineFunction = defineFunctionGen False
+defineFunctionVarArgs = defineFunctionGen True
+
+--------------------------------------------------------------------------------
+-- Block Stack
+--------------------------------------------------------------------------------
+
+entry :: (HasState "currentBlock" Name m) => m Name
+entry = get @"currentBlock"
+
+getBlock :: (HasState "currentBlock" Name m) => m Name
+getBlock = entry
+
+-- TODO ∷ hack make a proper algorithm later!
+addBlockNumber :: NewBlock m => Symbol -> Int -> m Name
+addBlockNumber bname number = do
+  bls <- get @"blocks"
+  nms <- get @"names"
+  let new = emptyBlock number
+      (qname, supply) = uniqueName bname nms
+      name = internName qname
+  put @"blocks" (Map.insert name new bls)
+  put @"names" supply
+  return name
+
+addBlock :: NewBlock m => Symbol -> m Name
+addBlock bname = do
+  bls <- get @"blocks"
+  ix <- get @"blockCount"
+  nms <- get @"names"
+  let new = emptyBlock ix
+      (qname, supply) = uniqueName bname nms
+      name = internName qname
+  put @"blocks" (Map.insert name new bls)
+  put @"blockCount" (succ ix)
+  put @"names" supply
+  return name
+
+setBlock :: HasState "currentBlock" Name m => Name -> m ()
+setBlock bName = put @"currentBlock" bName
+
+modifyBlock ::
+  ( HasState "blocks" (Map.T Name v) m,
+    HasState "currentBlock" Name m
+  ) =>
+  v ->
+  m ()
+modifyBlock new = do
+  active <- get @"currentBlock"
+  modify @"blocks" (Map.insert active new)
+
+current ::
+  ( HasState "blocks" (Map.T Name b) m,
+    HasState "currentBlock" Name m,
+    HasThrow "err" Errors m
+  ) =>
+  m b
+current = do
+  c <- get @"currentBlock"
+  b <- get @"blocks"
+  case Map.lookup c b of
+    Just x -> return x
+    Nothing -> throw @"err" (NoSuchBlock (show c))
+
+externf :: Externf m => Name -> m Operand
+externf name = getvar (nameToSymbol name)
+
+nameToSymbol :: Name -> Symbol
+nameToSymbol (UnName n) = (intern (filter (/= '\"') (show n)))
+nameToSymbol (Name n) = (intern (filter (/= '\"') (show n)))
+
+local :: Type -> Name -> Operand
+local = LocalReference
+
+instr :: RetInstruction m => Type -> Instruction -> m Operand
+instr typ ins = do
+  n <- fresh
+  let ref = UnName n
+  blk <- current
+  let i = stack blk
+  modifyBlock (blk {stack = (ref := ins) : i})
+  pure (local typ ref)
+
+unnminstr ::
+  ( HasState "blocks" (Map.T Name BlockState) m,
+    HasState "currentBlock" Name m,
+    HasThrow "err" Errors m
+  ) =>
+  Instruction ->
+  m ()
+unnminstr ins = do
+  blk <- current
+  let i = stack blk
+  modifyBlock (blk {stack = (Do ins) : i})
+
+terminator ::
+  ( HasState "blocks" (Map.T Name BlockState) m,
+    HasState "currentBlock" Name m,
+    HasThrow "err" Errors m
+  ) =>
+  Named Terminator ->
+  m (Named Terminator)
+terminator trm = do
+  blk <- current
+  modifyBlock (blk {term = Just trm})
+  return trm
+
+--------------------------------------------------------------------------------
+-- External linking
+--------------------------------------------------------------------------------
+
+external :: (HasState "moduleDefinitions" [Definition] m) => Type -> String -> [(Type, Name)] -> m Operand
+external retty label argtys = do
+  addDefn $
+    GlobalDefinition $
+      functionDefaults
+        { Global.parameters = ((\(ty, nm) -> Parameter ty nm []) <$> argtys, False),
+          Global.callingConvention = CC.Fast, -- TODO: Do we always want this?
+          Global.returnType = retty,
+          Global.basicBlocks = [],
+          Global.name = mkName label,
+          Global.linkage = L.External
+        }
+  return $
+    ConstantOperand $
+      C.GlobalReference
+        (Types.pointerOf (FunctionType retty (fst <$> argtys) False))
+        (mkName label)
+
+externalVar :: (HasState "moduleDefinitions" [Definition] m) => Type -> String -> [(Type, Name)] -> m Operand
+externalVar retty label argtys = do
+  addDefn $
+    GlobalDefinition $
+      functionDefaults
+        { Global.parameters =
+            ( ( \(ty, nm) ->
+                  Parameter
+                    ty
+                    nm
+                    [ParameterAttribute.NoAlias, ParameterAttribute.NoCapture]
+              )
+                <$> argtys,
+              True
+            ),
+          Global.callingConvention = CC.C, -- TODO: Do we always want this?
+          Global.returnType = retty,
+          Global.basicBlocks = [],
+          Global.name = mkName label,
+          Global.linkage = L.External
+        }
+  return $
+    ConstantOperand $
+      C.GlobalReference
+        (Types.pointerOf (FunctionType retty (fst <$> argtys) True))
+        (mkName label)
+
+--------------------------------------------------------------------------------
+-- Printing facility
+--------------------------------------------------------------------------------
+
+definePrintf :: External m => m ()
+definePrintf = do
+  let name = "printf"
+  op <- externalVar Type.i32 name [(Types.pointerOf Type.i8, "n")]
+  assign (intern name) op
+
+printf :: Call m => [Operand] -> m Operand
+printf args = do
+  printf <- externf "printf"
+  instr Type.i32 $ callConvention CC.C printf (emptyArgs args)
+
+cString :: [Char] -> C.Constant
+cString str = C.Array Type.i8 (C.Int 8 . fromIntegral . ord <$> terminatedStr)
+  where
+    terminatedStr = str <> "\00"
+
+cStringPointer :: RetInstruction m => [Char] -> m Operand
+cStringPointer str = do
+  t <- alloca (Type.ArrayType len Type.i8)
+  store t (Operand.ConstantOperand vec)
+  pure t
+  where
+    vec = cString str
+    len = fromIntegral (length str + 1)
+
+printCString :: Call m => [Char] -> [Operand] -> m Operand
+printCString str args = do
+  str <- cStringPointer str
+  ptrIn <-
+    getElementPtr $
+      Types.Minimal
+        { Types.type' = Types.pointerOf Type.i8,
+          Types.address' = str,
+          Types.indincies' = constant32List [0, 0]
+        }
+  printf (ptrIn : args)
+
+--------------------------------------------------------------------------------
+-- Memory management
+--------------------------------------------------------------------------------
+
+-- malloc & free need to be defined once and then can be called normally with `externf`
+
+defineMalloc :: External m => m ()
+defineMalloc = do
+  let name = "malloc"
+  op <- external (Types.pointerOf Type.i8) name [(Types.size_t, "size")]
+  assign (intern name) op
+
+defineFree :: External m => m ()
+defineFree = do
+  let name = "free"
+  op <- external voidTy name [(Types.pointerOf Type.i8, "type")]
+  assign (intern name) op
+
+malloc :: Call m => Integer -> Type -> m Operand
+malloc size type' = do
+  malloc <- externf "malloc"
+  i8Ptr <-
+    instr (Types.pointerOf Type.i8) $
+      callConvention
+        CC.Fast
+        malloc
+        (emptyArgs [Operand.ConstantOperand (C.Int Types.size_t_int size)])
+  bitCast i8Ptr type'
+
+free :: Call m => Operand -> m ()
+free thing = do
+  free <- externf "free"
+  casted <- bitCast thing (Types.pointerOf Type.i8)
+  unnminstr (callConvention CC.Fast free (emptyArgs [casted]))
+
+--------------------------------------------------------------------------------
+-- Integer Operations
+--------------------------------------------------------------------------------
+
+sdiv,
+  udiv,
+  add,
+  sub,
+  mul ::
+    RetInstruction m => Type -> Operand -> Operand -> m Operand
+sdiv t a b =
+  instr
+    t
+    SDiv
+      { exact = False,
+        operand0 = a,
+        operand1 = b,
+        metadata = []
+      }
+udiv t a b =
+  instr
+    t
+    UDiv
+      { exact = False,
+        operand0 = a,
+        operand1 = b,
+        metadata = []
+      }
+add t a b =
+  instr
+    t
+    Add
+      { -- no signed warp
+        nsw = True,
+        -- no unSigned warp
+        nuw = True,
+        operand0 = a,
+        operand1 = b,
+        metadata = []
+      }
+sub t a b =
+  instr
+    t
+    Sub
+      { -- no signed warp
+        nsw = True,
+        -- no unSigned warp
+        nuw = True,
+        operand0 = a,
+        operand1 = b,
+        metadata = []
+      }
+mul t a b =
+  instr
+    t
+    Mul
+      { -- no signed warp
+        nsw = True,
+        -- no unSigned warp
+        nuw = True,
+        operand0 = a,
+        operand1 = b,
+        metadata = []
+      }
+
+icmp ::
+  RetInstruction m => IntPred.IntegerPredicate -> Operand -> Operand -> m Operand
+icmp iPred op1 op2 = instr Type.i1 $ ICmp iPred op1 op2 []
+
+--------------------------------------------------------------------------------
+-- Floating Point Operations
+--------------------------------------------------------------------------------
+
+-- Floating Point operations
+
+fdiv,
+  fadd,
+  fsub,
+  fmul ::
+    RetInstruction m => Type -> Operand -> Operand -> m Operand
+fdiv t a b = instr t $ FDiv noFastMathFlags a b []
+fadd t a b = instr t $ FAdd noFastMathFlags a b []
+fsub t a b = instr t $ FSub noFastMathFlags a b []
+fmul t a b = instr t $ FMul noFastMathFlags a b []
+
+--------------------------------------------------------------------------------
+-- Control Flow
+--------------------------------------------------------------------------------
+
+ret :: Instruct m => Operand -> m (Named Terminator)
+ret val = terminator $ Do $ Ret (Just val) []
+
+retNull :: Instruct m => m (Named Terminator)
+retNull = terminator $ Do $ Ret Nothing []
+
+cbr :: Instruct m => Operand -> Name -> Name -> m (Named Terminator)
+cbr cond tr fl = terminator $ Do $ CondBr cond tr fl []
+
+br :: Instruct m => Name -> m (Named Terminator)
+br val = terminator $ Do $ Br val []
+
+phi :: RetInstruction m => Type -> [(Operand, Name)] -> m Operand
+phi ty incoming = instr ty $ Phi ty incoming []
+
+switch :: Instruct m => Operand -> Name -> [(C.Constant, Name)] -> m (Named Terminator)
+switch val default' dests = terminator $ Do $ Switch val default' dests []
+
+generateIf ::
+  ( RetInstruction m,
+    HasState "blockCount" Int m,
+    HasState "names" Names m
+  ) =>
+  Type ->
+  Operand ->
+  m Operand ->
+  m Operand ->
+  m Operand
+generateIf ty cond tr fl = do
+  ifThen <- addBlock "if.then"
+  ifElse <- addBlock "if.else"
+  ifExit <- addBlock "if.exit"
+  -- %entry
+  ------------------
+  test <- icmp IntPred.EQ cond (ConstantOperand (C.Int 1 1))
+  _ <- cbr test ifThen ifElse
+  -- if.then
+  ------------------
+  setBlock ifThen
+  t <- tr
+  _ <- br ifExit
+  ifThen <- getBlock
+  -- if.else
+  ------------------
+  setBlock ifElse
+  f <- fl
+  _ <- br ifExit
+  ifElse <- getBlock
+  -- if.exit
+  ------------------
+  setBlock ifExit
+  phi ty [(t, ifThen), (f, ifElse)]
+
+--------------------------------------------------------------------------------
+-- Effects
+--------------------------------------------------------------------------------
+
+emptyArgs :: Functor f => f a1 -> f (a1, [a2])
+emptyArgs = fmap (\x -> (x, []))
+
+callConvention ::
+  CC.CallingConvention ->
+  Operand ->
+  [(Operand, [ParameterAttribute.ParameterAttribute])] ->
+  Instruction
+callConvention convention fn args =
+  Call
+    { functionAttributes = [],
+      tailCallKind = Nothing,
+      callingConvention = convention,
+      returnAttributes = [],
+      function = Right fn,
+      arguments = args,
+      metadata = []
+    }
+
+callVoid ::
+  RetInstruction m =>
+  Operand ->
+  [(Operand, [ParameterAttribute.ParameterAttribute])] ->
+  m ()
+callVoid fn args =
+  unnminstr $
+    Call
+      { functionAttributes = [],
+        tailCallKind = Nothing,
+        callingConvention = CC.Fast,
+        returnAttributes = [],
+        function = Right fn,
+        arguments = args,
+        metadata = []
+      }
+
+call ::
+  RetInstruction m =>
+  Type ->
+  Operand ->
+  [(Operand, [ParameterAttribute.ParameterAttribute])] ->
+  m Operand
+call typ fn args =
+  instr typ $
+    Call
+      { functionAttributes = [],
+        tailCallKind = Nothing,
+        callingConvention = CC.Fast,
+        returnAttributes = [],
+        function = Right fn,
+        arguments = args,
+        metadata = []
+      }
+
+-- TODO :: is the pointerOf on the ty needed
+-- the LLVM8 testing on newKledi shows it being the same type back
+-- however that would be incorrect?!
+alloca :: RetInstruction m => Type -> m Operand
+alloca ty = instr (pointerOf ty) $ Alloca ty Nothing 0 []
+
+load :: RetInstruction m => Type -> Operand -> m Operand
+load typ ptr = instr typ $ Load False ptr Nothing 0 []
+
+store :: Instruct m => Operand -> Operand -> m ()
+store ptr val = unnminstr $ Store False ptr val Nothing 0 []
+
+--------------------------------------------------------------------------------
+-- Casting Operations
+--------------------------------------------------------------------------------
+
+bitCast :: RetInstruction m => Operand -> Type -> m Operand
+bitCast op typ = instr typ $ BitCast op typ []
+
+ptrToInt :: RetInstruction m => Operand -> Type -> m Operand
+ptrToInt op typ = instr typ $ AST.PtrToInt op typ []
+
+trunc :: RetInstruction m => Operand -> Type -> m Operand
+trunc op typ = instr typ $ Trunc op typ []
+
+--------------------------------------------------------------------------------
+-- Pointer Operations
+--------------------------------------------------------------------------------
+
+-- | 'getElementPtr' gets an index of a struct or an array as a pointer
+-- Takes a minimal data type to emulate named arguments
+getElementPtr :: RetInstruction m => MinimalPtr -> m Operand
+getElementPtr (Minimal address indices type') =
+  instr type' $
+    GetElementPtr
+      { inBounds = True,
+        metadata = [],
+        address = address,
+        indices = indices
+      }
+
+loadElementPtr :: RetInstruction m => MinimalPtr -> m Operand
+loadElementPtr minimal = do
+  ptr <-
+    getElementPtr
+      (minimal {Types.type' = pointerOf (Types.type' minimal)})
+  load (Types.type' minimal) ptr
+
+constant32List :: Functor f => f Integer -> f Operand
+constant32List = fmap (ConstantOperand . C.Int 32)
+
+--------------------------------------------------------------------------------
+-- Sum Type Declarations
+--------------------------------------------------------------------------------
+argsGen :: [Name.Name]
+argsGen = (mkName . ("_" <>) . show) <$> ([1 ..] :: [Integer])
+
+variantCreationName :: Symbol -> Symbol
+variantCreationName = (<> "_%func")
+
+-- | Generic logic to create a variant, used in 'createVariantAllocaFunction'
+-- and 'createVariantGen'
+variantCreation ::
+  ( RetInstruction m,
+    HasState "typTab" TypeTable m,
+    Integral a,
+    Foldable t
+  ) =>
+  Type ->
+  Symbol ->
+  Word32 ->
+  t Operand ->
+  a ->
+  (Type -> m Operand) ->
+  m Operand
+variantCreation sumTyp variantName tag args offset allocFn = do
+  typTable <- get @"typTab"
+  sum <- allocFn sumTyp
+  getEle <-
+    getElementPtr $
+      -- The pointerOf is now correct!
+      Minimal
+        { Types.type' = Types.pointerOf (Type.IntegerType tag),
+          Types.address' = sum,
+          Types.indincies' = constant32List [0, 0]
+        }
+  store
+    getEle
+    (ConstantOperand (C.Int tag (toInteger offset)))
+  -- TODO ∷ remove the ! call here
+  let varType = typTable Map.! variantName
+  casted <- bitCast sum (Types.pointerOf varType)
+  foldM_
+    ( \i inst -> do
+        ele <-
+          getElementPtr $
+            -- The pointerOf is now correct!
+            Minimal
+              { Types.type' = Types.pointerOf (intoStructTypeErr varType i),
+                Types.address' = casted,
+                Types.indincies' = constant32List [0, i]
+              }
+        store ele inst
+        pure (succ i)
+    )
+    1 -- not 0, as 0 is reserved for the tag that was set
+    args
+  pure casted
+
+-- TODO ∷ Remove repeat code!!!
+-- TODO ∷ use, so far the createVariant is only used
+
+-- | creates a variant creation definition function
+createVariantAllocaFunction ::
+  ( Define m,
+    HasState "typTab" TypeTable m,
+    HasState "varTab" VariantToType m
+  ) =>
+  Symbol ->
+  [Type] ->
+  m Operand
+createVariantAllocaFunction variantName argTypes = do
+  varTable <- get @"varTab"
+  typTable <- get @"typTab"
+  case Map.lookup variantName varTable of
+    Nothing ->
+      throw @"err" (NoSuchVariant (show variantName))
+    Just
+      ( S
+          { sum' = sumName,
+            offset = offset,
+            tagSize' = tag
+          }
+        ) ->
+        case Map.lookup sumName typTable of
+          Nothing ->
+            throw @"err" (DoesNotHappen ("type " <> show sumName <> "does not exist"))
+          Just sumTyp ->
+            let varCName = variantCreationName variantName
+                args = zip argTypes argsGen
+             in defineFunction sumTyp varCName args $ do
+                  argsName <- traverse (externf . snd) args
+                  casted <- variantCreation sumTyp variantName tag argsName offset alloca
+                  _ <- ret casted
+                  createBlocks
+
+createVariantGen ::
+  ( RetInstruction m,
+    HasState "typTab" TypeTable m,
+    HasState "varTab" VariantToType m,
+    Foldable t
+  ) =>
+  Symbol ->
+  t Operand ->
+  (Type -> m Operand) ->
+  m Operand
+createVariantGen variantName args allocFn = do
+  varTable <- get @"varTab"
+  typTable <- get @"typTab"
+  case Map.lookup variantName varTable of
+    Nothing ->
+      throw @"err" (NoSuchVariant (show variantName))
+    Just
+      ( S
+          { sum' = sumName,
+            offset = offset,
+            tagSize' = tag
+          }
+        ) ->
+        case Map.lookup sumName typTable of
+          Nothing ->
+            throw @"err" (DoesNotHappen ("type " <> show sumName <> "does not exist"))
+          Just sumTyp ->
+            variantCreation sumTyp variantName tag args offset allocFn
+
+-- | Creates a variant by calling alloca
+allocaVariant ::
+  ( RetInstruction m,
+    HasState "typTab" TypeTable m,
+    HasState "varTab" VariantToType m,
+    Foldable t
+  ) =>
+  Symbol ->
+  t Operand ->
+  m Operand
+allocaVariant variantName args = createVariantGen variantName args alloca
+
+-- | Creates a variant by calling malloc
+mallocVariant ::
+  ( Call m,
+    HasState "typTab" TypeTable m,
+    HasState "varTab" VariantToType m,
+    Foldable t
+  ) =>
+  Symbol ->
+  t Operand ->
+  Integer ->
+  m Operand
+mallocVariant variantName args size = createVariantGen variantName args (malloc size)
+
+-------------------------------------------------------------------------------
+-- Symbol Table
+-------------------------------------------------------------------------------
+
+assign :: (HasState "symTab" SymbolTable m) => Symbol -> Operand -> m ()
+assign var x = do
+  modify @"symTab" (Map.insert var x)
+
+getvar ::
+  ( HasState "symTab" SymbolTable m,
+    HasThrow "err" Errors m
+  ) =>
+  Symbol ->
+  m Operand
+getvar var = do
+  syms <- get @"symTab"
+  case Map.lookup var syms of
+    Just x ->
+      return x
+    Nothing ->
+      throw @"err"
+        ( VariableNotInScope $
+            "Local variable not in scope:"
+              <> "\n syms: "
+              <> show syms
+              <> "\n var: "
+              <> show var
+        )
+
+internName :: Symbol -> Name
+internName = mkName . unintern

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
@@ -202,6 +202,20 @@ defineFunction = defineFunctionGen False
 defineFunctionVarArgs = defineFunctionGen True
 
 --------------------------------------------------------------------------------
+-- Unique Name gen
+--------------------------------------------------------------------------------
+
+generateUniqueName :: NewBlock m => Symbol -> m Name
+generateUniqueName = fmap internName . generateUniqueSymbol
+
+generateUniqueSymbol :: NewBlock m => Symbol -> m Symbol
+generateUniqueSymbol bname = do
+  nms <- get @"names"
+  let (qname, supply) = uniqueName bname nms
+  put @"names" supply
+  return qname
+
+--------------------------------------------------------------------------------
 -- Block Stack
 --------------------------------------------------------------------------------
 
@@ -215,25 +229,19 @@ getBlock = entry
 addBlockNumber :: NewBlock m => Symbol -> Int -> m Name
 addBlockNumber bname number = do
   bls <- get @"blocks"
-  nms <- get @"names"
+  name <- generateUniqueName bname
   let new = emptyBlock number
-      (qname, supply) = uniqueName bname nms
-      name = internName qname
   put @"blocks" (Map.insert name new bls)
-  put @"names" supply
   return name
 
 addBlock :: NewBlock m => Symbol -> m Name
 addBlock bname = do
   bls <- get @"blocks"
   ix <- get @"blockCount"
-  nms <- get @"names"
+  name <- generateUniqueName bname
   let new = emptyBlock ix
-      (qname, supply) = uniqueName bname nms
-      name = internName qname
   put @"blocks" (Map.insert name new bls)
   put @"blockCount" (succ ix)
-  put @"names" supply
   return name
 
 setBlock :: HasState "currentBlock" Name m => Name -> m ()

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Constants.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Constants.hs
@@ -1,0 +1,25 @@
+-- | Module for predefined constants
+module Juvix.Backends.LLVM.Codegen.Constants where
+
+import Juvix.Library hiding (Type)
+import qualified LLVM.AST.Type as Type
+
+portLength :: Num p => p
+portLength = 32
+
+-- | An abbreviation for 'IntegerType' 4
+i4 :: Type.Type
+i4 = Type.IntegerType 4
+
+-- | An abbreviation for 'IntegerType' 8
+i8 :: Type.Type
+i8 = Type.IntegerType 8
+
+-- TODO ∷ change this based on the machine, C++ pargma?
+
+-- | Use 64 bit ints
+int :: Type.Type
+int = Type.IntegerType 64
+
+double :: Type.Type
+double = Type.FloatingPointType Type.DoubleFP

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types.hs
@@ -1,0 +1,338 @@
+{-# LANGUAGE ConstraintKinds #-}
+
+module Juvix.Backends.LLVM.Codegen.Types
+  ( module Juvix.Backends.LLVM.Codegen.Types,
+    module Juvix.Backends.LLVM.Codegen.Types.Shared,
+  )
+where
+
+import qualified Data.ByteString.Short as Short hiding (empty)
+import qualified Distribution.System as System
+import Juvix.Backends.LLVM.Codegen.Types.Shared
+import qualified Juvix.Backends.LLVM.Codegen.Types.Sum as Sum
+import Juvix.Library hiding (Type)
+import qualified Juvix.Library.HashMap as Map
+import LLVM.AST as AST
+import qualified LLVM.AST.AddrSpace as AddrSpace
+import LLVM.AST.DataLayout (DataLayout (..))
+import Prelude ((!!))
+
+--------------------------------------------------------------------------------
+-- Codegen State
+--------------------------------------------------------------------------------
+
+data CodegenState = CodegenState
+  { -- | Name of the active block to append to
+    currentBlock :: Name,
+    -- | Blocks for function
+    blocks :: Map.T Name BlockState,
+    -- | Function scope symbol table
+    symTab :: SymbolTable,
+    -- | Mapping from symbol to Type
+    typTab :: TypeTable,
+    -- | a mapping from the variants to the sum type
+    varTab :: VariantToType,
+    -- | Count of basic blocks
+    blockCount :: Int,
+    -- | Count of unnamed instructions
+    count :: Word,
+    -- | Name Supply
+    names :: Names,
+    moduleAST :: AST.Module,
+    -- | Debug level
+    debug :: Int
+  }
+  deriving (Show, Generic)
+
+data BlockState = BlockState
+  { -- | Block index
+    idx :: Int,
+    -- | Stack of instructions
+    stack :: [Named Instruction],
+    -- | Block terminator
+    term :: Maybe (Named Terminator)
+  }
+  deriving (Show, Generic)
+
+data Errors
+  = -- | Error when a block does not exist
+    NoSuchBlock Text
+  | -- | Error when a Variant does not exist
+    NoSuchVariant Text
+  | -- | Error that should never happen
+    DoesNotHappen Text
+  | -- | Error that happens when a variable out of scope is called
+    VariableNotInScope Text
+  | -- | Error that happens when a block lacks a terminator when it should have one
+    BlockLackingTerminator Int
+  deriving (Show, Eq)
+
+type CodegenAlias = ExceptT Errors (State CodegenState)
+
+newtype Codegen a = CodeGen {runCodegen :: CodegenAlias a}
+  deriving (Functor, Applicative, Monad)
+  deriving
+    ( HasState "currentBlock" Name,
+      HasSink "currentBlock" Name,
+      HasSource "currentBlock" Name
+    )
+    via StateField "currentBlock" CodegenAlias
+  deriving
+    ( HasState "blocks" (Map.T Name BlockState),
+      HasSink "blocks" (Map.T Name BlockState),
+      HasSource "blocks" (Map.T Name BlockState)
+    )
+    via StateField "blocks" CodegenAlias
+  deriving
+    ( HasState "symTab" SymbolTable,
+      HasSink "symTab" SymbolTable,
+      HasSource "symTab" SymbolTable
+    )
+    via StateField "symTab" CodegenAlias
+  deriving
+    ( HasState "varTab" VariantToType,
+      HasSink "varTab" VariantToType,
+      HasSource "varTab" VariantToType
+    )
+    via StateField "varTab" CodegenAlias
+  deriving
+    ( HasState "typTab" TypeTable,
+      HasSink "typTab" TypeTable,
+      HasSource "typTab" TypeTable
+    )
+    via StateField "typTab" CodegenAlias
+  deriving
+    ( HasState "blockCount" Int,
+      HasSink "blockCount" Int,
+      HasSource "blockCount" Int
+    )
+    via StateField "blockCount" CodegenAlias
+  deriving
+    ( HasState "count" Word,
+      HasSink "count" Word,
+      HasSource "count" Word
+    )
+    via StateField "count" CodegenAlias
+  deriving
+    ( HasState "names" Names,
+      HasSink "names" Names,
+      HasSource "names" Names
+    )
+    via StateField "names" CodegenAlias
+  deriving
+    ( HasState "moduleAST" AST.Module,
+      HasSink "moduleAST" AST.Module,
+      HasSource "moduleAST" AST.Module
+    )
+    via StateField "moduleAST" CodegenAlias
+  deriving
+    ( HasReader "debug" Int,
+      HasSource "debug" Int
+    )
+    via ReaderField "debug" CodegenAlias
+  deriving (HasThrow "err" Errors) via MonadError CodegenAlias
+
+instance HasState "moduleDefinitions" [Definition] Codegen where
+  state_ _ state = do
+    c <- get @"moduleDefinitions"
+    let (a, res) = state c
+    put @"moduleDefinitions" res
+    pure a
+
+instance HasSource "moduleDefinitions" [Definition] Codegen where
+  await_ _ = moduleDefinitions <$> (get @"moduleAST")
+
+instance HasSink "moduleDefinitions" [Definition] Codegen where
+  yield_ _ x = do
+    c <- get @"moduleAST"
+    put @"moduleAST" (c {moduleDefinitions = x})
+
+-- TODO ∷ see if this is still useful
+newtype LLVM a = LLVM {runLLVM :: State AST.Module a}
+  deriving (Functor, Applicative, Monad)
+  deriving
+    ( HasState "moduleName" Short.ShortByteString,
+      HasSink "moduleName" Short.ShortByteString,
+      HasSource "moduleName" Short.ShortByteString
+    )
+    via StateField "moduleName" (State AST.Module)
+  deriving
+    ( HasState "moduleSourceFileName" Short.ShortByteString,
+      HasSink "moduleSourceFileName" Short.ShortByteString,
+      HasSource "moduleSourceFileName" Short.ShortByteString
+    )
+    via StateField "moduleSourceFileName" (State AST.Module)
+  deriving
+    ( HasState "moduleDataLayout" (Maybe LLVM.AST.DataLayout.DataLayout),
+      HasSink "moduleDataLayout" (Maybe LLVM.AST.DataLayout.DataLayout),
+      HasSource "moduleDataLayout" (Maybe LLVM.AST.DataLayout.DataLayout)
+    )
+    via StateField "moduleDataLayout" (State AST.Module)
+  deriving
+    ( HasState "moduleTargetTriple" (Maybe Short.ShortByteString),
+      HasSink "moduleTargetTriple" (Maybe Short.ShortByteString),
+      HasSource "moduleTargetTriple" (Maybe Short.ShortByteString)
+    )
+    via StateField "moduleTargetTriple" (State AST.Module)
+  deriving
+    ( HasState "moduleDefinitions" [Definition],
+      HasSink "moduleDefinitions" [Definition],
+      HasSource "moduleDefinitions" [Definition]
+    )
+    via StateField "moduleDefinitions" (State AST.Module)
+
+--------------------------------------------------------------------------------
+-- Effect Aliases
+--------------------------------------------------------------------------------
+
+type Instruct m =
+  ( HasThrow "err" Errors m,
+    HasState "blocks" (Map.T Name BlockState) m,
+    HasState "currentBlock" Name m
+  )
+
+type RetInstruction m =
+  ( HasState "count" Word m,
+    Instruct m
+  )
+
+type MallocNode m =
+  ( RetInstruction m,
+    HasState "typTab" TypeTable m,
+    HasState "varTab" VariantToType m,
+    HasState "symTab" SymbolTable m
+  )
+
+type NewBlock m =
+  ( HasState "blockCount" Int m,
+    HasState "blocks" (Map.T Name BlockState) m,
+    HasState "names" Names m
+  )
+
+type AllocaNode m =
+  ( RetInstruction m,
+    HasState "typTab" TypeTable m,
+    HasState "varTab" VariantToType m
+  )
+
+type Define m =
+  ( RetInstruction m,
+    Externf m,
+    HasState "blockCount" Int m,
+    HasState "moduleDefinitions" [Definition] m,
+    HasState "names" Names m
+  )
+
+type External m =
+  ( HasState "moduleDefinitions" [Definition] m,
+    HasState "symTab" SymbolTable m
+  )
+
+type Externf m =
+  ( HasState "symTab" SymbolTable m,
+    HasThrow "err" Errors m
+  )
+
+type Call m =
+  ( RetInstruction m,
+    HasState "symTab" SymbolTable m
+  )
+
+type Debug m = HasReader "debug" Int m
+
+--------------------------------------------------------------------------------
+-- Haskell Types
+--------------------------------------------------------------------------------
+
+data MinimalPtr = Minimal
+  { address' :: Operand,
+    indincies' :: [Operand],
+    type' :: Type
+  }
+  deriving (Show)
+
+--------------------------------------------------------------------------------
+-- LLVM Type Operations
+--------------------------------------------------------------------------------
+
+-- TODO :: Replace with safe lens call instead!
+intoStructTypeErr :: Integral a => Type -> a -> Type
+intoStructTypeErr typ' i = elementTypes typ' !! fromIntegral i
+
+--------------------------------------------------------------------------------
+-- System Architecture
+--------------------------------------------------------------------------------
+
+-- for all architectures we will want to know the addressing space
+-- for architectures that are sufficiently big, we will want to really cut corners
+-- with indirection.
+-- In reality, it seems most architectures we should care about are 32 bit or higher
+-- however, on the off chance, we are forced into an 8 bit architecture, we have variants
+-- for port numbers, so we can support large number of arguments (is this even useful on small archs?)
+
+addressSpace :: Num p => p
+addressSpace =
+  case System.buildArch of
+    System.X86_64 -> 64
+    System.I386 -> 32
+    System.Mips -> 32
+    System.PPC -> 32
+    System.PPC64 -> 64
+    System.Sparc -> 64
+    System.Arm -> 32
+    System.AArch64 -> 64
+    -- has 16 bit instructions
+    System.SH -> 32
+    System.IA64 -> 64
+    -- These have 24/31 bit addressing
+    -- may be more apt to return 24/31?
+    System.S390 -> 32
+    System.Alpha -> 64
+    -- seems to be 64?
+    System.Hppa -> 64
+    -- seems to be PowerPC architecture!?!??
+    System.Rs6000 -> 32
+    -- may have to lower to 24?
+    System.M68k -> 32
+    System.Vax -> 32
+    -- 32 I guess?
+    System.JavaScript -> 32
+    -- otherwise assume it's a 32 bit architecture
+    System.OtherArch _ -> 32
+
+-- | 'bitSizeEncodingPoint' is used to determine if we need a layer of indirection
+-- around all our number types to have a bigger argument list
+bitSizeEncodingPoint :: Bool
+bitSizeEncodingPoint = addressSpace >= (17 :: Int)
+
+debugLevelOne :: HasReader "debug" Int m => m () -> m ()
+debugLevelOne = whenM ((1 <=) <$> ask @"debug")
+
+--------------------------------------------------------------------------------
+-- LLVM Types
+--------------------------------------------------------------------------------
+
+-- | 'varientToType' takes the type out of the variant
+varientToType :: Sum.VariantInfo -> Type
+varientToType = Sum.typ'
+
+pointerOf :: Type -> Type
+pointerOf typ = PointerType typ (AddrSpace.AddrSpace 0)
+
+pointerSizeInt :: Num p => p
+pointerSizeInt = addressSpace
+
+pointerSize :: Type
+pointerSize = IntegerType addressSpace
+
+voidStarTy :: Type
+voidStarTy = pointerOf VoidType
+
+voidTy :: Type
+voidTy = VoidType
+
+size_t :: Type
+size_t = IntegerType addressSpace
+
+size_t_int :: Num p => p
+size_t_int = addressSpace

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types.hs
@@ -65,6 +65,10 @@ data Errors
     VariableNotInScope Text
   | -- | Error that happens when a block lacks a terminator when it should have one
     BlockLackingTerminator Int
+  | -- | Operation that is current unsupported
+    UnsupportedOperation Text
+  | -- | Operation has the wrong number of arguments
+    WrongNumberOfArguments Text
   deriving (Show, Eq)
 
 type CodegenAlias = ExceptT Errors (State CodegenState)

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types/Shared.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types/Shared.hs
@@ -1,0 +1,34 @@
+-- | Shared between Types and Sum
+module Juvix.Backends.LLVM.Codegen.Types.Shared where
+
+import Juvix.Library hiding (Type)
+import qualified Juvix.Library.HashMap as Map
+import LLVM.AST
+import qualified LLVM.AST as AST ()
+import qualified LLVM.AST.Constant as C ()
+import LLVM.AST.Global as Global ()
+
+type SymbolTable = Map.T Symbol Operand
+
+type TypeTable = Map.T Symbol Type
+
+data SumInfo = S
+  { sum' :: Symbol,
+    offset :: Int,
+    tagSize' :: Word32
+  }
+  deriving (Show, Eq)
+
+-- | a mapping between the variant and the sum type along with
+-- the tag associated with it
+type VariantToType = Map.T Symbol SumInfo
+
+type Names = Map.T Symbol Int
+
+uniqueName :: Symbol -> Names -> (Symbol, Names)
+uniqueName nm ns =
+  case Map.lookup nm ns of
+    Nothing -> (nm, Map.insert nm 1 ns)
+    Just ix -> (intern (show nm <> show ix), Map.insert nm (succ ix) ns)
+
+instance Hashable Name

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types/Sum.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types/Sum.hs
@@ -1,0 +1,143 @@
+-- | Provides a mechanism for defining Sum types
+-- - Has the code to encode a sum type via what is defined by the user or
+--   what is defined to create the interaction net system.
+module Juvix.Backends.LLVM.Codegen.Types.Sum where
+
+import qualified Juvix.Backends.LLVM.Codegen.Constants as Constants
+import Juvix.Backends.LLVM.Codegen.Types.Shared
+import Juvix.Library hiding (Type)
+import qualified Juvix.Library.HashMap as Map
+import LLVM.AST
+import LLVM.AST.Type
+import qualified LLVM.AST.Type as Type
+import qualified Prelude as Prelude (error)
+
+-----------------------------------------------------------------------------------------
+-- Types
+-----------------------------------------------------------------------------------------
+
+type Size = Int
+
+-- | Data needed to make a Variant
+data VariantInfo = Variant
+  { size :: Size,
+    name :: Symbol,
+    typ' :: Type
+  }
+
+-----------------------------------------------------------------------------------------
+-- Helper functions
+-----------------------------------------------------------------------------------------
+
+-- TODO ∷ Optimize this using hacker's delight
+
+-- | 'sumSize' takes a list of variants and creates the array type to hold the
+-- largest variant
+sumSize :: [VariantInfo] -> Type
+sumSize variants
+  -- Assume 8 is the smallest allocation type
+  | largest `mod` 16 == 0 = ArrayType (divLarg 16) i16
+  | largest `mod` 08 == 0 = ArrayType (divLarg 08) i8
+  | otherwise = ArrayType (divLarg 4) Constants.i4
+  where
+    largest = maximumDef 0 (size <$> variants)
+    divLarg = div (fromIntegral largest)
+
+-- TODO ∷ optimize this using bit-wise functions
+-- Think hacker's delight
+-- Also should we allow smaller than i8?
+
+-- | 'tagSize' takes a list of variants and figures out what the size of the tag should be
+tagSize :: [VariantInfo] -> Type
+tagSize variants
+  | len < 16 = Constants.i4
+  | len < 256 = i8
+  | len < 65536 = i16
+  | len < 4294967296 = i32
+  | otherwise = i64
+  where
+    len = length variants
+
+-- | grabs the integer length from an IntegerType Type
+tagSizeIntExn :: Type -> Word32
+tagSizeIntExn (Type.IntegerType i) = i
+tagSizeIntExn _ = Prelude.error "unsupported operation"
+
+createVariantName :: Symbol -> Symbol -> Symbol
+createVariantName sumName varName = sumName <> "-" <> varName
+
+-----------------------------------------------------------------------------------------
+-- Important functions
+-----------------------------------------------------------------------------------------
+
+sumPack :: Bool
+sumPack = True
+
+createSum :: [VariantInfo] -> Type
+createSum variants =
+  StructureType
+    { isPacked = sumPack,
+      elementTypes =
+        [tag, arrSize]
+    }
+  where
+    tag = tagSize variants
+    arrSize = sumSize variants
+
+-- | updates the type of the variant, to properly have the tag
+updateVariant :: Type -> VariantInfo -> VariantInfo
+updateVariant tagSize (Variant s n (StructureType p ele)) =
+  Variant s n (StructureType p (tagSize : ele))
+updateVariant tagSize (Variant s n t) =
+  Variant s n (StructureType sumPack [tagSize, t])
+
+-- | 'insertSums' creates a sum type, and inserts the new types into the symbol table
+-- and the variant table for all the newly created variants
+insertSums ::
+  Symbol ->
+  [VariantInfo] ->
+  SymbolTable ->
+  VariantToType ->
+  TypeTable ->
+  (SymbolTable, VariantToType, TypeTable)
+insertSums sumName variants symTbl varTbl typTbl = (newSymTbl, newVarTbl, newTypTbl)
+  where
+    sum' = createSum variants
+    tag' = tagSizeIntExn (tagSize variants)
+    typTbl' = Map.insert sumName sum' typTbl
+    symTbl' =
+      Map.insert sumName (LocalReference sum' (mkName (unintern sumName))) symTbl
+    newVarTbl =
+      fst $
+        foldr
+          ( \(Variant {name = n}) (tbl, offset) ->
+              ( Map.insert
+                  (createVariantName sumName n)
+                  ( S
+                      { sum' = sumName,
+                        offset = offset,
+                        tagSize' = tag'
+                      }
+                  )
+                  tbl,
+                succ offset
+              )
+          )
+          (varTbl, 0)
+          variants
+    newTypTbl =
+      foldr
+        ( \(Variant _s n t) tbl ->
+            Map.insert (createVariantName sumName n) t tbl
+        )
+        typTbl'
+        variants
+    newSymTbl =
+      foldr
+        ( \(Variant _s n t) tbl ->
+            let name = createVariantName sumName n
+                operand = LocalReference t (mkName (unintern name))
+             in Map.insert name operand tbl
+        )
+        symTbl'
+        variants

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -1,5 +1,6 @@
 module Juvix.Backends.LLVM.Compilation
   ( compileProgram,
+    compileProgram',
   )
 where
 
@@ -43,34 +44,49 @@ compileProgram' ::
   ErasedAnn.AnnTerm PrimTy RawPrimVal ->
   Feedback.FeedbackT [] P.String m Text
 compileProgram' t =
-  Block.execEnvState (mkMain' t) mempty
-    |> Types.moduleAST
-    |> LLVM.ppllvm
-    |> toStrict
-    |> return
+  case Block.runEnvState (mkMain' t) mempty of
+    (Right _, state) ->
+      state
+        |> Types.moduleAST
+        |> LLVM.ppllvm
+        |> toStrict
+        |> return
+    (Left err, _) ->
+      show err
+        |> Feedback.fail
 
 --------------------------------------------------------------------------------
 -- Function Declaration
 --------------------------------------------------------------------------------
 
-mkMain' t@(ErasedAnn.Ann usage ty t') = do
-  let (paramTys, returnTy) = functionType ty
-      returnTy' = typeToLLVM returnTy
-      paramTys' = map typeToLLVM paramTys
+mkMain' ::
+  Types.Define m => ErasedAnn.AnnTerm PrimTy RawPrimVal -> m LLVM.Operand
+mkMain' t@(ErasedAnn.Ann _usage ty _t') = do
+  let (paramTys, returnTy) = functionTypeLLVM ty
       paramNames =
         zipWith
           (\l r -> Block.internName (l <> r))
-          (replicate (length paramTys') "arg")
+          (replicate (length paramTys) "arg")
           (fmap (intern . show) [1 ..])
-      params = zip paramTys' paramNames
-  Block.defineFunction returnTy' "main" params $
+      params = zip paramTys paramNames
+  Block.defineFunction returnTy "main" params $
     do
-      undefined
+      case params of
+        _ : _ -> do
+          lamBody <- compileTerm' t
+          arguments <- traverse Block.externf paramNames
+          called <- Block.call returnTy lamBody (zip arguments (repeat []))
+          Block.ret called
+        [] -> do
+          res <- compileTerm' t
+          Block.ret res
 
 --------------------------------------------------------------------------------
 -- Term Handling
 --------------------------------------------------------------------------------
 
+compileTerm' ::
+  Types.Define m => ErasedAnn.AnnTerm PrimTy RawPrimVal -> m LLVM.Operand
 compileTerm' (ErasedAnn.Ann _usage ty t) =
   case t of
     ErasedAnn.LamM caps as body -> compileLam ty caps as body
@@ -86,6 +102,13 @@ compileVar sym = do
   Block.externf (Block.internName (NameSymbol.toSymbol sym))
 
 -- TODO :: compile as closures, with captures
+compileLam ::
+  (Foldable t, Types.Define m) =>
+  ErasedAnn.Type PrimTy ->
+  t a ->
+  [NameSymbol.T] ->
+  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
+  m LLVM.Operand
 compileLam ty captures arguments body
   | length captures == 0 = do
     let (llvmArgty, llvmRetty) =
@@ -98,15 +121,22 @@ compileLam ty captures arguments body
     lamName <- Block.generateUniqueSymbol "lam"
     Block.defineFunction llvmRetty lamName llvmArguments $
       do
-        undefined
+        bod <- compileTerm' body
+        Block.ret bod
   | otherwise =
     throw @"err" (Types.UnsupportedOperation "closures are not supported")
 
-compileApp returnTy f@ErasedAnn.Ann {ErasedAnn.term, ErasedAnn.type'} xs =
+compileApp ::
+  Types.Define m =>
+  ErasedAnn.Type PrimTy ->
+  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
+  [ErasedAnn.AnnTerm PrimTy RawPrimVal] ->
+  m LLVM.Operand
+compileApp returnTy f@ErasedAnn.Ann {ErasedAnn.term} xs =
   case term of
     -- we only treat prims specially
     ErasedAnn.Prim prim ->
-      undefined
+      compilePrimApp returnTy prim xs
     _ -> do
       arguments <- traverse compileTerm' xs
       function <- compileTerm' f
@@ -118,6 +148,25 @@ compileApp returnTy f@ErasedAnn.Ann {ErasedAnn.term, ErasedAnn.type'} xs =
           argsAtrributes = zip arguments (repeat [])
       --
       Block.call functionType function argsAtrributes
+
+compilePrimApp ::
+  Types.Define m =>
+  ErasedAnn.Type PrimTy ->
+  RawPrimVal ->
+  [ErasedAnn.AnnTerm PrimTy RawPrimVal] ->
+  m LLVM.Operand
+compilePrimApp ty f xs
+  | arityRaw f == lengthN xs =
+    case f of
+      Add -> do
+        x <- compileTerm' (xs P.!! 0)
+        y <- compileTerm' (xs P.!! 1)
+        Block.add (typeToLLVM ty) x y
+  | otherwise =
+    throw @"err"
+      ( Types.WrongNumberOfArguments
+          ("Was expecsting " <> show (arityRaw f) <> "but got " <> show (lengthN xs))
+      )
 
 -- | Write the main function of the module. Here two distinct cases can be
 -- observed:
@@ -281,6 +330,7 @@ mkParameterName s = S.fromString $ unintern $ NameSymbol.toSymbol s
 globalRef :: LLVM.Type -> LLVM.Name -> LLVM.Operand
 globalRef ty name = LLVM.ConstantOperand $ LLVM.GlobalReference ty name
 
+functionTypeLLVM :: ErasedAnn.Type PrimTy -> ([LLVM.Type], LLVM.Type)
 functionTypeLLVM prim =
   functionType prim
     |> bimap (fmap typeToLLVM) typeToLLVM

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -1,27 +1,24 @@
 module Juvix.Backends.LLVM.Compilation
   ( compileProgram,
-    compileProgram',
   )
 where
 
-import qualified Data.String as S (fromString)
 import qualified Juvix.Backends.LLVM.Codegen.Block as Block
 import qualified Juvix.Backends.LLVM.Codegen.Types as Types
 import Juvix.Backends.LLVM.Primitive
 import qualified Juvix.Core.Erased.Ann as ErasedAnn
 import Juvix.Library
 import qualified Juvix.Library.Feedback as Feedback
-import qualified Juvix.Library.HashMap as Map
 import qualified Juvix.Library.NameSymbol as NameSymbol
-import qualified LLVM.AST as LLVM (Name, Operand (..))
+import qualified LLVM.AST as LLVM (Operand (..))
 import qualified LLVM.AST.Constant as LLVM (Constant (..))
 import qualified LLVM.AST.Type as LLVM
-import qualified LLVM.IRBuilder as LLVMBuild
 import qualified LLVM.Pretty as LLVM
 import qualified Prelude as P
 
--- | A mapping between Juvix variable names and their operands in LLVM.
-type Env = Map.Map NameSymbol.T LLVM.Operand
+--------------------------------------------------------------------------------
+-- Top Level Compilation
+--------------------------------------------------------------------------------
 
 -- | Compile the input program to an LLVM module.
 -- TODO: maybe do something smarter with the module name?
@@ -30,143 +27,21 @@ compileProgram ::
   -- | Term to compile.
   ErasedAnn.AnnTerm PrimTy RawPrimVal ->
   Feedback.FeedbackT [] P.String m Text
-compileProgram t = do
-  let llvmmod = LLVMBuild.buildModule "juvix-module" $ mkMain t
-  return $ toStrict $ LLVM.ppllvm llvmmod
-
---------------------------------------------------------------------------------
--- Top Level Compilation
---------------------------------------------------------------------------------
-
-compileProgram' ::
-  Monad m =>
-  -- | Term to compile.
-  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
-  Feedback.FeedbackT [] P.String m Text
-compileProgram' t =
-  case Block.runEnvState (mkMain' t) mempty of
+compileProgram t =
+  case Block.runEnvState (mkMain t) mempty of
     (Right _, state) ->
       state
         |> Types.moduleAST
         |> LLVM.ppllvm
         |> toStrict
         |> return
-    (Left err, _) ->
+    (Left err, _) -> do
       show err
         |> Feedback.fail
 
 --------------------------------------------------------------------------------
 -- Function Declaration
 --------------------------------------------------------------------------------
-
-mkMain' ::
-  Types.Define m => ErasedAnn.AnnTerm PrimTy RawPrimVal -> m LLVM.Operand
-mkMain' t@(ErasedAnn.Ann _usage ty _t') = do
-  let (paramTys, returnTy) = functionTypeLLVM ty
-      paramNames =
-        zipWith
-          (\l r -> Block.internName (l <> r))
-          (replicate (length paramTys) "arg")
-          (fmap (intern . show) [1 ..])
-      params = zip paramTys paramNames
-  Block.defineFunction returnTy "main" params $
-    do
-      case params of
-        _ : _ -> do
-          lamBody <- compileTerm' t
-          arguments <- traverse Block.externf paramNames
-          called <- Block.call returnTy lamBody (zip arguments (repeat []))
-          Block.ret called
-        [] -> do
-          res <- compileTerm' t
-          Block.ret res
-
---------------------------------------------------------------------------------
--- Term Handling
---------------------------------------------------------------------------------
-
-compileTerm' ::
-  Types.Define m => ErasedAnn.AnnTerm PrimTy RawPrimVal -> m LLVM.Operand
-compileTerm' (ErasedAnn.Ann _usage ty t) =
-  case t of
-    ErasedAnn.LamM caps as body -> compileLam ty caps as body
-    ErasedAnn.AppM fn arguments -> compileApp ty fn arguments
-    ErasedAnn.Var sym -> compileVar sym
-    ErasedAnn.Prim _t -> mkPrim t ty
-
-compileVar ::
-  (HasState "symTab" Types.SymbolTable m, HasThrow "err" Types.Errors m) =>
-  NameSymbol.T ->
-  m LLVM.Operand
-compileVar sym = do
-  Block.externf (Block.internName (NameSymbol.toSymbol sym))
-
--- TODO :: compile as closures, with captures
-compileLam ::
-  (Foldable t, Types.Define m) =>
-  ErasedAnn.Type PrimTy ->
-  t a ->
-  [NameSymbol.T] ->
-  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
-  m LLVM.Operand
-compileLam ty captures arguments body
-  | length captures == 0 = do
-    let (llvmArgty, llvmRetty) =
-          functionTypeLLVM ty
-        llvmArgNames =
-          fmap (Block.internName . NameSymbol.toSymbol) arguments
-        llvmArguments =
-          zip llvmArgty llvmArgNames
-    -- time to generate unique names
-    lamName <- Block.generateUniqueSymbol "lam"
-    Block.defineFunction llvmRetty lamName llvmArguments $
-      do
-        bod <- compileTerm' body
-        Block.ret bod
-  | otherwise =
-    throw @"err" (Types.UnsupportedOperation "closures are not supported")
-
-compileApp ::
-  Types.Define m =>
-  ErasedAnn.Type PrimTy ->
-  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
-  [ErasedAnn.AnnTerm PrimTy RawPrimVal] ->
-  m LLVM.Operand
-compileApp returnTy f@ErasedAnn.Ann {ErasedAnn.term} xs =
-  case term of
-    -- we only treat prims specially
-    ErasedAnn.Prim prim ->
-      compilePrimApp returnTy prim xs
-    _ -> do
-      arguments <- traverse compileTerm' xs
-      function <- compileTerm' f
-      --
-      let -- We should probably get the type from the function itself
-          -- rather than pass in what it should be here
-          functionType = typeToLLVM returnTy
-          -- ignore attributes for now!
-          argsAtrributes = zip arguments (repeat [])
-      --
-      Block.call functionType function argsAtrributes
-
-compilePrimApp ::
-  Types.Define m =>
-  ErasedAnn.Type PrimTy ->
-  RawPrimVal ->
-  [ErasedAnn.AnnTerm PrimTy RawPrimVal] ->
-  m LLVM.Operand
-compilePrimApp ty f xs
-  | arityRaw f == lengthN xs =
-    case f of
-      Add -> do
-        x <- compileTerm' (xs P.!! 0)
-        y <- compileTerm' (xs P.!! 1)
-        Block.add (typeToLLVM ty) x y
-  | otherwise =
-    throw @"err"
-      ( Types.WrongNumberOfArguments
-          ("Was expecsting " <> show (arityRaw f) <> "but got " <> show (lengthN xs))
-      )
 
 -- | Write the main function of the module. Here two distinct cases can be
 -- observed:
@@ -182,110 +57,132 @@ compilePrimApp ty f xs
 -- body of the main function by compiling @t@. The main function itself does
 -- not have any parameters in this case.
 mkMain ::
-  LLVMBuild.MonadModuleBuilder m =>
+  Types.Define m =>
   -- | Term to compile.
   ErasedAnn.AnnTerm PrimTy RawPrimVal ->
   m LLVM.Operand
-mkMain t@(ErasedAnn.Ann usage ty t') = do
-  let (paramTys, returnTy) = functionType ty
-      returnTy' = typeToLLVM returnTy
-      paramTys' = map typeToLLVM paramTys
-      paramNames = repeat "arg"
-      params = zip paramTys' (map mkParameterName paramNames)
-  LLVMBuild.function "main" params returnTy' $ \args -> do
-    out <- case t' of
-      ErasedAnn.LamM
-        { ErasedAnn.capture,
-          ErasedAnn.arguments,
-          ErasedAnn.body
-        } -> do
-          let env = Map.fromList $ zip paramNames args
-              callArgs = zip args (repeat []) -- No arg attributes.
-          funname <- mkLam env ty body arguments capture
-          LLVMBuild.call (globalRef (typeToLLVM ty) funname) callArgs
-      _ -> compileTerm mempty t
-    LLVMBuild.ret out
+mkMain t@(ErasedAnn.Ann _usage ty _t') = do
+  let (paramTys, returnTy) = functionTypeLLVM ty
+      paramNames =
+        zipWith
+          (\l r -> Block.internName (l <> r))
+          (replicate (length paramTys) "arg")
+          (fmap (intern . show) [1 ..])
+      params = zip paramTys paramNames
+  Block.defineFunction returnTy "main" params $
+    do
+      case params of
+        _ : _ -> do
+          lamBody <- compileTerm t
+          arguments <- traverse Block.externf paramNames
+          called <- Block.call returnTy lamBody (zip arguments (repeat []))
+          Block.ret called
+        [] -> do
+          res <- compileTerm t
+          Block.ret res
+
+--------------------------------------------------------------------------------
+-- Term Handling
+--------------------------------------------------------------------------------
 
 -- | Compile a term to its equivalent LLVM code.
--- TODO: implement other constructors of ErasedAnn.Term
 compileTerm ::
-  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
-  -- | Environment of Juvix variables to LLVM function arguments.
-  Env ->
-  -- | The term to compile.
-  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
+  Types.Define m => ErasedAnn.AnnTerm PrimTy RawPrimVal -> m LLVM.Operand
+compileTerm (ErasedAnn.Ann _usage ty t) =
+  case t of
+    ErasedAnn.LamM caps as body -> compileLam ty caps as body
+    ErasedAnn.AppM fn arguments -> compileApp ty fn arguments
+    ErasedAnn.Var sym -> compileVar sym
+    ErasedAnn.Prim _t -> mkPrim t ty
+
+compileVar ::
+  (HasState "symTab" Types.SymbolTable m, HasThrow "err" Types.Errors m) =>
+  NameSymbol.T ->
   m LLVM.Operand
-compileTerm env (ErasedAnn.Ann usage ty t) = case t of
-  ErasedAnn.Var symbol -> case Map.lookup symbol env of
-    Nothing ->
-      P.error $ "Variable not found: " <> show symbol <> " in " <> show env -- TODO improve error message.
-    Just var -> return var
-  ErasedAnn.Prim t' -> mkPrim t ty
-  ErasedAnn.AppM f xs -> mkApp env f ty xs
+compileVar sym = do
+  Block.externf (Block.internName (NameSymbol.toSymbol sym))
+
+-- TODO :: compile as closures, with captures
 
 -- | Write an LLVM function definition based on a the given lambda abstraction.
 -- The function returns the name of the create function.
-mkLam ::
-  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
-  -- | Environment of Juvix variables to LLVM function arguments.
-  Env ->
+compileLam ::
+  (Foldable t, Types.Define m) =>
   -- | The type of the lambda abstraction.
   ErasedAnn.Type PrimTy ->
-  -- | The body of the lambda abstraction.
-  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
+  -- | List of captures variables (free variables for the body).
+  t a ->
   -- | List of parameter names.
   [NameSymbol.T] ->
-  -- | List of captures variables (free variables for the body).
-  [NameSymbol.T] ->
-  m LLVM.Name
-mkLam env ty body args capt = do
-  funname <- LLVMBuild.freshName "lam"
-  let (argTys, returnTy) = functionType ty
-      returnTy' = typeToLLVM returnTy
-      paramNames = repeat "arg"
-      params = zipWith mkParameter argTys paramNames
-  LLVMBuild.function funname params returnTy' $ \refs -> do
-    let env' = env `Map.union` Map.fromList (zip args refs)
-    body' <- compileTerm env' body
-    LLVMBuild.ret body'
-  return funname
-
--- | Given a juvix name and type, construct an llvm function parameter
--- definition.
-mkParameter ::
-  -- | The type of the parameter.
-  ErasedAnn.Type PrimTy ->
-  -- | The name of the parameter.
-  NameSymbol.T ->
-  (LLVM.Type, LLVMBuild.ParameterName)
-mkParameter ty name = (typeToLLVM ty, mkParameterName name)
+  -- | The body of the lambda abstraction.
+  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
+  m LLVM.Operand
+compileLam ty captures arguments body
+  | length captures == 0 = do
+    let (llvmArgty, llvmRetty) =
+          functionTypeLLVM ty
+        llvmArgNames =
+          fmap (Block.internName . NameSymbol.toSymbol) arguments
+        llvmArguments =
+          zip llvmArgty llvmArgNames
+    -- time to generate unique names
+    lamName <- Block.generateUniqueSymbol "lambda"
+    Block.defineFunction llvmRetty lamName llvmArguments $
+      do
+        bod <- compileTerm body
+        Block.ret bod
+  | otherwise =
+    throw @"err" (Types.UnsupportedOperation "closures are not supported")
 
 -- | The function assumes the arguments passed are the arguments of an
 -- application.
-mkApp ::
-  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
-  -- | Environment of Juvix variables to LLVM function arguments.
-  Env ->
+compileApp ::
+  Types.Define m =>
+  -- | Application return type
+  ErasedAnn.Type PrimTy ->
   -- | The function term of an application.
   ErasedAnn.AnnTerm PrimTy RawPrimVal ->
-  -- | The type of the application.
-  ErasedAnn.Type PrimTy ->
   -- | The arguments to the application.
   [ErasedAnn.AnnTerm PrimTy RawPrimVal] ->
   m LLVM.Operand
-mkApp env f@(ErasedAnn.Ann {ErasedAnn.term, ErasedAnn.type'}) _ xs =
+compileApp returnTy f@ErasedAnn.Ann {ErasedAnn.term} xs =
   case term of
-    ErasedAnn.LamM {ErasedAnn.body, ErasedAnn.arguments, ErasedAnn.capture} -> do
-      funname <- mkLam env type' body arguments capture
-      xs' <- mapM (compileTerm env) xs
-      let xs'args = zip xs' (repeat [])
-      LLVMBuild.call (globalRef (typeToLLVM type') funname) xs'args
-    ErasedAnn.Prim prim -> applyPrim env prim xs
-    ErasedAnn.Var v -> do
-      f' <- compileTerm env f
-      xs' <- mapM (compileTerm env) xs
-      let xs'args = zip xs' (repeat []) -- Do not pass attributes to the args.
-      LLVMBuild.call f' xs'args
+    -- we only treat prims specially
+    ErasedAnn.Prim prim ->
+      compilePrimApp returnTy prim xs
+    _ -> do
+      arguments <- traverse compileTerm xs
+      function <- compileTerm f
+      --
+      let -- We should probably get the type from the function itself
+          -- rather than pass in what it should be here
+          functionType = typeToLLVM returnTy
+          -- ignore attributes for now!
+          argsAtrributes = zip arguments (repeat [])
+      --
+      Block.call functionType function argsAtrributes
+
+compilePrimApp ::
+  Types.Define m =>
+  -- | Return type of the application
+  ErasedAnn.Type PrimTy ->
+  -- | The function primitive of the application.
+  RawPrimVal ->
+  -- | The arguments to the application.
+  [ErasedAnn.AnnTerm PrimTy RawPrimVal] ->
+  m LLVM.Operand
+compilePrimApp ty f xs
+  | arityRaw f == lengthN xs =
+    case f of
+      Add -> do
+        x <- compileTerm (xs P.!! 0)
+        y <- compileTerm (xs P.!! 1)
+        Block.add (typeToLLVM ty) x y
+  | otherwise =
+    throw @"err"
+      ( Types.WrongNumberOfArguments
+          ("Was expecsting " <> show (arityRaw f) <> "but got " <> show (lengthN xs))
+      )
 
 -- | Write LLVM code for a primitive.
 -- TODO: implement other primitives.
@@ -302,33 +199,6 @@ mkPrim (ErasedAnn.Prim prim) ty = case prim of
       return $
         LLVM.ConstantOperand $
           LLVM.Int {LLVM.integerBits = typeBits, LLVM.integerValue = i}
-
--- | Generate code for primitives that are used as a function.
--- TODO: implement other primitives.
-applyPrim ::
-  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
-  -- | Environment of global variables.
-  Env ->
-  -- | The function primitive of the application.
-  RawPrimVal ->
-  -- | The arguments to the application.
-  [ErasedAnn.AnnTerm PrimTy RawPrimVal] ->
-  m LLVM.Operand
-applyPrim env f xs
-  | arityRaw f == lengthN xs =
-    case f of
-      Add -> do
-        x <- compileTerm env (xs P.!! 0)
-        y <- compileTerm env (xs P.!! 1)
-        LLVMBuild.add x y
-
--- | Counterpart of `mkName`: make a `ParameterName` given a name.
-mkParameterName :: NameSymbol.T -> LLVMBuild.ParameterName
-mkParameterName s = S.fromString $ unintern $ NameSymbol.toSymbol s
-
--- | Handy wrapper for creating global references based on a type and name.
-globalRef :: LLVM.Type -> LLVM.Name -> LLVM.Operand
-globalRef ty name = LLVM.ConstantOperand $ LLVM.GlobalReference ty name
 
 functionTypeLLVM :: ErasedAnn.Type PrimTy -> ([LLVM.Type], LLVM.Type)
 functionTypeLLVM prim =

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -1,22 +1,21 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Juvix.Backends.LLVM.Compilation
   ( compileProgram,
   )
 where
 
 import qualified Data.String as S (fromString)
+import qualified Juvix.Backends.LLVM.Codegen.Block as Block
+import qualified Juvix.Backends.LLVM.Codegen.Types as Types
 import Juvix.Backends.LLVM.Primitive
 import qualified Juvix.Core.Erased.Ann as ErasedAnn
 import Juvix.Library
-import Juvix.Library.Feedback
+import qualified Juvix.Library.Feedback as Feedback
 import qualified Juvix.Library.HashMap as Map
 import qualified Juvix.Library.NameSymbol as NameSymbol
-import qualified LLVM.AST as LLVM (Module, Name, Operand (..))
+import qualified LLVM.AST as LLVM (Name, Operand (..))
 import qualified LLVM.AST.Constant as LLVM (Constant (..))
 import qualified LLVM.AST.Type as LLVM
-import qualified LLVM.IRBuilder as LLVM
+import qualified LLVM.IRBuilder as LLVMBuild
 import qualified LLVM.Pretty as LLVM
 import qualified Prelude as P
 
@@ -29,10 +28,96 @@ compileProgram ::
   Monad m =>
   -- | Term to compile.
   ErasedAnn.AnnTerm PrimTy RawPrimVal ->
-  FeedbackT [] P.String m Text
+  Feedback.FeedbackT [] P.String m Text
 compileProgram t = do
-  let llvmmod = LLVM.buildModule "juvix-module" $ mkMain t
+  let llvmmod = LLVMBuild.buildModule "juvix-module" $ mkMain t
   return $ toStrict $ LLVM.ppllvm llvmmod
+
+--------------------------------------------------------------------------------
+-- Top Level Compilation
+--------------------------------------------------------------------------------
+
+compileProgram' ::
+  Monad m =>
+  -- | Term to compile.
+  ErasedAnn.AnnTerm PrimTy RawPrimVal ->
+  Feedback.FeedbackT [] P.String m Text
+compileProgram' t =
+  Block.execEnvState (mkMain' t) mempty
+    |> Types.moduleAST
+    |> LLVM.ppllvm
+    |> toStrict
+    |> return
+
+--------------------------------------------------------------------------------
+-- Function Declaration
+--------------------------------------------------------------------------------
+
+mkMain' t@(ErasedAnn.Ann usage ty t') = do
+  let (paramTys, returnTy) = functionType ty
+      returnTy' = typeToLLVM returnTy
+      paramTys' = map typeToLLVM paramTys
+      paramNames =
+        zipWith
+          (\l r -> Block.internName (l <> r))
+          (replicate (length paramTys') "arg")
+          (fmap (intern . show) [1 ..])
+      params = zip paramTys' paramNames
+  Block.defineFunction returnTy' "main" params $
+    do
+      undefined
+
+--------------------------------------------------------------------------------
+-- Term Handling
+--------------------------------------------------------------------------------
+
+compileTerm' (ErasedAnn.Ann _usage ty t) =
+  case t of
+    ErasedAnn.LamM caps as body -> compileLam ty caps as body
+    ErasedAnn.AppM fn arguments -> compileApp ty fn arguments
+    ErasedAnn.Var sym -> compileVar sym
+    ErasedAnn.Prim _t -> mkPrim t ty
+
+compileVar ::
+  (HasState "symTab" Types.SymbolTable m, HasThrow "err" Types.Errors m) =>
+  NameSymbol.T ->
+  m LLVM.Operand
+compileVar sym = do
+  Block.externf (Block.internName (NameSymbol.toSymbol sym))
+
+-- TODO :: compile as closures, with captures
+compileLam ty captures arguments body
+  | length captures == 0 = do
+    let (llvmArgty, llvmRetty) =
+          functionTypeLLVM ty
+        llvmArgNames =
+          fmap (Block.internName . NameSymbol.toSymbol) arguments
+        llvmArguments =
+          zip llvmArgty llvmArgNames
+    -- time to generate unique names
+    lamName <- Block.generateUniqueSymbol "lam"
+    Block.defineFunction llvmRetty lamName llvmArguments $
+      do
+        undefined
+  | otherwise =
+    throw @"err" (Types.UnsupportedOperation "closures are not supported")
+
+compileApp returnTy f@ErasedAnn.Ann {ErasedAnn.term, ErasedAnn.type'} xs =
+  case term of
+    -- we only treat prims specially
+    ErasedAnn.Prim prim ->
+      undefined
+    _ -> do
+      arguments <- traverse compileTerm' xs
+      function <- compileTerm' f
+      --
+      let -- We should probably get the type from the function itself
+          -- rather than pass in what it should be here
+          functionType = typeToLLVM returnTy
+          -- ignore attributes for now!
+          argsAtrributes = zip arguments (repeat [])
+      --
+      Block.call functionType function argsAtrributes
 
 -- | Write the main function of the module. Here two distinct cases can be
 -- observed:
@@ -48,7 +133,7 @@ compileProgram t = do
 -- body of the main function by compiling @t@. The main function itself does
 -- not have any parameters in this case.
 mkMain ::
-  LLVM.MonadModuleBuilder m =>
+  LLVMBuild.MonadModuleBuilder m =>
   -- | Term to compile.
   ErasedAnn.AnnTerm PrimTy RawPrimVal ->
   m LLVM.Operand
@@ -58,7 +143,7 @@ mkMain t@(ErasedAnn.Ann usage ty t') = do
       paramTys' = map typeToLLVM paramTys
       paramNames = repeat "arg"
       params = zip paramTys' (map mkParameterName paramNames)
-  LLVM.function "main" params returnTy' $ \args -> do
+  LLVMBuild.function "main" params returnTy' $ \args -> do
     out <- case t' of
       ErasedAnn.LamM
         { ErasedAnn.capture,
@@ -68,14 +153,14 @@ mkMain t@(ErasedAnn.Ann usage ty t') = do
           let env = Map.fromList $ zip paramNames args
               callArgs = zip args (repeat []) -- No arg attributes.
           funname <- mkLam env ty body arguments capture
-          LLVM.call (globalRef (typeToLLVM ty) funname) callArgs
+          LLVMBuild.call (globalRef (typeToLLVM ty) funname) callArgs
       _ -> compileTerm mempty t
-    LLVM.ret out
+    LLVMBuild.ret out
 
 -- | Compile a term to its equivalent LLVM code.
 -- TODO: implement other constructors of ErasedAnn.Term
 compileTerm ::
-  (LLVM.MonadIRBuilder m, LLVM.MonadModuleBuilder m) =>
+  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
   -- | Environment of Juvix variables to LLVM function arguments.
   Env ->
   -- | The term to compile.
@@ -92,7 +177,7 @@ compileTerm env (ErasedAnn.Ann usage ty t) = case t of
 -- | Write an LLVM function definition based on a the given lambda abstraction.
 -- The function returns the name of the create function.
 mkLam ::
-  (LLVM.MonadIRBuilder m, LLVM.MonadModuleBuilder m) =>
+  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
   -- | Environment of Juvix variables to LLVM function arguments.
   Env ->
   -- | The type of the lambda abstraction.
@@ -105,15 +190,15 @@ mkLam ::
   [NameSymbol.T] ->
   m LLVM.Name
 mkLam env ty body args capt = do
-  funname <- LLVM.freshName "lam"
+  funname <- LLVMBuild.freshName "lam"
   let (argTys, returnTy) = functionType ty
       returnTy' = typeToLLVM returnTy
       paramNames = repeat "arg"
       params = zipWith mkParameter argTys paramNames
-  LLVM.function funname params returnTy' $ \refs -> do
+  LLVMBuild.function funname params returnTy' $ \refs -> do
     let env' = env `Map.union` Map.fromList (zip args refs)
     body' <- compileTerm env' body
-    LLVM.ret body'
+    LLVMBuild.ret body'
   return funname
 
 -- | Given a juvix name and type, construct an llvm function parameter
@@ -123,13 +208,13 @@ mkParameter ::
   ErasedAnn.Type PrimTy ->
   -- | The name of the parameter.
   NameSymbol.T ->
-  (LLVM.Type, LLVM.ParameterName)
+  (LLVM.Type, LLVMBuild.ParameterName)
 mkParameter ty name = (typeToLLVM ty, mkParameterName name)
 
 -- | The function assumes the arguments passed are the arguments of an
 -- application.
 mkApp ::
-  (LLVM.MonadIRBuilder m, LLVM.MonadModuleBuilder m) =>
+  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
   -- | Environment of Juvix variables to LLVM function arguments.
   Env ->
   -- | The function term of an application.
@@ -145,18 +230,18 @@ mkApp env f@(ErasedAnn.Ann {ErasedAnn.term, ErasedAnn.type'}) _ xs =
       funname <- mkLam env type' body arguments capture
       xs' <- mapM (compileTerm env) xs
       let xs'args = zip xs' (repeat [])
-      LLVM.call (globalRef (typeToLLVM type') funname) xs'args
+      LLVMBuild.call (globalRef (typeToLLVM type') funname) xs'args
     ErasedAnn.Prim prim -> applyPrim env prim xs
     ErasedAnn.Var v -> do
       f' <- compileTerm env f
       xs' <- mapM (compileTerm env) xs
       let xs'args = zip xs' (repeat []) -- Do not pass attributes to the args.
-      LLVM.call f' xs'args
+      LLVMBuild.call f' xs'args
 
 -- | Write LLVM code for a primitive.
 -- TODO: implement other primitives.
 mkPrim ::
-  LLVM.MonadIRBuilder m =>
+  Monad m =>
   -- | Term that contains the primitive.
   ErasedAnn.Term PrimTy RawPrimVal ->
   -- | Type of the primitive.
@@ -172,7 +257,7 @@ mkPrim (ErasedAnn.Prim prim) ty = case prim of
 -- | Generate code for primitives that are used as a function.
 -- TODO: implement other primitives.
 applyPrim ::
-  (LLVM.MonadIRBuilder m, LLVM.MonadModuleBuilder m) =>
+  (LLVMBuild.MonadIRBuilder m, LLVMBuild.MonadModuleBuilder m) =>
   -- | Environment of global variables.
   Env ->
   -- | The function primitive of the application.
@@ -186,15 +271,19 @@ applyPrim env f xs
       Add -> do
         x <- compileTerm env (xs P.!! 0)
         y <- compileTerm env (xs P.!! 1)
-        LLVM.add x y
+        LLVMBuild.add x y
 
 -- | Counterpart of `mkName`: make a `ParameterName` given a name.
-mkParameterName :: NameSymbol.T -> LLVM.ParameterName
+mkParameterName :: NameSymbol.T -> LLVMBuild.ParameterName
 mkParameterName s = S.fromString $ unintern $ NameSymbol.toSymbol s
 
 -- | Handy wrapper for creating global references based on a type and name.
 globalRef :: LLVM.Type -> LLVM.Name -> LLVM.Operand
 globalRef ty name = LLVM.ConstantOperand $ LLVM.GlobalReference ty name
+
+functionTypeLLVM prim =
+  functionType prim
+    |> bimap (fmap typeToLLVM) typeToLLVM
 
 -- | Translate a Juvix type into an LLVM type.
 typeToLLVM :: ErasedAnn.Type PrimTy -> LLVM.Type

--- a/library/Backends/llvm/stack.yaml
+++ b/library/Backends/llvm/stack.yaml
@@ -9,6 +9,7 @@ packages:
 - ../../Frontend
 - ../../Sexp
 - ../../Translate
+- ../../Test/DataStructures
 
 extra-deps:
 

--- a/library/Backends/llvm/test/Test/Golden.hs
+++ b/library/Backends/llvm/test/Test/Golden.hs
@@ -50,8 +50,8 @@ compileTests =
         compileTestNeg "test/examples/negative/llvm/compile"
       ]
   where
-    compileTestPos = compileTest (expectSuccess . compile)
-    compileTestNeg = compileTest (expectFailure . compile)
+    compileTestPos = compileTest (expectSuccess . toNoQuotes compile)
+    compileTestNeg = compileTest (expectFailure . toNoQuotes compile)
     compile file = LLVM.compileProgram . ErasedAnn.toRaw =<< typecheck file
 
 typecheckTests :: IO TestTree
@@ -152,3 +152,14 @@ llvmGoldenTests ::
   FilePath ->
   IO TestTree
 llvmGoldenTests ext f (withJuvixRootPath -> p) = discoverGoldenTests [".ju"] ext getGolden f p
+
+compile :: FilePath -> Feedback.FeedbackT [] String IO Text
+compile file = LLVM.compileProgram . ErasedAnn.toRaw =<< typecheck file
+
+toEither :: Feedback.Feedback app msg b -> Either (app msg) (app msg, b)
+toEither (Feedback.Success app a) = Right (app, a)
+toEither (Feedback.Fail failure) = Left failure
+
+-- Running by hand example
+-- x <- Feedback.runFeedbackT (compile "../../../test/examples/positive/llvm/MainApply.ju")
+-- toEither x

--- a/scripts/yaml-generator/src/config.lisp
+++ b/scripts/yaml-generator/src/config.lisp
@@ -370,7 +370,7 @@ common ones to include"
    :name "Backends/llvm"
    :resolver 17.3
    :path-to-other "../../"
-   :packages (list *standard-library* *core* *context* *pipeline* *frontend* *sexp* *translate*)
+   :packages (list *standard-library* *core* *context* *pipeline* *frontend* *sexp* *translate* *datastructures*)
    :extra-deps (list (make-general-dependencies *capability* *extensible* *prettiest*)
                      *llvm-hs-deps*
 

--- a/test/examples-golden/positive/llvm/Const/Const.llvm
+++ b/test/examples-golden/positive/llvm/Const/Const.llvm
@@ -4,6 +4,7 @@
  
 
 
-define external ccc  i8 @main()    {
+define external fastcc  i8 @main()    {
+main:
   ret i8 10 
 }"

--- a/test/examples-golden/positive/llvm/ConstAddPrim/ConstAddPrim.llvm
+++ b/test/examples-golden/positive/llvm/ConstAddPrim/ConstAddPrim.llvm
@@ -4,7 +4,8 @@
  
 
 
-define external ccc  i8 @main()    {
-  %1 = add   i8 4, 6 
-  ret i8 %1 
+define external fastcc  i8 @main()    {
+main:
+  %0 = add nuw nsw i8 4, 6 
+  ret i8 %0 
 }"

--- a/test/examples-golden/positive/llvm/MainApply/MainApply.llvm
+++ b/test/examples-golden/positive/llvm/MainApply/MainApply.llvm
@@ -4,12 +4,14 @@
  
 
 
-define external ccc  i8 @lam_0(i8  %arg_0, i8  %arg_1)    {
-  ret i8 %arg_0 
+define external fastcc  i8 @lambda(i8  %"0", i8  %"1")    {
+"\22lambda\221":
+  ret i8 %"0" 
 }
 
 
-define external ccc  i8 @main()    {
-  %1 =  call ccc  i8  @lam_0(i8  10, i8  20)  
-  ret i8 %1 
+define external fastcc  i8 @main()    {
+main:
+  %0 =  call fastcc  i8  @lambda(i8  10, i8  20)  
+  ret i8 %0 
 }"

--- a/test/examples-golden/positive/llvm/MainLambda/MainLambda.llvm
+++ b/test/examples-golden/positive/llvm/MainLambda/MainLambda.llvm
@@ -4,12 +4,14 @@
  
 
 
-define external ccc  i8 @lam_0(i8  %arg_0, i8  %arg_1)    {
-  ret i8 %arg_1 
+define external fastcc  i8 @lambda(i8  %"0", i8  %"1")    {
+"\22lambda\221":
+  ret i8 %"1" 
 }
 
 
-define external ccc  i8 @main(i8  %arg_0, i8  %arg_1)    {
-  %1 =  call ccc  i8  @lam_0(i8  %arg_0, i8  %arg_1)  
-  ret i8 %1 
+define external fastcc  i8 @main(i8  %arg1, i8  %arg2)    {
+main:
+  %0 =  call fastcc  i8  @lambda(i8  %arg1, i8  %arg2)  
+  ret i8 %0 
 }"

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.0-desugar-module
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.0-desugar-module
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig" "main" "int" )
+,
+    ( ":defun" "main" ()
+        ( "let" "foo" ()
+            ( ":infix" ":" 3 "int" )
+            ( "let" "bar" () ( ":infix" ":" 5 "int" ) "bar" ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.1-desugar-let
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.1-desugar-let
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig" "main" "int" )
+,
+    ( ":defun" "main" ()
+        ( "let" "foo" ()
+            ( ":infix" ":" 3 "int" )
+            ( "let" "bar" () ( ":infix" ":" 5 "int" ) "bar" ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.2-desugar-cond
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.2-desugar-cond
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig" "main" "int" )
+,
+    ( ":defun" "main" ()
+        ( "let" "foo" ()
+            ( ":infix" ":" 3 "int" )
+            ( "let" "bar" () ( ":infix" ":" 5 "int" ) "bar" ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.3-desugar-if
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.3-desugar-if
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig" "main" "int" )
+,
+    ( ":defun" "main" ()
+        ( "let" "foo" ()
+            ( ":infix" ":" 3 "int" )
+            ( "let" "bar" () ( ":infix" ":" 5 "int" ) "bar" ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.4-desugar-multiple-let
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.4-desugar-multiple-let
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig" "main" "int" )
+,
+    ( ":defun" "main" ()
+        ( ":let-match" "foo"
+            ( () ( ":infix" ":" 3 "int" ) )
+            ( ":let-match" "bar" ( () ( ":infix" ":" 5 "int" ) ) "bar" ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.5-desugar-multiple-defun
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.5-desugar-multiple-defun
@@ -1,0 +1,13 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig" "main" "int" )
+,
+    ( ":defun-match" "main"
+        ( ()
+            ( ":let-match" "foo"
+                ( () ( ":infix" ":" 3 "int" ) )
+                ( ":let-match" "bar"
+                    ( () ( ":infix" ":" 5 "int" ) ) "bar" ) ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.6-desugar-multiple-sig
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.6-desugar-multiple-sig
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig-match" "main" "int"
+        ( ()
+            ( ":let-match" "foo"
+                ( () ( ":infix" ":" 3 "int" ) )
+                ( ":let-match" "bar"
+                    ( () ( ":infix" ":" 5 "int" ) ) "bar" ) ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.7-desugar-remove-punned-records
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.7-desugar-remove-punned-records
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig-match" "main" "int"
+        ( ()
+            ( ":let-match" "foo"
+                ( () ( ":infix" ":" 3 "int" ) )
+                ( ":let-match" "bar"
+                    ( () ( ":infix" ":" 5 "int" ) ) "bar" ) ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.8-desugar-handler-transform
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.8-desugar-handler-transform
@@ -1,0 +1,11 @@
+[
+    ( "open" "Prelude" )
+,
+    ( "open" "LLVM" )
+,
+    ( ":defsig-match" "main" "int"
+        ( ()
+            ( ":let-match" "foo"
+                ( () ( ":infix" ":" 3 "int" ) )
+                ( ":let-match" "bar"
+                    ( () ( ":infix" ":" 5 "int" ) ) "bar" ) ) ) ) ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.A-contextify-sexp
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.A-contextify-sexp
@@ -1,0 +1,118 @@
+ShowRec
+    { contents = T
+        { public = fromList
+            [
+                ( "main"
+                , Def
+                    ( D
+                        { defUsage = Nothing
+                        , defMTy = Just "int"
+                        , defTerm =
+                            ( ":lambda-case"
+                                ( ()
+                                    ( ":let-match" "foo"
+                                        ( () ( ":infix" ":" 3 "int" ) )
+                                        ( ":let-match" "bar"
+                                            ( ()
+                                                ( ":infix" ":" 5 "int" ) ) "bar" ) ) ) )
+                        , defPrecedence = Pred Left 9 } ) ) ]
+        , private = fromList [] }
+    , mTy = Nothing
+    , openList = []
+    , qualifiedMap = fromList
+        [
+            ( "sub"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "cat-coproduct-elim"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty_"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( ":"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "SAny"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Circuit"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "LLVM"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "->"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "add"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "arr"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Michelson"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "id"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "const"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-intro"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "int8"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "int"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "dpair"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } ) ] }

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.B-resolve-module
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.B-resolve-module
@@ -1,0 +1,119 @@
+ShowRec
+    { contents = T
+        { public = fromList
+            [
+                ( "main"
+                , Def
+                    ( D
+                        { defUsage = Nothing
+                        , defMTy = Just "TopLevel.Prelude.LLVM.int"
+                        , defTerm =
+                            ( ":lambda-case"
+                                ( ()
+                                    ( ":let-match" "foo"
+                                        ( ()
+                                            ( ":infix" "TopLevel.Prelude.:" 3 "TopLevel.Prelude.LLVM.int" ) )
+                                        ( ":let-match" "bar"
+                                            ( ()
+                                                ( ":infix" "TopLevel.Prelude.:" 5 "TopLevel.Prelude.LLVM.int" ) ) "bar" ) ) ) )
+                        , defPrecedence = Pred Left 9 } ) ) ]
+        , private = fromList [] }
+    , mTy = Nothing
+    , openList = []
+    , qualifiedMap = fromList
+        [
+            ( "sub"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "cat-coproduct-elim"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty_"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( ":"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "SAny"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Circuit"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "LLVM"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "->"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "add"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "arr"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Michelson"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "id"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "const"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-intro"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "int8"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "int"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "dpair"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } ) ] }

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.C-resolve-infix
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.C-resolve-infix
@@ -1,0 +1,119 @@
+ShowRec
+    { contents = T
+        { public = fromList
+            [
+                ( "main"
+                , Def
+                    ( D
+                        { defUsage = Nothing
+                        , defMTy = Just "TopLevel.Prelude.LLVM.int"
+                        , defTerm =
+                            ( ":lambda-case"
+                                ( ()
+                                    ( ":let-match" "foo"
+                                        ( ()
+                                            ( "TopLevel.Prelude.:" 3 "TopLevel.Prelude.LLVM.int" ) )
+                                        ( ":let-match" "bar"
+                                            ( ()
+                                                ( "TopLevel.Prelude.:" 5 "TopLevel.Prelude.LLVM.int" ) ) "bar" ) ) ) )
+                        , defPrecedence = Pred Left 9 } ) ) ]
+        , private = fromList [] }
+    , mTy = Nothing
+    , openList = []
+    , qualifiedMap = fromList
+        [
+            ( "sub"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "cat-coproduct-elim"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty_"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( ":"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "SAny"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Circuit"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "LLVM"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "->"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "add"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "arr"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Michelson"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "id"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "const"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-intro"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "int8"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "int"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "dpair"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } ) ] }

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.D-record-declaration
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.D-record-declaration
@@ -1,0 +1,119 @@
+ShowRec
+    { contents = T
+        { public = fromList
+            [
+                ( "main"
+                , Def
+                    ( D
+                        { defUsage = Nothing
+                        , defMTy = Just "TopLevel.Prelude.LLVM.int"
+                        , defTerm =
+                            ( ":lambda-case"
+                                ( ()
+                                    ( ":let-match" "foo"
+                                        ( ()
+                                            ( "TopLevel.Prelude.:" 3 "TopLevel.Prelude.LLVM.int" ) )
+                                        ( ":let-match" "bar"
+                                            ( ()
+                                                ( "TopLevel.Prelude.:" 5 "TopLevel.Prelude.LLVM.int" ) ) "bar" ) ) ) )
+                        , defPrecedence = Pred Left 9 } ) ) ]
+        , private = fromList [] }
+    , mTy = Nothing
+    , openList = []
+    , qualifiedMap = fromList
+        [
+            ( "sub"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "cat-coproduct-elim"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty_"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( ":"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "SAny"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Circuit"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "LLVM"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "->"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "add"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "arr"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Michelson"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "id"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "const"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-intro"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "int8"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "int"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "dpair"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } ) ] }

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.E-symbol-to-lookup
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.E-symbol-to-lookup
@@ -1,0 +1,119 @@
+ShowRec
+    { contents = T
+        { public = fromList
+            [
+                ( "main"
+                , Def
+                    ( D
+                        { defUsage = Nothing
+                        , defMTy = Just "TopLevel.Prelude.LLVM.int"
+                        , defTerm =
+                            ( ":lambda-case"
+                                ( ()
+                                    ( ":let-match" "foo"
+                                        ( ()
+                                            ( "TopLevel.Prelude.:" 3 "TopLevel.Prelude.LLVM.int" ) )
+                                        ( ":let-match" "bar"
+                                            ( ()
+                                                ( "TopLevel.Prelude.:" 5 "TopLevel.Prelude.LLVM.int" ) ) "bar" ) ) ) )
+                        , defPrecedence = Pred Left 9 } ) ) ]
+        , private = fromList [] }
+    , mTy = Nothing
+    , openList = []
+    , qualifiedMap = fromList
+        [
+            ( "sub"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "cat-coproduct-elim"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty_"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( ":"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "ty"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "SAny"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Circuit"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "LLVM"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "->"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "add"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "arr"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "Michelson"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "id"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-elim-right"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "const"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-product-intro"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "int8"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "int"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude", "LLVM" ] } )
+        ,
+            ( "dpair"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } )
+        ,
+            ( "cat-coproduct-intro-left"
+            , SymInfo
+                { used = NotUsed, mod = "TopLevel" :| [ "Prelude" ] } ) ] }

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.erased
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.erased
@@ -1,0 +1,157 @@
+Ann
+    { usage = SAny
+    , type' = PrimTy
+        ( Return
+            { retType = PrimType
+                { getPrimType = STAR :| [] }
+            , retTerm = PrimTy
+                ( IntegerType
+                    { typeBits = 8 }
+                )
+            }
+        )
+    , term = AppM
+        ( Ann
+            { usage = SAny
+            , type' = Pi SAny
+                ( PrimTy
+                    ( Return
+                        { retType = PrimType
+                            { getPrimType = STAR :| [] }
+                        , retTerm = PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            )
+                        }
+                    )
+                )
+                ( PrimTy
+                    ( Return
+                        { retType = PrimType
+                            { getPrimType = STAR :| [] }
+                        , retTerm = PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            )
+                        }
+                    )
+                )
+            , term = LamM
+                { capture = []
+                , arguments =
+                    [ "0" :| [] ]
+                , body = Ann
+                    { usage = SAny
+                    , type' = PrimTy
+                        ( Return
+                            { retType = PrimType
+                                { getPrimType = STAR :| [] }
+                            , retTerm = PrimTy
+                                ( IntegerType
+                                    { typeBits = 8 }
+                                )
+                            }
+                        )
+                    , term = AppM
+                        ( Ann
+                            { usage = SAny
+                            , type' = Pi SAny
+                                ( PrimTy
+                                    ( Return
+                                        { retType = PrimType
+                                            { getPrimType = STAR :| [] }
+                                        , retTerm = PrimTy
+                                            ( IntegerType
+                                                { typeBits = 8 }
+                                            )
+                                        }
+                                    )
+                                )
+                                ( PrimTy
+                                    ( Return
+                                        { retType = PrimType
+                                            { getPrimType = STAR :| [] }
+                                        , retTerm = PrimTy
+                                            ( IntegerType
+                                                { typeBits = 8 }
+                                            )
+                                        }
+                                    )
+                                )
+                            , term = LamM
+                                { capture = []
+                                , arguments =
+                                    [ "1" :| [] ]
+                                , body = Ann
+                                    { usage = SAny
+                                    , type' = PrimTy
+                                        ( Return
+                                            { retType = PrimType
+                                                { getPrimType = STAR :| [] }
+                                            , retTerm = PrimTy
+                                                ( IntegerType
+                                                    { typeBits = 8 }
+                                                )
+                                            }
+                                        )
+                                    , term = Var
+                                        ( "1" :| [] )
+                                    }
+                                }
+                            }
+                        )
+                        [ Ann
+                            { usage = SAny
+                            , type' = PrimTy
+                                ( Return
+                                    { retType = PrimType
+                                        { getPrimType = STAR :| [] }
+                                    , retTerm = PrimTy
+                                        ( IntegerType
+                                            { typeBits = 8 }
+                                        )
+                                    }
+                                )
+                            , term = Prim
+                                ( Return
+                                    { retType = PrimType
+                                        { getPrimType = PrimTy
+                                            ( IntegerType
+                                                { typeBits = 8 }
+                                            ) :| []
+                                        }
+                                    , retTerm = LitInt 5
+                                    }
+                                )
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+        [ Ann
+            { usage = SAny
+            , type' = PrimTy
+                ( Return
+                    { retType = PrimType
+                        { getPrimType = STAR :| [] }
+                    , retTerm = PrimTy
+                        ( IntegerType
+                            { typeBits = 8 }
+                        )
+                    }
+                )
+            , term = Prim
+                ( Return
+                    { retType = PrimType
+                        { getPrimType = PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            ) :| []
+                        }
+                    , retTerm = LitInt 3
+                    }
+                )
+            }
+        ]
+    }

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.hr
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.hr
@@ -1,0 +1,359 @@
+fromList
+    [
+        ( "Prelude" :|
+            [ "LLVM"
+            , "int8"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "int8"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Elim
+                    ( ElimX
+                        ( "Prelude" :| [ "ty" ] )
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = PrimTy
+                        ( PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            )
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :|
+            [ "LLVM"
+            , "int"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "int"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Elim
+                    ( ElimX
+                        ( "Prelude" :| [ "ty" ] )
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = Elim
+                        ( ElimX
+                            ( "Prelude" :|
+                                [ "LLVM"
+                                , "int8"
+                                ]
+                            )
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :|
+            [ "LLVM"
+            , "add"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "add"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( ElimX
+                            ( "Prelude" :| [ "ty" ] )
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( ElimX
+                                ( "x" :| [] )
+                            ) ()
+                        )
+                        ( Pi SAny
+                            ( Elim
+                                ( ElimX
+                                    ( "x" :| [] )
+                                ) ()
+                            )
+                            ( Elim
+                                ( ElimX
+                                    ( "x" :| [] )
+                                ) ()
+                            )
+                            ( "" :| [] )
+                        )
+                        ( "" :| [] )
+                    )
+                    ( "x" :| [] )
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PatternX
+                            ( "_" :| [] )
+                        ]
+                    , rawClauseBody = Prim Add ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :|
+            [ "LLVM"
+            , "sub"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "sub"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( ElimX
+                            ( "Prelude" :| [ "ty" ] )
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( ElimX
+                                ( "x" :| [] )
+                            ) ()
+                        )
+                        ( Pi SAny
+                            ( Elim
+                                ( ElimX
+                                    ( "x" :| [] )
+                                ) ()
+                            )
+                            ( Elim
+                                ( ElimX
+                                    ( "x" :| [] )
+                                ) ()
+                            )
+                            ( "" :| [] )
+                        )
+                        ( "" :| [] )
+                    )
+                    ( "x" :| [] )
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PatternX
+                            ( "_" :| [] )
+                        ]
+                    , rawClauseBody = Prim Sub ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :| [ "id" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :| [ "id" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( ElimX
+                            ( "Prelude" :| [ "ty" ] )
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( ElimX
+                                ( "a" :| [] )
+                            ) ()
+                        )
+                        ( Elim
+                            ( ElimX
+                                ( "a" :| [] )
+                            ) ()
+                        )
+                        ( "" :| [] )
+                    )
+                    ( "a" :| [] )
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PatternX
+                            ( "_" :| [] )
+                        , PatternX
+                            ( "x" :| [] )
+                        ]
+                    , rawClauseBody = Elim
+                        ( ElimX
+                            ( "x" :| [] )
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "MultipleLambdas" :| [ "main" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "MultipleLambdas" :| [ "main" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Elim
+                    ( ElimX
+                        ( "Prelude" :|
+                            [ "LLVM"
+                            , "int"
+                            ]
+                        )
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = Let SAny
+                        ( Ann
+                            ( SNat 1 )
+                            ( Prim
+                                ( LitInt 3 ) ()
+                            )
+                            ( Elim
+                                ( ElimX
+                                    ( "Prelude" :|
+                                        [ "LLVM"
+                                        , "int"
+                                        ]
+                                    )
+                                ) ()
+                            ) ()
+                        )
+                        ( Let SAny
+                            ( Ann
+                                ( SNat 1 )
+                                ( Prim
+                                    ( LitInt 5 ) ()
+                                )
+                                ( Elim
+                                    ( ElimX
+                                        ( "Prelude" :|
+                                            [ "LLVM"
+                                            , "int"
+                                            ]
+                                        )
+                                    ) ()
+                                ) ()
+                            )
+                            ( Elim
+                                ( ElimX
+                                    ( "bar" :| [] )
+                                ) ()
+                            )
+                            ( "bar" :| [] )
+                        )
+                        ( "foo" :| [] )
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :| [ "const" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :| [ "const" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( ElimX
+                            ( "Prelude" :| [ "ty" ] )
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( ElimX
+                                ( "Prelude" :| [ "ty" ] )
+                            ) ()
+                        )
+                        ( Pi SAny
+                            ( Elim
+                                ( ElimX
+                                    ( "a" :| [] )
+                                ) ()
+                            )
+                            ( Pi SAny
+                                ( Elim
+                                    ( ElimX
+                                        ( "b" :| [] )
+                                    ) ()
+                                )
+                                ( Elim
+                                    ( ElimX
+                                        ( "a" :| [] )
+                                    ) ()
+                                )
+                                ( "" :| [] )
+                            )
+                            ( "" :| [] )
+                        )
+                        ( "b" :| [] )
+                    )
+                    ( "a" :| [] )
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PatternX
+                            ( "_" :| [] )
+                        , PatternX
+                            ( "_" :| [] )
+                        , PatternX
+                            ( "x" :| [] )
+                        ]
+                    , rawClauseBody = Lam
+                        ( Elim
+                            ( ElimX
+                                ( "x" :| [] )
+                            ) ()
+                        )
+                        ( "_" :| [] )
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :| [ "ty" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :| [ "ty" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Star
+                    ( U'
+                        ( CU 1 )
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = Star
+                        ( U'
+                            ( CU 0 )
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ]

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.ir
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.ir
@@ -1,0 +1,335 @@
+( fromList []
+, fromList
+    [
+        ( "Prelude" :|
+            [ "LLVM"
+            , "int8"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "int8"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Elim
+                    ( Free
+                        ( Global
+                            ( "Prelude" :| [ "ty" ] )
+                        ) ()
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = PrimTy
+                        ( PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            )
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :|
+            [ "LLVM"
+            , "int"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "int"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Elim
+                    ( Free
+                        ( Global
+                            ( "Prelude" :| [ "ty" ] )
+                        ) ()
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = Elim
+                        ( Free
+                            ( Global
+                                ( "Prelude" :|
+                                    [ "LLVM"
+                                    , "int8"
+                                    ]
+                                )
+                            ) ()
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :|
+            [ "LLVM"
+            , "add"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "add"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( Free
+                            ( Global
+                                ( "Prelude" :| [ "ty" ] )
+                            ) ()
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( Bound 0 () ) ()
+                        )
+                        ( Pi SAny
+                            ( Elim
+                                ( Bound 1 () ) ()
+                            )
+                            ( Elim
+                                ( Bound 2 () ) ()
+                            ) ()
+                        ) ()
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PVar 0 () ]
+                    , rawClauseBody = Prim Add ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :|
+            [ "LLVM"
+            , "sub"
+            ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :|
+                    [ "LLVM"
+                    , "sub"
+                    ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( Free
+                            ( Global
+                                ( "Prelude" :| [ "ty" ] )
+                            ) ()
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( Bound 0 () ) ()
+                        )
+                        ( Pi SAny
+                            ( Elim
+                                ( Bound 1 () ) ()
+                            )
+                            ( Elim
+                                ( Bound 2 () ) ()
+                            ) ()
+                        ) ()
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PVar 0 () ]
+                    , rawClauseBody = Prim Sub ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :| [ "id" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :| [ "id" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( Free
+                            ( Global
+                                ( "Prelude" :| [ "ty" ] )
+                            ) ()
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( Bound 0 () ) ()
+                        )
+                        ( Elim
+                            ( Bound 1 () ) ()
+                        ) ()
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PVar 0 ()
+                        , PVar 1 ()
+                        ]
+                    , rawClauseBody = Elim
+                        ( Free
+                            ( Pattern 1 ) ()
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "MultipleLambdas" :| [ "main" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "MultipleLambdas" :| [ "main" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Elim
+                    ( Free
+                        ( Global
+                            ( "Prelude" :|
+                                [ "LLVM"
+                                , "int"
+                                ]
+                            )
+                        ) ()
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = Let SAny
+                        ( Ann
+                            ( SNat 1 )
+                            ( Prim
+                                ( LitInt 3 ) ()
+                            )
+                            ( Elim
+                                ( Free
+                                    ( Global
+                                        ( "Prelude" :|
+                                            [ "LLVM"
+                                            , "int"
+                                            ]
+                                        )
+                                    ) ()
+                                ) ()
+                            ) ()
+                        )
+                        ( Let SAny
+                            ( Ann
+                                ( SNat 1 )
+                                ( Prim
+                                    ( LitInt 5 ) ()
+                                )
+                                ( Elim
+                                    ( Free
+                                        ( Global
+                                            ( "Prelude" :|
+                                                [ "LLVM"
+                                                , "int"
+                                                ]
+                                            )
+                                        ) ()
+                                    ) ()
+                                ) ()
+                            )
+                            ( Elim
+                                ( Bound 0 () ) ()
+                            ) ()
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :| [ "const" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :| [ "const" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Pi SAny
+                    ( Elim
+                        ( Free
+                            ( Global
+                                ( "Prelude" :| [ "ty" ] )
+                            ) ()
+                        ) ()
+                    )
+                    ( Pi SAny
+                        ( Elim
+                            ( Free
+                                ( Global
+                                    ( "Prelude" :| [ "ty" ] )
+                                ) ()
+                            ) ()
+                        )
+                        ( Pi SAny
+                            ( Elim
+                                ( Bound 1 () ) ()
+                            )
+                            ( Pi SAny
+                                ( Elim
+                                    ( Bound 1 () ) ()
+                                )
+                                ( Elim
+                                    ( Bound 3 () ) ()
+                                ) ()
+                            ) ()
+                        ) ()
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats =
+                        [ PVar 0 ()
+                        , PVar 1 ()
+                        , PVar 2 ()
+                        ]
+                    , rawClauseBody = Lam
+                        ( Elim
+                            ( Free
+                                ( Pattern 2 ) ()
+                            ) ()
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ,
+        ( "Prelude" :| [ "ty" ]
+        , RawGFunction
+            ( RawFunction
+                { rawFunName = "Prelude" :| [ "ty" ]
+                , rawFunUsage = GSAny
+                , rawFunType = Star
+                    ( U'
+                        ( CU 1 )
+                    ) ()
+                , rawFunClauses = RawFunClause
+                    { rawClauseTel = []
+                    , rawClausePats = []
+                    , rawClauseBody = Star
+                        ( U'
+                            ( CU 0 )
+                        ) ()
+                    , rawClauseCatchall = False
+                    } :| []
+                }
+            )
+        )
+    ]
+)

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.llvm
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.llvm
@@ -1,0 +1,24 @@
+"; ModuleID = 'juvix-module'
+
+
+ 
+
+
+define external fastcc  i8 @"\22lambda\222"(i8  %"1")    {
+"\22lambda\222":
+  ret i8 %"1" 
+}
+
+
+define external fastcc  i8 @lambda(i8  %"0")    {
+"\22lambda\221":
+  %0 =  call fastcc  i8  @"\22lambda\222"(i8  5)  
+  ret i8 %0 
+}
+
+
+define external fastcc  i8 @main()    {
+main:
+  %0 =  call fastcc  i8  @lambda(i8  3)  
+  ret i8 %0 
+}"

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.parsed
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.parsed
@@ -1,0 +1,76 @@
+Right
+    ( Header
+        ( "MultipleLambdas" :| [] )
+        [ ModuleOpen
+            ( Open
+                ( "Prelude" :| [] )
+            )
+        , ModuleOpen
+            ( Open
+                ( "LLVM" :| [] )
+            )
+        , Signature
+            ( Sig
+                { signatureName = "main"
+                , signatureUsage = Nothing
+                , signatureArrowType = Name
+                    ( "int" :| [] )
+                , signatureConstraints = []
+                }
+            )
+        , Function
+            ( Func
+                ( Like
+                    { functionLikedName = "main"
+                    , functionLikeArgs = []
+                    , functionLikeBody = Body
+                        ( Let
+                            ( Let'
+                                { letBindings = Like
+                                    { functionLikedName = "foo"
+                                    , functionLikeArgs = []
+                                    , functionLikeBody = Body
+                                        ( Infix
+                                            ( Inf
+                                                { infixLeft = Constant
+                                                    ( Number
+                                                        ( Integer' 3 )
+                                                    )
+                                                , infixOp = ":" :| []
+                                                , infixRight = Name
+                                                    ( "int" :| [] )
+                                                }
+                                            )
+                                        )
+                                    }
+                                , letBody = Let
+                                    ( Let'
+                                        { letBindings = Like
+                                            { functionLikedName = "bar"
+                                            , functionLikeArgs = []
+                                            , functionLikeBody = Body
+                                                ( Infix
+                                                    ( Inf
+                                                        { infixLeft = Constant
+                                                            ( Number
+                                                                ( Integer' 5 )
+                                                            )
+                                                        , infixOp = ":" :| []
+                                                        , infixRight = Name
+                                                            ( "int" :| [] )
+                                                        }
+                                                    )
+                                                )
+                                            }
+                                        , letBody = Name
+                                            ( "bar" :| [] )
+                                        }
+                                    )
+                                }
+                            )
+                        )
+                    }
+                )
+            )
+        ]
+    )

--- a/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.typecheck
+++ b/test/examples-golden/positive/llvm/MultipleLambda/MultipleLambda.typecheck
@@ -1,0 +1,157 @@
+Ann
+    { usage = SAny
+    , type' = PrimTy
+        ( Return
+            { retType = PrimType
+                { getPrimType = STAR :| [] }
+            , retTerm = PrimTy
+                ( IntegerType
+                    { typeBits = 8 }
+                )
+            }
+        )
+    , term = AppM
+        ( Ann
+            { usage = SAny
+            , type' = Pi SAny
+                ( PrimTy
+                    ( Return
+                        { retType = PrimType
+                            { getPrimType = STAR :| [] }
+                        , retTerm = PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            )
+                        }
+                    )
+                )
+                ( PrimTy
+                    ( Return
+                        { retType = PrimType
+                            { getPrimType = STAR :| [] }
+                        , retTerm = PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            )
+                        }
+                    )
+                )
+            , term = LamM
+                { capture = []
+                , arguments =
+                    [ "0" :| [] ]
+                , body = Ann
+                    { usage = SAny
+                    , type' = PrimTy
+                        ( Return
+                            { retType = PrimType
+                                { getPrimType = STAR :| [] }
+                            , retTerm = PrimTy
+                                ( IntegerType
+                                    { typeBits = 8 }
+                                )
+                            }
+                        )
+                    , term = AppM
+                        ( Ann
+                            { usage = SAny
+                            , type' = Pi SAny
+                                ( PrimTy
+                                    ( Return
+                                        { retType = PrimType
+                                            { getPrimType = STAR :| [] }
+                                        , retTerm = PrimTy
+                                            ( IntegerType
+                                                { typeBits = 8 }
+                                            )
+                                        }
+                                    )
+                                )
+                                ( PrimTy
+                                    ( Return
+                                        { retType = PrimType
+                                            { getPrimType = STAR :| [] }
+                                        , retTerm = PrimTy
+                                            ( IntegerType
+                                                { typeBits = 8 }
+                                            )
+                                        }
+                                    )
+                                )
+                            , term = LamM
+                                { capture = []
+                                , arguments =
+                                    [ "1" :| [] ]
+                                , body = Ann
+                                    { usage = SAny
+                                    , type' = PrimTy
+                                        ( Return
+                                            { retType = PrimType
+                                                { getPrimType = STAR :| [] }
+                                            , retTerm = PrimTy
+                                                ( IntegerType
+                                                    { typeBits = 8 }
+                                                )
+                                            }
+                                        )
+                                    , term = Var
+                                        ( "1" :| [] )
+                                    }
+                                }
+                            }
+                        )
+                        [ Ann
+                            { usage = SAny
+                            , type' = PrimTy
+                                ( Return
+                                    { retType = PrimType
+                                        { getPrimType = STAR :| [] }
+                                    , retTerm = PrimTy
+                                        ( IntegerType
+                                            { typeBits = 8 }
+                                        )
+                                    }
+                                )
+                            , term = Prim
+                                ( Return
+                                    { retType = PrimType
+                                        { getPrimType = PrimTy
+                                            ( IntegerType
+                                                { typeBits = 8 }
+                                            ) :| []
+                                        }
+                                    , retTerm = LitInt 5
+                                    }
+                                )
+                            }
+                        ]
+                    }
+                }
+            }
+        )
+        [ Ann
+            { usage = SAny
+            , type' = PrimTy
+                ( Return
+                    { retType = PrimType
+                        { getPrimType = STAR :| [] }
+                    , retTerm = PrimTy
+                        ( IntegerType
+                            { typeBits = 8 }
+                        )
+                    }
+                )
+            , term = Prim
+                ( Return
+                    { retType = PrimType
+                        { getPrimType = PrimTy
+                            ( IntegerType
+                                { typeBits = 8 }
+                            ) :| []
+                        }
+                    , retTerm = LitInt 3
+                    }
+                )
+            }
+        ]
+    }

--- a/test/examples/positive/llvm/MultipleLambda.ju
+++ b/test/examples/positive/llvm/MultipleLambda.ju
@@ -1,0 +1,11 @@
+-- This tests whether multiple lambdas can compile at once
+mod MultipleLambdas where
+
+open Prelude
+open LLVM
+
+sig main : int
+let main =
+  let foo = 3 : int in
+  let bar = 5 : int in
+  bar


### PR DESCRIPTION
This PR seeks to bring back some of the old infrastructure of the LLVM backend:

This includes

- Sum type infrastructure
- Custom Monad
- Operations on the Custom Monad
- Refactoring the Current Implementation to use the custom Monad


Currently the backend works for
  - 5/4 cases.
  - An extra case was added for the following
  ```haskell
sig main : int
let main =
  let foo = 3 : int in
  let bar = 5 : int in
  bar
```

This shows that multiple lambdas can be involved. However if we were to try to return `foo` this would die due to capture issues. A new pr is needed to implement closure to effectively compile it.