### PR TITLE
Give a proper type to literal natural numbers

### DIFF
--- a/examples/milestone/ValidityPredicates/Anoma/Base.juvix
+++ b/examples/milestone/ValidityPredicates/Anoma/Base.juvix
@@ -36,7 +36,7 @@ open import Data.Int.Ops;
 import Stdlib.Data.String.Ord;
 
 from-int : Int → Maybe Int;
-from-int i ≔ if (i < 0) nothing (just i);
+from-int i ≔ if (i < Int_0) nothing (just i);
 
 from-string : String → Maybe String;
 from-string s ≔ if (s Stdlib.Data.String.Ord.== "") nothing (just s);
@@ -73,6 +73,6 @@ is-balance-key : String → String → Maybe String;
 is-balance-key token key ≔ from-string (isBalanceKey token key);
 
 unwrap-default : Maybe Int → Int;
-unwrap-default ≔ maybe 0 id;
+unwrap-default ≔ maybe Int_0 id;
 
 end;

--- a/examples/milestone/ValidityPredicates/Data/Int.juvix
+++ b/examples/milestone/ValidityPredicates/Data/Int.juvix
@@ -6,4 +6,14 @@ compile Int {
   c ↦ "int";
 };
 
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
+};
+
 end;

--- a/examples/milestone/ValidityPredicates/SimpleFungibleToken.juvix
+++ b/examples/milestone/ValidityPredicates/SimpleFungibleToken.juvix
@@ -9,7 +9,7 @@ import Data.Int.Ops;
 -- Misc
 
 pair-from-optionString : (String → Int × Bool) → Maybe String → Int × Bool;
-pair-from-optionString ≔ maybe (0 , false);
+pair-from-optionString ≔ maybe (Int_0 , false);
 
 -- Validity Predicate
 
@@ -19,7 +19,7 @@ change-from-key key ≔ unwrap-default (read-post key) Data.Int.Ops.- unwrap-def
 check-vp : List String → String → Int → String → Int × Bool;
 check-vp verifiers key change owner ≔
     if
-        (change-from-key key Data.Int.Ops.< 0)
+        (change-from-key key Data.Int.Ops.< Int_0)
         -- make sure the spender approved the transaction
         (change Data.Int.Ops.+ (change-from-key key), elem (Stdlib.Data.String.Ord.==) owner verifiers)
         (change Data.Int.Ops.+ (change-from-key key),  true);
@@ -29,16 +29,16 @@ check-keys token verifiers (change , is-success) key ≔
     if
         is-success
         (pair-from-optionString (check-vp verifiers key change) (is-balance-key token key))
-        (0 , false);
+        (Int_0 , false);
 
 check-result : Int × Bool → Bool;
-check-result (change , all-checked) ≔ (change Data.Int.Ops.== 0) && all-checked;
+check-result (change , all-checked) ≔ (change Data.Int.Ops.== Int_0) && all-checked;
 
 vp : String → List String → List String → Bool;
 vp token keys-changed verifiers ≔
     check-result
         (foldl
             (check-keys token verifiers)
-            (0 , true)
+            (Int_0 , true)
             keys-changed);
 end;

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -5,6 +5,7 @@ module Juvix.Compiler.Internal.Translation.FromInternal
 where
 
 import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Builtins.Effect
 import Juvix.Compiler.Internal.Language
 import Juvix.Compiler.Internal.Translation.FromAbstract.Data.Context
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking qualified as ArityChecking
@@ -31,7 +32,7 @@ arityChecking res@InternalResult {..} =
     table = buildTable _resultModules
 
 typeChecking ::
-  Members '[Error JuvixError, NameIdGen] r =>
+  Members '[Error JuvixError, NameIdGen, Builtins] r =>
   ArityChecking.InternalArityResult ->
   Sem r InternalTypedResult
 typeChecking res@ArityChecking.InternalArityResult {..} =

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -152,7 +152,7 @@ pipelineAbstract ::
 pipelineAbstract = mapError (JuvixError @Scoper.ScoperError) . Abstract.fromConcrete
 
 pipelineInternalTyped ::
