### PR TITLE
Fixes TicTacToe Web example

### DIFF
--- a/examples/milestone/TicTacToe/Web/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/Web/TicTacToe.juvix
@@ -36,6 +36,19 @@ compile div {
   c ↦ "div";
 };
 
+-- IO extensions
+
+axiom IOUnit : IO;
+compile IOUnit {
+  c ↦ "0";
+};
+
+sequenceIO : List IO → IO;
+sequenceIO ≔ foldr (>>) IOUnit;
+
+mapIO : {A : Type} → (A → IO) → List A → IO;
+mapIO f xs ≔ sequenceIO (map f xs);
+
 -- List extensions
 
 zip : {A : Type} → {B : Type} → List A → List B → List (A × B);
@@ -112,10 +125,10 @@ renderRowAux : ℕ → (ℕ × Square) → IO;
 renderRowAux col (row , s) ≔ renderSquare row col s;
 
 renderRow : ℕ × (List Square) → IO;
-renderRow (n , xs) ≔ foldr (>>) 0 (map (renderRowAux n) (enumerate xs));
+renderRow (n , xs) ≔ mapIO (renderRowAux n) (enumerate xs);
 
 renderBoard : Board → IO;
-renderBoard (board squares) ≔ foldr (>>) 0 (map renderRow (enumerate squares));
+renderBoard (board squares) ≔ mapIO renderRow (enumerate squares);
 
 renderFooterText : String → IO;
 renderFooterText msg ≔ renderText msg 0 3 left;
@@ -124,7 +137,7 @@ nextPlayerText : Symbol → String;
 nextPlayerText s ≔ "Next player: " ++str (showSymbol s);
 
 renderError : Error → IO;
-renderError noError ≔ 0;
+renderError noError ≔ IOUnit;
 renderError (continue msg) ≔ renderText msg 0 3 left;
 renderError (terminate msg) ≔ renderText msg 0 3 left;
 

--- a/test/BackendC/Base.hs
+++ b/test/BackendC/Base.hs
@@ -28,6 +28,12 @@ clangCompile mkClangArgs cResult execute step =
         execute wasmOutputFile
     )
 
+wasmClangAssertionCGenOnly :: FilePath -> ((String -> IO ()) -> Assertion)
+wasmClangAssertionCGenOnly mainFile step = do
+  step "C Generation"
+  let entryPoint = defaultEntryPoint mainFile
+  (void . runIO) (upToMiniC entryPoint)
+
 wasmClangAssertion :: WASMInfo -> FilePath -> FilePath -> ((String -> IO ()) -> Assertion)
 wasmClangAssertion WASMInfo {..} mainFile expectedFile step = do
   step "Check clang and wasmer are on path"

--- a/test/BackendC/Examples.hs
+++ b/test/BackendC/Examples.hs
@@ -4,31 +4,51 @@ import BackendC.Base
 import Base
 import Data.FileEmbed
 
-data ExampleTest = ExampleTest
+data ExampleTest
+  = ExampleExecTest ExecTest
+  | ExampleCGenOnlyTest TestSpec
+
+data TestSpec = TestSpec
   { _name :: String,
     _relDir :: FilePath,
-    _mainFile :: FilePath,
+    _mainFile :: FilePath
+  }
+
+data ExecTest = ExecTest
+  { _spec :: TestSpec,
     _expectedDir :: FilePath,
     _stdinText :: Text,
     _compileMode :: CompileMode
   }
 
-makeLenses ''ExampleTest
+makeLenses ''ExecTest
+makeLenses ''TestSpec
+
+execTest :: String -> FilePath -> FilePath -> FilePath -> Text -> CompileMode -> ExecTest
+execTest _name _relDir _mainFile _expectedDir _stdinText _compileMode = ExecTest {_spec = TestSpec {..}, ..}
 
 exampleRoot :: FilePath
 exampleRoot = "examples/milestone"
 
 testDescr :: ExampleTest -> TestDescr
