### PR TITLE
CI: Run build on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: The Juvix compiler CI
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
According to this: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

CI builds of PRs can only see the caches from `main` or themselves. Unless we run the build on `main` after merging a PR, every new PR will build all the dependencies from scratch as it doesn't have access to a `~/.stack` cache.

This PR adds a build of `main` on push (this includes after merging a PR) which will populate the caches and hopefully speed up PR feedback times.