### PR TITLE
example/tic-tac-toe: clear screen in between prints

### DIFF
--- a/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
@@ -22,6 +22,11 @@ compile parsePositiveInt {
   c ↦ "parsePositiveInt";
 };
 
+axiom clear : IO;
+compile clear {
+  c ↦ "system(\"clear\")";
+};
+
 -- | Reads a ;ℕ; from stdin
 getMove : Maybe ℕ;
 getMove ≔ validMove (parsePositiveInt (readline));
@@ -36,9 +41,11 @@ prompt x ≔ "\n" ++str (showGameState x) ++str "\nPlayer " ++str showSymbol (pl
 -- | Main loop
 terminating
 run : (IO × GameState → GameState) → GameState → IO;
-run _ (state b p (terminate msg)) ≔ putStrLn ("\n" ++str (showGameState (state b p noError)) ++str "\n" ++str msg);
-run f (state b p (continue msg)) ≔ run f (f (putStr (msg ++str prompt (state b p noError)) , state b p noError));
-run f x ≔ run f (f (putStr (prompt x) , x));
+run _ (state b p (terminate msg)) ≔
+  clear >>
+  putStrLn ("\n" ++str (showGameState (state b p noError)) ++str "\n" ++str msg);
+run f (state b p (continue msg)) ≔ run f (f ((clear >> putStr (msg ++str prompt (state b p noError))), state b p noError));
+run f x ≔ run f (f ((clear >> putStr (prompt x)), x));
 
 --- The welcome message
 welcome : String;


### PR DESCRIPTION
I was playing around with this example - there are some issues with my changes and I expect they'll also break some tests, so I wouldn't merge this, but I just wanted to share some observations. I'm not sure if it's relevant for now, as @lukaszcz mentioned that the `IO` will be refactored and `>>` is temp, but here goes:
- on e.g. line 48, I had to use parens around `clear >> putStr (prompt x)`, because otherwise `,` operator takes precedence over `>>` and fails with:
  ```
  The expression , {_} {_} (putStr (++str msg (prompt (state b p noError)))) (state b p noError) has type:
    × _ _
  but is expected to have type:
    IO
  ```
- I'm not sure what's going with this, but I tried to do something like:
  ```
  clearBefore : IO -> IO;
  clearBefore x ≔ clear >> x;
  ```
  When I replaced the calls to `clear >>` with `clearBefore $`, it seems that the order of these effects is reversed and the screen is cleared after the prints