### PR TITLE
Introduce LLVM sum types

### DIFF
--- a/docs/Code/Library.org
+++ b/docs/Code/Library.org
@@ -369,6 +369,7 @@ Surface language
   + [[Block]]
   + [[Codegen/Closure]]
   + [[Record]]
+  + [[Codegen/Sum]]
   + [[Codegen/Types]]
   + [[CString]]
   + [[Pass/Conversion]]
@@ -490,12 +491,22 @@ Module for predefined constants
   + [[Library]]
   + [[HashMap]]
   + [[NameSymbol]]
+******** Sum <<Codegen/Sum>>
+- _Relies on_
+  + [[Block]]
+  + [[Codegen/Closure]]
+  + [[Codegen/Types]]
+  + [[Shared]]
+  + [[Pass/Types]]
+  + [[Library]]
+  + [[HashMap]]
+  + [[NameSymbol]]
 ******** Types <<Codegen/Types>>
 - _Relies on_
   + [[CString]]
   + [[CString]]
   + [[Shared]]
-  + [[Sum]]
+  + [[Types/Sum]]
   + [[Library]]
   + [[HashMap]]
 ********* CString
@@ -509,7 +520,7 @@ Shared between Types and Sum
   + [[CString]]
   + [[Library]]
   + [[HashMap]]
-********* Sum
+********* Sum <<Types/Sum>>
 Provides a mechanism for defining Sum types
 - Has the code to encode a sum type via what is defined by the user or
   what is defined to create the interaction net system.
@@ -545,7 +556,7 @@ Provides a mechanism for defining Sum types
 - _Relies on_
   + [[Block]]
   + [[Codegen/Types]]
-  + [[Sum]]
+  + [[Types/Sum]]
   + [[LLVM/Compilation]]
   + [[Pass/Types]]
   + [[Primitive]]

--- a/docs/Code/Library.org
+++ b/docs/Code/Library.org
@@ -446,9 +446,8 @@ machine looks a bit different, we can see it in this example here
 @
   compileLam ty captures arguments body
    | length captures == 0 = do
-      let (llvmArgty, llvmRetty) =
-            functionTypeLLVM ty
-          llvmArgNames =
+      (llvmArgty, llvmRetty) <- functionTypeLLVM ty
+      let llvmArgNames =
             fmap (Block.internName . NameSymbol.toSymbol) arguments
           llvmArguments =
             zip llvmArgty llvmArgNames

--- a/library/Backends/llvm/package.yaml
+++ b/library/Backends/llvm/package.yaml
@@ -22,18 +22,19 @@ description:         LLVM backend for the Juvix programming language.
 dependencies:
   - aeson
   - base >= 4.7 && < 5
-  - core
-  - hashable
-  - pipeline
-  - llvm-hs-pretty
-  - text
-  - llvm-hs-pure >= 9.0 && < 9.1
-  - llvm-hs >= 9.0 && < 9.1
-  - standard-library
-  - unordered-containers >= 0.2.13
   - Cabal
   - bytestring
+  - core
   - data-structures
+  - hashable
+  - llvm-hs >= 9.0 && < 9.1
+  - llvm-hs-pretty
+  - llvm-hs-pure >= 9.0 && < 9.1
+  - pipeline
+  - safe
+  - standard-library
+  - text
+  - unordered-containers >= 0.2.13
 
 default-extensions:
 - BlockArguments

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
@@ -46,9 +46,8 @@
 -- @
 --   compileLam ty captures arguments body
 --    | length captures == 0 = do
---       let (llvmArgty, llvmRetty) =
---             functionTypeLLVM ty
---           llvmArgNames =
+--       (llvmArgty, llvmRetty) <- functionTypeLLVM ty
+--       let llvmArgNames =
 --             fmap (Block.internName . NameSymbol.toSymbol) arguments
 --           llvmArguments =
 --             zip llvmArgty llvmArgNames
@@ -1159,7 +1158,7 @@ callVoid fn args =
 -- --
 -- let -- We should probably get the type from the function itself
 --     -- rather than pass in what it should be here
