### PR TITLE
Add --stdin flag

### DIFF
--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -11,6 +11,7 @@ data GlobalOptions = GlobalOptions
   { _globalNoColors :: Bool,
     _globalShowNameIds :: Bool,
     _globalOnlyErrors :: Bool,
+    _globalStdin :: Bool,
     _globalNoTermination :: Bool,
     _globalNoPositivity :: Bool,
     _globalNoStdlib :: Bool,
@@ -27,6 +28,7 @@ defaultGlobalOptions =
       _globalShowNameIds = False,
       _globalOnlyErrors = False,
       _globalNoTermination = False,
+      _globalStdin = False,
       _globalNoPositivity = False,
       _globalNoStdlib = False,
       _globalInputFiles = []
@@ -38,6 +40,7 @@ instance Semigroup GlobalOptions where
       { _globalNoColors = o1 ^. globalNoColors || o2 ^. globalNoColors,
         _globalShowNameIds = o1 ^. globalShowNameIds || o2 ^. globalShowNameIds,
         _globalOnlyErrors = o1 ^. globalOnlyErrors || o2 ^. globalOnlyErrors,
+        _globalStdin = o1 ^. globalStdin || o2 ^. globalStdin,
         _globalNoTermination = o1 ^. globalNoTermination || o2 ^. globalNoTermination,
         _globalNoPositivity = o1 ^. globalNoPositivity || o2 ^. globalNoPositivity,
         _globalNoStdlib = o1 ^. globalNoStdlib || o2 ^. globalNoStdlib,
@@ -62,6 +65,12 @@ parseGlobalFlags b = do
     switch
       ( long "show-name-ids"
           <> help "Show the unique number of each identifier when pretty printing"
+          <> hidden b
+      )
+  _globalStdin <-
+    switch
+      ( long "stdin"
+          <> help "Read from Stdin"
           <> hidden b
       )
   _globalOnlyErrors <-

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -14,6 +14,7 @@ data EntryPoint = EntryPoint
     _entryPointNoPositivity :: Bool,
     _entryPointNoStdlib :: Bool,
     _entryPointPackage :: Package,
+    _entryPointStdin :: Maybe Text,
     _entryPointModulePaths :: NonEmpty FilePath
   }
   deriving stock (Eq, Show)
@@ -25,6 +26,7 @@ defaultEntryPoint mainFile =
       _entryPointNoTermination = False,
       _entryPointNoPositivity = False,
       _entryPointNoStdlib = False,
+      _entryPointStdin = Nothing,
       _entryPointPackage = emptyPackage,
       _entryPointModulePaths = pure mainFile
     }

--- a/test/Reachability/Positive.hs
+++ b/test/Reachability/Positive.hs
@@ -30,13 +30,9 @@ testDescr PosTest {..} =
             entryFile <- canonicalizePath _file
             let noStdlib = _stdlibMode == StdlibExclude
                 entryPoint =
-                  EntryPoint
+                  (defaultEntryPoint entryFile)
                     { _entryPointRoot = cwd,
-                      _entryPointNoTermination = False,
-                      _entryPointNoPositivity = False,
-                      _entryPointPackage = emptyPackage,
-                      _entryPointNoStdlib = noStdlib,
-                      _entryPointModulePaths = pure entryFile
+                      _entryPointNoStdlib = noStdlib
                     }
 
             step "Pipeline up to reachability"

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -37,13 +37,9 @@ testDescr PosTest {..} =
             entryFile <- canonicalizePath _file
             let noStdlib = _stdlibMode == StdlibExclude
                 entryPoint =
-                  EntryPoint
+                  (defaultEntryPoint entryFile)
                     { _entryPointRoot = cwd,
-                      _entryPointNoTermination = False,
-                      _entryPointNoPositivity = False,
-                      _entryPointPackage = emptyPackage,
-                      _entryPointNoStdlib = noStdlib,
-                      _entryPointModulePaths = pure entryFile
+                      _entryPointNoStdlib = noStdlib
                     }
                 stdlibMap :: HashMap FilePath Text
                 stdlibMap = HashMap.mapKeys (cwd </>) (HashMap.fromList stdlibDir)

--- a/test/Termination/Positive.hs
+++ b/test/Termination/Positive.hs
@@ -39,13 +39,10 @@ testDescrFlag N.NegTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             let entryPoint =
-                  EntryPoint
+                  (defaultEntryPoint _file)
                     { _entryPointRoot = ".",
                       _entryPointNoTermination = True,
-                      _entryPointNoPositivity = False,
-                      _entryPointNoStdlib = True,
-                      _entryPointPackage = emptyPackage,
-                      _entryPointModulePaths = pure _file
+                      _entryPointNoStdlib = True
                     }
 
             (void . runIO) (upToInternal entryPoint)

--- a/test/TypeCheck/Positive.hs
+++ b/test/TypeCheck/Positive.hs
@@ -39,13 +39,8 @@ testNoPositivityFlag N.NegTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             let entryPoint =
-                  EntryPoint
-                    { _entryPointRoot = ".",
-                      _entryPointNoTermination = False,
-                      _entryPointNoPositivity = True,
-                      _entryPointNoStdlib = False,
-                      _entryPointPackage = emptyPackage,
-                      _entryPointModulePaths = pure _file
+                  (defaultEntryPoint _file)
+                    { _entryPointNoPositivity = True
                     }
 
             (void . runIO) (upToInternal entryPoint)

--- a/tests/CLI/help.test
+++ b/tests/CLI/help.test
@@ -1,8 +1,8 @@
 $ juvix --help
-> /Usage: juvix \(\(\-v\|\-\-version\) \| \(\-h\|\-\-help\) \| \[\-\-no\-colors\] \[\-\-show\-name\-ids\] 
-               \[\-\-only\-errors\] \[\-\-no\-termination\] \[\-\-no\-positivity\] 
-               \[\-\-no\-stdlib\] COMPILER_CMD \|
-               UTILITY_CMD.*/
+> /Usage: juvix ((\-v|\-\-version) | (\-h|\-\-help) | \[\-\-no\-colors\] \[\-\-show\-name\-ids\] 
+               \[\-\-stdin\] \[\-\-only\-errors\] \[\-\-no\-termination\] \[\-\-no\-positivity\] 
+               \[\-\-no-stdlib\] COMPILER_CMD |
+               UTILITY_CMD)*/
 >= 0
 
 


### PR DESCRIPTION
Adds the `--stdin` flag. When active, the main file is read from stdin. Useful for VScode and probably for emacs as well.