### PR TITLE
Add string and other prim types and ops in LLVM

### DIFF
--- a/library/Backends/llvm/package.yaml
+++ b/library/Backends/llvm/package.yaml
@@ -27,6 +27,7 @@ dependencies:
 - llvm-hs-pure >= 9.0 && < 9.1
 - standard-library
 - unordered-containers >= 0.2.13
+- pretty-simple
 
 default-extensions:
 - TypeSynonymInstances

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -70,9 +70,7 @@ mkMain t@(ErasedAnn.Ann usage ty t') = do
               callArgs = zip args (repeat []) -- No arg attributes.
           funname <- mkLam env ty body arguments capture
           LLVM.call (globalRef (typeToLLVM ty) funname) callArgs
-      other -> do
-        pTraceM $ "Other not found: " <> show other 
-        compileTerm mempty t
+      other -> compileTerm mempty t
     LLVM.ret out
 
 -- | Compile a term to its equivalent LLVM code.

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -19,6 +19,7 @@ import qualified LLVM.AST.Type as LLVM
 import qualified LLVM.IRBuilder as LLVM
 import qualified LLVM.Pretty as LLVM
 import qualified Prelude as P
+import Debug.Pretty.Simple
 
 -- | A mapping between Juvix variable names and their operands in LLVM.
 type Env = Map.Map NameSymbol.T LLVM.Operand
@@ -69,7 +70,9 @@ mkMain t@(ErasedAnn.Ann usage ty t') = do
               callArgs = zip args (repeat []) -- No arg attributes.
           funname <- mkLam env ty body arguments capture
           LLVM.call (globalRef (typeToLLVM ty) funname) callArgs
-      _ -> compileTerm mempty t
+      other -> do
+        pTraceM $ "Other not found: " <> show other 
+        compileTerm mempty t
     LLVM.ret out
 
 -- | Compile a term to its equivalent LLVM code.

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
@@ -56,7 +56,8 @@ llvm =
     builtinTypes =
       [ ("LLVM.int8", PrimTy LLVM.i8),
         ("LLVM.int16", PrimTy LLVM.i16),
-        ("LLVM.double", PrimTy LLVM.double)
+        ("LLVM.double", PrimTy LLVM.double),
+        ("LLVM.string", PrimTy (LLVM.ptr i8))
       ]
 
     -- The primitive LLVM values available to Juvix users.

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
@@ -37,7 +37,7 @@ llvm =
       Param.builtinValues = builtinValues,
       Param.stringVal = const Nothing,
       Param.intVal = integerToRawPrimVal,
-      Param.floatVal = const Nothing
+      Param.floatVal = doubleToRawPrimVal
     }
   where
     -- Typechecking of primitive values.
@@ -46,13 +46,17 @@ llvm =
       Add -> Param.check3Equal ty
       Sub -> Param.check3Equal ty
       Mul -> Param.check3Equal ty
+      Exp -> Param.check3Equal ty
+      Sqrt -> length ty == 2
       LitInt _ -> length ty == 1
+      LitDouble _ -> length ty == 1
 
     -- The primitive LLVM types available to Juvix users.
     builtinTypes :: Param.Builtins PrimTy
     builtinTypes =
       [ ("LLVM.int8", PrimTy LLVM.i8),
         ("LLVM.int16", PrimTy LLVM.i16)
+        ("LLVM.double", PrimTy LLVM.double)
       ]
 
     -- The primitive LLVM values available to Juvix users.
@@ -62,6 +66,8 @@ llvm =
         ("LLVM.sub", Sub),
         ("LLVM.mul", Mul),
         ("LLVM.litint", LitInt 0) -- TODO: what to do with the 0?
+        ("LLVM.sqrt", Sqrt),
+        ("LLVM.exp", Exp)
       ]
 
     -- Translate an integer into a RawPrimVal.
@@ -70,6 +76,9 @@ llvm =
     -- function.
     integerToRawPrimVal :: Integer -> Maybe RawPrimVal
     integerToRawPrimVal = Just . LitInt
+
+    doubleToRawPrimVal :: Double -> Maybe RawPrimVal
+    doubleToRawPrimVal = Just . LitDouble
 
 -- | TODO: for now these are just copied over from the Michelson backend.
 instance IR.HasWeak PrimTy where weakBy' _ _ t = t

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
@@ -55,7 +55,7 @@ llvm =
     builtinTypes :: Param.Builtins PrimTy
     builtinTypes =
       [ ("LLVM.int8", PrimTy LLVM.i8),
-        ("LLVM.int16", PrimTy LLVM.i16)
+        ("LLVM.int16", PrimTy LLVM.i16),
         ("LLVM.double", PrimTy LLVM.double)
       ]
 
@@ -65,7 +65,7 @@ llvm =
       [ ("LLVM.add", Add),
         ("LLVM.sub", Sub),
         ("LLVM.mul", Mul),
-        ("LLVM.litint", LitInt 0) -- TODO: what to do with the 0?
+        ("LLVM.litint", LitInt 0), -- TODO: what to do with the 0?
         ("LLVM.sqrt", Sqrt),
         ("LLVM.exp", Exp)
       ]

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Primitive.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Primitive.hs
@@ -30,7 +30,10 @@ data RawPrimVal
   = Add
   | Sub
   | Mul