---     functionType = typeToLLVM returnTy
+--     functionType <- typeToLLVM returnTy
 --     -- ignore attributes for now!
 --     argsAtrributes = zip arguments (repeat [])
 --

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Block.hs
@@ -235,6 +235,7 @@ emptyCodegen =
       Types.typTab = Map.empty,
       Types.varTab = Map.empty,
       Types.recordTab = Map.empty,
+      Types.sumTab = Map.empty,
       Types.count = 0,
       Types.names = Map.empty,
       Types.strings = mempty,

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Record.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Record.hs
@@ -3,6 +3,7 @@ module Juvix.Backends.LLVM.Codegen.Record
     restoreTable,
     loadField,
     makeRecord,
+    lookupType,
   )
 where
 
@@ -56,6 +57,17 @@ llvmRecordType llvmFieldTypes =
         -- having to perform any recursive size calculations for now.
         map Types.pointerOf llvmFieldTypes
     }
+
+lookupType :: Types.LookupType m => PassTypes.RecordName -> m Type.Type
+lookupType recordName = do
+  recordTable <- get @"recordTab"
+  record <-
+    case Map.lookup (toSymbol recordName) recordTable of
+      Just recordDesc -> pure recordDesc
+      Nothing ->
+        throw @"err" $
+          Types.NonExistentRecordType "typechecker allowed record of non-existent type"
+  pure $ fst record
 
 -- | Get the names and types of the fields of the record type with the given name.
 recordFields :: Types.Define m => PassTypes.RecordName -> m [(Symbol, Type.Type)]

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
@@ -8,6 +8,7 @@ module Juvix.Backends.LLVM.Codegen.Sum
 where
 
 import qualified Data.List as List
+import qualified Safe.Exact as Exact
 import qualified Juvix.Backends.LLVM.Codegen.Block as Block
 import qualified Juvix.Backends.LLVM.Codegen.Closure as Closure
 import qualified Juvix.Backends.LLVM.Codegen.Types as Types
@@ -164,7 +165,7 @@ makeCase sumName outputType caseTypes term cases environments = do
               Block.call outputType caseFunc [(environment, []), (variant, [])]
           )
           (zip variantTypes $ zip cases environments)
-  Block.generateSwitch outputType index variantNames values appliedCases
+  Block.generateSwitch outputType index (Exact.zip3Exact variantNames values appliedCases) Nothing
 
 -- | Given the name of a sum type and a compiled variant term,
 -- | allocate a sum type and store the given term in it.

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
@@ -8,7 +8,6 @@ module Juvix.Backends.LLVM.Codegen.Sum
 where
 
 import qualified Data.List as List
-import qualified Safe.Exact as Exact
 import qualified Juvix.Backends.LLVM.Codegen.Block as Block
 import qualified Juvix.Backends.LLVM.Codegen.Closure as Closure
 import qualified Juvix.Backends.LLVM.Codegen.Types as Types
@@ -20,6 +19,7 @@ import Juvix.Library.NameSymbol as NameSymbol
 import qualified LLVM.AST as AST
 import qualified LLVM.AST.Constant as Constant
 import qualified LLVM.AST.Type as Type