-  Members '[Files, NameIdGen, Error JuvixError] r =>
+  Members '[Files, NameIdGen, Error JuvixError, Builtins] r =>
   Internal.InternalArityResult ->
   Sem r Internal.InternalTypedResult
 pipelineInternalTyped =

--- a/tests/positive/FullExamples/MonoSimpleFungibleToken.juvix
+++ b/tests/positive/FullExamples/MonoSimpleFungibleToken.juvix
@@ -69,6 +69,11 @@ compile Int {
   ghc ↦ "Int";
 };
 
+axiom Int_0 : Int;
+compile Int_0 {
+  ghc ↦ "0";
+};
+
 axiom lt : Int → Int → BackendBool;
 compile lt {
   ghc ↦ "(<)";
@@ -156,7 +161,7 @@ if-optionInt true x _ ≔ x;
 if-optionInt false _ y ≔ y;
 
 from-int : Int → OptionInt;
-from-int i ≔ if-optionInt (i < 0) NothingInt (JustInt i);
+from-int i ≔ if-optionInt (i < Int_0) NothingInt (JustInt i);
 
 maybe-int : Int → OptionInt → Int;
 maybe-int d NothingInt ≔ d;
@@ -175,7 +180,7 @@ from-string : String → OptionString;
 from-string s ≔ if-optionString (s ==String "") NothingString (JustString s);
 
 pair-from-optionString : (String → PairIntBool) → OptionString → PairIntBool;
-pair-from-optionString _ NothingString ≔ MakePair 0 false;
+pair-from-optionString _ NothingString ≔ MakePair Int_0 false;
 pair-from-optionString f (JustString o) ≔ f o;
 
 --------------------------------------------------------------------------------
@@ -215,7 +220,7 @@ is-balance-key : String → String → OptionString;
 is-balance-key token key ≔ from-string (isBalanceKey token key);
 
 unwrap-default : OptionInt → Int;
-unwrap-default o ≔ maybe-int 0 o;
+unwrap-default o ≔ maybe-int Int_0 o;
 
 --------------------------------------------------------------------------------
 -- Validity Predicate
@@ -227,7 +232,7 @@ change-from-key key ≔ unwrap-default (read-post key) - unwrap-default (read-pr
 check-vp : ListString → String → Int → String → PairIntBool;
 check-vp verifiers key change owner ≔
     if-pairIntBool
-        (change-from-key key < 0)
+        (change-from-key key < Int_0)
         -- make sure the spender approved the transaction
         (MakePair (change + (change-from-key key)) (elem owner verifiers))
         (MakePair (change + (change-from-key key)) true);
@@ -237,17 +242,17 @@ check-keys token verifiers (MakePair change is-success) key ≔
     if-pairIntBool
         is-success
         (pair-from-optionString (check-vp verifiers key change) (is-balance-key token key))
-        (MakePair 0 false);
+        (MakePair Int_0 false);
 
 check-result : PairIntBool → Bool;
-check-result (MakePair change all-checked) ≔ (change ==Int 0) && all-checked;
+check-result (MakePair change all-checked) ≔ (change ==Int Int_0) && all-checked;
 
 vp : String → ListString → ListString → Bool;
 vp token keys-changed verifiers ≔
     check-result
         (foldl
             (check-keys token verifiers)
-            (MakePair 0 true)
+            (MakePair Int_0 true)
             keys-changed);
 
 --------------------------------------------------------------------------------

--- a/tests/positive/FullExamples/SimpleFungibleTokenImplicit.juvix
+++ b/tests/positive/FullExamples/SimpleFungibleTokenImplicit.juvix
@@ -81,6 +81,17 @@ compile Int {
   ghc ↦ "Int";
 };
 
+
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
+};
+
 infix 4 <';
 axiom <' : Int → Int → BackendBool;
 compile <' {
@@ -168,7 +179,7 @@ inductive Maybe (A : Type) {
 };
 
 from-int : Int → Maybe Int;
-from-int i ≔ if (i < 0) nothing (just i);
+from-int i ≔ if (i < Int_0) nothing (just i);
 
 maybe : {A : Type} → {B : Type} → B → (A → B) → Maybe A → B;
 maybe b _ nothing ≔ b;
@@ -178,7 +189,7 @@ from-string : String → Maybe String;
 from-string s ≔ if (s ==String "") nothing (just s);
 
 pair-from-optionString : (String → Int × Bool) → Maybe String → Int × Bool;
-pair-from-optionString ≔ maybe (0 , false);
+pair-from-optionString ≔ maybe (Int_0 , false);
 
 --------------------------------------------------------------------------------
 -- Anoma
@@ -209,7 +220,7 @@ is-balance-key : String → String → Maybe String;
 is-balance-key token key ≔ from-string (isBalanceKey token key);
 
 unwrap-default : Maybe Int → Int;
-unwrap-default ≔ maybe 0 id;
+unwrap-default ≔ maybe Int_0 id;
 
 --------------------------------------------------------------------------------
 -- Validity Predicate
@@ -221,7 +232,7 @@ change-from-key key ≔ unwrap-default (read-post key) - unwrap-default (read-pr
 check-vp : List String → String → Int → String → Int × Bool;
 check-vp verifiers key change owner ≔
     if
-        (change-from-key key < 0)
+        (change-from-key key < Int_0)
         -- make sure the spender approved the transaction
         (change + (change-from-key key), elem (==String) owner verifiers)
         (change + (change-from-key key),  true);
@@ -231,17 +242,17 @@ check-keys token verifiers (change , is-success) key ≔
     if
         is-success
         (pair-from-optionString (check-vp verifiers key change) (is-balance-key token key))
-        (0 , false);
+        (Int_0 , false);
 
 check-result : Int × Bool → Bool;
-check-result (change , all-checked) ≔ (change ==Int 0) && all-checked;
+check-result (change , all-checked) ≔ (change ==Int Int_0) && all-checked;
 
 vp : String → List String → List String → Bool;
 vp token keys-changed verifiers ≔
     check-result
         (foldl
             (check-keys token verifiers)
-            (0 , true)
+            (Int_0 , true)
             keys-changed);
 
 --------------------------------------------------------------------------------

--- a/tests/positive/Internal/LiteralInt.juvix
+++ b/tests/positive/Internal/LiteralInt.juvix
@@ -1,4 +1,5 @@
 module LiteralInt;
+  open import Stdlib.Prelude;
   inductive A {
     a : A;
   };
@@ -7,6 +8,6 @@ module LiteralInt;
     b : B;
   };
 
-  f : A;
+  f : ℕ;
   f ≔ 1;
 end;

--- a/tests/positive/MiniC/AlwaysValidVP/Input.juvix
+++ b/tests/positive/MiniC/AlwaysValidVP/Input.juvix
@@ -17,9 +17,19 @@ compile AnomaBool {
   c ↦ "uint64_t";
 };
 
+axiom AnomaBool_true : AnomaBool;
+compile AnomaBool_true {
+  c ↦ "1";
+};
+
+axiom AnomaBool_false : AnomaBool;
+compile AnomaBool_false {
+  c ↦ "0";
+};
+
 encodeBool : Bool → AnomaBool;
-encodeBool true ≔ 1;
-encodeBool false ≔ 0;
+encodeBool true ≔ AnomaBool_true;
+encodeBool false ≔ AnomaBool_false;
 
 --- The module entrypoint callable by wasm runtime
 _validate_tx : AnomaPtr → AnomaSize → AnomaPtr → AnomaSize → AnomaPtr → AnomaSize → AnomaPtr → AnomaSize → AnomaBool;

--- a/tests/positive/MiniC/Builtins/Input.juvix
+++ b/tests/positive/MiniC/Builtins/Input.juvix
@@ -19,6 +19,9 @@ mult (suc n) m ≔ m + (mult n m);
 plusOne : ℕ → ℕ;
 plusOne ≔ suc;
 
+someLiteral : _;
+someLiteral ≔ 123;
+
 builtin IO axiom IO : Type;
 
 infixl 1 >>;

--- a/tests/positive/MiniC/ClosureEnv/Input.juvix
+++ b/tests/positive/MiniC/ClosureEnv/Input.juvix
@@ -4,9 +4,18 @@ open import Data.IO;
 open import Data.String;
 
 axiom Int : Type;
-
 compile Int {
   c ↦ "int";
+};
+
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
 };
 
 axiom to-str : Int → String;
