### PR TITLE
Add a native compile target for demos

### DIFF
--- a/tests/CLI/Commands/compile.test
+++ b/tests/CLI/Commands/compile.test
@@ -6,3 +6,7 @@ $ juvix compile --help
 $ cd tests/positive/MiniC/HelloWorld && juvix compile Input.juvix -o hello.wasm
 >
 >= 0
+
+$ cd examples/milestone/HelloWorld && juvix compile -t native HelloWorld.juvix && ./HelloWorld
+hello world!
+>= 0


### PR DESCRIPTION
Add an option to compile a Juvix program to a native executable:

```
$ cd examples/milestone/HelloWorld
$ juvix compile -t native HelloWorld.juvix
$ ./HelloWorld
hello world!
```

This option is useful for demos because it does not depend on the Wasmer / Wasi environment.