+import qualified Safe.Exact as Exact
 import qualified Prelude as P
 
 -- | @register@ registers a sum type with the given name and

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
@@ -1,0 +1,223 @@
+module Juvix.Backends.LLVM.Codegen.Sum
+  ( register,
+    restoreTable,
+    makeSum,
+    makeCase,
+    lookupType,
+  )
+where
+
+import qualified Data.List as List
+import qualified Juvix.Backends.LLVM.Codegen.Block as Block
+import qualified Juvix.Backends.LLVM.Codegen.Closure as Closure
+import qualified Juvix.Backends.LLVM.Codegen.Types as Types
+import qualified Juvix.Backends.LLVM.Codegen.Types.Shared as Shared
+import qualified Juvix.Backends.LLVM.Pass.Types as PassTypes
+import Juvix.Library hiding (Type, local)
+import qualified Juvix.Library.HashMap as Map
+import Juvix.Library.NameSymbol as NameSymbol
+import qualified LLVM.AST as AST
+import qualified LLVM.AST.Constant as Constant
+import qualified LLVM.AST.Type as Type
+import qualified Prelude as P
+
+-- | @register@ registers a sum type with the given name and
+-- | variant names and types.  It returns the old sum table so
+-- | that the caller can restore it (with restoreTable) after leaving
+-- | the scope of a sum declaration.
+register ::
+  Types.Define m =>
+  PassTypes.SumName ->
+  [PassTypes.VariantName] ->
+  [Type.Type] ->
+  m Types.SumTable
+register sumName variantNames llvmVariantTypes = do
+  oldTable <- get @"sumTab"
+  llvmTypeName <- sumTypeName sumName
+  Block.addType llvmTypeName llvmSumType
+  let typeRef = Type.NamedTypeReference llvmTypeName
+  let variantDescs = zip (map toSymbol variantNames) llvmVariantTypes
+  put @"sumTab" $ Map.insert (toSymbol sumName) (typeRef, variantDescs) oldTable
+  pure oldTable
+
+restoreTable ::
+  Types.Define m =>
+  Types.SumTable ->
+  m ()
+restoreTable = put @"sumTab"
+
+sumTypeName :: Types.Define m => NameSymbol.T -> m AST.Name
+sumTypeName sumName = do
+  symbol <- Block.generateUniqueSymbol $ "sum-" <> toSymbol sumName
+  pure $ Block.internName symbol
+
+indexBits :: Word32
+indexBits = 32
+
+indexType :: Type.Type
+indexType = Type.i32
+
+tagConstant :: Int -> Constant.Constant
+tagConstant variantIndex =
+  Constant.Int
+    { Constant.integerBits = indexBits,
+      Constant.integerValue = toInteger variantIndex
+    }
+
+tagOperand :: Int -> AST.Operand
+tagOperand = AST.ConstantOperand . tagConstant
+
+variantPtrType :: Type.Type
+variantPtrType = Types.pointerOf Type.i8
+
+llvmSumType :: Type.Type
+llvmSumType =
+  Type.StructureType
+    { isPacked = True,
+      -- We box types, both to allow recursive structures and also to avoid
+      -- having to perform any recursive size calculations for now.
+      -- Hence, the structure representing a sum contains a single
+      -- pointer to point to a structure representing whichever variant
+      -- the sum contains, and an index indicating which variant it is
+      -- (by its index within the list of variants in the sum type
+      -- declaration).
+      elementTypes = [indexType, variantPtrType]
+    }
+
+getIndexPtr :: Types.Define m => AST.Operand -> m AST.Operand
+getIndexPtr sumPtr =
+  Block.getElementPtr
+    Types.Minimal
+      { type' = Types.pointerOf indexType,
+        address' = sumPtr,
+        indincies' = Block.constant32List [0, 0]
+      }
+
+getVariantPtr :: Types.Define m => AST.Operand -> m AST.Operand
+getVariantPtr sumPtr =
+  Block.getElementPtr
+    Types.Minimal
+      { type' = Types.pointerOf variantPtrType,
+        address' = sumPtr,
+        indincies' = Block.constant32List [0, 1]
+      }
+
+getSumDesc :: Types.LookupType m => PassTypes.SumName -> m Types.SumDesc
+getSumDesc sumName = do
+  sumTable <- get @"sumTab"
+  case Map.lookup (toSymbol sumName) sumTable of
+    Just sumDesc -> pure sumDesc
+    Nothing ->
+      throw @"err" $
+        Types.NonExistentSumType "typechecker allowed sum of non-existent type"
+
+lookupType :: Types.LookupType m => PassTypes.SumName -> m Type.Type
+lookupType sumName = do
+  getSumDesc sumName >>= pure . fst
+
+oneArgFunctionType :: Type.Type -> Type.Type -> Type.Type
+oneArgFunctionType arg result =
+  Types.pointerOf
+    Type.FunctionType
+      { Type.resultType = result,
+        Type.argumentTypes = [arg],
+        Type.isVarArg = False
+      }
+
+makeCase ::
+  Types.Define m =>
+  PassTypes.SumName ->
+  Type.Type ->
+  [Type.Type] ->
+  AST.Operand ->
+  [AST.Operand] ->
+  m AST.Operand
+makeCase sumName outputType caseTypes term cases = do
+  (sumType, variantDescs) <- getSumDesc sumName
+  let values = map tagConstant [0 .. length variantDescs - 1]
+  let variantNames = map fst variantDescs
+  let variantTypes = map snd variantDescs
+  let expectedCaseTypes = map (`oneArgFunctionType` outputType) variantTypes
+  if caseTypes /= expectedCaseTypes
+    then
+      throw @"err" $
+        Types.MismatchedCaseTypes $
+          "typechecker allowed mismatched case types: expected "
+            <> show expectedCaseTypes
+            <> "; got "
+            <> show caseTypes
+            <> "; outputType "
+            <> show outputType
+            <> "; variantTypes "
+            <> show variantTypes
+    else pure ()
+  indexPtr <- getIndexPtr term
+  index <- Block.load indexType indexPtr
+  variantPtrLoc <- getVariantPtr term
+  variantPtr <- Block.load variantPtrType variantPtrLoc
+  let appliedCases =
+        map
+          ( \(ty, c) -> do
+              castedPtr <- Block.bitCast variantPtr (Types.pointerOf ty)
+              variant <- Block.load ty castedPtr
+              Block.call outputType c [(Block.null Closure.environmentPtr, []), (variant, [])]
+          )
+          (zip variantTypes cases)
+  Block.generateSwitch outputType index variantNames values appliedCases
+
+-- | Given the name of a sum type and a compiled variant term,
+-- | allocate a sum type and store the given term in it.
+-- |
+-- | WARNING:  The memory allocations herein leak memory, pending our
+-- | implementing garbage collection.
+makeSum ::
+  Types.Define m =>
+  PassTypes.SumName ->
+  PassTypes.VariantName ->
+  Type.Type ->
+  Type.Type ->
+  AST.Operand ->
+  m AST.Operand
+makeSum sumName variantName compiledSumType compiledVariantType variantTerm = do
+  (sumType, variantDescs) <- getSumDesc sumName
+  if compiledSumType /= sumType
+    then
+      throw @"err" $
+        Types.MismatchedSumTypes $
+          "typechecker allowed mismatched sum types: expected "
+            <> show sumType
+            <> "; got "
+            <> show compiledSumType
+    else pure ()
+  variantIndex <- case List.findIndex (\desc -> fst desc == toSymbol variantName) variantDescs of
+    Just index -> pure index
+    Nothing ->
+      throw @"err" $
+        Types.NonExistentVariant "typechecker allowed selection of non-existent variant"
+  let variantType = snd $ variantDescs P.!! variantIndex
+  if compiledVariantType /= variantType
+    then
+      throw @"err" $
+        Types.MismatchedVariantTypes $
+          "typechecker allowed mismatched variant types: expected "
+            <> show variantType
+            <> "; got "
+            <> show compiledVariantType
+    else pure ()
+  -- Allocate the storage for the sum type structure, which contains a
+  -- tag (which is an index into the variant list) and a pointer (to
+  -- the memory allocated for the particular variant selected by the caller).
+  sumPtr <- Block.mallocType sumType
+  -- Store the index in the "tag" field of the sum type structure.
+  indexPtr <- getIndexPtr sumPtr
+  Block.store indexPtr $ tagOperand variantIndex
+  -- Allocate the storage for the particular variant selected.
+  newVariant <- Block.mallocType variantType
+  -- Store the variant term passed in by the caller in the newly-allocated
+  -- variant structure.
+  Block.store newVariant variantTerm
+  -- Store the pointer to the allocated variant in the variant-pointer
+  -- field of the sum type structure.
+  variantPtr <- getVariantPtr sumPtr
+  Block.bitCast newVariant variantPtrType >>= Block.store variantPtr
+  pure sumPtr

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs
@@ -41,7 +41,7 @@ register sumName variants = do
   put @"sumTab" $ Map.insert (toSymbol sumName) (typeRef, variantDescs) oldTable
   pure oldTable
   where