@@ -37,8 +46,8 @@ nplus zero n ≔ n;
 nplus (suc m) n ≔ suc (nplus m n);
 
 nplus-to-int : Nat → Int;
-nplus-to-int zero ≔ 0;
-nplus-to-int (suc n) ≔ plus 1 (nplus-to-int n);
+nplus-to-int zero ≔ Int_0;
+nplus-to-int (suc n) ≔ plus Int_1 (nplus-to-int n);
 
 nOne : Nat;
 nOne ≔ suc zero;
@@ -46,14 +55,17 @@ nOne ≔ suc zero;
 nplusOne : Nat → Nat → Nat;
 nplusOne n ≔ nplus nOne;
 
+plusOneInt : Int → Int;
+plusOneInt ≔ plus Int_1;
+
 one : Int;
-one ≔ 1;
+one ≔ Int_1;
 
 two : Int;
-two ≔ 2;
+two ≔ plusOneInt one;
 
 three : Int;
-three ≔ 3;
+three ≔ plusOneInt two;
 
 plusXIgnore2 : Int → Int → Int → Int → Int;
 plusXIgnore2 _ _ ≔ plus;

--- a/tests/positive/MiniC/ClosureNoEnv/Input.juvix
+++ b/tests/positive/MiniC/ClosureNoEnv/Input.juvix
@@ -4,9 +4,23 @@ open import Data.IO;
 open import Data.String;
 
 axiom Int : Type;
