### PR TITLE
Fix `doc/` -> `docs/` links in several files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-compile: build update-local-stdlibs
 	rm test/examples/positive/llvm/*.ll
 
 bench:
-	$(STACK) bench --benchmark-arguments="--output ./doc/Code/bench.html"
+	$(STACK) bench --benchmark-arguments="--output ./docs/Code/bench.html"
 
 repl-lib:
 	$(STACK) ghci juvix:lib

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Contributing
 ------------
 
 We welcome contributions to the development of Juvix. See
-[CONTRIBUTING.md](./doc/CONTRIBUTING.md) for contribution guidelines.
+[CONTRIBUTING.md](./docs/CONTRIBUTING.md) for contribution guidelines.
 
 Community
 ---------

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome! Please follow the [style guide](https://github.com/cryptiumlabs/juvix/blob/develop/doc/STYLEGUIDE.md) and the below guidelines.
+Contributions are welcome! Please follow the [style guide](https://github.com/cryptiumlabs/juvix/blob/develop/docs/STYLEGUIDE.md) and the below guidelines.
 
 ### Installation requirements
 
@@ -8,14 +8,14 @@ Contributions are welcome! Please follow the [style guide](https://github.com/cr
 
 The formatter should run each time you commit. See "Pre-commit hooks"
 section below. See also the [style
-guide](https://github.com/cryptiumlabs/juvix/blob/develop/doc/STYLEGUIDE.md).
+guide](https://github.com/cryptiumlabs/juvix/blob/develop/docs/STYLEGUIDE.md).
 
 [Ormolu](https://github.com/tweag/ormolu) required for source formatting. Run
 `stack install ormolu` to get the latest version (0.0.3.1).
 
 #### Documentation Generator
 
-[Roswell](https://github.com/roswell/roswell) is required for automatic generation of documentation in [doc/Code](https://github.com/metastatedev/juvix/tree/develop/doc/Code).
+[Roswell](https://github.com/roswell/roswell) is required for automatic generation of documentation in [docs/Code](https://github.com/metastatedev/juvix/tree/develop/docs/Code).
 
 Once Roswell is installed one only needs to add `~/.roswell/bin` to their bash path along with running `ros install heliaxdev/org-generation`.
 

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -4,7 +4,7 @@ Juvix's Haskell Style Guide
 This document describes the preferred coding style for Juvix.
 When something isn't covered by this guide you should stay
 consistent with the existing code.
-See also [CONTRIBUTING.md](https://github.com/cryptiumlabs/juvix/blob/develop/doc/CONTRIBUTING.md).
+See also [CONTRIBUTING.md](https://github.com/cryptiumlabs/juvix/blob/develop/docs/CONTRIBUTING.md).
 
 HLint
 -----


### PR DESCRIPTION
This should also be fixed on the `How to contribute` button at https://juvix.org/community/, and there's also [one last file](https://github.com/anoma/juvix/blob/develop/experimental/ML%20Conversion/Conversion/ML.hs) that contains `doc/` but it liked to `doc/Aricheture/Sexp.org` which appears to have been deleted in [6cee9c52](https://github.com/anoma/juvix/commit/6cee9c52779c7fb487cae8bfa1d4a0373f4c0720) so I'm not sure how you would like to deal with this case.