### PR TITLE
WASM import all non-compile axioms with alphanum names in entrypoint

### DIFF
--- a/docs/org/SUMMARY.org
+++ b/docs/org/SUMMARY.org
@@ -6,6 +6,8 @@
   - [[./getting-started/quick-start.md][Quick start]]
   - [[./getting-started/dependencies.md][Installing dependencies]]
 - [[./examples/README.md][Juvix Examples]]
+- [[./tutorials/README.md][Tutorials]]
+  - [[./tutorials/nodejs-interop.md][NodeJS Interop]]
 
 - [[./language-reference/README.md][Language reference]]
   - [[./language-reference/comments.md][Comments]]

--- a/docs/org/tutorials/README.org
+++ b/docs/org/tutorials/README.org
@@ -1,0 +1,1 @@
+  - [[./nodejs-interop.md][NodeJS Interop]]

--- a/docs/org/tutorials/nodejs-interop.org
+++ b/docs/org/tutorials/nodejs-interop.org
@@ -1,0 +1,108 @@
+* NodeJS Interop
+
+A Juvix module can be compiled to a Wasm module. When a Wasm module is
+instantiated by a host, functions from the host can be injected into a Wasm
+module and functions from the Wasm module can be called by the host.
+
+In this tutorial you will see how to call host functions in Juvix and call Juvix
+functions from the host using the Wasm mechanism.
+
+** The Juvix module
+
+The following Juvix module has two functions.
+
+The function =hostDisplayString= is an =axiom= with no corresponding =compile=
+block that implements it. We will inject an implementation for this function
+when we instantiate the module from NodeJS.
+
+The function =juvixRender= is a normal Juvix function. We will call this from
+NodeJS.
+
+#+begin_src
+-- NodeJsInterop.juvix
+module NodeJsInterop;
+
+open import Stdlib.Prelude;
+
+axiom hostDisplayString : String → IO;
+
+juvixRender : IO;
+juvixRender ≔ hostDisplayString "Hello World from Juvix!";
+
+end;
+#+end_src
+
+** Compiling the Juvix module
+
+The Juvix module can be compiled using the following command:
+
+#+begin_src
+juvix compile -r standalone NodeJsInterop.juvix
+#+end_src
+
+This will create a file containing a Wasm module called =NodeJsInterop.wasm=.
+
+** The NodeJS module
+
+The following NodeJS module demonstrates both calling a Juvix function from
+NodeJS and injecting a NodeJS function into a Juvix module.
+
+The NodeJS function =hostDisplayString= is passed to the Wasm module
+=NodeJSInterop.wasm= when it is instantiated. After instantiation the Juvix
+function =juvixRender= is called.
+
+The functions =ptrToCstr= and =cstrlen= are necessary to convert the =char=
+pointer passed from Juvix to a JS =String=.
+
+#+begin_src
+-- NodeJSInterop.js
+const fs = require('fs');
+let wasmModule = null;
+
+function cstrlen(mem, ptr) {
+    let len = 0;
+    while (mem[ptr] != 0) {
+        len++;
+        ptr++;
+    }
+    return len;
+}
+
+function ptrToCstr(ptr) {
+    const wasmMemory = wasmModule.instance.exports.memory.buffer;
+    const mem = new Uint8Array(wasmMemory);
+    const len = cstrlen(mem, ptr);
+    const bytes = new Uint8Array(wasmMemory, ptr, len);
+    return new TextDecoder().decode(bytes);
+}
+
+function hostDisplayString(strPtr) {
+    const text = ptrToCstr(strPtr);
+    console.log(text);
+}
+
+const wasmBuffer = fs.readFileSync("NodeJsInterop.wasm");
+WebAssembly.instantiate(wasmBuffer, {
+    env: {
+        hostDisplayString,
+    }
+}).then((w) => {
+    wasmModule = w;
+    wasmModule.instance.exports.juvixRender();
+});
+#+end_src
+
+** Running the Wasm module
+
+Now you should have the files =NodeJsInterop.wasm= and =NodeJsInterop.js= in the
+same directory. Run the following command to execute the module:
+
+#+begin_src
+node NodeJsInterop.js
+#+end_src
+
+You should see the following output:
+
+#+begin_src
+Hello World from Juvix!
+#+end_src

--- a/src/Juvix/Syntax/MiniC/Language.hs
+++ b/src/Juvix/Syntax/MiniC/Language.hs
@@ -82,7 +82,7 @@ data Qualifier
 -- Attributes
 --------------------------------------------------------------------------------
 
