### PR TITLE
Compute name dependency graph and filter unreachable definitions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ dependencies:
 - text == 1.2.*
 - th-utilities == 0.2.*
 - unordered-containers == 0.2.*
+- containers == 0.6.*
 
 # the tasty dependencies are here to avoid having to recompile
 # juvix when running the tests.

--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ dependencies:
 - base == 4.16.*
 - blaze-html == 0.9.*
 - bytestring == 0.11.*
+- containers == 0.6.*
 - directory == 1.3.*
 - edit-distance == 0.2.*
 - extra == 1.7.*
@@ -49,7 +50,6 @@ dependencies:
 - text == 1.2.*
 - th-utilities == 0.2.*
 - unordered-containers == 0.2.*
-- containers == 0.6.*
 
 # the tasty dependencies are here to avoid having to recompile
 # juvix when running the tests.

--- a/src/Juvix/Analysis/Scoping/Scoper.hs
+++ b/src/Juvix/Analysis/Scoping/Scoper.hs
@@ -50,15 +50,16 @@ scopeCheck pr root modules =
         runReader scopeParameters $
           evalState iniScoperState $ do
             mergeTable (pr ^. Parser.resultTable)
-            mapM checkTopModule_ modules
+            checkTopModules modules
   where
-    mkResult :: (Parser.InfoTable, (InfoTable, NonEmpty (Module 'Scoped 'ModuleTop))) -> ScoperResult
-    mkResult (pt, (st, ms)) =
+    mkResult :: (Parser.InfoTable, (InfoTable, (NonEmpty (Module 'Scoped 'ModuleTop), HashSet NameId))) -> ScoperResult
+    mkResult (pt, (st, (ms, exp))) =
       ScoperResult
         { _resultParserResult = pr,
           _resultParserTable = pt,
           _resultScoperTable = st,
-          _resultModules = ms
+          _resultModules = ms,
+          _resultExports = exp
         }
     iniScoperState :: ScoperState
     iniScoperState =
@@ -474,6 +475,26 @@ checkInductiveDef ty@InductiveDef {..} = do
           _inductiveConstructors = inductiveConstructors',
           _inductivePositive = ty ^. inductivePositive
         }
+
+createExportsTable :: ExportInfo -> HashSet NameId
+createExportsTable ei = foldr (HashSet.insert . getNameId) HashSet.empty (HashMap.elems (ei ^. exportSymbols))
+  where
+    getNameId = \case
+      EntryAxiom r -> getNameRefId (r ^. axiomRefName)
+      EntryInductive r -> getNameRefId (r ^. inductiveRefName)
+      EntryFunction r -> getNameRefId (r ^. functionRefName)
+      EntryConstructor r -> getNameRefId (r ^. constructorRefName)
+      EntryModule r -> getNameRefId (getModuleRefNameType r)
+
+checkTopModules ::
+  forall r.
+  Members '[Error ScoperError, Reader ScopeParameters, Files, State ScoperState, InfoTableBuilder, Parser.InfoTableBuilder, NameIdGen] r =>
+  NonEmpty (Module 'Parsed 'ModuleTop) ->
+  Sem r (NonEmpty (Module 'Scoped 'ModuleTop), HashSet NameId)
+checkTopModules modules = do
+  r <- checkTopModule (head modules)
+  mods <- (:|) (r ^. moduleRefModule) <$> mapM checkTopModule_ (NonEmpty.tail modules)
+  return (mods, createExportsTable (r ^. moduleExportInfo))
 
 checkTopModule_ ::
   forall r.

--- a/src/Juvix/Analysis/Scoping/Scoper.hs
+++ b/src/Juvix/Analysis/Scoping/Scoper.hs
@@ -493,7 +493,7 @@ checkTopModules ::
   Sem r (NonEmpty (Module 'Scoped 'ModuleTop), HashSet NameId)
 checkTopModules modules = do
   r <- checkTopModule (head modules)
-  mods <- (:|) (r ^. moduleRefModule) <$> mapM checkTopModule_ (NonEmpty.tail modules)
+  mods <- (r ^. moduleRefModule :|) <$> mapM checkTopModule_ (NonEmpty.tail modules)
   return (mods, createExportsTable (r ^. moduleExportInfo))
 
 checkTopModule_ ::

--- a/src/Juvix/Analysis/Scoping/ScoperResult.hs
+++ b/src/Juvix/Analysis/Scoping/ScoperResult.hs
@@ -2,9 +2,9 @@ module Juvix.Analysis.Scoping.ScoperResult where
 
 import Juvix.Parsing.Parser qualified as Parser
 import Juvix.Prelude
-import Juvix.Syntax.NameId
 import Juvix.Syntax.Concrete.Language
 import Juvix.Syntax.Concrete.Scoped.InfoTable qualified as Scoped
