### PR TITLE
Add initial support for examples in Html documentation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,11 +22,11 @@ import Juvix.Compiler.Concrete.Data.InfoTable qualified as Scoper
 import Juvix.Compiler.Concrete.Pretty qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
-import Juvix.Compiler.Internal.Pretty qualified as Micro
-import Juvix.Compiler.Internal.Translation.FromAbstract qualified as Micro
+import Juvix.Compiler.Internal.Pretty qualified as Internal
+import Juvix.Compiler.Internal.Translation.FromAbstract qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromAbstract.Analysis.Termination qualified as Termination
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context qualified as MicroArity
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking qualified as MicroTyped
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context qualified as InternalArity
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking qualified as InternalTyped
 import Juvix.Compiler.Mono.Pretty qualified as Mono
 import Juvix.Compiler.Mono.Translation.FromInternal qualified as Mono
 import Juvix.Compiler.Pipeline
@@ -148,41 +148,48 @@ runCommand cmdWithOpts = do
                   forM_ l $ \s -> do
                     renderStdOut (Scoper.ppOut (mkScopePrettyOptions globalOpts localOpts) s)
                 Doc localOpts -> do
-                  l <-
-                    (^. Scoper.mainModule)
-                      <$> runPipeline
-                        (upToScoping entryPoint)
-                  let docDir = localOpts ^. docOutputDir
-                  runReader entryPoint (Doc.compileModuleHtmlText docDir "proj" l)
-                  embed (when (localOpts ^. docOpen) (Process.callProcess "xdg-open" [docDir </> Doc.indexFileName]))
+                  ctx :: InternalTyped.InternalTypedResult <-
+                    runPipeline
+                      (upToInternalTyped entryPoint)
+                  let mainMod =
+                        ctx
+                          ^. InternalTyped.resultInternalArityResult
+                          . InternalArity.resultInternalResult
+                          . Internal.resultAbstract
+                          . Abstract.resultScoper
+                          . Scoper.mainModule
+                      docDir = localOpts ^. docOutputDir
+                      normalized = ctx ^. InternalTyped.resultNormalized
+                  runReader normalized (runReader entryPoint (Doc.compileModule docDir "proj" mainMod))
+                  embed (when (localOpts ^. docOpen) (void (Process.spawnProcess "xdg-open" [docDir </> Doc.indexFileName])))
                 Internal Pretty -> do
                   micro <-
-                    head . (^. Micro.resultModules)
+                    head . (^. Internal.resultModules)
                       <$> runPipeline (upToInternal entryPoint)
                   let ppOpts =