-newtype Attribute = ExportName Text
+data Attribute = ExportName Text | ImportName Text
 
 --------------------------------------------------------------------------------
 -- Types

--- a/src/Juvix/Syntax/MiniC/Serialization.hs
+++ b/src/Juvix/Syntax/MiniC/Serialization.hs
@@ -29,7 +29,11 @@ prettyCpp = \case
 
 prettyAttribute :: Attribute -> HP.Doc
 prettyAttribute = \case
-  ExportName n -> "__attribute__" HP.<> HP.parens (HP.parens ("export_name" HP.<> HP.parens (HP.doubleQuotes (prettyText n))))
+  ExportName n -> attr "export_name" n
+  ImportName n -> attr "import_name" n
+  where
+    attr :: Text -> Text -> HP.Doc
+    attr n v = "__attribute__" HP.<> HP.parens (HP.parens (prettyText n HP.<> HP.parens (HP.doubleQuotes (prettyText v))))
 
 prettyCCode :: CCode -> HP.Doc
 prettyCCode = \case

--- a/src/Juvix/Translation/MicroJuvixToMiniC.hs
+++ b/src/Juvix/Translation/MicroJuvixToMiniC.hs
@@ -463,7 +463,7 @@ goAxiom a
       case backend of
         Nothing -> do
           sig <- ExternalFuncSig <$> (cFunTypeToFunSig defineName <$> typeToFunType (mkPolyType' (a ^. Micro.axiomType)))
-          return [sig]
+          return [ExternalAttribute (ImportName (axiomName ^. Micro.nameText)), sig]
         Just defineBody ->
           return
             [ ExternalMacro

--- a/src/Juvix/Translation/MicroJuvixToMiniC.hs
+++ b/src/Juvix/Translation/MicroJuvixToMiniC.hs
@@ -461,9 +461,7 @@ goAxiom a
   | otherwise = do
       backend <- runFail (lookupBackends (axiomName ^. Micro.nameId) >>= firstBackendMatch)
       case backend of
-        Nothing -> do
-          sig <- ExternalFuncSig <$> (cFunTypeToFunSig defineName <$> typeToFunType (mkPolyType' (a ^. Micro.axiomType)))
-          return [ExternalAttribute (ImportName (axiomName ^. Micro.nameText)), sig]
+        Nothing -> genFunctionDef a
         Just defineBody ->
           return
             [ ExternalMacro
@@ -495,6 +493,22 @@ goAxiom a
       NameId ->
       Sem r [BackendItem]
     lookupBackends f = ask >>= failMaybe . fmap (^. Scoper.compileInfoBackendItems) . HashMap.lookup f
+    genFunctionDef ::
+      forall r.
+      Members [Reader Micro.InfoTable, Reader CompileInfoTable] r =>
+      Micro.AxiomDef ->
+      Sem r [CCode]
+    genFunctionDef d
+      | T.all isAlphaNum nameText = (ExternalAttribute (ImportName (axiomName ^. Micro.nameText)) :) <$> sig
+      | otherwise = sig
+      where
+        nameText :: Text
+        nameText = axiomName ^. Micro.nameText
+
+        sig :: Sem r [CCode]
+        sig = do
+          s <- cFunTypeToFunSig defineName <$> typeToFunType (mkPolyType' (d ^. Micro.axiomType))
+          return [ExternalFuncSig s]
 
 goForeign :: ForeignBlock -> [CCode]
 goForeign b = case b ^. foreignBackend of

--- a/test/BackendC/Base.hs
+++ b/test/BackendC/Base.hs
@@ -18,7 +18,7 @@ clangCompile mkClangArgs cResult execute step =
   withTempDir
     ( \dirPath -> do
         let cOutputFile = dirPath </> "out.c"
-            wasmOutputFile = dirPath </> "out.wasm"
+            wasmOutputFile = dirPath </> "Input.wasm"
         TIO.writeFile cOutputFile (cResult ^. MiniC.resultCCode)
         step "WASM generation"
         P.callProcess

--- a/test/BackendC/Base.hs
+++ b/test/BackendC/Base.hs
@@ -40,16 +40,8 @@ wasmClangAssertion WASMInfo {..} mainFile expectedFile step = do
 
   expected <- TIO.readFile expectedFile
 
-  let execute :: FilePath -> IO Text
-      execute outputFile =
-        pack
-          <$> P.readProcess
-            "wasmer"
-            (["run", outputFile, "--invoke", unpack _wasmInfoFunctionName] <> (unpack <$> _wasmInfoFunctionArgs))
-            ""
-
   step "Compile C with wasm standalone runtime"
-  actualStandalone <- clangCompile standaloneArgs p execute step
+  actualStandalone <- clangCompile standaloneArgs p _wasmInfoActual step
   step "Compare expected and actual program output"
   assertEqDiff ("Check: WASM output = " <> expectedFile) actualStandalone expected
 

--- a/test/BackendC/Positive.hs
+++ b/test/BackendC/Positive.hs
@@ -2,6 +2,7 @@ module BackendC.Positive where
 
 import BackendC.Base
 import Base
+import System.Process qualified as P
 
 data PosTest = PosTest
   { _name :: String,
@@ -19,6 +20,25 @@ mainFile = "Input.juvix"
 
 expectedFile :: FilePath
 expectedFile = "expected.golden"
+
+actualCallExport :: Text -> [Text] -> FilePath -> IO Text
+actualCallExport funName funArgs outputFile =
+  pack
+    <$> P.readProcess
+      "wasmer"
+      (["run", outputFile, "--invoke", unpack funName] <> (unpack <$> funArgs))
+      ""
+
+actualCallNode :: FilePath -> FilePath -> IO Text
+actualCallNode jsFile outputFile = do
+  assertCmdExists "node"
+  let outputJsFile = takeDirectory outputFile </> jsFile
+  copyFile jsFile outputJsFile
+  pack
+    <$> P.readProcess
+      "node"
+      [outputJsFile]
+      ""
 
 testDescr :: PosTest -> TestDescr
 testDescr PosTest {..} =
@@ -55,6 +75,7 @@ tests =
     PosTest "Builtin types and functions" "Builtins" (WASI StdlibExclude),
     PosTest "Import from embedded standard library" "StdlibImport" (WASI StdlibInclude),
     PosTest "Axiom without a compile block" "AxiomNoCompile" (WASI StdlibInclude),
-    PosTest "Invoke a function using exported name" "ExportName" (WASM (WASMInfo "fun" [])),
-    PosTest "Invoke a function using exported name with args" "ExportNameArgs" (WASM (WASMInfo "fun" ["0"]))
+    PosTest "Invoke a function using exported name" "ExportName" (WASM (WASMInfo (actualCallExport "fun" []))),
+    PosTest "Invoke a function using exported name with args" "ExportNameArgs" (WASM (WASMInfo (actualCallExport "fun" ["0"]))),
+    PosTest "Invoke an imported function in Juvix and exported function in JS" "ImportExportName" (WASM (WASMInfo (actualCallNode "input.js")))
   ]

--- a/test/BackendC/Positive.hs
+++ b/test/BackendC/Positive.hs
@@ -32,13 +32,17 @@ actualCallExport funName funArgs outputFile =
 actualCallNode :: FilePath -> FilePath -> IO Text
 actualCallNode jsFile outputFile = do
   assertCmdExists "node"
-  let outputJsFile = takeDirectory outputFile </> jsFile
+  let outputDir = takeDirectory outputFile
+      outputJsFile = outputDir </> jsFile
   copyFile jsFile outputJsFile
-  pack
-    <$> P.readProcess
-      "node"
-      [outputJsFile]
-      ""
+  withCurrentDirectory
+    outputDir
+    ( pack
+        <$> P.readProcess
+          "node"
+          [outputJsFile]
+          ""
+    )
 
 testDescr :: PosTest -> TestDescr
 testDescr PosTest {..} =

--- a/test/Base.hs
+++ b/test/Base.hs
@@ -26,9 +26,8 @@ data TestDescr = TestDescr
     _testAssertion :: AssertionDescr
   }
 
-data WASMInfo = WASMInfo
-  { _wasmInfoFunctionName :: Text,
-    _wasmInfoFunctionArgs :: [Text]
+newtype WASMInfo = WASMInfo
+  { _wasmInfoActual :: FilePath -> IO Text
   }
 
 makeLenses ''TestDescr

--- a/tests/positive/MiniC/ImportExportName/Input.juvix
+++ b/tests/positive/MiniC/ImportExportName/Input.juvix
@@ -1,0 +1,16 @@
+module Input;
+
+open import Stdlib.Prelude;
+
+axiom Void : Type;
+
+compile Void {
+  c ↦ "void";
+};
+
+axiom hostDisplayString : String → Void;
+
+juvixRender : Void;
+juvixRender ≔ hostDisplayString "Hello World from Juvix!";
+
+end;

--- a/tests/positive/MiniC/ImportExportName/Input.juvix
+++ b/tests/positive/MiniC/ImportExportName/Input.juvix
@@ -2,15 +2,9 @@ module Input;
 
 open import Stdlib.Prelude;
 
-axiom Void : Type;
+axiom hostDisplayString : String → IO;
 
-compile Void {
-  c ↦ "void";
-};
-
-axiom hostDisplayString : String → Void;
-
-juvixRender : Void;
+juvixRender : IO;
 juvixRender ≔ hostDisplayString "Hello World from Juvix!";
 
 end;

--- a/tests/positive/MiniC/ImportExportName/expected.golden
+++ b/tests/positive/MiniC/ImportExportName/expected.golden
@@ -1,0 +1,1 @@
+Hello World from Juvix!

--- a/tests/positive/MiniC/ImportExportName/input.js
+++ b/tests/positive/MiniC/ImportExportName/input.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+
+let wasmModule = null;
+
+function cstrlen(mem, ptr) {
+    let len = 0;
+    while (mem[ptr] != 0) {
+        len++;
+        ptr++;
+    }
+    return len;
+}
+
+function ptrToCstr(wasmMemory, ptr) {
+    const mem = new Uint8Array(wasmMemory);
+    const len = cstrlen(mem, ptr);
+    const bytes = new Uint8Array(wasmMemory, ptr, len);
+    return new TextDecoder().decode(bytes);
+}
+
+function hostDisplayString(strPtr) {
+    const wasmMemory = wasmModule.instance.exports.memory.buffer;
+    const text = ptrToCstr(wasmMemory, strPtr);
+    console.log(text);
+}
+
+const wasmBuffer = fs.readFileSync("Input.wasm");
+WebAssembly.instantiate(wasmBuffer, {
+    env: {
+        hostDisplayString,
+    }
+}).then((w) => {
+    wasmModule = w;
+    wasmModule.instance.exports.juvixRender();
+});

--- a/tests/positive/MiniC/ImportExportName/input.js
+++ b/tests/positive/MiniC/ImportExportName/input.js
@@ -11,7 +11,8 @@ function cstrlen(mem, ptr) {
     return len;
 }
 
-function ptrToCstr(wasmMemory, ptr) {
+function ptrToCstr(ptr) {
+    const wasmMemory = wasmModule.instance.exports.memory.buffer;
     const mem = new Uint8Array(wasmMemory);
     const len = cstrlen(mem, ptr);
     const bytes = new Uint8Array(wasmMemory, ptr, len);
@@ -19,8 +20,7 @@ function ptrToCstr(wasmMemory, ptr) {
 }
 
 function hostDisplayString(strPtr) {
-    const wasmMemory = wasmModule.instance.exports.memory.buffer;
-    const text = ptrToCstr(wasmMemory, strPtr);
+    const text = ptrToCstr(strPtr);
     console.log(text);
 }
 


### PR DESCRIPTION
> ⚠️ The tests now depend on `node` in order to test injecting WASM import functions into a Juvix program.

This is part of the implementation for https://github.com/anoma/juvix/issues/1355

This PR adds `__attribute__((import_name(<name>))` declarations to every type signature corresponding to axioms with no-compile block that has an alpha numeric name in the entry point module (so that it can safely be present in the output C file). 
This causes these functions to be present in the import table of the resulting WASM module.

To try this out:

```shell
cd tests/positive/MiniC/ImportExportName
juvix compile --runtime standalone Input.juvix
```

To see the imports and exports of the module:

```shell
wasmer inspect Input.wasm
Type: wasm
Size: 172 B
Imports:
  Functions:
    "env"."hostDisplayString": [I32] -> []
  Memories:
  Tables:
  Globals:
Exports:
  Functions:
    "juvixRender": [] -> []
  Memories:
    "memory": not shared (2 pages..)
  Tables:
  Globals:
```

You can then inject an implementation of `hostDisplayString` from nodeJS, which is called in Juvix and invoke the `juvixRender` Juvix function from the nodeJS file with:

```shell
node input.js
Hello World from Juvix!
```