-  (variantNames, llvmVariantTypes) = unzip variants
+    (variantNames, llvmVariantTypes) = unzip variants
 
 restoreTable ::
   Types.Define m =>
@@ -53,7 +53,7 @@ sumTypeName :: Types.Define m => NameSymbol.T -> m AST.Name
 sumTypeName sumName =
   Block.internName <$> Block.generateUniqueSymbol taggedName
   where
-  taggedName = "sum-" <> toSymbol sumName
+    taggedName = "sum-" <> toSymbol sumName
 
 indexBits :: Word32
 indexBits = 32
@@ -142,19 +142,19 @@ makeCase ::
 makeCase sumName outputType term cases = do
   (sumType, variantDescs) <- getSumDesc sumName
   let values = map tagConstant [0 .. length variantDescs - 1]
-      (variantNames, variantTypes ) = unzip variantDescs
+      (variantNames, variantTypes) = unzip variantDescs
       expectedCaseTypes = map (`oneArgFunctionType` outputType) variantTypes
   unless (caseTypes == expectedCaseTypes) $
-      throw @"err" $
-        Types.MismatchedCaseTypes $
-          "typechecker allowed mismatched case types: expected "
-            <> show expectedCaseTypes
-            <> "; got "
-            <> show caseTypes
-            <> "; outputType "
-            <> show outputType
-            <> "; variantTypes "
-            <> show variantTypes
+    throw @"err" $
+      Types.MismatchedCaseTypes $
+        "typechecker allowed mismatched case types: expected "
+          <> show expectedCaseTypes
+          <> "; got "
+          <> show caseTypes
+          <> "; outputType "
+          <> show outputType
+          <> "; variantTypes "
+          <> show variantTypes
   indexPtr <- getIndexPtr term
   index <- Block.load indexType indexPtr
   variantPtrLoc <- getVariantPtr term