+  | Exp
+  | Sqrt
   | LitInt Integer
+  | LitDouble Double
   deriving (Eq, Show, Read)
 
 -- | The primitive values as exposed to users of Juvix, wrapping inside a
@@ -48,3 +51,7 @@ arityRaw :: RawPrimVal -> Natural
 arityRaw Add = 2
 arityRaw Sub = 2
 arityRaw Mul = 2
+arityRaw Exp = 2
+arityRaw Sqrt = 1
+arityRaw (LitInt _) = 0
+arityRaw (LitDouble _) = 0

--- a/library/Core/package.yaml
+++ b/library/Core/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - containers
 - unordered-containers
 - mtl
+- pretty-simple
 
 default-extensions:
   - NoImplicitPrelude

--- a/library/Core/src/Juvix/Core/IR/Evaluator.hs
+++ b/library/Core/src/Juvix/Core/IR/Evaluator.hs
@@ -89,7 +89,7 @@ inlineAllGlobals ::
   Core.PatternMap Core.GlobalName ->
   Core.Term ext primTy primVal
 inlineAllGlobals t lookupFun patternMap =
-  case pTraceShow t t of
+  case t of
     Core.Unit {} -> t
     Core.UnitTy {} -> t
     Core.Pair p1 p2 ann ->
@@ -141,7 +141,7 @@ inlineAllGlobalsElim t lookupFun patternMap =
   case t of
     Core.Bound {} -> t
     Core.Free (Core.Global name) _ann ->
-      maybe t (\t' -> inlineAllGlobalsElim t' lookupFun patternMap) $ pTrace ("Looking up: " <> show name <> " || " <> (show $ lookupFun name)) $ lookupFun name
+      maybe t (\t' -> inlineAllGlobalsElim t' lookupFun patternMap) $ lookupFun name
     Core.Free (Core.Pattern i) _ -> fromMaybe t $ PM.lookup i patternMap >>= lookupFun
     Core.App elim term ann ->
       Core.App (inlineAllGlobalsElim elim lookupFun patternMap) (inlineAllGlobals term lookupFun patternMap) ann