-
 compile Int {
   c ↦ "int";
+};
+
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
+};
+
+axiom Int_2 : Int;
+compile Int_2 {
+  c ↦ "2";
 };
 
 axiom to-str : Int → String;
@@ -46,8 +60,8 @@ apply-nat2 : (Nat → Nat → Nat) → Nat → Nat → Nat;
 apply-nat2 f a b ≔ f a b;
 
 nat-to-int : Nat → Int;
-nat-to-int zero ≔ 0;
-nat-to-int (suc n) ≔ plus 1 (nat-to-int n);
+nat-to-int zero ≔ Int_0;
+nat-to-int (suc n) ≔ plus Int_1 (nat-to-int n);
 
 one : Nat;
 one ≔ suc zero;
@@ -60,7 +74,7 @@ two ≔ suc one;
 
 main : Action;
 main ≔ put-str "plus 1 2: "
-        >> put-str-ln (to-str (apply plus 1 2))
+        >> put-str-ln (to-str (apply plus Int_1 Int_2))
         >> put-str "suc one: "
         >> put-str-ln (to-str (nat-to-int (apply-nat suc one)))
         >> put-str "plus-nat 1 2: "

--- a/tests/positive/MiniC/HigherOrder/Input.juvix
+++ b/tests/positive/MiniC/HigherOrder/Input.juvix
@@ -55,6 +55,16 @@ compile Int {
   c ↦ "int";
 };
 
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
+};
+
 foreign c {
   int plus(int l, int r) {
     return l + r;
@@ -90,8 +100,8 @@ infixl 6 +;
 + (suc m) n ≔ suc (m + n);
 
 to-int : Nat → Int;
-to-int zero ≔ 0;
-to-int (suc n) ≔ 1 +int (to-int n);
+to-int zero ≔ Int_0;
+to-int (suc n) ≔ Int_1 +int (to-int n);
 
 nat-to-str : Nat → String;
 nat-to-str n ≔ to-str (to-int n);

--- a/tests/positive/MiniC/MultiModules/Data/Int.juvix
+++ b/tests/positive/MiniC/MultiModules/Data/Int.juvix
@@ -7,6 +7,16 @@ compile Int {
   c ↦ "int";
 };
 
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
+};
+
 axiom intToStr : Int → String;
 
 compile intToStr {

--- a/tests/positive/MiniC/MultiModules/Data/Nat.juvix
+++ b/tests/positive/MiniC/MultiModules/Data/Nat.juvix
@@ -22,8 +22,8 @@ compile natInd {
 };
 
 natToInt : Nat → Int;
-natToInt zero ≔ 0;
-natToInt (suc n) ≔ 1 + (natToInt n);
+natToInt zero ≔ Int_0;
+natToInt (suc n) ≔ Int_1 + (natToInt n);
 
 natToStr : Nat → String;
 natToStr n ≔ intToStr (natToInt n);

--- a/tests/positive/MiniC/MutuallyRecursive/Data/Int.juvix
+++ b/tests/positive/MiniC/MutuallyRecursive/Data/Int.juvix
@@ -7,6 +7,27 @@ compile Int {
   c ↦ "int";
 };
 
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
+};
+
+axiom Int_4 : Int;
+compile Int_4 {
+  c ↦ "4";
+};
+
+
+axiom Int_9 : Int;
+compile Int_9 {
+  c ↦ "9";
+};
+
 axiom intToStr : Int → String;
 
 compile intToStr {

--- a/tests/positive/MiniC/MutuallyRecursive/Data/Nat.juvix
+++ b/tests/positive/MiniC/MutuallyRecursive/Data/Nat.juvix
@@ -22,8 +22,8 @@ compile natInd {
 };
 
 natToInt : Nat → Int;
-natToInt zero ≔ 0;
-natToInt (suc n) ≔ 1 + (natToInt n);
+natToInt zero ≔ Int_0;
+natToInt (suc n) ≔ Int_1 + (natToInt n);
 
 natToStr : Nat → String;
 natToStr n ≔ intToStr (natToInt n);

--- a/tests/positive/MiniC/MutuallyRecursive/Input.juvix
+++ b/tests/positive/MiniC/MutuallyRecursive/Input.juvix
@@ -22,11 +22,11 @@ checkOdd : Int → String;
 checkOdd ≔ check odd;
 
 main : Action;
-main ≔ put-str "even 1: " >> put-str-ln (checkEven 1)
-        >> put-str "even 4: " >> put-str-ln (checkEven 4)
-        >> put-str "even 9: " >> put-str-ln (checkEven 9)
-        >> put-str "odd 1: " >> put-str-ln (checkOdd 1)
-        >> put-str "odd 4: " >> put-str-ln (checkOdd 4)
-        >> put-str "odd 9: " >> put-str-ln (checkOdd 9)
+main ≔ put-str "even 1: " >> put-str-ln (checkEven Int_1)
+        >> put-str "even 4: " >> put-str-ln (checkEven Int_4)
+        >> put-str "even 9: " >> put-str-ln (checkEven Int_9)
+        >> put-str "odd 1: " >> put-str-ln (checkOdd Int_1)
+        >> put-str "odd 4: " >> put-str-ln (checkOdd Int_4)
+        >> put-str "odd 9: " >> put-str-ln (checkOdd Int_9)
 
 end;

--- a/tests/positive/MiniC/Nat/Input.juvix
+++ b/tests/positive/MiniC/Nat/Input.juvix
@@ -68,10 +68,19 @@ bool-to-str false ≔ "False";
 --------------------------------------------------------------------------------
 
 axiom Int : Type;
-
 compile Int {
   ghc ↦ "Int";
   c ↦ "int";
+};
+
+axiom Int_0 : Int;
+compile Int_0 {
+  c ↦ "0";
+};
+
+axiom Int_1 : Int;
+compile Int_1 {
+  c ↦ "1";
 };
 
 foreign c {
@@ -121,8 +130,8 @@ infix 4 ==Nat;
 ==Nat _ _ ≔ false;
 
 to-int : Nat → Int;
-to-int zero ≔ 0;
-to-int (suc n) ≔ 1 +int (to-int n);
+to-int zero ≔ Int_0;
+to-int (suc n) ≔ Int_1 +int (to-int n);
 
 nat-to-str : Nat → String;
 nat-to-str n ≔ to-str (to-int n);

--- a/tests/positive/MiniC/PolymorphicTarget/Input.juvix
+++ b/tests/positive/MiniC/PolymorphicTarget/Input.juvix
@@ -20,7 +20,12 @@ compile Action {
   c ↦ "int";
 };
 
+axiom Int_0 : Action;
+compile Int_0 {
+  c ↦ "0";
+};
+
 main : Action;
-main := 0;
+main := Int_0;
 
 end;

--- a/tests/positive/MiniC/SimpleFungibleTokenImplicit/Input.juvix
+++ b/tests/positive/MiniC/SimpleFungibleTokenImplicit/Input.juvix
@@ -98,8 +98,14 @@ id a ≔ a;
 --------------------------------------------------------------------------------
 
 axiom Int : Type;
+axiom Int_0 : Int;
+
 compile Int {
   c ↦ "int";
+};
+
+compile Int_0 {
+  c ↦ "0";
 };
 
 foreign c {
@@ -129,6 +135,9 @@ compile <' {
 infix 4 <;
 < : Int → Int → Bool;
 < i1 i2 ≔ from-backend-bool (i1 <' i2);
+
+isNegative : Int → Bool;
+isNegative n ≔ n < Int_0;
 
 axiom eqInt : Int → Int → BackendBool;
 compile eqInt {
@@ -213,7 +222,7 @@ inductive Maybe (A : Type) {
 };
 
 from-int : Int → Maybe Int;
-from-int i ≔ if (i < 0) nothing (just i);
+from-int i ≔ if (isNegative i) nothing (just i);
 
 maybe : {A : Type} → {B : Type} → B → (A → B) → Maybe A → B;
 maybe b _ nothing ≔ b;
@@ -223,7 +232,7 @@ from-string : String → Maybe String;
 from-string s ≔ if (s ==String "") nothing (just s);
 
 pair-from-optionString : (String → Int × Bool) → Maybe String → Int × Bool;
-pair-from-optionString ≔ maybe (0 , false);
+pair-from-optionString ≔ maybe (Int_0 , false);
 
 --------------------------------------------------------------------------------
 -- Anoma
@@ -254,7 +263,7 @@ is-balance-key : String → String → Maybe String;
 is-balance-key token key ≔ from-string (isBalanceKey token key);
 
 unwrap-default : Maybe Int → Int;
-unwrap-default ≔ maybe 0 id;
+unwrap-default ≔ maybe Int_0 id;
 
 --------------------------------------------------------------------------------
 -- Validity Predicate
@@ -266,7 +275,7 @@ change-from-key key ≔ unwrap-default (read-post key) - unwrap-default (read-pr
 check-vp : List String → String → Int → String → Int × Bool;
 check-vp verifiers key change owner ≔
     if
-        (change-from-key key < 0)
+        (isNegative (change-from-key key))
         -- make sure the spender approved the transaction
         (change + (change-from-key key), elem (==String) owner verifiers)
         (change + (change-from-key key),  true);
@@ -276,17 +285,17 @@ check-keys token verifiers (change , is-success) key ≔
     if
         is-success
         (pair-from-optionString (check-vp verifiers key change) (is-balance-key token key))
-        (0 , false);
+        (Int_0 , false);
 
 check-result : Int × Bool → Bool;
-check-result (change , all-checked) ≔ (change ==Int 0) && all-checked;
+check-result (change , all-checked) ≔ (change ==Int Int_0) && all-checked;
 
 vp : String → List String → List String → Bool;
 vp token keys-changed verifiers ≔
     check-result
         (foldl
             (check-keys token verifiers)
-            (0 , true)
+            (Int_0 , true)
             keys-changed);
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Before this PR, literal natural numbers were assigned the type `{A : Type} -> A`.
Now, when the type checker finds a literal number, it checks that the builtin natural numbers have been defined and it gives it the proper type. This change was easy. Most of the changed lines are about fixing tests.