@@ -169,7 +169,7 @@ makeCase sumName outputType term cases = do
           (zip variantTypes $ zip caseBodies caseEnvs)
   Block.generateSwitch outputType index (Exact.zip3Exact variantNames values appliedCases) Nothing
   where
-  (caseTypes, caseBodies, caseEnvs) = List.unzip3 cases
+    (caseTypes, caseBodies, caseEnvs) = List.unzip3 cases
 
 -- | Given the name of a sum type and a compiled variant term,
 -- | allocate a sum type and store the given term in it.
@@ -189,12 +189,12 @@ makeSum ::
 makeSum sumName variantName compiledSumType compiledVariantType variantTerm = do
   (sumType, variantDescs) <- getSumDesc sumName
   unless (compiledSumType == sumType) $
-      throw @"err" $
-        Types.MismatchedSumTypes $
-          "typechecker allowed mismatched sum types: expected "
-            <> show sumType
-            <> "; got "
-            <> show compiledSumType
+    throw @"err" $
+      Types.MismatchedSumTypes $
+        "typechecker allowed mismatched sum types: expected "
+          <> show sumType
+          <> "; got "
+          <> show compiledSumType
   variantIndex <- case List.findIndex (\desc -> fst desc == toSymbol variantName) variantDescs of
     Just index -> pure index
     Nothing ->
@@ -202,12 +202,12 @@ makeSum sumName variantName compiledSumType compiledVariantType variantTerm = do
         Types.NonExistentVariant "typechecker allowed selection of non-existent variant"
   let variantType = snd $ variantDescs P.!! variantIndex
   unless (compiledVariantType == variantType) $
-      throw @"err" $
-        Types.MismatchedVariantTypes $
-          "typechecker allowed mismatched variant types: expected "
-            <> show variantType
-            <> "; got "
-            <> show compiledVariantType
+    throw @"err" $
+      Types.MismatchedVariantTypes $
+        "typechecker allowed mismatched variant types: expected "
+          <> show variantType
+          <> "; got "
+          <> show compiledVariantType
   -- Allocate the storage for the sum type structure, which contains a
   -- tag (which is an index into the variant list) and a pointer (to
   -- the memory allocated for the particular variant selected by the caller).

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types.hs
@@ -101,6 +101,31 @@ data Errors
     -- | typechecker, if the type of the term did not come directly from a
     -- | test, or some other module that bypasses the typechecker)
     MismatchedFieldTypes Text