@@ -274,7 +274,6 @@ toLambda' ::
   Core.Term ext primTy primVal ->
   Maybe (Core.Elim (OnlyExts.T ext') primTy primVal)
 toLambda' π' ty' pats rhs = do
-  pTraceM $ "ToLambda': " <> show ( π', ty', pats, rhs)
   patVars <- traverse singleVar pats
   let len = fromIntegral $ length patVars
   let vars = map bound $ genericTake len (iterate (subtract 1) (len - 1))
@@ -395,7 +394,7 @@ rawLookupFun ::
   Core.RawGlobals ext primTy primVal ->
   LookupFun (OnlyExts.T ext') primTy primVal
 rawLookupFun globals x =
-  pTrace ("rawLookupFun: " <> show x <> " || " <> show (HashMap.lookup x globals))HashMap.lookup x globals >>= toLambdaR
+  HashMap.lookup x globals >>= toLambdaR
 
 -- | Variant of `lookupFun` that creates a extension free elimination.
 lookupFun' ::

--- a/library/Pipeline/src/Juvix/Pipeline.hs
+++ b/library/Pipeline/src/Juvix/Pipeline.hs
@@ -45,7 +45,8 @@ import Juvix.Pipeline.Types
 import qualified Juvix.Sexp as Sexp
 import qualified System.IO.Temp as Temp
 import qualified Text.Megaparsec as P
-import Text.Pretty.Simple (pShowNoColor)
+import Text.Pretty.Simple 
+import Debug.Pretty.Simple
 import qualified Text.PrettyPrint.Leijen.Text as Pretty
 
 ------------------------------------------------------------------------------
@@ -155,6 +156,8 @@ class HasBackend b where
   toErased param (patToSym, globalDefs) = do
     (usage, term, mainTy) <- getMain >>= toLambda
     let inlinedTerm = IR.inlineAllGlobals term lookupGlobal patToSym
+    pTraceM $ "Globals: " <> show globalDefs
+    pTraceM $ "Inline term" <> show inlinedTerm
     let erasedAnn = ErasedAnn.irToErasedAnn @(Err b) inlinedTerm usage mainTy
     res <- liftIO $ fst <$> exec erasedAnn param evaluatedGlobals
     case res of

--- a/library/Pipeline/src/Juvix/Pipeline.hs
+++ b/library/Pipeline/src/Juvix/Pipeline.hs
@@ -14,7 +14,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.IntMap.Strict as PM
 import qualified Data.Text as Text
 import qualified Data.Text.IO as T
-import Debug.Pretty.Simple (pTraceShowM)
 import qualified Juvix.Context as Context
 import qualified Juvix.Core.Application as CoreApp
 import qualified Juvix.Core.Base as Core
@@ -156,8 +155,6 @@ class HasBackend b where
   toErased param (patToSym, globalDefs) = do
     (usage, term, mainTy) <- getMain >>= toLambda
     let inlinedTerm = IR.inlineAllGlobals term lookupGlobal patToSym
-    pTraceM $ "Globals: " <> show globalDefs
-    pTraceM $ "Inline term" <> show inlinedTerm
     let erasedAnn = ErasedAnn.irToErasedAnn @(Err b) inlinedTerm usage mainTy
     res <- liftIO $ fst <$> exec erasedAnn param evaluatedGlobals
     case res of

--- a/stdlib/LLVM.ju
+++ b/stdlib/LLVM.ju
@@ -9,14 +9,29 @@ sig int16 : ty
 let int16 = %LLVM.int16
 
 -- Alias for int8 to be more compitable with the Michelson backend.
+sig double : ty
+let double = %LLVM.double
+
+-- Alias for int8 to be more compatible with the Michelson backend.
 sig int : ty
 let int = int8
 
 sig add : (x : ty) -> x -> x -> x
 let add _ = %LLVM.add
 
+sig (+) : (x : ty) -> x -> x -> x
+let (+) = %LLVM.add
+declare infixl (+) 5
+
 sig sub : (x : ty) -> x -> x -> x
 let sub _ = %LLVM.sub
 
 sig mul : (x : ty) -> x -> x -> x
 let mul _ = %LLVM.mul
+
+sig sqrt : (x : ty) -> x -> double
+let sqrt _ = %LLVM.sqrt
+
+sig (^) : (x: ty) -> x -> int -> x
+let (^) = %LLVM.exp
+declare infixl (^) 8

--- a/test/examples/positive/llvm/HelloWorld.ju
+++ b/test/examples/positive/llvm/HelloWorld.ju
@@ -1,0 +1,7 @@
+mod HelloWorld where
+
+open Prelude
+open Michelson
+
+sig main : string
+let main = "hello-world"

--- a/test/examples/positive/llvm/Norm.ju
+++ b/test/examples/positive/llvm/Norm.ju
@@ -3,17 +3,11 @@ mod Norm where
 open Prelude
 open LLVM
 
-type SomePoint = P3 int int int -- | P2 int int 
+type SomePoint = P3 int int int | P2 int int 
 
 sig norm : SomePoint -> double
 let norm (P3 x y z) = sqrt (x^2 + y^2 + z^2)
--- let norm (P2 x y) = sqrt (x^2 + y^2)
-
--- sig main : double
--- let main = norm (P2 3 4)
-
--- sig norm : int -> int -> int
--- let norm = %LLVM.add
+let norm (P2 x y) = sqrt (x^2 + y^2)
 
 sig main : double
 let main = norm (P3 2 3 4)

--- a/test/examples/positive/llvm/Norm.ju
+++ b/test/examples/positive/llvm/Norm.ju
@@ -3,11 +3,11 @@ mod Norm where
 open Prelude
 open LLVM
 
-type SomePoint = P3 int int int | P2 int int 
+type SomePoint = P3 int int int -- | P2 int int 
 
 sig norm : SomePoint -> double
 let norm (P3 x y z) = sqrt (x^2 + y^2 + z^2)
-let norm (P2 x y) = sqrt (x^2 + y^2)
+-- let norm (P2 x y) = sqrt (x^2 + y^2)
 
 -- sig main : double
 -- let main = norm (P2 3 4)
@@ -16,4 +16,4 @@ let norm (P2 x y) = sqrt (x^2 + y^2)
 -- let norm = %LLVM.add
 
 sig main : double
-let main = norm (P2 3 4)
+let main = norm (P3 2 3 4)

--- a/test/examples/positive/llvm/Norm.ju
+++ b/test/examples/positive/llvm/Norm.ju
@@ -1,0 +1,19 @@
+mod Norm where
+
+open Prelude
+open LLVM
+
+type SomePoint = P3 int int int | P2 int int 
+
+sig norm : SomePoint -> double
+let norm (P3 x y z) = sqrt (x^2 + y^2 + z^2)
+let norm (P2 x y) = sqrt (x^2 + y^2)
+
+-- sig main : double
+-- let main = norm (P2 3 4)
+
+-- sig norm : int -> int -> int
+-- let norm = %LLVM.add
+
+sig main : double
+let main = norm (P2 3 4)

--- a/test/examples/to-fix/llvm/Norm.ju
+++ b/test/examples/to-fix/llvm/Norm.ju
@@ -1,3 +1,5 @@
+-- The reason this is not working is due to pattern matching
+
 mod Norm where
 
 open Prelude

--- a/test/examples/to-fix/llvm/Vector.ju
+++ b/test/examples/to-fix/llvm/Vector.ju
@@ -1,0 +1,15 @@
+-- Hello World dependent types
+
+mod Vector where
+
+open Prelude
+open LLVM
+
+type nat : ty = | Zero |  Suc nat
+
+type Vec : nat -> ty -> ty = 
+    | Nil : Vec Zero a 
+    | Cons : a -> Vec n a -> Vec (Suc n) a
+
+sig main : int
+let main = 10


### PR DESCRIPTION
Includes examples of 
- Hello World
- Hello World (for dependent types)
- Pattern matching (norm of a point)