-                        Micro.defaultOptions
-                          { Micro._optShowNameIds = globalOpts ^. globalShowNameIds
+                        Internal.defaultOptions
+                          { Internal._optShowNameIds = globalOpts ^. globalShowNameIds
                           }
-                  App.renderStdOut (Micro.ppOut ppOpts micro)
+                  App.renderStdOut (Internal.ppOut ppOpts micro)
                 Internal Arity -> do
-                  micro <- head . (^. MicroArity.resultModules) <$> runPipeline (upToInternalArity entryPoint)
-                  App.renderStdOut (Micro.ppOut Micro.defaultOptions micro)
+                  micro <- head . (^. InternalArity.resultModules) <$> runPipeline (upToInternalArity entryPoint)
+                  App.renderStdOut (Internal.ppOut Internal.defaultOptions micro)
                 Internal (TypeCheck localOpts) -> do
                   res <- runPipeline (upToInternalTyped entryPoint)
                   say "Well done! It type checks"
                   when (localOpts ^. microJuvixTypePrint) $ do
                     let ppOpts =
-                          Micro.defaultOptions
-                            { Micro._optShowNameIds = globalOpts ^. globalShowNameIds
+                          Internal.defaultOptions
+                            { Internal._optShowNameIds = globalOpts ^. globalShowNameIds
                             }
-                        checkedModule = head (res ^. MicroTyped.resultModules)
-                    renderStdOut (Micro.ppOut ppOpts checkedModule)
+                        checkedModule = head (res ^. InternalTyped.resultModules)
+                    renderStdOut (Internal.ppOut ppOpts checkedModule)
                     newline
                     let typeCalls = Mono.buildTypeCallMap res
-                    renderStdOut (Micro.ppOut ppOpts typeCalls)
+                    renderStdOut (Internal.ppOut ppOpts typeCalls)
                     newline
                     let concreteTypeCalls = Mono.collectTypeCalls res
-                    renderStdOut (Micro.ppOut ppOpts concreteTypeCalls)
+                    renderStdOut (Internal.ppOut ppOpts concreteTypeCalls)
                 MonoJuvix -> do
                   let ppOpts =
                         Mono.defaultOptions

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -30,6 +30,7 @@ import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking qu
 import Juvix.Compiler.Mono.Pretty qualified as Mono
 import Juvix.Compiler.Mono.Translation.FromInternal qualified as Mono
 import Juvix.Compiler.Pipeline
+import Juvix.Extra.Process
 import Juvix.Extra.Version (runDisplayVersion)
 import Juvix.Prelude hiding (Doc)
 import Juvix.Prelude.Pretty hiding (Doc)
@@ -153,7 +154,9 @@ runCommand cmdWithOpts = do
                       (upToInternalTyped entryPoint)
                   let docDir = localOpts ^. docOutputDir
                   Doc.compile docDir "proj" ctx
-                  embed (when (localOpts ^. docOpen) (void (Process.spawnProcess "xdg-open" [docDir </> Doc.indexFileName])))
+                  when (localOpts ^. docOpen) $ case openCmd of
+                    Nothing -> say "Could not recognize the 'open' command for your OS"
+                    Just opencmd -> embed (void (Process.spawnProcess opencmd [docDir </> Doc.indexFileName]))
                 Internal Pretty -> do
                   micro <-
                     head . (^. Internal.resultModules)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,8 +15,8 @@ import Juvix.Compiler.Abstract.Translation.FromConcrete qualified as Abstract
 import Juvix.Compiler.Backend.C.Translation.FromInternal qualified as MiniC
 import Juvix.Compiler.Backend.Haskell.Pretty qualified as MiniHaskell
 import Juvix.Compiler.Backend.Haskell.Translation.FromMono qualified as MiniHaskell
-import Juvix.Compiler.Backend.Html.Translation.FromScoped qualified as Doc
-import Juvix.Compiler.Backend.Html.Translation.FromScoped qualified as Html
+import Juvix.Compiler.Backend.Html.Translation.FromTyped qualified as Doc
+import Juvix.Compiler.Backend.Html.Translation.FromTyped qualified as Html
 import Juvix.Compiler.Concrete.Data.Highlight qualified as Highlight
 import Juvix.Compiler.Concrete.Data.InfoTable qualified as Scoper
 import Juvix.Compiler.Concrete.Pretty qualified as Scoper
@@ -151,16 +151,8 @@ runCommand cmdWithOpts = do
                   ctx :: InternalTyped.InternalTypedResult <-
                     runPipeline
                       (upToInternalTyped entryPoint)
-                  let mainMod =
-                        ctx
-                          ^. InternalTyped.resultInternalArityResult
-                          . InternalArity.resultInternalResult
-                          . Internal.resultAbstract
-                          . Abstract.resultScoper
-                          . Scoper.mainModule
-                      docDir = localOpts ^. docOutputDir
-                      normalized = ctx ^. InternalTyped.resultNormalized
-                  runReader normalized (runReader entryPoint (Doc.compileModule docDir "proj" mainMod))
+                  let docDir = localOpts ^. docOutputDir
+                  Doc.compile docDir "proj" ctx
                   embed (when (localOpts ^. docOpen) (void (Process.spawnProcess "xdg-open" [docDir </> Doc.indexFileName])))
                 Internal Pretty -> do
                   micro <-

--- a/examples/milestone/TicTacToe/Logic/Game.juvix
+++ b/examples/milestone/TicTacToe/Logic/Game.juvix
@@ -69,6 +69,16 @@ inductive Square {
   occupied : Symbol → Square;
 };
 
+--- A row in a board implemented as ;List Square;
+---
+--- >>> Row;
+Row : Type;
+Row ≔ List Square;
+
+-- A column in a board implemented as ;List Square;
+-- Column : Type;
+-- Column ≔ Row;
+
 --- Equality for ;Square;s
 ==Square : Square → Square → Bool;
 ==Square (empty m) (empty n) ≔ m == n;
@@ -79,14 +89,6 @@ inductive Square {
 showSquare : Square → String;
 showSquare (empty n) ≔ " " ++str natToStr n ++str " ";
 showSquare (occupied s) ≔ " " ++str showSymbol s ++str " ";
-
--- A row in a board implemented as ;List Square;
--- Row : Type;
--- Row ≔ List Square;
-
--- A column in a board implemented as ;List Square;
--- Column : Type;
--- Column ≔ Row;
 
 -- TODO use a type alias?
 --- A grid of squares

--- a/examples/milestone/TicTacToe/Logic/Game.juvix
+++ b/examples/milestone/TicTacToe/Logic/Game.juvix
@@ -69,11 +69,11 @@ inductive Square {
   occupied : Symbol → Square;
 };
 
---- A row in a board implemented as ;List Square;
----
---- >>> Row;
-Row : Type;
-Row ≔ List Square;
+-- --- A row in a board implemented as ;List Square;
+-- ---
+-- --- >>> Row;
+-- Row : Type;
+-- Row ≔ List Square;
 
 -- A column in a board implemented as ;List Square;
 -- Column : Type;

--- a/src/Juvix/Compiler/Abstract/Language.hs
+++ b/src/Juvix/Compiler/Abstract/Language.hs
@@ -49,9 +49,16 @@ data Statement
   | StatementAxiom AxiomDef
   deriving stock (Eq, Show)
 
+data Example = Example {
+  _exampleId :: NameId,
+  _exampleExpression :: Expression
+  }
+  deriving stock (Eq, Show)
+
 data FunctionDef = FunctionDef
   { _funDefName :: FunctionName,
     _funDefTypeSig :: Expression,
+    _funDefExamples :: [Example],
     _funDefClauses :: NonEmpty FunctionClause,
     _funDefBuiltin :: Maybe BuiltinFunction,
     _funDefTerminating :: Bool
@@ -193,6 +200,7 @@ data AxiomDef = AxiomDef
   deriving stock (Eq, Show)
 
 makeLenses ''Module
+makeLenses ''Example
 makeLenses ''PatternArg
 makeLenses ''FunctionParameter
 makeLenses ''Function

--- a/src/Juvix/Compiler/Abstract/Language.hs
+++ b/src/Juvix/Compiler/Abstract/Language.hs
@@ -31,6 +31,7 @@ type TopModuleName = Name
 
 data Module = Module
   { _moduleName :: Name,
+    _moduleExamples :: [Example],
     _moduleBody :: ModuleBody
   }
   deriving stock (Eq, Show)
@@ -181,6 +182,7 @@ data InductiveDef = InductiveDef
     _inductiveBuiltin :: Maybe BuiltinInductive,
     _inductiveParameters :: [FunctionParameter],
     _inductiveType :: Expression,
+    _inductiveExamples :: [Example],
     _inductiveConstructors :: [InductiveConstructorDef],
     _inductivePositive :: Bool
   }
@@ -188,6 +190,7 @@ data InductiveDef = InductiveDef
 
 data InductiveConstructorDef = InductiveConstructorDef
   { _constructorName :: ConstrName,
+    _constructorExamples :: [Example],
     _constructorType :: Expression
   }
   deriving stock (Eq, Show)

--- a/src/Juvix/Compiler/Abstract/Language.hs
+++ b/src/Juvix/Compiler/Abstract/Language.hs
@@ -49,9 +49,9 @@ data Statement
   | StatementAxiom AxiomDef
   deriving stock (Eq, Show)
 
-data Example = Example {
-  _exampleId :: NameId,
-  _exampleExpression :: Expression
+data Example = Example
+  { _exampleId :: NameId,
+    _exampleExpression :: Expression
   }
   deriving stock (Eq, Show)
 

--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -16,6 +16,7 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error
 import Juvix.Prelude
 import Juvix.Prelude.Pretty
+import Juvix.Compiler.Abstract.Language (FunctionDef(_funDefExamples))
 
 newtype ModulesCache = ModulesCache
   {_cachedModules :: HashMap S.NameId Abstract.TopModule}
@@ -172,9 +173,20 @@ goFunctionDef TypeSignature {..} clauses = do
       _funDefBuiltin = _sigBuiltin
   _funDefClauses <- mapM goFunctionClause clauses
   _funDefTypeSig <- goExpression _sigType
+  _funDefExamples <- maybe (return []) (mapM goExample . judocExamples) _sigDoc
   let fun = Abstract.FunctionDef {..}
   whenJust _sigBuiltin (registerBuiltinFunction fun)
   registerFunction' fun
+
+goExample ::   Member (Error ScoperError) r =>
+  Example 'Scoped ->
+  Sem r Abstract.Example
+goExample ex = do
+  e' <- goExpression (ex ^. exampleExpression)
+  return Abstract.Example {
+    _exampleExpression = e',
+    _exampleId = ex ^. exampleId
+                          }
 
 goFunctionClause ::
   Member (Error ScoperError) r =>

--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -6,6 +6,7 @@ where
 
 import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Abstract.Data.InfoTableBuilder
+import Juvix.Compiler.Abstract.Language (FunctionDef (_funDefExamples))
 import Juvix.Compiler.Abstract.Language qualified as Abstract
 import Juvix.Compiler.Abstract.Translation.FromConcrete.Data.Context
 import Juvix.Compiler.Builtins
@@ -16,7 +17,6 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error
 import Juvix.Prelude
 import Juvix.Prelude.Pretty
-import Juvix.Compiler.Abstract.Language (FunctionDef(_funDefExamples))
 
 newtype ModulesCache = ModulesCache
   {_cachedModules :: HashMap S.NameId Abstract.TopModule}
@@ -178,15 +178,17 @@ goFunctionDef TypeSignature {..} clauses = do
   whenJust _sigBuiltin (registerBuiltinFunction fun)
   registerFunction' fun
 
-goExample ::   Member (Error ScoperError) r =>
+goExample ::
+  Member (Error ScoperError) r =>
   Example 'Scoped ->
   Sem r Abstract.Example
 goExample ex = do
   e' <- goExpression (ex ^. exampleExpression)
-  return Abstract.Example {
-    _exampleExpression = e',
-    _exampleId = ex ^. exampleId
-                          }
+  return
+    Abstract.Example
+      { _exampleExpression = e',
+        _exampleId = ex ^. exampleId
+      }
 
 goFunctionClause ::
   Member (Error ScoperError) r =>

--- a/src/Juvix/Compiler/Backend/Haskell/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Backend/Haskell/Pretty/Base.hs
@@ -12,8 +12,8 @@ import Juvix.Compiler.Concrete.Data.Literal
 import Juvix.Data.Fixity
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
+import Juvix.Prelude.Pretty
 import Juvix.Prelude.Pretty qualified as PP
-import Prettyprinter
 
 doc :: PrettyCode c => Options -> c -> Doc Ann
 doc opts =

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromScoped/Generation.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromScoped/Generation.hs
@@ -12,6 +12,7 @@ import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
 import Juvix.Compiler.Concrete.Extra
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Pretty.Base
+import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Extra.Paths
 import Juvix.Extra.Version
 import Juvix.Prelude
@@ -142,6 +143,22 @@ ppCodeHtml :: (Members '[Reader HtmlOptions] r, PrettyCode a) => a -> Sem r Html
 ppCodeHtml x = do
   o <- ask
   return (ppCodeHtml' o defaultOptions x)
+
+ppCodeHtmlInternal :: (Members '[Reader HtmlOptions] r, Internal.PrettyCode a) => a -> Sem r Html
+ppCodeHtmlInternal x = do
+  o <- ask
+  return (ppCodeHtmlInternal' o Internal.defaultOptions x)
+  where
+    ppCodeHtmlInternal' :: Internal.PrettyCode a => HtmlOptions -> Internal.Options -> a -> Html
+    ppCodeHtmlInternal' htmlOpts opts = run . runReader htmlOpts . renderTree . treeForm . docStreamInternal' opts
+    docStreamInternal' :: Internal.PrettyCode a => Internal.Options -> a -> SimpleDocStream Ann
+    docStreamInternal' opts m = goTag <$> layoutPretty defaultLayoutOptions (Internal.runPrettyCode opts m)
+    goTag :: Internal.Ann -> Ann
+    goTag = \case
+      Internal.AnnKind k -> AnnKind k
+      Internal.AnnKeyword -> AnnKeyword
+      Internal.AnnLiteralInteger -> AnnLiteralInteger
+      Internal.AnnLiteralString -> AnnLiteralString
 
 go :: Members '[Reader HtmlOptions] r => SimpleDocTree Ann -> Sem r Html
 go sdt = case sdt of

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -30,7 +30,6 @@ import Juvix.Prelude
 import Juvix.Prelude qualified as Prelude
 import Juvix.Prelude.Pretty
 import Text.Blaze.Html.Renderer.Utf8 qualified as Html
--- import Data.HashMap.Strict    qualified          as HashMap
 import Text.Blaze.Html5 as Html hiding (map)
 import Text.Blaze.Html5.Attributes qualified as Attr
 
@@ -109,14 +108,8 @@ createIndexFile ps = do
                 (a ! Attr.href lnk $ toHtml (prettyText lbl'))
         attrBase :: Html.AttributeValue
         attrBase = "details-toggle-control details-toggle collapser"
-        -- dataDetailsId :: AttributeValue -> Attribute
-        -- dataDetailsId = Html.dataAttribute "details-id"
         attrBare :: Html.AttributeValue
         attrBare = attrBase <> "module"
-        -- attr :: Html.AttributeValue
-        -- attr = case lbl of
-        --   Nothing -> attrBare
-        --   Just {} -> attrBase
         node :: Sem r Html
         node = do
           row' <- nodeRow
@@ -131,7 +124,6 @@ createIndexFile ps = do
                   return $
                     Just $
                       details ! Attr.open "open" $
-                        -- (summary ! Attr.class_ "hide-when-js-enabled" $ "Submodules")
                         summary "Subtree"
                           <> ul (mconcatMap li c')
 
@@ -215,7 +207,6 @@ template rightMenu' content' = do
             ! Attr.name "viewport"
             ! Attr.content "width=device-width, initial-scale=1"
           <> mathJaxCdn
-          -- <> highlightJs
           <> livejs
           <> ayuCss
           <> linuwialCss
@@ -360,7 +351,7 @@ goJudoc (Judoc bs) = mconcatMapM goBlock bs
   where
     goBlock :: JudocBlock 'Scoped -> Sem r Html
     goBlock = \case
-      JudocParagraph ls -> mconcatMapM goLine (toList ls)
+      JudocParagraph ls -> concatWith (\l r -> l <> " " <> r) <$> mapM goLine (toList ls)
       JudocExample e -> goExample e
     goLine :: JudocParagraphLine 'Scoped -> Sem r Html
     goLine (JudocParagraphLine atoms) = mconcatMapM goAtom (toList atoms)

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped/Source.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped/Source.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Backend.Html.Translation.FromScoped.Generation where
+module Juvix.Compiler.Backend.Html.Translation.FromTyped.Source where
 
 import Data.ByteString qualified as BS
 import Data.Text qualified as Text

--- a/src/Juvix/Compiler/Builtins/Natural.hs
+++ b/src/Juvix/Compiler/Builtins/Natural.hs
@@ -17,13 +17,17 @@ registerNaturalDef d = do
     _ -> error "Natural numbers should have exactly two constructors"
 
 registerZero :: Member Builtins r => InductiveConstructorDef -> Sem r ()
-registerZero d@(InductiveConstructorDef zero ty) = do
+registerZero d@InductiveConstructorDef {..} = do
+  let zero = _constructorName
+      ty = _constructorType
   nat <- getBuiltinName (getLoc d) BuiltinNatural
   unless (ty === nat) (error $ "zero has the wrong type " <> ppTrace ty <> " | " <> ppTrace nat)
   registerBuiltin BuiltinNaturalZero zero
 
 registerSuc :: Member Builtins r => InductiveConstructorDef -> Sem r ()
-registerSuc d@(InductiveConstructorDef suc ty) = do
+registerSuc d@InductiveConstructorDef {..} = do
+  let suc = _constructorName
+      ty = _constructorType
   nat <- getBuiltinName (getLoc d) BuiltinNatural
   unless (ty === (nat --> nat)) (error "suc has the wrong type")
   registerBuiltin BuiltinNaturalSuc suc

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -904,18 +904,19 @@ deriving stock instance (Eq (ExpressionType s), Eq (SymbolType s)) => Eq (Judoc 
 
 deriving stock instance (Ord (ExpressionType s), Ord (SymbolType s)) => Ord (Judoc s)
 
-data Example (s :: Stage) = Example {
-  _exampleId :: NameId,
-  _exampleExpression :: ExpressionType s
+data Example (s :: Stage) = Example
+  { _exampleId :: NameId,
+    _exampleExpression :: ExpressionType s
   }
+
 deriving stock instance Show (ExpressionType s) => Show (Example s)
 
 deriving stock instance Eq (ExpressionType s) => Eq (Example s)
 
 deriving stock instance Ord (ExpressionType s) => Ord (Example s)
 
-data JudocBlock (s :: Stage) =
-  JudocParagraph (NonEmpty (JudocParagraphLine s))
+data JudocBlock (s :: Stage)
+  = JudocParagraph (NonEmpty (JudocParagraphLine s))
   | JudocExample (Example s)
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocBlock s)
@@ -924,8 +925,8 @@ deriving stock instance (Eq (ExpressionType s), Eq (SymbolType s)) => Eq (JudocB
 
 deriving stock instance (Ord (ExpressionType s), Ord (SymbolType s)) => Ord (JudocBlock s)
 
-newtype JudocParagraphLine (s :: Stage) =
-   JudocParagraphLine (NonEmpty (JudocAtom s))
+newtype JudocParagraphLine (s :: Stage)
+  = JudocParagraphLine (NonEmpty (JudocAtom s))
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocParagraphLine s)
 
@@ -1194,11 +1195,11 @@ entryIsExpression = \case
 
 judocExamples :: Judoc s -> [Example s]
 judocExamples (Judoc bs) = concatMap go bs
- where
- go :: JudocBlock s -> [Example s]
- go = \case
-   JudocExample e -> [e]
-   _ -> mempty
+  where
+    go :: JudocBlock s -> [Example s]
+    go = \case
+      JudocExample e -> [e]
+      _ -> mempty
 
 instance HasLoc SymbolEntry where
   getLoc = (^. S.nameDefined) . entryName

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -554,7 +554,7 @@ ppJudocExampleStart :: Doc Ann
 ppJudocExampleStart = pretty (Str.judocExample :: Text)
 
 instance SingI s => PrettyCode (Example s) where
-  ppCode e =  do
+  ppCode e = do
     e' <- ppExpression (e ^. exampleExpression)
     return (ppJudocStart <+> ppJudocExampleStart <+> e' <> kwSemicolon <> line)
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1217,14 +1217,16 @@ checkJudoc ::
   Sem r (Judoc 'Scoped)
 checkJudoc (Judoc atoms) = Judoc <$> mapM checkJudocBlock atoms
 
-checkJudocBlock :: Members '[Error ScoperError, State Scope, State ScoperState, Reader LocalVars, InfoTableBuilder, NameIdGen] r =>
+checkJudocBlock ::
+  Members '[Error ScoperError, State Scope, State ScoperState, Reader LocalVars, InfoTableBuilder, NameIdGen] r =>
   JudocBlock 'Parsed ->
   Sem r (JudocBlock 'Scoped)
 checkJudocBlock = \case
   JudocParagraph l -> JudocParagraph <$> mapM checkJudocLine l
   JudocExample e -> JudocExample <$> traverseOf exampleExpression checkParseExpressionAtoms e
 
-checkJudocLine :: Members '[Error ScoperError, State Scope, State ScoperState, Reader LocalVars, InfoTableBuilder, NameIdGen] r =>
+checkJudocLine ::
+  Members '[Error ScoperError, State Scope, State ScoperState, Reader LocalVars, InfoTableBuilder, NameIdGen] r =>
   JudocParagraphLine 'Parsed ->
   Sem r (JudocParagraphLine 'Scoped)
 checkJudocLine (JudocParagraphLine atoms) = JudocParagraphLine <$> mapM checkJudocAtom atoms

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -118,6 +118,7 @@ statement = do
     <|> ( either StatementTypeSignature StatementFunctionClause
             <$> auxTypeSigFunClause
         )
+
 stashJudoc :: forall r. Members '[Reader ParserParams, InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r ()
 stashJudoc = do
   b <- judocBlocks

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -90,6 +90,15 @@ string =
   lexemeInterval $
     pack <$> (char '"' >> manyTill L.charLiteral (char '"'))
 
+judocExampleStart :: ParsecS r ()
+judocExampleStart = P.chunk Str.judocExample >> hspace
+
+judocStart :: ParsecS r ()
+judocStart = P.chunk Str.judocStart >> hspace
+
+judocEmptyLine :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
+judocEmptyLine = lexeme (void (P.try (judocStart >> P.newline)))
+
 curLoc :: Member (Reader ParserParams) r => ParsecS r Loc
 curLoc = do
   sp <- getSourcePos

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -225,11 +225,22 @@ instance HasExpressions FunctionClause where
     b' <- leafExpressions f b
     pure (FunctionClause n ps b')
 
+instance HasExpressions Example where
+  leafExpressions f = traverseOf exampleExpression (leafExpressions f)
+
 instance HasExpressions FunctionDef where
-  leafExpressions f (FunctionDef name ty clauses bi) = do
-    clauses' <- traverse (leafExpressions f) clauses
-    ty' <- leafExpressions f ty
-    pure (FunctionDef name ty' clauses' bi)
+  -- leafExpressions f (FunctionDef name ty clauses bi) = do
+  leafExpressions f FunctionDef {..} = do
+    clauses' <- traverse (leafExpressions f) _funDefClauses
+    ty' <- leafExpressions f _funDefType
+    examples' <- traverse (leafExpressions f) _funDefExamples
+    pure FunctionDef {
+      _funDefClauses = clauses',
+      _funDefType = ty',
+      _funDefExamples = examples',
+      _funDefName,
+      _funDefBuiltin
+      }
 
 instance HasExpressions InductiveParameter where
   leafExpressions _ param@(InductiveParameter _) = do

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -234,13 +234,14 @@ instance HasExpressions FunctionDef where
     clauses' <- traverse (leafExpressions f) _funDefClauses
     ty' <- leafExpressions f _funDefType
     examples' <- traverse (leafExpressions f) _funDefExamples
-    pure FunctionDef {
-      _funDefClauses = clauses',
-      _funDefType = ty',
-      _funDefExamples = examples',
-      _funDefName,
-      _funDefBuiltin
-      }
+    pure
+      FunctionDef
+        { _funDefClauses = clauses',
+          _funDefType = ty',
+          _funDefExamples = examples',
+          _funDefName,
+          _funDefBuiltin
+        }
 
 instance HasExpressions InductiveParameter where
   leafExpressions _ param@(InductiveParameter _) = do

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -248,16 +248,33 @@ instance HasExpressions InductiveParameter where
     pure param
 
 instance HasExpressions InductiveDef where
-  leafExpressions f (InductiveDef name built params constrs pos) = do
-    params' <- traverse (leafExpressions f) params
-    constrs' <- traverse (leafExpressions f) constrs
-    pure (InductiveDef name built params' constrs' pos)
+  leafExpressions f InductiveDef {..} = do
+    params' <- traverse (leafExpressions f) _inductiveParameters
+    constrs' <- traverse (leafExpressions f) _inductiveConstructors
+    examples' <- traverse (leafExpressions f) _inductiveExamples
+    pure
+      InductiveDef
+        { _inductiveParameters = params',
+          _inductiveConstructors = constrs',
+          _inductiveExamples = examples',
+          _inductiveName,
+          _inductiveBuiltin,
+          _inductivePositive
+        }
 
 instance HasExpressions InductiveConstructorDef where
-  leafExpressions f (InductiveConstructorDef c args ret) = do
-    args' <- traverse (leafExpressions f) args
-    ret' <- leafExpressions f ret
-    pure (InductiveConstructorDef c args' ret')
+  -- leafExpressions f InductiveConstructorDef c args ret = do
+  leafExpressions f InductiveConstructorDef {..} = do
+    args' <- traverse (leafExpressions f) _inductiveConstructorParameters
+    ret' <- leafExpressions f _inductiveConstructorReturnType
+    examples' <- traverse (leafExpressions f) _inductiveConstructorExamples
+    pure
+      InductiveConstructorDef
+        { _inductiveConstructorExamples = examples',
+          _inductiveConstructorParameters = args',
+          _inductiveConstructorReturnType = ret',
+          _inductiveConstructorName
+        }
 
 fillHolesFunctionDef :: HashMap Hole Expression -> FunctionDef -> FunctionDef
 fillHolesFunctionDef = subsHoles

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -23,6 +23,7 @@ import Juvix.Prelude
 
 data Module = Module
   { _moduleName :: Name,
+    _moduleExamples :: [Example],
     _moduleBody :: ModuleBody
   }
 
@@ -149,6 +150,7 @@ newtype InductiveParameter = InductiveParameter
 data InductiveDef = InductiveDef
   { _inductiveName :: InductiveName,
     _inductiveBuiltin :: Maybe BuiltinInductive,
+    _inductiveExamples :: [Example],
     _inductiveParameters :: [InductiveParameter],
     _inductiveConstructors :: [InductiveConstructorDef],
     _inductivePositive :: Bool
@@ -157,6 +159,7 @@ data InductiveDef = InductiveDef
 data InductiveConstructorDef = InductiveConstructorDef
   { _inductiveConstructorName :: ConstrName,
     _inductiveConstructorParameters :: [Expression],
+    _inductiveConstructorExamples :: [Example],
     _inductiveConstructorReturnType :: Expression
   }
 

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -50,6 +50,7 @@ data AxiomDef = AxiomDef
 data FunctionDef = FunctionDef
   { _funDefName :: FunctionName,
     _funDefType :: Expression,
+    _funDefExamples :: [Example],
     _funDefClauses :: NonEmpty FunctionClause,
     _funDefBuiltin :: Maybe BuiltinFunction
   }
@@ -94,6 +95,11 @@ data Expression
   deriving stock (Eq, Generic)
 
 instance Hashable Expression
+
+data Example = Example {
+  _exampleId :: NameId
+  , _exampleExpression :: Expression
+  }
 
 data Lambda = Lambda
   { _lambdaVar :: VarName,
@@ -172,6 +178,7 @@ data Function = Function
 instance Hashable Function
 
 makeLenses ''Module
+makeLenses ''Example
 makeLenses ''PatternArg
 makeLenses ''Include
 makeLenses ''FunctionDef

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -96,9 +96,9 @@ data Expression
 
 instance Hashable Expression
 
-data Example = Example {
-  _exampleId :: NameId
-  , _exampleExpression :: Expression
+data Example = Example
+  { _exampleId :: NameId,
+    _exampleExpression :: Expression
   }
 
 data Lambda = Lambda

--- a/src/Juvix/Compiler/Internal/Pretty.hs
+++ b/src/Juvix/Compiler/Internal/Pretty.hs
@@ -1,5 +1,6 @@
 module Juvix.Compiler.Internal.Pretty
   ( module Juvix.Compiler.Internal.Pretty,
+    module Juvix.Compiler.Internal.Pretty.Base,
     module Juvix.Compiler.Internal.Pretty.Options,
   )
 where

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -149,16 +149,26 @@ goFunctionDef :: Abstract.FunctionDef -> Sem r FunctionDef
 goFunctionDef f = do
   _funDefClauses' <- mapM (goFunctionClause _funDefName') (f ^. Abstract.funDefClauses)
   _funDefType' <- goType (f ^. Abstract.funDefTypeSig)
+  _funDefExamples' <- mapM goExample (f ^. Abstract.funDefExamples)
   return
     FunctionDef
       { _funDefName = _funDefName',
         _funDefType = _funDefType',
         _funDefClauses = _funDefClauses',
+        _funDefExamples = _funDefExamples',
         _funDefBuiltin = f ^. Abstract.funDefBuiltin
       }
   where
     _funDefName' :: Name
     _funDefName' = f ^. Abstract.funDefName
+
+goExample :: Abstract.Example -> Sem r Example
+goExample e = do
+  e' <- goExpression (e ^. Abstract.exampleExpression)
+  return Example {
+    _exampleExpression = e',
+    _exampleId = e ^. Abstract.exampleId
+  }
 
 goFunctionClause :: Name -> Abstract.FunctionClause -> Sem r FunctionClause
 goFunctionClause n c = do

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -67,9 +67,11 @@ goModule ::
   Sem r Module
 goModule m = do
   _moduleBody' <- goModuleBody (m ^. Abstract.moduleBody)
+  examples' <- mapM goExample (m ^. Abstract.moduleExamples)
   return
     Module
       { _moduleName = m ^. Abstract.moduleName,
+        _moduleExamples = examples',
         _moduleBody = _moduleBody'
       }
 
@@ -290,22 +292,26 @@ goInductiveDef i =
             mapM
               goConstructorDef
               (i ^. Abstract.inductiveConstructors)
+          examples' <- mapM goExample (i ^. Abstract.inductiveExamples)
           return
             InductiveDef
               { _inductiveName = indTypeName,
                 _inductiveParameters = inductiveParameters',
                 _inductiveBuiltin = i ^. Abstract.inductiveBuiltin,
                 _inductiveConstructors = inductiveConstructors',
+                _inductiveExamples = examples',
                 _inductivePositive = i ^. Abstract.inductivePositive
               }
   where
     goConstructorDef :: Abstract.InductiveConstructorDef -> Sem r InductiveConstructorDef
     goConstructorDef c = do
       (cParams, cReturnType) <- viewConstructorType (c ^. Abstract.constructorType)
+      examples' <- mapM goExample (c ^. Abstract.constructorExamples)
       return
         InductiveConstructorDef
           { _inductiveConstructorName = c ^. Abstract.constructorName,
             _inductiveConstructorParameters = cParams,
+            _inductiveConstructorExamples = examples',
             _inductiveConstructorReturnType = cReturnType
           }
 

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -165,10 +165,11 @@ goFunctionDef f = do
 goExample :: Abstract.Example -> Sem r Example
 goExample e = do
   e' <- goExpression (e ^. Abstract.exampleExpression)
-  return Example {
-    _exampleExpression = e',
-    _exampleId = e ^. Abstract.exampleId
-  }
+  return
+    Example
+      { _exampleExpression = e',
+        _exampleId = e ^. Abstract.exampleId
+      }
 
 goFunctionClause :: Name -> Abstract.FunctionClause -> Sem r FunctionClause
 goFunctionClause n c = do

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -4,15 +4,15 @@ module Juvix.Compiler.Internal.Translation.FromInternal
   )
 where
 
+import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Internal.Language
 import Juvix.Compiler.Internal.Translation.FromAbstract.Data.Context
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking qualified as ArityChecking
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Reachability
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Data.Effect.NameIdGen
-import Juvix.Compiler.Internal.Language
 import Juvix.Prelude hiding (fromEither)
-import Data.HashMap.Strict qualified as HashMap
 
 arityChecking ::
   Members '[Error JuvixError, NameIdGen] r =>

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -55,4 +55,4 @@ typeChecking res@ArityChecking.InternalArityResult {..} =
     table = buildTable _resultModules
 
     entryPoint :: EntryPoint
-    entryPoint = res ^. ArityChecking.microJuvixArityResultEntryPoint
+    entryPoint = res ^. ArityChecking.internalArityResultEntryPoint

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -59,9 +59,11 @@ checkFunctionDef ::
 checkFunctionDef FunctionDef {..} = do
   arity <- typeArity _funDefType
   _funDefClauses' <- mapM (checkFunctionClause arity) _funDefClauses
+  _funDefExamples' <- withEmptyLocalVars (mapM checkExample _funDefExamples)
   return
     FunctionDef
       { _funDefClauses = _funDefClauses',
+        _funDefExamples = _funDefExamples',
         ..
       }
 
@@ -87,6 +89,9 @@ checkFunctionClause ari cl = do
 lambda :: a
 lambda = error "lambda expressions are not supported by the arity checker"
 
+withEmptyLocalVars :: Sem (Reader LocalVars : r) a -> Sem r a
+withEmptyLocalVars = runReader emptyLocalVars
+
 guessArity ::
   forall r.
   Members '[Reader InfoTable] r =>
@@ -104,7 +109,7 @@ guessArity = \case
     idenHelper :: Iden -> Sem r (Maybe Arity)
     idenHelper i = case i of
       IdenVar {} -> return Nothing
-      _ -> Just <$> runReader (LocalVars mempty) (idenArity i)
+      _ -> Just <$> withEmptyLocalVars (idenArity i)
 
     appHelper :: Application -> Sem r (Maybe Arity)
     appHelper a = do
@@ -300,6 +305,11 @@ typeArity = go
           { _functionArityLeft = l',
             _functionArityRight = r'
           }
+
+checkExample ::  forall r.
+  Members '[Reader InfoTable, NameIdGen, Error ArityCheckerError, Reader LocalVars] r =>
+  Example -> Sem r Example
+checkExample = traverseOf exampleExpression (checkExpression ArityUnknown)
 
 checkExpression ::
   forall r.

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -306,9 +306,11 @@ typeArity = go
             _functionArityRight = r'
           }
 
-checkExample ::  forall r.
+checkExample ::
+  forall r.
   Members '[Reader InfoTable, NameIdGen, Error ArityCheckerError, Reader LocalVars] r =>
-  Example -> Sem r Example
+  Example ->
+  Sem r Example
 checkExample = traverseOf exampleExpression (checkExpression ArityUnknown)
 
 checkExpression ::

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Context.hs
@@ -15,5 +15,5 @@ makeLenses ''InternalArityResult
 mainModule :: Lens' InternalArityResult Module
 mainModule = resultModules . _head
 
-microJuvixArityResultEntryPoint :: Lens' InternalArityResult E.EntryPoint
-microJuvixArityResultEntryPoint = resultInternalResult . M.microJuvixResultEntryPoint
+internalArityResultEntryPoint :: Lens' InternalArityResult E.EntryPoint
+internalArityResultEntryPoint = resultInternalResult . M.microJuvixResultEntryPoint

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -66,44 +66,65 @@ checkStatement s = case s of
 
 checkInductiveDef ::
   forall r.
-  Members '[Reader EntryPoint, Reader InfoTable, Reader FunctionsTable, Error TypeCheckerError, NameIdGen, State TypesTable, State FunctionsTable, State NegativeTypeParameters] r =>
+  Members '[Reader EntryPoint, Reader InfoTable, Reader FunctionsTable, Error TypeCheckerError, NameIdGen, State TypesTable, State FunctionsTable, State NegativeTypeParameters, Output Example] r =>
   InductiveDef ->
   Sem r InductiveDef
-checkInductiveDef (InductiveDef name built params constrs pos) = runInferenceDef $ do
-  constrs' <- mapM goConstructor constrs
-  ty <- inductiveType name
-  modify (HashMap.insert name ty)
-  let d = InductiveDef name built params constrs' pos
+-- checkInductiveDef (InductiveDef name built params constrs pos) = runInferenceDef $ do
+checkInductiveDef InductiveDef {..} = runInferenceDef $ do
+  constrs' <- mapM goConstructor _inductiveConstructors
+  ty <- inductiveType _inductiveName
+  modify (HashMap.insert _inductiveName ty)
+  examples' <- mapM checkExample _inductiveExamples
+  let d =
+        InductiveDef
+          { _inductiveConstructors = constrs',
+            _inductiveExamples = examples',
+            _inductiveName,
+            _inductiveBuiltin,
+            _inductivePositive,
+            _inductiveParameters
+          }
   checkPositivity d
   return d
   where
     paramLocals :: LocalVars
     paramLocals =
       LocalVars
-        { _localTypes = HashMap.fromList [(p ^. inductiveParamName, smallUniverseE (getLoc p)) | p <- params],
+        { _localTypes = HashMap.fromList [(p ^. inductiveParamName, smallUniverseE (getLoc p)) | p <- _inductiveParameters],
           _localTyMap = mempty
         }
     goConstructor :: InductiveConstructorDef -> Sem (Inference ': r) InductiveConstructorDef
-    goConstructor (InductiveConstructorDef n cty ret) = do
-      expectedRetTy <- constructorReturnType n
+    goConstructor (InductiveConstructorDef {..}) = do
+      expectedRetTy <- constructorReturnType _inductiveConstructorName
       cty' <- runReader paramLocals $ do
         void (checkIsType (getLoc ret) ret)
-        mapM (checkIsType (getLoc n)) cty
+        mapM (checkIsType (getLoc _inductiveConstructorName)) _inductiveConstructorParameters
+      examples' <- mapM checkExample _inductiveConstructorExamples
       whenJustM (matchTypes expectedRetTy ret) (const (errRet expectedRetTy))
-      let c' = InductiveConstructorDef n cty' ret
+      let c' =
+            InductiveConstructorDef
+              { _inductiveConstructorParameters = cty',
+                _inductiveConstructorExamples = examples',
+                _inductiveConstructorReturnType,
+                _inductiveConstructorName
+              }
       registerConstructor c'
       return c'
       where
+        ret = _inductiveConstructorReturnType
         errRet :: Expression -> Sem (Inference ': r) a
         errRet expected =
           throw
             ( ErrWrongReturnType
                 WrongReturnType
-                  { _wrongReturnTypeConstructorName = n,
+                  { _wrongReturnTypeConstructorName = _inductiveConstructorName,
                     _wrongReturnTypeExpected = expected,
                     _wrongReturnTypeActual = ret
                   }
             )
+
+withEmptyVars :: Sem (Reader LocalVars : r) a -> Sem r a
+withEmptyVars = runReader emptyLocalVars
 
 checkFunctionDef ::
   Members '[Reader InfoTable, Error TypeCheckerError, NameIdGen, State TypesTable, State FunctionsTable, Output Example] r =>
@@ -111,7 +132,7 @@ checkFunctionDef ::
   Sem r FunctionDef
 checkFunctionDef FunctionDef {..} = do
   funDef <- readerState @FunctionsTable $ runInferenceDef $ do
-    _funDefType' <- runReader emptyLocalVars (checkFunctionDefType _funDefType)
+    _funDefType' <- withEmptyVars (checkFunctionDefType _funDefType)
     registerIden _funDefName _funDefType'
     _funDefClauses' <- mapM (checkFunctionClause _funDefType') _funDefClauses
     return
@@ -121,7 +142,7 @@ checkFunctionDef FunctionDef {..} = do
           ..
         }
   registerFunctionDef funDef
-  readerState @FunctionsTable (runReader emptyLocalVars (traverseOf funDefExamples (mapM checkExample) funDef))
+  readerState @FunctionsTable (traverseOf funDefExamples (mapM checkExample) funDef)
 
 checkIsType ::
   Members '[Reader InfoTable, Reader FunctionsTable, Error TypeCheckerError, NameIdGen, Reader LocalVars, Inference] r =>
@@ -144,11 +165,11 @@ checkFunctionDefType ty = do
     go h = freshMetavar h
 
 checkExample ::
-  Members '[Reader InfoTable, Reader FunctionsTable, Error TypeCheckerError, NameIdGen, Reader LocalVars, Output Example, State TypesTable] r =>
+  Members '[Reader InfoTable, Reader FunctionsTable, Error TypeCheckerError, NameIdGen, Output Example, State TypesTable] r =>
   Example ->
   Sem r Example
 checkExample e = do
-  e' <- runInferenceDef (traverseOf exampleExpression (inferExpression >=> strongNormalize) e)
+  e' <- withEmptyVars (runInferenceDef (traverseOf exampleExpression (inferExpression >=> strongNormalize) e))
   output e'
   return e'
 

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
@@ -16,7 +16,7 @@ type NormalizedTable = HashMap NameId Expression
 data InternalTypedResult = InternalTypedResult
   { _resultInternalArityResult :: InternalArityResult,
     _resultModules :: NonEmpty Module,
-   _resultNormalized :: NormalizedTable,
+    _resultNormalized :: NormalizedTable,
     _resultIdenTypes :: TypesTable
   }
 

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
@@ -7,6 +7,8 @@ where
 import Juvix.Compiler.Internal.Data.InfoTable
 import Juvix.Compiler.Internal.Language
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context (InternalArityResult)
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context qualified as Arity
+import Juvix.Compiler.Pipeline.EntryPoint qualified as E
 import Juvix.Prelude
 
 type TypesTable = HashMap Name Expression
@@ -24,3 +26,6 @@ makeLenses ''InternalTypedResult
 
 mainModule :: Lens' InternalTypedResult Module
 mainModule = resultModules . _head
+
+internalTypedResultEntryPoint :: Lens' InternalTypedResult E.EntryPoint
+internalTypedResultEntryPoint = resultInternalArityResult . Arity.internalArityResultEntryPoint

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
@@ -11,9 +11,12 @@ import Juvix.Prelude
 
 type TypesTable = HashMap Name Expression
 
+type NormalizedTable = HashMap NameId Expression
+
 data InternalTypedResult = InternalTypedResult
   { _resultInternalArityResult :: InternalArityResult,
     _resultModules :: NonEmpty Module,
+   _resultNormalized :: NormalizedTable,
     _resultIdenTypes :: TypesTable
   }
 

--- a/src/Juvix/Compiler/Mono/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Mono/Translation/FromInternal.hs
@@ -414,6 +414,7 @@ goFunctionDefPoly def poly
         (Just funName)
         Micro.FunctionDef
           { _funDefName = impossible,
+            _funDefExamples = mempty,
             _funDefType = sig' ^. Micro.unconcreteType,
             _funDefClauses = _funDefClauses,
             _funDefBuiltin = def ^. Micro.funDefBuiltin

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -86,7 +86,7 @@ upToSetup ::
 upToSetup = Setup.entrySetup
 
 upToParsing ::
-  Members '[Files, Error JuvixError] r =>
+  Members '[Files, Error JuvixError, NameIdGen] r =>
   EntryPoint ->
   Sem r Parser.ParserResult
 upToParsing = upToSetup >=> Parser.fromSource

--- a/src/Juvix/Extra/Process.hs
+++ b/src/Juvix/Extra/Process.hs
@@ -1,0 +1,10 @@
+module Juvix.Extra.Process where
+
+import Juvix.Prelude
+import System.Info
+
+openCmd :: Maybe String
+openCmd = case os of
+  "darwin" -> Just "open"
+  "linux" -> Just "xdg-open"
+  _ -> Nothing

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -11,6 +11,9 @@ axiom = "axiom"
 judocStart :: IsString s => s
 judocStart = "---"
 
+judocExample :: IsString s => s
+judocExample = ">>>"
+
 end :: IsString s => s
 end = "end"
 

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -185,6 +185,12 @@ toUpperFirst (x : xs) = Char.toUpper x : xs
 mconcatMap :: (Monoid c, Foldable t) => (a -> c) -> t a -> c
 mconcatMap f = List.mconcatMap f . toList
 
+concatWith :: (Foldable t, Monoid a) => (a -> a -> a) -> t a -> a
+concatWith f ds
+  | null ds = mempty
+  | otherwise = foldr1 f ds
+{-# INLINE concatWith #-}
+
 --------------------------------------------------------------------------------
 -- HashMap
 --------------------------------------------------------------------------------

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -6,7 +6,7 @@ module Juvix.Prelude.Pretty
 where
 
 import Juvix.Prelude.Base
-import Prettyprinter hiding (hsep, vsep)
+import Prettyprinter hiding (concatWith, hsep, vsep)
 import Prettyprinter qualified as PP
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import Prettyprinter.Render.Terminal qualified as Ansi


### PR DESCRIPTION
Closes #1441.

This PR adds the possibility to add _examples_ in judoc comments.
An example has the following syntax:
```
--- >>> expr;
```
The `---` is used to prefix judoc comments as usual. The `>>>` syntax is borrowed from haddock (we are free to change it if we want). The trailing `;` is convenient to stop the parsing of the expression.

Examples are passed down the pipeline and normalized during type checking. The normalized expression is showed in the html generated documentation.

Note that currently we only support normalization for a small subset of expressions (see https://github.com/anoma/juvix/pull/1404).

A concrete example.
Given the following definitions
```
--- A row in a board implemented as ;List Square;
---
--- >>> Row;
Row : Type;
Row ≔ List Square;
```
The output looks like this:
![image](https://user-images.githubusercontent.com/5511599/183400798-7929acc7-801d-4935-8515-de0200a6e820.png)