-testDescr ExampleTest {..} =
-  let mainRoot = exampleRoot </> _relDir
-      expectedFile = $(makeRelativeToProject "tests/examplesExpected" >>= strToExp) </> _expectedDir </> "expected.golden"
-   in TestDescr
-        { _testName = _name,
-          _testRoot = mainRoot,
-          _testAssertion = case _compileMode of
-            WASI stdlibMode -> Steps $ wasiClangAssertion stdlibMode _mainFile expectedFile _stdinText
-            WASM i -> Steps $ wasmClangAssertion i _mainFile expectedFile
-        }
+testDescr = \case
+  ExampleExecTest (ExecTest {..}) ->
+    let mainRoot = exampleRoot </> _spec ^. relDir
+        expectedFile = $(makeRelativeToProject "tests/examplesExpected" >>= strToExp) </> _expectedDir </> "expected.golden"
+     in TestDescr
+          { _testName = _spec ^. name,
+            _testRoot = mainRoot,
+            _testAssertion = case _compileMode of
+              WASI stdlibMode -> Steps $ wasiClangAssertion stdlibMode (_spec ^. mainFile) expectedFile _stdinText
+              WASM i -> Steps $ wasmClangAssertion i (_spec ^. mainFile) expectedFile
+          }
+  ExampleCGenOnlyTest (TestSpec {..}) ->
+    let mainRoot = exampleRoot </> _relDir
+     in TestDescr
+          { _testName = _name,
+            _testRoot = mainRoot,
+            _testAssertion = Steps $ wasmClangAssertionCGenOnly _mainFile
+          }
 
 allTests :: TestTree
 allTests =
@@ -38,10 +58,11 @@ allTests =
 
 tests :: [ExampleTest]
 tests =
-  [ ExampleTest "Validity Predicate example" "ValidityPredicates" "Tests.juvix" "ValidityPredicates" "" (WASI StdlibInclude),
-    ExampleTest "TicTacToe CLI example" "TicTacToe" "CLI/TicTacToe.juvix" "TicTacToe" "aaa\n0\n10\n1\n2\n3\n3\n4\n5\n6\n7\n8\n9\n" (WASI StdlibInclude),
-    ExampleTest "Fibonacci example" "Fibonacci" "Fibonacci.juvix" "Fibonacci" "" (WASI StdlibInclude),
-    ExampleTest "Collatz sequence generator" "Collatz" "Collatz.juvix" "Collatz" "123\n" (WASI StdlibInclude),
-    ExampleTest "Towers of Hanoi" "Hanoi" "Hanoi.juvix" "Hanoi" "" (WASI StdlibInclude),
-    ExampleTest "Pascal's triangle" "PascalsTriangle" "PascalsTriangle.juvix" "PascalsTriangle" "" (WASI StdlibInclude)
+  [ ExampleExecTest $ execTest "Validity Predicate example" "ValidityPredicates" "Tests.juvix" "ValidityPredicates" "" (WASI StdlibInclude),
+    ExampleExecTest $ execTest "TicTacToe CLI example" "TicTacToe" "CLI/TicTacToe.juvix" "TicTacToe" "aaa\n0\n10\n1\n2\n3\n3\n4\n5\n6\n7\n8\n9\n" (WASI StdlibInclude),
+    ExampleCGenOnlyTest $ TestSpec "TicTacToe Web example (C gen only)" "TicTacToe" "Web/TicTacToe.juvix",
+    ExampleExecTest $ execTest "Fibonacci example" "Fibonacci" "Fibonacci.juvix" "Fibonacci" "" (WASI StdlibInclude),
+    ExampleExecTest $ execTest "Collatz sequence generator" "Collatz" "Collatz.juvix" "Collatz" "123\n" (WASI StdlibInclude),
+    ExampleExecTest $ execTest "Towers of Hanoi" "Hanoi" "Hanoi.juvix" "Hanoi" "" (WASI StdlibInclude),
+    ExampleExecTest $ execTest "Pascal's triangle" "PascalsTriangle" "PascalsTriangle.juvix" "PascalsTriangle" "" (WASI StdlibInclude)
   ]


### PR DESCRIPTION
Now that integer literals have the builtin int type we need an actual
IOUnit value to use in the IO sequence implementation.

This commit also adds the TicTacToe web example to the test suite. It is
a typecheck / C generation only test because it uses the Wasm browser APIs.