+  | -- | Found a sum term with an undeclared sum type (this indicates a
+    -- | bug in the typechecker, if the type of the term did not come
+    -- | directly from a test, or some other module that bypasses the
+    -- | typechecker)
+    NonExistentSumType Text
+  | -- | Found a sum term whose variants' types did not match the variant
+    -- | types in the sum type declaration (this indicates a bug in the
+    -- | typechecker, if the type of the term did not come directly from a
+    -- | test, or some other module that bypasses the typechecker)
+    MismatchedVariantTypes Text
+  | -- | Found a variant term with a name not present in its type's list of
+    -- | variants (this indicates a bug in the typechecker, if the type of the
+    -- | term did not come directly from a test, or some other module that
+    -- | bypasses the typechecker)
+    NonExistentVariant Text
+  | -- | Found a match term whose cases' types did not match the variant
+    -- | types in the sum type declaration (this indicates a bug in the
+    -- | typechecker, if the type of the term did not come directly from a
+    -- | test, or some other module that bypasses the typechecker)
+    MismatchedCaseTypes Text
+  | -- | Found a sum term whose type did not match the one found by
+    -- | looking up the type's name (this indicates a bug in the
+    -- | typechecker, if the type of the term did not come directly from a
+    -- | test, or some other module that bypasses the typechecker)
+    MismatchedSumTypes Text
   deriving (Show, Eq)
 
 type CodegenAlias = ExceptT Errors (State CodegenState)

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types/Shared.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Types/Shared.hs
@@ -2,7 +2,10 @@
 module Juvix.Backends.LLVM.Codegen.Types.Shared
   ( SymbolTable,
     TypeTable,
+    RecordDesc,
     RecordTable,
+    SumDesc,
+    SumTable,
     StringsTable,
     SumInfo (..),
     VariantToType,
@@ -37,9 +40,19 @@ type VariantToType = Map.T Symbol SumInfo
 -- numbering to go along with a given name.
 type Names = Map.T Symbol Int
 
+-- | The information associated with a single record type.
+type RecordDesc = (Type, [(Symbol, Type)])
+
 -- | A mapping of record names to LLVM types and lists of (name, type) pairs
 -- | (one for each field).
-type RecordTable = Map.T Symbol (Type, [(Symbol, Type)])
+type RecordTable = Map.T Symbol RecordDesc
+
+-- | The information associated with a single sum type.
+type SumDesc = (Type, [(Symbol, Type)])
+
+-- | A mapping of sum names to LLVM types and lists of (name, type) pairs
+-- | (one for each variant).
+type SumTable = Map.T Symbol SumDesc
 
 -- | @uniqueName@ given a symbol and a name table, generate a new
 -- unique name and give back the updated nametable.

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -7,6 +7,7 @@ where
 import qualified Juvix.Backends.LLVM.Codegen.Block as Block
 import qualified Juvix.Backends.LLVM.Codegen.Closure as Closure
 import qualified Juvix.Backends.LLVM.Codegen.Record as Record
+import qualified Juvix.Backends.LLVM.Codegen.Sum as Sum
 import qualified Juvix.Backends.LLVM.Codegen.Types as Types
 import qualified Juvix.Backends.LLVM.Codegen.Types.CString as CString
 import qualified Juvix.Backends.LLVM.Pass.Conversion as Conversion

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -419,7 +419,8 @@ compileMatch ty (sumName, term, cases) = do
   llvmCaseTypes <- mapM (typeToLLVM . Types.annTy) cases
   compiledTerm <- compileTerm term
   compiledCases <- mapM compileTerm cases
-  Sum.makeCase sumName outputType llvmCaseTypes compiledTerm compiledCases
+  environments <- mapM getCompiledEnvironment compiledCases
+  Sum.makeCase sumName outputType llvmCaseTypes compiledTerm compiledCases environments
 
 --------------------------------------------------------------------------------
 -- Capture Conversion

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Compilation.hs
@@ -57,6 +57,7 @@ registerPreProcessed t = do
   Closure.register
   Block.defineMalloc
   Block.defineFree
+  Block.defineAbort
   mkMain t
 
 register ::

--- a/test/examples-golden/positive/llvm/Const/Const.llvm
+++ b/test/examples-golden/positive/llvm/Const/Const.llvm
@@ -13,6 +13,9 @@ declare external fastcc  i8* @malloc(i32)
 declare external fastcc  void @free(i8*)    
 
 
+declare external fastcc  void @abort()    
+
+
 define external fastcc  i8 @main()    {
 main:
   ret i8 10 

--- a/test/examples-golden/positive/llvm/ConstAddPrim/ConstAddPrim.llvm
+++ b/test/examples-golden/positive/llvm/ConstAddPrim/ConstAddPrim.llvm
@@ -13,6 +13,9 @@ declare external fastcc  i8* @malloc(i32)
 declare external fastcc  void @free(i8*)    
 
 
+declare external fastcc  void @abort()    
+
+
 define external fastcc  i8 @main()    {
 main:
   %0 = add nuw nsw i8 4, 6 

--- a/test/examples-golden/positive/llvm/HelloWorld/HelloWorld.llvm
+++ b/test/examples-golden/positive/llvm/HelloWorld/HelloWorld.llvm
@@ -13,6 +13,9 @@ declare external fastcc  i8* @malloc(i32)
 declare external fastcc  void @free(i8*)    
 
 
+declare external fastcc  void @abort()    
+
+
 @LitString =    global [12 x i8] c"hello-world\00"
 
 

--- a/test/examples-golden/positive/llvm/Instructions/Instructions.llvm
+++ b/test/examples-golden/positive/llvm/Instructions/Instructions.llvm
@@ -13,6 +13,9 @@ declare external fastcc  i8* @malloc(i32)
 declare external fastcc  void @free(i8*)    
 
 
+declare external fastcc  void @abort()    
+
+
 @LitString =    global [14 x i8] c"Hello, world!\00"
 
 

--- a/test/examples-golden/positive/llvm/MainApply/MainApply.llvm
+++ b/test/examples-golden/positive/llvm/MainApply/MainApply.llvm
@@ -13,6 +13,9 @@ declare external fastcc  i8* @malloc(i32)
 declare external fastcc  void @free(i8*)    
 
 
+declare external fastcc  void @abort()    
+
+
 define external fastcc  i8 @lambda(i8**  %juvix_environmentArray, i8  %"0", i8  %"1")    {
 lambda1:
   ret i8 %"0" 

--- a/test/examples-golden/positive/llvm/MainLambda/MainLambda.llvm
+++ b/test/examples-golden/positive/llvm/MainLambda/MainLambda.llvm
@@ -13,6 +13,9 @@ declare external fastcc  i8* @malloc(i32)
 declare external fastcc  void @free(i8*)    
 
 
+declare external fastcc  void @abort()    
+
+
 define external fastcc  i8 @lambda(i8**  %juvix_environmentArray, i8  %"0", i8  %"1")    {
 lambda1:
   ret i8 %"1" 


### PR DESCRIPTION
This PR introduces sum types to LLVM, as #1106 does for record types.  It's only a draft right now, for two reasons:

- It's based off #1106 , which isn't merged yet, as it in turn is blocked waiting for the merge of https://github.com/anoma/juvix/tree/samuli/stack-nix .  (The commits specific to this PR begin after https://github.com/anoma/juvix/pull/1107/commits/dd0f5ad006386595d57e77d8395be501a285647d .)
- There is an open unsolved problem:  the code generation for a sum destructor (i.e. a case statement) takes a set of functions, one for each variant, mapping the variant type to the output type.  But I haven't been able to figure out yet how to get the environment at the point of the case statement and pass it to the code that generates the LLVM code for the case statement.  So it only works if the per-variant functions don't use their environment yet.  That's why `makeCase` has this `Block.null Closure.environmentPtr` instead of a potentially-populated environment:  https://github.com/anoma/juvix/blob/6cdac05639fe0df9c4e467c8a96d425cf816e11b/library/Backends/llvm/src/Juvix/Backends/LLVM/Codegen/Sum.hs#L158-L163