+import Juvix.Syntax.NameId
 
 data ScoperResult = ScoperResult
   { _resultParserResult :: Parser.ParserResult,

--- a/src/Juvix/Analysis/Scoping/ScoperResult.hs
+++ b/src/Juvix/Analysis/Scoping/ScoperResult.hs
@@ -2,6 +2,7 @@ module Juvix.Analysis.Scoping.ScoperResult where
 
 import Juvix.Parsing.Parser qualified as Parser
 import Juvix.Prelude
+import Juvix.Syntax.NameId
 import Juvix.Syntax.Concrete.Language
 import Juvix.Syntax.Concrete.Scoped.InfoTable qualified as Scoped
 
@@ -9,7 +10,8 @@ data ScoperResult = ScoperResult
   { _resultParserResult :: Parser.ParserResult,
     _resultParserTable :: Parser.InfoTable,
     _resultScoperTable :: Scoped.InfoTable,
-    _resultModules :: NonEmpty (Module 'Scoped 'ModuleTop)
+    _resultModules :: NonEmpty (Module 'Scoped 'ModuleTop),
+    _resultExports :: HashSet NameId
   }
 
 makeLenses ''ScoperResult

--- a/src/Juvix/DependencyInfo.hs
+++ b/src/Juvix/DependencyInfo.hs
@@ -1,0 +1,52 @@
+module Juvix.DependencyInfo where
+
+import Data.Graph (Graph, Vertex)
+import Data.Graph qualified as Graph
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
+import Juvix.Prelude
+
+-- DependencyInfo is polymorphic to anticipate future use with other identifier
+-- types in JuvixCore and further. The graph algorithms don't depend on the
+-- exact type of names (the polymorphic type n), so I see no reason to
+-- specialise DependencyInfo to any particular name type
+data DependencyInfo n = DependencyInfo
+  { _depInfoGraph :: Graph,
+    _depInfoNodeFromVertex :: Vertex -> (n, [n]),
+    _depInfoVertexFromName :: n -> Maybe Vertex,
+    _depInfoReachable :: Maybe (HashSet n)
+  }
+
+makeLenses ''DependencyInfo
+
+createDependencyInfo :: Ord n => HashMap n [n] -> DependencyInfo n
+createDependencyInfo edges =
+  DependencyInfo
+    { _depInfoGraph = graph,
+      _depInfoNodeFromVertex = \v -> case nodeFromVertex v of (_, x, y) -> (x, y),
+      _depInfoVertexFromName = vertexFromName,
+      _depInfoReachable = Nothing
+    }
+  where
+    (graph, nodeFromVertex, vertexFromName) =
+      Graph.graphFromEdges $
+        map (\(x, y) -> (x, x, nubSort y)) (HashMap.toList edges)
+
+nameFromVertex :: DependencyInfo n -> Vertex -> n
+nameFromVertex depInfo v = fst $ (depInfo ^. depInfoNodeFromVertex) v
+
+computeReachability :: Hashable n => DependencyInfo n -> [n] -> DependencyInfo n
+computeReachability depInfo startNames =
+  depInfo {_depInfoReachable = Just reachableNames}
+  where
+    reachableNames =
+      HashSet.fromList $
+        map (nameFromVertex depInfo) $
+          concatMap (Graph.reachable (depInfo ^. depInfoGraph)) startVertices
+    startVertices = mapMaybe (depInfo ^. depInfoVertexFromName) startNames
+
+isReachable :: Hashable n => DependencyInfo n -> n -> Bool
+isReachable depInfo n = HashSet.member n (fromMaybe err (depInfo ^. depInfoReachable))
+  where
+    err :: a
+    err = error "call `computeReachability` before using `isReachable`"

--- a/src/Juvix/DependencyInfo.hs
+++ b/src/Juvix/DependencyInfo.hs
@@ -12,7 +12,7 @@ import Juvix.Prelude
 -- specialise DependencyInfo to any particular name type
 data DependencyInfo n = DependencyInfo
   { _depInfoGraph :: Graph,
-    _depInfoNodeFromVertex :: Vertex -> (n, [n]),
+    _depInfoNodeFromVertex :: Vertex -> (n, HashSet n),
     _depInfoVertexFromName :: n -> Maybe Vertex,
     _depInfoReachable :: HashSet n
   }
@@ -23,7 +23,7 @@ createDependencyInfo :: (Hashable n, Ord n) => HashMap n (HashSet n) -> HashSet 
 createDependencyInfo edges startNames =
   DependencyInfo
     { _depInfoGraph = graph,
-      _depInfoNodeFromVertex = \v -> case nodeFromVertex v of (_, x, y) -> (x, y),
+      _depInfoNodeFromVertex = \v -> case nodeFromVertex v of (_, x, y) -> (x, HashSet.fromList y),
       _depInfoVertexFromName = vertexFromName,
       _depInfoReachable = reachableNames
     }

--- a/src/Juvix/DependencyInfo.hs
+++ b/src/Juvix/DependencyInfo.hs
@@ -8,45 +8,37 @@ import Juvix.Prelude
 
 -- DependencyInfo is polymorphic to anticipate future use with other identifier
 -- types in JuvixCore and further. The graph algorithms don't depend on the
--- exact type of names (the polymorphic type n), so I see no reason to
+-- exact type of names (the polymorphic type n), so there is no reason to
 -- specialise DependencyInfo to any particular name type
 data DependencyInfo n = DependencyInfo
   { _depInfoGraph :: Graph,
     _depInfoNodeFromVertex :: Vertex -> (n, [n]),
     _depInfoVertexFromName :: n -> Maybe Vertex,
-    _depInfoReachable :: Maybe (HashSet n)
+    _depInfoReachable :: HashSet n
   }
 
 makeLenses ''DependencyInfo
 
-createDependencyInfo :: Ord n => HashMap n [n] -> DependencyInfo n
-createDependencyInfo edges =
+createDependencyInfo :: (Hashable n, Ord n) => HashMap n (HashSet n) -> HashSet n -> DependencyInfo n
+createDependencyInfo edges startNames =
   DependencyInfo
     { _depInfoGraph = graph,
       _depInfoNodeFromVertex = \v -> case nodeFromVertex v of (_, x, y) -> (x, y),
       _depInfoVertexFromName = vertexFromName,
-      _depInfoReachable = Nothing
+      _depInfoReachable = reachableNames
     }
   where
     (graph, nodeFromVertex, vertexFromName) =
       Graph.graphFromEdges $
-        map (\(x, y) -> (x, x, nubSort y)) (HashMap.toList edges)
+        map (\(x, y) -> (x, x, HashSet.toList y)) (HashMap.toList edges)
+    reachableNames =
+      HashSet.fromList $
+        map (\v -> case nodeFromVertex v of (_, x, _) -> x) $
+          concatMap (Graph.reachable graph) startVertices
+    startVertices = mapMaybe vertexFromName (HashSet.toList startNames)
 
 nameFromVertex :: DependencyInfo n -> Vertex -> n
 nameFromVertex depInfo v = fst $ (depInfo ^. depInfoNodeFromVertex) v
 
-computeReachability :: Hashable n => DependencyInfo n -> [n] -> DependencyInfo n
-computeReachability depInfo startNames =
-  depInfo {_depInfoReachable = Just reachableNames}
-  where
-    reachableNames =
-      HashSet.fromList $
-        map (nameFromVertex depInfo) $
-          concatMap (Graph.reachable (depInfo ^. depInfoGraph)) startVertices
-    startVertices = mapMaybe (depInfo ^. depInfoVertexFromName) startNames
-
 isReachable :: Hashable n => DependencyInfo n -> n -> Bool
-isReachable depInfo n = HashSet.member n (fromMaybe err (depInfo ^. depInfoReachable))
-  where
-    err :: a
-    err = error "call `computeReachability` before using `isReachable`"
+isReachable depInfo n = HashSet.member n (depInfo ^. depInfoReachable)

--- a/src/Juvix/Syntax/Abstract/AbstractResult.hs
+++ b/src/Juvix/Syntax/Abstract/AbstractResult.hs
@@ -14,7 +14,8 @@ import Juvix.Syntax.Abstract.Language
 data AbstractResult = AbstractResult
   { _resultScoper :: ScoperResult,
     _resultTable :: InfoTable,
-    _resultModules :: NonEmpty TopModule
+    _resultModules :: NonEmpty TopModule,
+    _resultExports :: HashSet NameId
   }
 
 makeLenses ''AbstractResult

--- a/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
+++ b/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
@@ -2,30 +2,51 @@ module Juvix.Syntax.Abstract.DependencyBuilder (buildDependencyInfo) where
 
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
-import Juvix.DependencyInfo
 import Juvix.Prelude
 import Juvix.Syntax.Abstract.Language
+import Juvix.Syntax.Abstract.NameDependencyInfo
 
--- adjacency list representation
-type DependencyGraph = HashMap Name [Name]
+-- adjacency set representation
+type DependencyGraph = HashMap Name (HashSet Name)
+
+type StartNodes = HashSet Name
 
 type VisitedModules = HashSet Name
 
-buildDependencyInfo :: [TopModule] -> DependencyInfo Name
-buildDependencyInfo ms =
-  createDependencyInfo
-    (fst (run (evalState (HashSet.empty :: VisitedModules) (runState HashMap.empty (mapM_ goModule ms)))))
+type ExportsTable = HashSet NameId
+
+buildDependencyInfo :: NonEmpty TopModule -> ExportsTable -> NameDependencyInfo
+buildDependencyInfo ms tab =
+  createDependencyInfo graph startNodes
+  where
+    (startNodes, graph) =
+      run $
+        evalState (HashSet.empty :: VisitedModules) $
+          runState HashSet.empty $
+            execState HashMap.empty $
+              runReader tab $
+                mapM_ goModule ms
+
+addStartNode :: Member (State StartNodes) r => Name -> Sem r ()
+addStartNode n = modify (HashSet.insert n)
 
 addEdge :: Member (State DependencyGraph) r => Name -> Name -> Sem r ()
 addEdge n1 n2 =
   modify
     ( HashMap.alter
         ( \case
-            Just ns -> Just (n2 : ns)
-            Nothing -> Just [n2]
+            Just ns -> Just (HashSet.insert n2 ns)
+            Nothing -> Just (HashSet.singleton n2)
         )
         n1
     )
+
+checkStartNode :: Members '[Reader ExportsTable, State StartNodes] r => Name -> Sem r ()
+checkStartNode n = do
+  tab <- ask
+  if
+    | HashSet.member (n ^. nameId) tab -> addStartNode n
+    | otherwise -> return ()
 
 guardNotVisited :: Member (State VisitedModules) r => Name -> Sem r () -> Sem r ()
 guardNotVisited n cont = do
@@ -36,41 +57,52 @@ guardNotVisited n cont = do
           put (HashSet.insert n s)
           cont
 
-goModule :: Members '[State DependencyGraph, State VisitedModules] r => Module -> Sem r ()
-goModule m =
+goModule :: Members '[Reader ExportsTable, State DependencyGraph, State StartNodes, State VisitedModules] r => Module -> Sem r ()
+goModule m = do
+  checkStartNode (m ^. moduleName)
   mapM_ (goStatement (m ^. moduleName)) (m ^. (moduleBody . moduleStatements))
 
-goLocalModule :: Members '[State DependencyGraph, State VisitedModules] r => Name -> Module -> Sem r ()
+goLocalModule :: Members '[Reader ExportsTable, State DependencyGraph, State StartNodes, State VisitedModules] r => Name -> Module -> Sem r ()
 goLocalModule mn m = do
   addEdge (m ^. moduleName) mn
   goModule m
 
 -- declarations in a module depend on the module, not the other way round (a
 -- module is reachable if at least one of the declarations in it is reachable)
-goStatement :: Members '[State DependencyGraph, State VisitedModules] r => Name -> Statement -> Sem r ()
+goStatement :: Members '[Reader ExportsTable, State DependencyGraph, State StartNodes, State VisitedModules] r => Name -> Statement -> Sem r ()
 goStatement mn = \case
   StatementAxiom ax -> do
+    checkStartNode (ax ^. axiomName)
     addEdge (ax ^. axiomName) mn
     goExpression (ax ^. axiomName) (ax ^. axiomType)
   StatementForeign {} -> return ()
   StatementFunction f -> do
+    checkStartNode (f ^. funDefName)
     addEdge (f ^. funDefName) mn
     goExpression (f ^. funDefName) (f ^. funDefTypeSig)
     mapM_ (goFunctionClause (f ^. funDefName)) (f ^. funDefClauses)
   StatementImport m -> guardNotVisited (m ^. moduleName) (goModule m)
   StatementLocalModule m -> goLocalModule mn m
   StatementInductive i -> do
+    checkStartNode (i ^. inductiveName)
     addEdge (i ^. inductiveName) mn
     mapM_ (goFunctionParameter (i ^. inductiveName)) (i ^. inductiveParameters)
     goExpression (i ^. inductiveName) (i ^. inductiveType)
     mapM_ (goConstructorDef (i ^. inductiveName)) (i ^. inductiveConstructors)
 
-goFunctionClause :: Members '[State DependencyGraph, State VisitedModules] r => Name -> FunctionClause -> Sem r ()
+-- constructors of an inductive type depend on the inductive type, not the other
+-- way round
+goConstructorDef :: Member (State DependencyGraph) r => Name -> InductiveConstructorDef -> Sem r ()
+goConstructorDef indName c = do
+  addEdge (c ^. constructorName) indName
+  goExpression (c ^. constructorName) (c ^. constructorType)
+
+goFunctionClause :: Member (State DependencyGraph) r => Name -> FunctionClause -> Sem r ()
 goFunctionClause p c = goExpression p (c ^. clauseBody)
 
-goExpression :: Members '[State DependencyGraph, State VisitedModules] r => Name -> Expression -> Sem r ()
+goExpression :: Member (State DependencyGraph) r => Name -> Expression -> Sem r ()
 goExpression p e = case e of
-  ExpressionIden i -> addEdge p (getName i)
+  ExpressionIden i -> addEdge p (getIdenName i)
   ExpressionUniverse {} -> return ()
   ExpressionFunction f -> do
     goFunctionParameter p (f ^. funParameter)
@@ -81,12 +113,5 @@ goExpression p e = case e of
   ExpressionLiteral {} -> return ()
   ExpressionHole {} -> return ()
 
-goFunctionParameter :: Members '[State DependencyGraph, State VisitedModules] r => Name -> FunctionParameter -> Sem r ()
+goFunctionParameter :: Member (State DependencyGraph) r => Name -> FunctionParameter -> Sem r ()
 goFunctionParameter p param = goExpression p (param ^. paramType)
-
--- constructors of an inductive type depend on the inductive type, not the other
--- way round
-goConstructorDef :: Members '[State DependencyGraph, State VisitedModules] r => Name -> InductiveConstructorDef -> Sem r ()
-goConstructorDef indName c = do
-  addEdge (c ^. constructorName) indName
-  goExpression (c ^. constructorName) (c ^. constructorType)

--- a/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
+++ b/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
@@ -55,6 +55,7 @@ goStatement mn = \case
   StatementForeign {} -> return ()
   StatementFunction f -> do
     addEdge (f ^. funDefName) mn
+    goExpression (f ^. funDefName) (f ^. funDefTypeSig)
     mapM_ (goFunctionClause (f ^. funDefName)) (f ^. funDefClauses)
   StatementImport m -> guardNotVisited (m ^. moduleName) (goModule m)
   StatementLocalModule m -> goLocalModule mn m

--- a/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
+++ b/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
@@ -45,8 +45,8 @@ checkStartNode :: Members '[Reader ExportsTable, State StartNodes] r => Name -> 
 checkStartNode n = do
   tab <- ask
   if
-    | HashSet.member (n ^. nameId) tab -> addStartNode n
-    | otherwise -> return ()
+      | HashSet.member (n ^. nameId) tab -> addStartNode n
+      | otherwise -> return ()
 
 guardNotVisited :: Member (State VisitedModules) r => Name -> Sem r () -> Sem r ()
 guardNotVisited n cont = do

--- a/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
+++ b/src/Juvix/Syntax/Abstract/DependencyBuilder.hs
@@ -1,0 +1,91 @@
+module Juvix.Syntax.Abstract.DependencyBuilder (buildDependencyInfo) where
+
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
+import Juvix.DependencyInfo
+import Juvix.Prelude
+import Juvix.Syntax.Abstract.Language
+
+-- adjacency list representation
+type DependencyGraph = HashMap Name [Name]
+
+type VisitedModules = HashSet Name
+
+buildDependencyInfo :: [TopModule] -> DependencyInfo Name
+buildDependencyInfo ms =
+  createDependencyInfo
+    (fst (run (evalState (HashSet.empty :: VisitedModules) (runState HashMap.empty (mapM_ goModule ms)))))
+
+addEdge :: Member (State DependencyGraph) r => Name -> Name -> Sem r ()
+addEdge n1 n2 =
+  modify
+    ( HashMap.alter
+        ( \case
+            Just ns -> Just (n2 : ns)
+            Nothing -> Just [n2]
+        )
+        n1
+    )
+
+guardNotVisited :: Member (State VisitedModules) r => Name -> Sem r () -> Sem r ()
+guardNotVisited n cont = do
+  s <- get
+  if
+      | HashSet.member n s -> return ()
+      | otherwise -> do
+          put (HashSet.insert n s)
+          cont
+
+goModule :: Members '[State DependencyGraph, State VisitedModules] r => Module -> Sem r ()
+goModule m =
+  mapM_ (goStatement (m ^. moduleName)) (m ^. (moduleBody . moduleStatements))
+
+goLocalModule :: Members '[State DependencyGraph, State VisitedModules] r => Name -> Module -> Sem r ()
+goLocalModule mn m = do
+  addEdge (m ^. moduleName) mn
+  goModule m
+
+-- declarations in a module depend on the module, not the other way round (a
+-- module is reachable if at least one of the declarations in it is reachable)
+goStatement :: Members '[State DependencyGraph, State VisitedModules] r => Name -> Statement -> Sem r ()
+goStatement mn = \case
+  StatementAxiom ax -> do
+    addEdge (ax ^. axiomName) mn
+    goExpression (ax ^. axiomName) (ax ^. axiomType)
+  StatementForeign {} -> return ()
+  StatementFunction f -> do
+    addEdge (f ^. funDefName) mn
+    mapM_ (goFunctionClause (f ^. funDefName)) (f ^. funDefClauses)
+  StatementImport m -> guardNotVisited (m ^. moduleName) (goModule m)
+  StatementLocalModule m -> goLocalModule mn m
+  StatementInductive i -> do
+    addEdge (i ^. inductiveName) mn
+    mapM_ (goFunctionParameter (i ^. inductiveName)) (i ^. inductiveParameters)
+    goExpression (i ^. inductiveName) (i ^. inductiveType)
+    mapM_ (goConstructorDef (i ^. inductiveName)) (i ^. inductiveConstructors)
+
+goFunctionClause :: Members '[State DependencyGraph, State VisitedModules] r => Name -> FunctionClause -> Sem r ()
+goFunctionClause p c = goExpression p (c ^. clauseBody)
+
+goExpression :: Members '[State DependencyGraph, State VisitedModules] r => Name -> Expression -> Sem r ()
+goExpression p e = case e of
+  ExpressionIden i -> addEdge p (getName i)
+  ExpressionUniverse {} -> return ()
+  ExpressionFunction f -> do
+    goFunctionParameter p (f ^. funParameter)
+    goExpression p (f ^. funReturn)
+  ExpressionApplication (Application l r _) -> do
+    goExpression p l
+    goExpression p r
+  ExpressionLiteral {} -> return ()
+  ExpressionHole {} -> return ()
+
+goFunctionParameter :: Members '[State DependencyGraph, State VisitedModules] r => Name -> FunctionParameter -> Sem r ()
+goFunctionParameter p param = goExpression p (param ^. paramType)
+
+-- constructors of an inductive type depend on the inductive type, not the other
+-- way round
+goConstructorDef :: Members '[State DependencyGraph, State VisitedModules] r => Name -> InductiveConstructorDef -> Sem r ()
+goConstructorDef indName c = do
+  addEdge (c ^. constructorName) indName
+  goExpression (c ^. constructorName) (c ^. constructorType)

--- a/src/Juvix/Syntax/Abstract/Language.hs
+++ b/src/Juvix/Syntax/Abstract/Language.hs
@@ -219,3 +219,11 @@ instance HasLoc AxiomDef where
 
 instance HasLoc FunctionDef where
   getLoc = getLoc . (^. funDefName)
+
+getName :: Iden -> Name
+getName = \case
+  IdenFunction r -> r ^. functionRefName
+  IdenConstructor r -> r ^. constructorRefName
+  IdenVar n -> n
+  IdenAxiom r -> r ^. axiomRefName
+  IdenInductive r -> r ^. inductiveRefName

--- a/src/Juvix/Syntax/Abstract/Language.hs
+++ b/src/Juvix/Syntax/Abstract/Language.hs
@@ -219,11 +219,3 @@ instance HasLoc AxiomDef where
 
 instance HasLoc FunctionDef where
   getLoc = getLoc . (^. funDefName)
-
-getIdenName :: Iden -> Name
-getIdenName = \case
-  IdenFunction r -> r ^. functionRefName
-  IdenConstructor r -> r ^. constructorRefName
-  IdenVar n -> n
-  IdenAxiom r -> r ^. axiomRefName
-  IdenInductive r -> r ^. inductiveRefName

--- a/src/Juvix/Syntax/Abstract/Language.hs
+++ b/src/Juvix/Syntax/Abstract/Language.hs
@@ -220,8 +220,8 @@ instance HasLoc AxiomDef where
 instance HasLoc FunctionDef where
   getLoc = getLoc . (^. funDefName)
 
-getName :: Iden -> Name
-getName = \case
+getIdenName :: Iden -> Name
+getIdenName = \case
   IdenFunction r -> r ^. functionRefName
   IdenConstructor r -> r ^. constructorRefName
   IdenVar n -> n

--- a/src/Juvix/Syntax/Abstract/NameDependencyInfo.hs
+++ b/src/Juvix/Syntax/Abstract/NameDependencyInfo.hs
@@ -1,0 +1,9 @@
+module Juvix.Syntax.Abstract.NameDependencyInfo(
+    module Juvix.Syntax.Abstract.NameDependencyInfo,
+    module Juvix.DependencyInfo
+) where
+
+import Juvix.DependencyInfo
+import Juvix.Syntax.Abstract.Name
+
+type NameDependencyInfo = DependencyInfo Name

--- a/src/Juvix/Syntax/Abstract/NameDependencyInfo.hs
+++ b/src/Juvix/Syntax/Abstract/NameDependencyInfo.hs
@@ -1,7 +1,8 @@
-module Juvix.Syntax.Abstract.NameDependencyInfo(
-    module Juvix.Syntax.Abstract.NameDependencyInfo,
-    module Juvix.DependencyInfo
-) where
+module Juvix.Syntax.Abstract.NameDependencyInfo
+  ( module Juvix.Syntax.Abstract.NameDependencyInfo,
+    module Juvix.DependencyInfo,
+  )
+where
 
 import Juvix.DependencyInfo
 import Juvix.Syntax.Abstract.Name

--- a/src/Juvix/Syntax/MicroJuvix/MicroJuvixResult.hs
+++ b/src/Juvix/Syntax/MicroJuvix/MicroJuvixResult.hs
@@ -5,19 +5,17 @@ module Juvix.Syntax.MicroJuvix.MicroJuvixResult
 where
 
 import Juvix.Pipeline.EntryPoint qualified as E
-import Juvix.DependencyInfo qualified as DepInfo
+import Juvix.Syntax.Abstract.NameDependencyInfo qualified as DepInfo
 import Juvix.Prelude
 import Juvix.Syntax.Abstract.AbstractResult qualified as Abstract
 import Juvix.Syntax.MicroJuvix.InfoTable
 import Juvix.Syntax.MicroJuvix.Language
 
-type DependencyInfo = DepInfo.DependencyInfo Name
-
 data MicroJuvixResult = MicroJuvixResult
   { _resultAbstract :: Abstract.AbstractResult,
     -- _resultTable :: InfoTable,
     _resultModules :: NonEmpty Module,
-    _resultDepInfo :: DependencyInfo
+    _resultDepInfo :: DepInfo.NameDependencyInfo
   }
 
 makeLenses ''MicroJuvixResult

--- a/src/Juvix/Syntax/MicroJuvix/MicroJuvixResult.hs
+++ b/src/Juvix/Syntax/MicroJuvix/MicroJuvixResult.hs
@@ -5,9 +5,9 @@ module Juvix.Syntax.MicroJuvix.MicroJuvixResult
 where
 
 import Juvix.Pipeline.EntryPoint qualified as E
-import Juvix.Syntax.Abstract.NameDependencyInfo qualified as DepInfo
 import Juvix.Prelude
 import Juvix.Syntax.Abstract.AbstractResult qualified as Abstract
+import Juvix.Syntax.Abstract.NameDependencyInfo qualified as DepInfo
 import Juvix.Syntax.MicroJuvix.InfoTable
 import Juvix.Syntax.MicroJuvix.Language
 

--- a/src/Juvix/Syntax/MicroJuvix/MicroJuvixResult.hs
+++ b/src/Juvix/Syntax/MicroJuvix/MicroJuvixResult.hs
@@ -5,15 +5,19 @@ module Juvix.Syntax.MicroJuvix.MicroJuvixResult
 where
 
 import Juvix.Pipeline.EntryPoint qualified as E
+import Juvix.DependencyInfo qualified as DepInfo
 import Juvix.Prelude
 import Juvix.Syntax.Abstract.AbstractResult qualified as Abstract
 import Juvix.Syntax.MicroJuvix.InfoTable
 import Juvix.Syntax.MicroJuvix.Language
 
+type DependencyInfo = DepInfo.DependencyInfo Name
+
 data MicroJuvixResult = MicroJuvixResult
   { _resultAbstract :: Abstract.AbstractResult,
     -- _resultTable :: InfoTable,
-    _resultModules :: NonEmpty Module
+    _resultModules :: NonEmpty Module,
+    _resultDepInfo :: DependencyInfo
   }
 
 makeLenses ''MicroJuvixResult

--- a/src/Juvix/Syntax/MicroJuvix/Reachability.hs
+++ b/src/Juvix/Syntax/MicroJuvix/Reachability.hs
@@ -1,0 +1,52 @@
+module Juvix.Syntax.MicroJuvix.Reachability where
+
+import Juvix.DependencyInfo qualified as DepInfo
+import Juvix.Prelude
+import Juvix.Syntax.MicroJuvix.Language
+import Juvix.Syntax.MicroJuvix.MicroJuvixArityResult qualified as MicroArity
+import Juvix.Syntax.MicroJuvix.MicroJuvixResult
+import Juvix.Syntax.MicroJuvix.MicroJuvixTypedResult qualified as MicroTyped
+
+filterUnreachable :: MicroTyped.MicroJuvixTypedResult -> MicroTyped.MicroJuvixTypedResult
+filterUnreachable r = r {MicroTyped._resultModules = modules'}
+  where
+    depInfo =
+      DepInfo.computeReachability
+        (r ^. (MicroTyped.resultMicroJuvixArityResult . MicroArity.resultMicroJuvixResult . resultDepInfo))
+        startNames
+    startNames = getTopLevelNames (head modules)
+    modules = r ^. MicroTyped.resultModules
+    modules' = run $ runReader depInfo (mapM goModule modules)
+
+getTopLevelNames :: Module -> [Name]
+getTopLevelNames m = mapMaybe getDeclName (m ^. (moduleBody . moduleStatements))
+  where
+    getDeclName :: Statement -> Maybe Name
+    getDeclName = \case
+      StatementInductive i -> Just (i ^. inductiveName)
+      StatementFunction f -> Just (f ^. funDefName)
+      StatementForeign {} -> Nothing
+      StatementAxiom ax -> Just (ax ^. axiomName)
+      StatementInclude {} -> Nothing
+
+returnIfReachable :: Member (Reader DependencyInfo) r => Name -> a -> Sem r (Maybe a)
+returnIfReachable n a = do
+  depInfo <- ask
+  return $ if DepInfo.isReachable depInfo n then Just a else Nothing
+
+goModule :: Member (Reader DependencyInfo) r => Module -> Sem r Module
+goModule m = do
+  stmts <- mapM goStatement (body ^. moduleStatements)
+  return m {_moduleBody = body {_moduleStatements = catMaybes stmts}}
+  where
+    body = m ^. moduleBody
+
+goStatement :: Member (Reader DependencyInfo) r => Statement -> Sem r (Maybe Statement)
+goStatement s = case s of
+  StatementInductive i -> returnIfReachable (i ^. inductiveName) s
+  StatementFunction f -> returnIfReachable (f ^. funDefName) s
+  StatementForeign {} -> return (Just s)
+  StatementAxiom ax -> returnIfReachable (ax ^. axiomName) s
+  StatementInclude i -> do
+    m <- goModule (i ^. includeModule)
+    return (Just (StatementInclude i {_includeModule = m}))

--- a/src/Juvix/Syntax/MicroJuvix/Reachability.hs
+++ b/src/Juvix/Syntax/MicroJuvix/Reachability.hs
@@ -1,7 +1,7 @@
 module Juvix.Syntax.MicroJuvix.Reachability where
 
-import Juvix.Syntax.Abstract.NameDependencyInfo
 import Juvix.Prelude
+import Juvix.Syntax.Abstract.NameDependencyInfo
 import Juvix.Syntax.MicroJuvix.Language
 import Juvix.Syntax.MicroJuvix.MicroJuvixArityResult qualified as MicroArity
 import Juvix.Syntax.MicroJuvix.MicroJuvixResult

--- a/src/Juvix/Translation/AbstractToMicroJuvix.hs
+++ b/src/Juvix/Translation/AbstractToMicroJuvix.hs
@@ -10,6 +10,7 @@ import Juvix.Analysis.Termination.Checker
 import Juvix.Pipeline.EntryPoint qualified as E
 import Juvix.Prelude
 import Juvix.Syntax.Abstract.AbstractResult qualified as Abstract
+import Juvix.Syntax.Abstract.DependencyBuilder
 import Juvix.Syntax.Abstract.Language qualified as Abstract
 import Juvix.Syntax.MicroJuvix.Error
 import Juvix.Syntax.MicroJuvix.Language
@@ -51,7 +52,8 @@ entryMicroJuvix abstractResults = do
   return
     MicroJuvixResult
       { _resultAbstract = abstractResults,
-        _resultModules = _resultModules'
+        _resultModules = _resultModules',
+        _resultDepInfo = depInfo
       }
   where
     topModule = head (abstractResults ^. Abstract.resultModules)
@@ -60,6 +62,7 @@ entryMicroJuvix abstractResults = do
       abstractResults
         ^. Abstract.abstractResultEntryPoint
         . E.entryPointNoTermination
+    depInfo = buildDependencyInfo (toList (abstractResults ^. Abstract.resultModules))
 
 goModule ::
   Members '[State TranslationState, Error TypeCheckerError] r =>

--- a/src/Juvix/Translation/AbstractToMicroJuvix.hs
+++ b/src/Juvix/Translation/AbstractToMicroJuvix.hs
@@ -62,7 +62,7 @@ entryMicroJuvix abstractResults = do
       abstractResults
         ^. Abstract.abstractResultEntryPoint
         . E.entryPointNoTermination
-    depInfo = buildDependencyInfo (toList (abstractResults ^. Abstract.resultModules))
+    depInfo = buildDependencyInfo (abstractResults ^. Abstract.resultModules) (abstractResults ^. Abstract.resultExports)
 
 goModule ::
   Members '[State TranslationState, Error TypeCheckerError] r =>

--- a/src/Juvix/Translation/ScopedToAbstract.hs
+++ b/src/Juvix/Translation/ScopedToAbstract.hs
@@ -29,6 +29,7 @@ unsupported msg = error $ msg <> "Scoped to Abstract: not yet supported"
 entryAbstract :: Members '[Error ScoperError, Builtins, NameIdGen] r => Scoper.ScoperResult -> Sem r AbstractResult
 entryAbstract _resultScoper = do
   (_resultTable, _resultModules) <- runInfoTableBuilder (evalState (ModulesCache mempty) (mapM goTopModule ms))
+  let _resultExports = _resultScoper ^. Scoper.resultExports
   return AbstractResult {..}
   where
     ms = _resultScoper ^. Scoper.resultModules

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,6 +7,7 @@ import MonoJuvix qualified
 import Scope qualified
 import Termination qualified
 import TypeCheck qualified
+import Reachability qualified
 
 slowTests :: TestTree
 slowTests =
@@ -22,6 +23,7 @@ fastTests =
       Termination.allTests,
       Arity.allTests,
       TypeCheck.allTests,
+      Reachability.allTests,
       MonoJuvix.allTests
     ]
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,10 +4,10 @@ import Arity qualified
 import BackendC qualified
 import Base
 import MonoJuvix qualified
+import Reachability qualified
 import Scope qualified
 import Termination qualified
 import TypeCheck qualified
-import Reachability qualified
 
 slowTests :: TestTree
 slowTests =

--- a/test/Reachability.hs
+++ b/test/Reachability.hs
@@ -1,0 +1,10 @@
+module Reachability
+  ( allTests,
+  )
+where
+
+import Base
+import Reachability.Positive qualified as P
+
+allTests :: TestTree
+allTests = testGroup "Reachability tests" [P.allTests]

--- a/test/Reachability/Positive.hs
+++ b/test/Reachability/Positive.hs
@@ -1,0 +1,85 @@
+module Reachability.Positive where
+
+import Base
+import Data.HashSet qualified as HashSet
+import Juvix.Pipeline
+import Juvix.Syntax.MicroJuvix.Language qualified as Micro
+import Juvix.Syntax.MicroJuvix.MicroJuvixTypedResult qualified as Micro
+
+data PosTest = PosTest
+  { _name :: String,
+    _relDir :: FilePath,
+    _stdlibMode :: StdlibMode,
+    _file :: FilePath,
+    _reachable :: HashSet String
+  }
+
+makeLenses ''PosTest
+
+root :: FilePath
+root = "tests/positive"
+
+testDescr :: PosTest -> TestDescr
+testDescr PosTest {..} =
+  let tRoot = root </> _relDir
+   in TestDescr
+        { _testName = _name,
+          _testRoot = tRoot,
+          _testAssertion = Steps $ \step -> do
+            cwd <- getCurrentDirectory
+            entryFile <- canonicalizePath _file
+            let noStdlib = _stdlibMode == StdlibExclude
+                entryPoint =
+                  EntryPoint
+                    { _entryPointRoot = cwd,
+                      _entryPointNoTermination = False,
+                      _entryPointNoStdlib = noStdlib,
+                      _entryPointModulePaths = pure entryFile
+                    }
+
+            step "Pipeline up to reachability"
+            p :: Micro.MicroJuvixTypedResult <- runIO (upToMicroJuvixReachability entryPoint)
+
+            step "Check reachability results"
+            let names = concatMap getNames (p ^. Micro.resultModules)
+            mapM_ check names
+        }
+  where
+    check n = assertBool ("unreachable not filtered: " ++ unpack n) (HashSet.member (unpack n) _reachable)
+
+getNames :: Micro.Module -> [Text]
+getNames m = concatMap getDeclName (m ^. (Micro.moduleBody . Micro.moduleStatements))
+  where
+    getDeclName :: Micro.Statement -> [Text]
+    getDeclName = \case
+      Micro.StatementInductive i -> [i ^. (Micro.inductiveName . Micro.nameText)]
+      Micro.StatementFunction f -> [f ^. (Micro.funDefName . Micro.nameText)]
+      Micro.StatementForeign {} -> []
+      Micro.StatementAxiom ax -> [ax ^. (Micro.axiomName . Micro.nameText)]
+      Micro.StatementInclude i -> getNames (i ^. Micro.includeModule)
+
+allTests :: TestTree
+allTests =
+  testGroup
+    "Reachability positive tests"
+    (map (mkTest . testDescr) tests)
+
+tests :: [PosTest]
+tests =
+  [ PosTest
+      "Reachability with modules"
+      "Reachability"
+      StdlibInclude
+      "M.juvix"
+      ( HashSet.fromList
+          ["f", "g", "h", "Bool", "Maybe"]
+      ),
+    PosTest
+      "Reachability with modules and standard library"
+      "Reachability"
+      StdlibInclude
+      "N.juvix"
+      ( HashSet.fromList
+          ["test", "Unit"]
+      )
+  ]

--- a/test/Reachability/Positive.hs
+++ b/test/Reachability/Positive.hs
@@ -33,6 +33,7 @@ testDescr PosTest {..} =
                   EntryPoint
                     { _entryPointRoot = cwd,
                       _entryPointNoTermination = False,
+                      _entryPointNoPositivity = False,
                       _entryPointNoStdlib = noStdlib,
                       _entryPointModulePaths = pure entryFile
                     }

--- a/test/Reachability/Positive.hs
+++ b/test/Reachability/Positive.hs
@@ -81,5 +81,13 @@ tests =
       "N.juvix"
       ( HashSet.fromList
           ["test", "Unit"]
+      ),
+    PosTest
+      "Reachability with public imports"
+      "Reachability"
+      StdlibInclude
+      "O.juvix"
+      ( HashSet.fromList
+          ["f", "g", "h", "k", "Bool", "Maybe"]
       )
   ]

