### PR TITLE
Fix version shell test for 0.2.2

### DIFF
--- a/tests/CLI/version.test
+++ b/tests/CLI/version.test
@@ -1,5 +1,5 @@
 $ juvix --version
-> /Juvix version 0.2.1-([a-f0-9]{7})
+> /Juvix version 0.2.2-([a-f0-9]{7})
 Branch: .*
 Commit: .*
 Date: .*


### PR DESCRIPTION
Shell test is failing on main because the version.test needs to be updated to the latest version.

https://github.com/anoma/juvix/runs/7505147070?check_suite_focus=true