### PR TITLE
Add `juvix init` command

### DIFF
--- a/app/CLI.hs
+++ b/app/CLI.hs
@@ -17,6 +17,7 @@ data CLI
   | DisplayHelp
   | Command CommandGlobalOptions
   | Doctor DoctorOptions
+  | Init
 
 parseDisplayVersion :: Parser CLI
 parseDisplayVersion =
@@ -30,30 +31,43 @@ parseDisplayHelp =
     DisplayHelp
     (long "help" <> short 'h' <> help "Show the help text" <> noGlobal)
 
-parseDoctor :: Parser CLI
-parseDoctor =
+parseUtility :: Parser CLI
+parseUtility =
   hsubparser
     ( mconcat
         [ commandGroup "Utility commands:",
           metavar "UTILITY_CMD",
-          command
-            "doctor"
-            ( info
-                (CLI.Doctor <$> parseDoctorOptions)
-                (progDesc "Perform checks on your Juvix development environment")
-            )
+          cmdDoctor,
+          cmdInit
         ]
     )
+  where
+    cmdInit :: Mod CommandFields CLI
+    cmdInit =
+      command
+        "init"
+        ( info
+            (pure Init)
+            (progDesc "Initialize a juvix project in the current directory")
+        )
+    cmdDoctor :: Mod CommandFields CLI
+    cmdDoctor =
+      command
+        "doctor"
+        ( info
+            (Doctor <$> parseDoctorOptions)
+            (progDesc "Perform checks on your Juvix development environment")
+        )
 
-parseCommand :: Parser CLI
-parseCommand = Command <$> parseCommandGlobalOptions
+parseCompiler :: Parser CLI
+parseCompiler = Command <$> parseCommandGlobalOptions
 
 parseCLI :: Parser CLI
 parseCLI =
   parseDisplayVersion
     <|> parseDisplayHelp
-    <|> parseCommand
-    <|> parseDoctor
+    <|> parseCompiler
+    <|> parseUtility
 
 commandFirstFile :: CommandGlobalOptions -> Maybe FilePath
 commandFirstFile CommandGlobalOptions {_cliGlobalOptions = GlobalOptions {..}} =

--- a/app/CLI.hs
+++ b/app/CLI.hs
@@ -48,7 +48,7 @@ parseUtility =
         "init"
         ( info
             (pure Init)
-            (progDesc "Initialize a juvix project in the current directory")
+            (progDesc "Interactively initialize a juvix project in the current directory")
         )
     cmdDoctor :: Mod CommandFields CLI
     cmdDoctor =

--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -4,6 +4,7 @@ import Data.Text qualified as Text
 import Data.Versions
 import Data.Yaml (encodeFile)
 import Juvix.Compiler.Pipeline.Package
+import Juvix.Extra.Paths
 import Juvix.Prelude
 import Juvix.Prelude.Pretty
 import Text.Megaparsec (Parsec)
@@ -24,13 +25,13 @@ init = do
   say "✨ Your next Juvix adventure is about to begin! ✨"
   say "I will help you set it up"
   pkg <- getPackage
-  say "creating juvix.yaml..."
-  embed (encodeFile "juvix.yaml" pkg)
+  say ("creating " <> pack juvixYamlFile)
+  embed (encodeFile juvixYamlFile pkg)
   say "yo are all set"
 
 checkNotInProject :: forall r. Members '[Embed IO] r => Sem r ()
 checkNotInProject =
-  whenM (embed (doesFileExist "juvix.yaml")) err
+  whenM (embed (doesFileExist juvixYamlFile)) err
   where
     err :: Sem r ()
     err = do