--- a/tests/positive/Reachability/Data/Bool.juvix
+++ b/tests/positive/Reachability/Data/Bool.juvix
@@ -1,0 +1,21 @@
+module Data.Bool;
+  inductive Bool {
+    true : Bool;
+    false : Bool;
+  };
+
+  not : Bool → Bool;
+  not true ≔ false;
+  not false ≔ true;
+
+  -- infixr 2 ||;
+  -- || : Bool → Bool → Bool;
+  -- || false a ≔ a;
+  -- || true _ ≔ true;
+
+  -- infixr 2 &&;
+  -- && : Bool → Bool → Bool;
+  -- && false _ ≔ false;
+  -- && true a ≔ a;
+
+end;

--- a/tests/positive/Reachability/Data/Maybe.juvix
+++ b/tests/positive/Reachability/Data/Maybe.juvix
@@ -1,0 +1,8 @@
+module Data.Maybe;
+
+  inductive Maybe (a : Type) {
+     nothing : Maybe a;
+     just : a → Maybe a;
+  }
+
+end;

--- a/tests/positive/Reachability/Data/Nat.juvix
+++ b/tests/positive/Reachability/Data/Nat.juvix
@@ -1,0 +1,17 @@
+module Data.Nat;
+  inductive ℕ  {
+    zero : ℕ;
+    suc : ℕ → ℕ;
+  };
+
+  infixl 6 +;
+  + : ℕ → ℕ → ℕ;
+  + zero b ≔ b;
+  + (suc a) b ≔ suc (a + b);
+
+  infixl 7 *;
+  * : ℕ → ℕ → ℕ;
+  * zero b ≔ zero;
+  * (suc a) b ≔ b + a * b;
+
+end;

