### PR TITLE
Do not add `-src` suffix to links in HTML when running `juvix html`

### DIFF
--- a/src/Juvix/Documentation/Compiler.hs
+++ b/src/Juvix/Documentation/Compiler.hs
@@ -259,7 +259,7 @@ goTopModule m = do
     srcHtml :: forall s. Members '[Reader HtmlOptions, Embed IO] s => Sem s Html
     srcHtml = do
       utc <- Prelude.embed getCurrentTime
-      return (genModuleHtml defaultOptions True utc Ayu m)
+      return (genModuleHtml defaultOptions HtmlSrc True utc Ayu m)
 
     docHtml :: forall s. Members '[Reader HtmlOptions, Reader EntryPoint] s => Sem s Html
     docHtml = do


### PR DESCRIPTION
The `juvix internal doc` command generates 2 files per Juvix module.
One for the main documentation and one for the HTML source file.
The HTML source file is given the prefix `-src` and so links have this
prefix.

However when HTML is generated using `juvix html` only one file is
generated per Juvix module. The filenames do not have the `-src` suffix
and so the links should not have this suffix either.

Closes #1428 