### PR TITLE
Add debugging custom function to Prelude

### DIFF
--- a/src/Juvix/Prelude/Trace.hs
+++ b/src/Juvix/Prelude/Trace.hs
@@ -6,11 +6,11 @@ import GHC.IO (unsafePerformIO)
 import Juvix.Prelude.Base
 
 setDebugMsg :: Text -> Text
-setDebugMsg msg = "[debug] " <> fmsg
+setDebugMsg msg = "[debug] " <> fmsg <> "\n"
   where
     fmsg
       | Text.null msg = ""
-      | otherwise = msg <> " :\n"
+      | otherwise = msg <> " :"
 
 traceLabel :: Text -> Text -> a -> a
 traceLabel msg a = T.trace (unpack $ setDebugMsg msg <> a)

--- a/src/Juvix/Syntax/MicroJuvix/Pretty.hs
+++ b/src/Juvix/Syntax/MicroJuvix/Pretty.hs
@@ -10,6 +10,7 @@ import Juvix.Syntax.MicroJuvix.Pretty.Ann
 import Juvix.Syntax.MicroJuvix.Pretty.Ansi qualified as Ansi
 import Juvix.Syntax.MicroJuvix.Pretty.Base
 import Juvix.Syntax.MicroJuvix.Pretty.Options
+import Prettyprinter.Render.Terminal qualified as Ansi
 
 newtype PPOutput = PPOutput (Doc Ann)
 
@@ -20,7 +21,7 @@ ppOut :: PrettyCode c => Options -> c -> AnsiText
 ppOut o = AnsiText . PPOutput . doc o
 
 ppSimple :: PrettyCode c => c -> Text
-ppSimple = toAnsiText False . ppOutDefault
+ppSimple = Ansi.renderStrict . reAnnotateS Ansi.stylize . layoutPretty defaultLayoutOptions . doc defaultOptions
 
 instance HasAnsiBackend PPOutput where
   toAnsiStream (PPOutput o) = reAnnotateS Ansi.stylize (layoutPretty defaultLayoutOptions o)

--- a/src/Juvix/Syntax/MicroJuvix/TypeChecker.hs
+++ b/src/Juvix/Syntax/MicroJuvix/TypeChecker.hs
@@ -14,7 +14,6 @@ import Juvix.Syntax.MicroJuvix.Language.Extra
 import Juvix.Syntax.MicroJuvix.LocalVars
 import Juvix.Syntax.MicroJuvix.MicroJuvixArityResult
 import Juvix.Syntax.MicroJuvix.MicroJuvixTypedResult
-import Juvix.Syntax.MicroJuvix.Pretty
 import Juvix.Syntax.MicroJuvix.TypeChecker.Inference
 
 addIdens :: Member (State TypesTable) r => TypesTable -> Sem r ()


### PR DESCRIPTION
This PR adds a useful custom set of basic debugging functions to the Prelude. In addition, some warnings have been provided in case one forgets to remove them from the codebase.

The main functions are:

```haskell
traceLabel :: Text -> Text -> a -> a
trace :: Text -> a -> a
traceShow :: Show b => b -> b
traceToFile :: FilePath -> Text -> a -> a
traceToFile' :: Text -> a -> a
traceToFileM :: (Applicative m) => FilePath -> Text -> a -> m ()
```

An example of how to use them is the following.

```haskell
-- Typechecker.hs
...
checkStatement s = case s of
  StatementFunction fun -> StatementFunction <$> checkFunctionDef fun
  StatementForeign {} -> return s
  StatementInductive ind ->
     traceToFile "run.log" (ppSimple ind) $
     traceLabel "check inductiveTy" (ppSimple ind) $
     trace (ppSimple ind) $ do 
    ...
```

The output (with colors) looks like this (using `debugTextToFile'`)  :

```bash
juvix typecheck example.juvix
[debug] [./juvix.log]:
data T (A : Type) =
  c T
Well done! It type checks
```