### PR TITLE
Properly handle paragraphs in judoc

### DIFF
--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -351,7 +351,7 @@ goJudoc (Judoc bs) = mconcatMapM goBlock bs
   where
     goBlock :: JudocBlock 'Scoped -> Sem r Html
     goBlock = \case
-      JudocParagraph ls -> concatWith (\l r -> l <> " " <> r) <$> mapM goLine (toList ls)
+      JudocParagraph ls -> Html.p . concatWith (\l r -> l <> " " <> r) <$> mapM goLine (toList ls)
       JudocExample e -> goExample e
     goLine :: JudocParagraphLine 'Scoped -> Sem r Html
     goLine (JudocParagraphLine atoms) = mconcatMapM goAtom (toList atoms)


### PR DESCRIPTION
hotfix PR:

Before:
![image](https://user-images.githubusercontent.com/5511599/183875621-2e2c8a46-748e-47c7-ae35-3920278264eb.png)

After:
![image](https://user-images.githubusercontent.com/5511599/183875805-9705baf6-ad14-4f11-950c-45898fd55fb6.png)