--- a/tests/positive/Reachability/Data/Ord.juvix
+++ b/tests/positive/Reachability/Data/Ord.juvix
@@ -1,0 +1,7 @@
+module Data.Ord;
+    inductive Ordering {
+      LT : Ordering;
+      EQ : Ordering;
+      GT : Ordering;
+    };
+end;

--- a/tests/positive/Reachability/Data/Product.juvix
+++ b/tests/positive/Reachability/Data/Product.juvix
@@ -1,0 +1,8 @@
+module Data.Product;
+
+infixr 2 ×;
+inductive × (a : Type) (b : Type) {
+  , : a → b → a × b;
+};
+
+end;

--- a/tests/positive/Reachability/M.juvix
+++ b/tests/positive/Reachability/M.juvix
@@ -1,0 +1,18 @@
+module M;
+
+open import Data.Nat;
+open import Data.Maybe;
+open import Data.Product;
+open import Data.Bool;
+open import Data.Ord;
+
+f : Bool -> Bool;
+f x := x;
+
+g : {A : Type} -> A -> Bool -> Bool;
+g x y := f y;
+
+h : {A : Type} -> A -> Maybe Bool;
+h x := nothing;
+
+end;

--- a/tests/positive/Reachability/N.juvix
+++ b/tests/positive/Reachability/N.juvix
@@ -1,0 +1,13 @@
+module N;
+
+open import M;
+open import Stdlib.Prelude;
+
+test : {A : Type} -> A -> A;
+test x := x;
+
+inductive Unit {
+  unit : Unit;
+};
+
+end;

--- a/tests/positive/Reachability/O.juvix
+++ b/tests/positive/Reachability/O.juvix
@@ -1,0 +1,9 @@
+module O;
+
+open import M public;
+open import Stdlib.Prelude;
+
+k : Bool;
+k := true;
+
+end;


### PR DESCRIPTION
# Description

* DependencyInfo type added which encapsulates algorithms on identifier dependency graphs.
* Dependencies computed in AbstractToMicroJuvix and stored in MicroJuvixResult.
* Reachability of definitions checked as a new step in the pipeline, just after typechecking.
* Fixes #1383

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works:
  - [ ] Negative tests
  - [x] Positive tests
  - [ ] Shell tests