--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -1,0 +1,109 @@
+module Commands.Init where
+
+import Data.Text qualified as Text
+import Data.Versions
+import Data.Yaml (encodeFile)
+import Juvix.Compiler.Pipeline.Package
+import Juvix.Prelude
+import Juvix.Prelude.Pretty
+import Text.Megaparsec (Parsec)
+import Text.Megaparsec qualified as P
+import Text.Megaparsec.Char qualified as P
+
+type Err = Text
+
+parse :: Parsec Void Text a -> Text -> Either Err a
+parse p t = mapLeft ppErr (P.runParser p "<stdin>" t)
+
+ppErr :: P.ParseErrorBundle Text Void -> Text
+ppErr = pack . errorBundlePretty
+
+init :: forall r. Members '[Embed IO] r => Sem r ()
+init = do
+  checkNotInProject
+  say "✨ Your next Juvix adventure is about to begin! ✨"
+  say "I will help you set it up"
+  pkg <- getPackage
+  say "creating juvix.yaml..."
+  embed (encodeFile "juvix.yaml" pkg)
+  say "yo are all set"
+
+checkNotInProject :: forall r. Members '[Embed IO] r => Sem r ()
+checkNotInProject =
+  whenM (embed (doesFileExist "juvix.yaml")) err
+  where
+    err :: Sem r ()
+    err = do
+      say "You are already in a Juvix project"
+      embed exitFailure
+
+getPackage :: forall r. Members '[Embed IO] r => Sem r Package
+getPackage = do
+  say "Tell me the name of your project (lower case letters, numbers and dashes are allowed): "
+  tproj <- getProjName
+  say "Tell me the version of your project (leave empty for 0.0.0)"
+  tversion <- getVersion
+  return
+    Package
+      { _packageName = Just tproj,
+        _packageVersion = Just (prettySemVer tversion)
+      }
+
+getProjName :: forall r. Members '[Embed IO] r => Sem r Text
+getProjName = do
+  txt <- embed getLine
+  case parse projectNameParser txt of
+    Right p
+      | Text.length p <= projextNameMaxLength -> return p
+      | otherwise -> do
+          say ("The project name cannot exceed " <> prettyText projextNameMaxLength <> " characters")
+          retry
+    Left err -> do
+      say err
+      retry
+  where
+    retry :: Sem r Text
+    retry = do
+      tryAgain
+      getProjName
+
+say :: Members '[Embed IO] r => Text -> Sem r ()
+say = embed . putStrLn
+
+tryAgain :: Members '[Embed IO] r => Sem r ()
+tryAgain = say "Please, try again:"
+
+getVersion :: forall r. Members '[Embed IO] r => Sem r SemVer
+getVersion = do
+  txt <- embed getLine
+  if
+      | Text.null txt -> return mempty
+      | otherwise -> case parse semver' txt of
+          Right r -> return r
+          Left err -> do
+            say err
+            say "The version must follow the 'Semantic Versioning 2.0.0' specification"
+            retry
+  where
+    retry :: Sem r SemVer
+    retry = do
+      tryAgain
+      getVersion
+
+projextNameMaxLength :: Int
+projextNameMaxLength = 100
+
+projectNameParser :: Parsec Void Text Text
+projectNameParser = do
+  h <- P.satisfy validFirstChar
+  t <- P.takeWhileP (Just "project name character") validChar
+  P.hspace
+  P.eof
+  return (Text.cons h t)
+  where
+    validFirstChar :: Char -> Bool
+    validFirstChar c =
+      isAscii c
+        && (isLower c || isNumber c)
+    validChar :: Char -> Bool
+    validChar c = c == '-' || validFirstChar c

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import App
 import CLI
 import Commands.Dev.Termination as Termination
+import Commands.Init qualified as Init
 import Control.Exception qualified as IO
 import Control.Monad.Extra
 import Data.ByteString qualified as ByteString
@@ -271,3 +272,4 @@ main = do
     DisplayHelp -> showHelpText p
     Command cmd -> runM (runAppIO (cmd ^. cliGlobalOptions) (runCommand cmd))
     Doctor opts -> runM (runLogIO (doctor opts))
+    Init -> runM (runLogIO Init.init)

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ dependencies:
 - text == 1.2.*
 - th-utilities == 0.2.*
 - unordered-containers == 0.2.*
+- versions == 5.0.*
 - yaml == 0.11.*
 
 # the tasty dependencies are here to avoid having to recompile

--- a/src/Juvix/Compiler/Pipeline/Package.hs
+++ b/src/Juvix/Compiler/Pipeline/Package.hs
@@ -10,7 +10,7 @@ data Package = Package
   }
   deriving stock (Eq, Show, Generic)
 
-$( deriveFromJSON
+$( deriveJSON
      defaultOptions
        { fieldLabelModifier = over Lens._head toLower . dropPrefix "_package",
          rejectUnknownFields = True

--- a/src/Juvix/Data/Effect/Fail/Extra.hs
+++ b/src/Juvix/Data/Effect/Fail/Extra.hs
@@ -1,0 +1,17 @@
+module Juvix.Data.Effect.Fail.Extra
+  ( module Juvix.Data.Effect.Fail.Extra,
+    module Juvix.Data.Effect.Fail,
+  )
+where
+
+import Juvix.Data.Effect.Fail
+import Juvix.Prelude.Base
+import Juvix.Prelude.Base qualified as Prelude
+
+last :: Members '[Fail] r => [a] -> Sem r a
+last = failMaybe . fmap Prelude.last . nonEmpty
+
+fromRight :: Members '[Fail] s => Either l r -> Sem s r
+fromRight = \case
+  Left {} -> fail
+  Right r -> return r


### PR DESCRIPTION
This pr adds the command `juvix init`, which has no additional flags or parameters for now.

See the following video to see how it works
https://youtu.be/OIGyhIdIc4Y
