### PR TITLE
Add an option to show name ids in errors

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -10,8 +10,8 @@ import System.Console.ANSI qualified as Ansi
 
 data App m a where
   ExitMsg :: ExitCode -> Text -> App m ()
-  ExitJuvixError :: JuvixError -> App m a
-  PrintJuvixError :: JuvixError -> App m ()
+  ExitJuvixError :: GenericOptions -> JuvixError -> App m a
+  PrintJuvixError :: GenericOptions -> JuvixError -> App m ()
   ReadGlobalOptions :: App m GlobalOptions
   RenderStdOut :: (HasAnsiBackend a, HasTextBackend a) => a -> App m ()
   RunPipelineEither :: Sem PipelineEff a -> App m (Either JuvixError a)
@@ -32,22 +32,22 @@ runAppIO g = interpret $ \case
   Say t
     | g ^. globalOnlyErrors -> return ()
     | otherwise -> embed (putStrLn t)
-  PrintJuvixError e -> do
-    printErr e
-  ExitJuvixError e -> do
-    printErr e
+  PrintJuvixError opts e -> do
+    printErr opts e
+  ExitJuvixError opts e -> do
+    printErr opts e
     embed exitFailure
   ExitMsg exitCode t -> embed (putStrLn t >> exitWith exitCode)
   Raw b -> embed (ByteString.putStr b)
   where
-    printErr e =
-      (embed . hPutStrLn stderr . Error.render (not (g ^. globalNoColors)) (g ^. globalOnlyErrors)) e
+    printErr opts e =
+      (embed . hPutStrLn stderr . Error.render opts (not (g ^. globalNoColors)) (g ^. globalOnlyErrors)) e
 
-runPipeline :: Member App r => Sem PipelineEff a -> Sem r a
-runPipeline p = do
+runPipeline :: Member App r => GenericOptions -> Sem PipelineEff a -> Sem r a
+runPipeline opts p = do
   r <- runPipelineEither p
   case r of
-    Left err -> exitJuvixError err
+    Left err -> exitJuvixError opts err
     Right res -> return res
 
 newline :: Member App r => Sem r ()

--- a/app/App.hs
+++ b/app/App.hs
@@ -41,7 +41,7 @@ runAppIO g = interpret $ \case
   Raw b -> embed (ByteString.putStr b)
   where
     printErr opts e =
-      (embed . hPutStrLn stderr . Error.render opts (not (g ^. globalNoColors)) (g ^. globalOnlyErrors)) e
+      embed $ hPutStrLn stderr $ run $ runReader opts $ Error.render (not (g ^. globalNoColors)) (g ^. globalOnlyErrors) e
 
 runPipeline :: Member App r => GenericOptions -> Sem PipelineEff a -> Sem r a
 runPipeline opts p = do

--- a/app/Commands/Dev/Core.hs
+++ b/app/Commands/Dev/Core.hs
@@ -11,9 +11,8 @@ newtype CoreReplOptions = CoreReplOptions
   { _coreReplShowDeBruijn :: Bool
   }
 
-data CoreEvalOptions = CoreEvalOptions
-  { _coreEvalShowDeBruijn :: Bool,
-    _coreEvalNoIO :: Bool
+newtype CoreEvalOptions = CoreEvalOptions
+  { _coreEvalNoIO :: Bool
   }
 
 makeLenses ''CoreReplOptions
@@ -22,8 +21,7 @@ makeLenses ''CoreEvalOptions
 defaultCoreEvalOptions :: CoreEvalOptions
 defaultCoreEvalOptions =
   CoreEvalOptions
-    { _coreEvalShowDeBruijn = False,
-      _coreEvalNoIO = False
+    { _coreEvalNoIO = False
     }
 
 parseCoreCommand :: Parser CoreCommand
@@ -54,11 +52,6 @@ parseCoreCommand =
 
 parseCoreEvalOptions :: Parser CoreEvalOptions
 parseCoreEvalOptions = do
-  _coreEvalShowDeBruijn <-
-    switch
-      ( long "show-de-bruijn"
-          <> help "Show variable de Bruijn indices"
-      )
   _coreEvalNoIO <-
     switch
       ( long "no-io"

--- a/app/Commands/Dev/Core.hs
+++ b/app/Commands/Dev/Core.hs
@@ -11,8 +11,9 @@ newtype CoreReplOptions = CoreReplOptions
   { _coreReplShowDeBruijn :: Bool
   }
 
-newtype CoreEvalOptions = CoreEvalOptions
-  { _coreEvalNoIO :: Bool
+data CoreEvalOptions = CoreEvalOptions
+  { _coreEvalShowDeBruijn :: Bool,
+    _coreEvalNoIO :: Bool
   }
 
 makeLenses ''CoreReplOptions
@@ -21,7 +22,8 @@ makeLenses ''CoreEvalOptions
 defaultCoreEvalOptions :: CoreEvalOptions
 defaultCoreEvalOptions =
   CoreEvalOptions
-    { _coreEvalNoIO = False
+    { _coreEvalShowDeBruijn = False,
+      _coreEvalNoIO = False
     }
 
 parseCoreCommand :: Parser CoreCommand
@@ -52,6 +54,11 @@ parseCoreCommand =
 
 parseCoreEvalOptions :: Parser CoreEvalOptions
 parseCoreEvalOptions = do
+  _coreEvalShowDeBruijn <-
+    switch
+      ( long "show-de-bruijn"
+          <> help "Show variable de Bruijn indices"
+      )
   _coreEvalNoIO <-
     switch
       ( long "no-io"

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -107,4 +107,4 @@ parseGlobalOptions b = do
   return opts {_globalInputFiles = files}
 
 genericFromGlobalOptions :: GlobalOptions -> E.GenericOptions
-genericFromGlobalOptions GlobalOptions {..} = E.GenericOptions {E._optShowNameIds = _globalShowNameIds}
+genericFromGlobalOptions GlobalOptions {..} = E.GenericOptions {E._showNameIds = _globalShowNameIds}

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -4,6 +4,7 @@ module GlobalOptions
 where
 
 import Commands.Extra
+import Juvix.Data.Error.GenericError qualified as E
 import Juvix.Prelude
 import Options.Applicative hiding (hidden)
 
@@ -104,3 +105,6 @@ parseGlobalOptions b = do
   opts <- parseGlobalFlags b
   files <- parserInputFiles
   return opts {_globalInputFiles = files}
+
+genericFromGlobalOptions :: GlobalOptions -> E.GenericOptions
+genericFromGlobalOptions GlobalOptions {..} = E.GenericOptions {E._optShowNameIds = _globalShowNameIds}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -380,7 +380,7 @@ runCoreCommand globalOpts = \case
               | Info.member Info.kNoDisplayInfo (Core.getInfo node') ->
                   return ()
             Right node' -> do
-              renderStdOut (Core.ppOut (docOpts False) node')
+              renderStdOut (Core.ppOut (docOpts (opts ^. coreEvalShowDeBruijn)) node')
               embed (putStrLn "")
         Right (_, Nothing) -> return ()
       where

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -137,7 +137,7 @@ runCommand cmdWithOpts = do
                 Highlight HighlightOptions {..} -> do
                   res <- runPipelineEither (upToScoping entryPoint)
                   case res of
-                    Left err -> say (Highlight.goError (errorIntervals genericOpts err))
+                    Left err -> say (Highlight.goError (run $ runReader genericOpts $ errorIntervals err))
                     Right r -> do
                       let tbl = r ^. Scoper.resultParserTable
                           items = tbl ^. Parser.infoParsedItems

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -380,7 +380,7 @@ runCoreCommand globalOpts = \case
               | Info.member Info.kNoDisplayInfo (Core.getInfo node') ->
                   return ()
             Right node' -> do
-              renderStdOut (Core.ppOut (docOpts (opts ^. coreEvalShowDeBruijn)) node')
+              renderStdOut (Core.ppOut (docOpts False) node')
               embed (putStrLn "")
         Right (_, Nothing) -> return ()
       where

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -97,6 +97,7 @@ getEntryPoint r pkg opts = nonEmpty (opts ^. globalInputFiles) >>= Just <$> entr
               _entryPointNoStdlib = opts ^. globalNoStdlib,
               _entryPointPackage = pkg,
               _entryPointModulePaths = l,
+              _entryPointGenericOptions = genericFromGlobalOptions opts,
               _entryPointStdin
             }
 
@@ -104,7 +105,6 @@ runCommand :: Members '[Embed IO, App] r => CommandGlobalOptions -> Sem r ()
 runCommand cmdWithOpts = do
   let cmd = cmdWithOpts ^. cliCommand
       globalOpts = cmdWithOpts ^. cliGlobalOptions
-      genericOpts = genericFromGlobalOptions globalOpts
       toAnsiText' :: forall a. (HasAnsiBackend a, HasTextBackend a) => a -> Text
       toAnsiText' = toAnsiText (not (globalOpts ^. globalNoColors))
   (root, pkg) <- embed (findRoot cmdWithOpts)
@@ -123,21 +123,21 @@ runCommand cmdWithOpts = do
               -- Visible commands
               Check -> commandHelper entryPoint (Dev (Internal (TypeCheck mempty)))
               Compile localOpts -> do
-                miniC <- (^. MiniC.resultCCode) <$> runPipeline genericOpts (upToMiniC entryPoint)
+                miniC <- (^. MiniC.resultCCode) <$> runPipeline (entryPoint ^. entryPointGenericOptions) (upToMiniC entryPoint)
                 let inputFile = entryPoint ^. mainModulePath
                 result <- embed (runCompile root inputFile localOpts miniC)
                 case result of
                   Left err -> printFailureExit err
                   _ -> return ()
               Html HtmlOptions {..} -> do
-                res <- runPipeline genericOpts (upToScoping entryPoint)
+                res <- runPipeline (entryPoint ^. entryPointGenericOptions) (upToScoping entryPoint)
                 let m = head (res ^. Scoper.resultModules)
                 embed (Html.genHtml Scoper.defaultOptions _htmlRecursive _htmlTheme _htmlOutputDir _htmlPrintMetadata m)
               (Dev cmd') -> case cmd' of
                 Highlight HighlightOptions {..} -> do
                   res <- runPipelineEither (upToScoping entryPoint)
                   case res of
-                    Left err -> say (Highlight.goError (run $ runReader genericOpts $ errorIntervals err))
+                    Left err -> say (Highlight.goError (run $ runReader (entryPoint ^. entryPointGenericOptions) $ errorIntervals err))
                     Right r -> do
                       let tbl = r ^. Scoper.resultParserTable
                           items = tbl ^. Parser.infoParsedItems
@@ -154,20 +154,20 @@ runCommand cmdWithOpts = do
                 Parse localOpts -> do
                   m <-
                     head . (^. Parser.resultModules)
-                      <$> runPipeline genericOpts (upToParsing entryPoint)
+                      <$> runPipeline (entryPoint ^. entryPointGenericOptions) (upToParsing entryPoint)
                   if localOpts ^. parseNoPrettyShow then say (show m) else say (pack (ppShow m))
                 Scope localOpts -> do
                   l <-
                     (^. Scoper.resultModules)
                       <$> runPipeline
-                        genericOpts
+                        (entryPoint ^. entryPointGenericOptions)
                         (upToScoping entryPoint)
                   forM_ l $ \s -> do
                     renderStdOut (Scoper.ppOut (mkScopePrettyOptions globalOpts localOpts) s)
                 Doc localOpts -> do
                   ctx :: InternalTyped.InternalTypedResult <-
                     runPipeline
-                      genericOpts
+                      (entryPoint ^. entryPointGenericOptions)
                       (upToInternalTyped entryPoint)
                   let docDir = localOpts ^. docOutputDir
                   Doc.compile docDir "proj" ctx
@@ -177,17 +177,17 @@ runCommand cmdWithOpts = do
                 Internal Pretty -> do
                   micro <-
                     head . (^. Internal.resultModules)
-                      <$> runPipeline genericOpts (upToInternal entryPoint)
+                      <$> runPipeline (entryPoint ^. entryPointGenericOptions) (upToInternal entryPoint)
                   let ppOpts =
                         Internal.defaultOptions
                           { Internal._optShowNameIds = globalOpts ^. globalShowNameIds
                           }
                   App.renderStdOut (Internal.ppOut ppOpts micro)
                 Internal Arity -> do
-                  micro <- head . (^. InternalArity.resultModules) <$> runPipeline genericOpts (upToInternalArity entryPoint)
+                  micro <- head . (^. InternalArity.resultModules) <$> runPipeline (entryPoint ^. entryPointGenericOptions) (upToInternalArity entryPoint)
                   App.renderStdOut (Internal.ppOut Internal.defaultOptions micro)
                 Internal (TypeCheck localOpts) -> do
-                  res <- runPipeline genericOpts (upToInternalTyped entryPoint)
+                  res <- runPipeline (entryPoint ^. entryPointGenericOptions) (upToInternalTyped entryPoint)
                   say "Well done! It type checks"
                   when (localOpts ^. microJuvixTypePrint) $ do
                     let ppOpts =
@@ -197,10 +197,10 @@ runCommand cmdWithOpts = do
                         checkedModule = head (res ^. InternalTyped.resultModules)
                     renderStdOut (Internal.ppOut ppOpts checkedModule)
                 MiniC -> do
-                  miniC <- (^. MiniC.resultCCode) <$> runPipeline genericOpts (upToMiniC entryPoint)
+                  miniC <- (^. MiniC.resultCCode) <$> runPipeline (entryPoint ^. entryPointGenericOptions) (upToMiniC entryPoint)
                   say miniC
                 Termination (Calls localOpts@CallsOptions {..}) -> do
-                  results <- runPipeline genericOpts (upToAbstract entryPoint)
+                  results <- runPipeline (entryPoint ^. entryPointGenericOptions) (upToAbstract entryPoint)
                   let topModule = head (results ^. Abstract.resultModules)
                       infotable = results ^. Abstract.resultTable
                       callMap0 = Termination.buildCallMap infotable topModule
@@ -211,7 +211,7 @@ runCommand cmdWithOpts = do
                   renderStdOut (Abstract.ppOut localOpts' callMap)
                   newline
                 Termination (CallGraph CallGraphOptions {..}) -> do
-                  results <- runPipeline genericOpts (upToAbstract entryPoint)
+                  results <- runPipeline (entryPoint ^. entryPointGenericOptions) (upToAbstract entryPoint)
                   let topModule = head (results ^. Abstract.resultModules)
                       infotable = results ^. Abstract.resultTable
                       callMap = Termination.buildCallMap infotable topModule

--- a/src/Juvix/Compiler/Builtins/Error.hs
+++ b/src/Juvix/Compiler/Builtins/Error.hs
@@ -13,11 +13,12 @@ makeLenses ''AlreadyDefined
 
 instance ToGenericError AlreadyDefined where
   genericError e =
-    return GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = ppOutput msg,
+          _genericErrorIntervals = [i]
+        }
     where
       i = e ^. alreadyDefinedLoc
       msg = "The builtin" <+> code (pretty (e ^. alreadyDefinedBuiltin)) <+> "has already been defined"
@@ -31,11 +32,12 @@ makeLenses ''NotDefined
 
 instance ToGenericError NotDefined where
   genericError e =
-    return GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = ppOutput msg,
+          _genericErrorIntervals = [i]
+        }
     where
       i = e ^. notDefinedLoc
       msg = "The builtin" <+> code (pretty (e ^. notDefinedBuiltin)) <+> "has not been defined"

--- a/src/Juvix/Compiler/Builtins/Error.hs
+++ b/src/Juvix/Compiler/Builtins/Error.hs
@@ -12,8 +12,8 @@ data AlreadyDefined = AlreadyDefined
 makeLenses ''AlreadyDefined
 
 instance ToGenericError AlreadyDefined where
-  genericError _ e =
-    GenericError
+  genericError e =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,
         _genericErrorIntervals = [i]
@@ -30,8 +30,8 @@ data NotDefined = NotDefined
 makeLenses ''NotDefined
 
 instance ToGenericError NotDefined where
-  genericError _ e =
-    GenericError
+  genericError e =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,
         _genericErrorIntervals = [i]

--- a/src/Juvix/Compiler/Builtins/Error.hs
+++ b/src/Juvix/Compiler/Builtins/Error.hs
@@ -12,7 +12,7 @@ data AlreadyDefined = AlreadyDefined
 makeLenses ''AlreadyDefined
 
 instance ToGenericError AlreadyDefined where
-  genericError e =
+  genericError _ e =
     GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,
@@ -30,7 +30,7 @@ data NotDefined = NotDefined
 makeLenses ''NotDefined
 
 instance ToGenericError NotDefined where
-  genericError e =
+  genericError _ e =
     GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,

--- a/src/Juvix/Compiler/Concrete/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Options.hs
@@ -15,3 +15,6 @@ defaultOptions =
     }
 
 makeLenses ''Options
+
+fromGenericOptions :: GenericOptions -> Options
+fromGenericOptions GenericOptions {..} = set optShowNameIds _optShowNameIds defaultOptions

--- a/src/Juvix/Compiler/Concrete/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Options.hs
@@ -17,4 +17,4 @@ defaultOptions =
 makeLenses ''Options
 
 fromGenericOptions :: GenericOptions -> Options
-fromGenericOptions GenericOptions {..} = set optShowNameIds _optShowNameIds defaultOptions
+fromGenericOptions GenericOptions {..} = set optShowNameIds _showNameIds defaultOptions

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -40,30 +40,30 @@ data ScoperError
   deriving stock (Show)
 
 instance ToGenericError ScoperError where
-  genericError = \case
-    ErrParser e -> genericError e
-    ErrInfixParser e -> genericError e
-    ErrAppLeftImplicit e -> genericError e
-    ErrInfixPattern e -> genericError e
-    ErrMultipleDeclarations e -> genericError e
-    ErrLacksTypeSig e -> genericError e
-    ErrImportCycle e -> genericError e
-    ErrSymNotInScope e -> genericError e
-    ErrQualSymNotInScope e -> genericError e
-    ErrModuleNotInScope e -> genericError e
-    ErrBindGroup e -> genericError e
-    ErrDuplicateFixity e -> genericError e
-    ErrMultipleExport e -> genericError e
-    ErrAmbiguousSym e -> genericError e
-    ErrWrongTopModuleName e -> genericError e
-    ErrAmbiguousModuleSym e -> genericError e
-    ErrUnusedOperatorDef e -> genericError e
-    ErrLacksFunctionClause e -> genericError e
-    ErrWrongLocationCompileBlock e -> genericError e
-    ErrMultipleCompileBlockSameName e -> genericError e
-    ErrMultipleCompileRuleSameBackend e -> genericError e
-    ErrWrongKindExpressionCompileBlock e -> genericError e
-    ErrDuplicateInductiveParameterName e -> genericError e
-    ErrDoubleBracesPattern e -> genericError e
-    ErrImplicitPatternLeftApplication e -> genericError e
-    ErrConstructorExpectedLeftApplication e -> genericError e
+  genericError opts = \case
+    ErrParser e -> genericError opts e
+    ErrInfixParser e -> genericError opts e
+    ErrAppLeftImplicit e -> genericError opts e
+    ErrInfixPattern e -> genericError opts e
+    ErrMultipleDeclarations e -> genericError opts e
+    ErrLacksTypeSig e -> genericError opts e
+    ErrImportCycle e -> genericError opts e
+    ErrSymNotInScope e -> genericError opts e
+    ErrQualSymNotInScope e -> genericError opts e
+    ErrModuleNotInScope e -> genericError opts e
+    ErrBindGroup e -> genericError opts e
+    ErrDuplicateFixity e -> genericError opts e
+    ErrMultipleExport e -> genericError opts e
+    ErrAmbiguousSym e -> genericError opts e
+    ErrWrongTopModuleName e -> genericError opts e
+    ErrAmbiguousModuleSym e -> genericError opts e
+    ErrUnusedOperatorDef e -> genericError opts e
+    ErrLacksFunctionClause e -> genericError opts e
+    ErrWrongLocationCompileBlock e -> genericError opts e
+    ErrMultipleCompileBlockSameName e -> genericError opts e
+    ErrMultipleCompileRuleSameBackend e -> genericError opts e
+    ErrWrongKindExpressionCompileBlock e -> genericError opts e
+    ErrDuplicateInductiveParameterName e -> genericError opts e
+    ErrDoubleBracesPattern e -> genericError opts e
+    ErrImplicitPatternLeftApplication e -> genericError opts e
+    ErrConstructorExpectedLeftApplication e -> genericError opts e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -40,30 +40,30 @@ data ScoperError
   deriving stock (Show)
 
 instance ToGenericError ScoperError where
-  genericError opts = \case
-    ErrParser e -> genericError opts e
-    ErrInfixParser e -> genericError opts e
-    ErrAppLeftImplicit e -> genericError opts e
-    ErrInfixPattern e -> genericError opts e
-    ErrMultipleDeclarations e -> genericError opts e
-    ErrLacksTypeSig e -> genericError opts e
-    ErrImportCycle e -> genericError opts e
-    ErrSymNotInScope e -> genericError opts e
-    ErrQualSymNotInScope e -> genericError opts e
-    ErrModuleNotInScope e -> genericError opts e
-    ErrBindGroup e -> genericError opts e
-    ErrDuplicateFixity e -> genericError opts e
-    ErrMultipleExport e -> genericError opts e
-    ErrAmbiguousSym e -> genericError opts e
-    ErrWrongTopModuleName e -> genericError opts e
-    ErrAmbiguousModuleSym e -> genericError opts e
-    ErrUnusedOperatorDef e -> genericError opts e
-    ErrLacksFunctionClause e -> genericError opts e
-    ErrWrongLocationCompileBlock e -> genericError opts e
-    ErrMultipleCompileBlockSameName e -> genericError opts e
-    ErrMultipleCompileRuleSameBackend e -> genericError opts e
-    ErrWrongKindExpressionCompileBlock e -> genericError opts e
-    ErrDuplicateInductiveParameterName e -> genericError opts e
-    ErrDoubleBracesPattern e -> genericError opts e
-    ErrImplicitPatternLeftApplication e -> genericError opts e
-    ErrConstructorExpectedLeftApplication e -> genericError opts e
+  genericError = \case
+    ErrParser e -> genericError e
+    ErrInfixParser e -> genericError e
+    ErrAppLeftImplicit e -> genericError e
+    ErrInfixPattern e -> genericError e
+    ErrMultipleDeclarations e -> genericError e
+    ErrLacksTypeSig e -> genericError e
+    ErrImportCycle e -> genericError e
+    ErrSymNotInScope e -> genericError e
+    ErrQualSymNotInScope e -> genericError e
+    ErrModuleNotInScope e -> genericError e
+    ErrBindGroup e -> genericError e
+    ErrDuplicateFixity e -> genericError e
+    ErrMultipleExport e -> genericError e
+    ErrAmbiguousSym e -> genericError e
+    ErrWrongTopModuleName e -> genericError e
+    ErrAmbiguousModuleSym e -> genericError e
+    ErrUnusedOperatorDef e -> genericError e
+    ErrLacksFunctionClause e -> genericError e
+    ErrWrongLocationCompileBlock e -> genericError e
+    ErrMultipleCompileBlockSameName e -> genericError e
+    ErrMultipleCompileRuleSameBackend e -> genericError e
+    ErrWrongKindExpressionCompileBlock e -> genericError e
+    ErrDuplicateInductiveParameterName e -> genericError e
+    ErrDoubleBracesPattern e -> genericError e
+    ErrImplicitPatternLeftApplication e -> genericError e
+    ErrConstructorExpectedLeftApplication e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Pretty.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Pretty.hs
@@ -10,11 +10,11 @@ import Juvix.Data.PPOutput
 import Juvix.Prelude
 import Text.EditDistance
 
-ppCode :: Scoped.PrettyCode c => c -> Doc Ann
-ppCode = runPP . Scoped.ppCode
+ppCode :: Scoped.PrettyCode c => Scoped.Options -> c -> Doc Ann
+ppCode opts = runPP opts . Scoped.ppCode
 
-runPP :: Sem '[Reader Scoped.Options] (Doc Scoped.Ann) -> Doc Ann
-runPP = code . run . runReader Scoped.defaultOptions
+runPP :: Scoped.Options -> Sem '[Reader Scoped.Options] (Doc Scoped.Ann) -> Doc Ann
+runPP opts = code . run . runReader opts
 
 prettyError :: Doc Ann -> AnsiText
 prettyError = AnsiText . PPOutput

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -27,11 +27,12 @@ data MultipleDeclarations = MultipleDeclarations
 
 instance ToGenericError MultipleDeclarations where
   genericError MultipleDeclarations {..} =
-    return GenericError
-      { _genericErrorLoc = i1,
-        _genericErrorMessage = prettyError msg,
-        _genericErrorIntervals = [i1, _multipleDeclSecond]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i1,
+          _genericErrorMessage = prettyError msg,
+          _genericErrorIntervals = [i1, _multipleDeclSecond]
+        }
     where
       i1 :: Interval
       i1 = entryName _multipleDeclEntry ^. S.nameDefined
@@ -53,11 +54,12 @@ instance ToGenericError InfixError where
   genericError InfixError {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _infixErrorAtoms
@@ -77,11 +79,12 @@ instance ToGenericError InfixErrorP where
   genericError InfixErrorP {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _infixErrorAtomsP
@@ -101,11 +104,12 @@ instance ToGenericError LacksTypeSig where
   genericError LacksTypeSig {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = _lacksTypeSigClause ^. clauseOwnerFunction . symbolLoc
@@ -124,11 +128,12 @@ instance ToGenericError LacksFunctionClause where
   genericError LacksFunctionClause {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (_lacksFunctionClause ^. sigName)
@@ -147,11 +152,12 @@ instance ToGenericError ImportCycle where
   genericError ImportCycle {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           h = head _importCycleImports
@@ -176,11 +182,12 @@ instance ToGenericError QualSymNotInScope where
   genericError QualSymNotInScope {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _qualSymNotInScope
@@ -196,11 +203,12 @@ instance ToGenericError BindGroupConflict where
   genericError BindGroupConflict {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i2,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i1, i2]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i2,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i1, i2]
+            }
         where
           opts' = fromGenericOptions opts
           i1 = getLoc _bindGroupFirst
@@ -223,11 +231,12 @@ instance ToGenericError DuplicateFixity where
   genericError DuplicateFixity {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i2,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i1, i2]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i2,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i1, i2]
+            }
         where
           opts' = fromGenericOptions opts
           i1 = getLoc _dupFixityFirst
@@ -254,11 +263,12 @@ instance ToGenericError MultipleExportConflict where
   genericError MultipleExportConflict {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _multipleExportModule
@@ -281,11 +291,12 @@ instance ToGenericError NotInScope where
   genericError e@NotInScope {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = e ^. notInScopeSymbol . symbolLoc,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [e ^. notInScopeSymbol . symbolLoc]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = e ^. notInScopeSymbol . symbolLoc,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [e ^. notInScopeSymbol . symbolLoc]
+            }
         where
           opts' = fromGenericOptions opts
           msg =
@@ -325,11 +336,12 @@ instance ToGenericError AppLeftImplicit where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (e ^. appLeftImplicit)
@@ -351,11 +363,12 @@ instance ToGenericError ModuleNotInScope where
   genericError e@ModuleNotInScope {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (e ^. moduleNotInScopeName)
@@ -378,11 +391,12 @@ instance ToGenericError UnusedOperatorDef where
   genericError UnusedOperatorDef {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _unusedOperatorDef
@@ -402,11 +416,12 @@ instance ToGenericError WrongTopModuleName where
   genericError WrongTopModuleName {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _wrongTopModuleNameActualName
@@ -431,11 +446,12 @@ instance ToGenericError AmbiguousSym where
   genericError AmbiguousSym {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = i : is
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = i : is
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _ambiguousSymName
@@ -452,11 +468,12 @@ instance ToGenericError AmbiguousModuleSym where
   genericError AmbiguousModuleSym {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = i : is
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = i : is
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _ambiguousModName
@@ -473,11 +490,12 @@ instance ToGenericError WrongLocationCompileBlock where
   genericError WrongLocationCompileBlock {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           name = _wrongLocationCompileBlockName
@@ -496,14 +514,15 @@ data MultipleCompileBlockSameName = MultipleCompileBlockSameName
   deriving stock (Show)
 
 instance ToGenericError MultipleCompileBlockSameName where
-  genericError MultipleCompileBlockSameName {..} =ask >>= generr
+  genericError MultipleCompileBlockSameName {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i2,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i1, i2]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i2,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i1, i2]
+            }
         where
           opts' = fromGenericOptions opts
           i1 = _multipleCompileBlockFirstDefined
@@ -522,11 +541,12 @@ instance ToGenericError MultipleCompileRuleSameBackend where
   genericError MultipleCompileRuleSameBackend {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           backend = _multipleCompileRuleSameBackendBackendItem ^. backendItemBackend
@@ -550,11 +570,12 @@ instance ToGenericError WrongKindExpressionCompileBlock where
   genericError WrongKindExpressionCompileBlock {..} = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc _wrongKindExpressionCompileBlockSym
@@ -595,11 +616,12 @@ instance ToGenericError DuplicateInductiveParameterName where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           param = e ^. duplicateInductiveParameterName
@@ -622,11 +644,12 @@ instance ToGenericError DoubleBracesPattern where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           pat :: PatternArg
@@ -647,11 +670,12 @@ instance ToGenericError ImplicitPatternLeftApplication where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           pat :: PatternApp
@@ -672,11 +696,12 @@ instance ToGenericError ConstructorExpectedLeftApplication where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = prettyError msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           pat :: Pattern

--- a/src/Juvix/Compiler/Core/Error.hs
+++ b/src/Juvix/Compiler/Core/Error.hs
@@ -12,8 +12,8 @@ data CoreError = CoreError
 makeLenses ''CoreError
 
 instance ToGenericError CoreError where
-  genericError _ e =
-    GenericError
+  genericError e =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = AnsiText $ pretty @_ @AnsiStyle e,
         _genericErrorIntervals = [i]

--- a/src/Juvix/Compiler/Core/Error.hs
+++ b/src/Juvix/Compiler/Core/Error.hs
@@ -15,11 +15,12 @@ instance ToGenericError CoreError where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           i = getLoc e
           opts' = fromGenericOptions opts

--- a/src/Juvix/Compiler/Core/Error.hs
+++ b/src/Juvix/Compiler/Core/Error.hs
@@ -12,7 +12,7 @@ data CoreError = CoreError
 makeLenses ''CoreError
 
 instance ToGenericError CoreError where
-  genericError e =
+  genericError _ e =
     GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = AnsiText $ pretty @_ @AnsiStyle e,

--- a/src/Juvix/Compiler/Core/Pretty.hs
+++ b/src/Juvix/Compiler/Core/Pretty.hs
@@ -18,8 +18,11 @@ ppOutDefault = AnsiText . PPOutput . doc defaultOptions
 ppOut :: PrettyCode c => Options -> c -> AnsiText
 ppOut o = AnsiText . PPOutput . doc o
 
+ppTrace' :: PrettyCode c => Options -> c -> Text
+ppTrace' opts = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc opts
+
 ppTrace :: PrettyCode c => c -> Text
-ppTrace = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc defaultOptions
+ppTrace = ppTrace' defaultOptions
 
 ppPrint :: PrettyCode c => c -> Text
 ppPrint = show . ppOutDefault

--- a/src/Juvix/Compiler/Core/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Options.hs
@@ -17,3 +17,6 @@ defaultOptions =
     }
 
 makeLenses ''Options
+
+fromGenericOptions :: GenericOptions -> Options
+fromGenericOptions GenericOptions {..} = set optShowNameIds _showNameIds defaultOptions

--- a/src/Juvix/Compiler/Internal/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Options.hs
@@ -13,3 +13,6 @@ defaultOptions =
     }
 
 makeLenses ''Options
+
+fromGenericOptions :: GenericOptions -> Options
+fromGenericOptions GenericOptions {..} = Options {..}

--- a/src/Juvix/Compiler/Internal/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Options.hs
@@ -15,4 +15,4 @@ defaultOptions =
 makeLenses ''Options
 
 fromGenericOptions :: GenericOptions -> Options
-fromGenericOptions GenericOptions {..} = Options {..}
+fromGenericOptions GenericOptions {..} = Options {_optShowNameIds = _showNameIds}

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error.hs
@@ -12,6 +12,6 @@ newtype TerminationError
   deriving stock (Show)
 
 instance ToGenericError TerminationError where
-  genericError :: TerminationError -> GenericError
-  genericError = \case
-    ErrNoLexOrder e -> genericError e
+  genericError :: GenericOptions -> TerminationError -> GenericError
+  genericError opts = \case
+    ErrNoLexOrder e -> genericError opts e

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error.hs
@@ -12,6 +12,6 @@ newtype TerminationError
   deriving stock (Show)
 
 instance ToGenericError TerminationError where
-  genericError :: GenericOptions -> TerminationError -> GenericError
-  genericError opts = \case
-    ErrNoLexOrder e -> genericError opts e
+  genericError :: Member (Reader GenericOptions) r => TerminationError -> Sem r GenericError
+  genericError = \case
+    ErrNoLexOrder e -> genericError e

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
@@ -13,11 +13,12 @@ makeLenses 'NoLexOrder
 
 instance ToGenericError NoLexOrder where
   genericError NoLexOrder {..} =
-    return GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = ppOutput msg,
+          _genericErrorIntervals = [i]
+        }
     where
       name = _noLexOrderFun
       i = getLoc name

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
@@ -12,7 +12,7 @@ newtype NoLexOrder = NoLexOrder
 makeLenses 'NoLexOrder
 
 instance ToGenericError NoLexOrder where
-  genericError NoLexOrder {..} =
+  genericError _ NoLexOrder {..} =
     GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
@@ -12,8 +12,8 @@ newtype NoLexOrder = NoLexOrder
 makeLenses 'NoLexOrder
 
 instance ToGenericError NoLexOrder where
-  genericError _ NoLexOrder {..} =
-    GenericError
+  genericError NoLexOrder {..} =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,
         _genericErrorIntervals = [i]

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error.hs
@@ -17,12 +17,12 @@ data ArityCheckerError
   | ErrFunctionApplied FunctionApplied
 
 instance ToGenericError ArityCheckerError where
-  genericError :: ArityCheckerError -> GenericError
-  genericError = \case
-    ErrWrongConstructorAppLength e -> genericError e
-    ErrLhsTooManyPatterns e -> genericError e
-    ErrWrongPatternIsImplicit e -> genericError e
-    ErrExpectedExplicitArgument e -> genericError e
-    ErrPatternFunction e -> genericError e
-    ErrTooManyArguments e -> genericError e
-    ErrFunctionApplied e -> genericError e
+  genericError :: GenericOptions -> ArityCheckerError -> GenericError
+  genericError opts = \case
+    ErrWrongConstructorAppLength e -> genericError opts e
+    ErrLhsTooManyPatterns e -> genericError opts e
+    ErrWrongPatternIsImplicit e -> genericError opts e
+    ErrExpectedExplicitArgument e -> genericError opts e
+    ErrPatternFunction e -> genericError opts e
+    ErrTooManyArguments e -> genericError opts e
+    ErrFunctionApplied e -> genericError opts e

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error.hs
@@ -17,12 +17,12 @@ data ArityCheckerError
   | ErrFunctionApplied FunctionApplied
 
 instance ToGenericError ArityCheckerError where
-  genericError :: GenericOptions -> ArityCheckerError -> GenericError
-  genericError opts = \case
-    ErrWrongConstructorAppLength e -> genericError opts e
-    ErrLhsTooManyPatterns e -> genericError opts e
-    ErrWrongPatternIsImplicit e -> genericError opts e
-    ErrExpectedExplicitArgument e -> genericError opts e
-    ErrPatternFunction e -> genericError opts e
-    ErrTooManyArguments e -> genericError opts e
-    ErrFunctionApplied e -> genericError opts e
+  genericError :: Member (Reader GenericOptions) r => ArityCheckerError -> Sem r GenericError
+  genericError = \case
+    ErrWrongConstructorAppLength e -> genericError e
+    ErrLhsTooManyPatterns e -> genericError e
+    ErrWrongPatternIsImplicit e -> genericError e
+    ErrExpectedExplicitArgument e -> genericError e
+    ErrPatternFunction e -> genericError e
+    ErrTooManyArguments e -> genericError e
+    ErrFunctionApplied e -> genericError e

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error/Types.hs
@@ -17,11 +17,12 @@ instance ToGenericError WrongConstructorAppLength where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (e ^. wrongConstructorAppLength)
@@ -50,11 +51,12 @@ makeLenses ''LhsTooManyPatterns
 
 instance ToGenericError LhsTooManyPatterns where
   genericError e =
-    return GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = ppOutput msg,
+          _genericErrorIntervals = [i]
+        }
     where
       i = getLocSpan (e ^. lhsTooManyPatternsRemaining)
       n = length (e ^. lhsTooManyPatternsRemaining)
@@ -79,11 +81,12 @@ instance ToGenericError WrongPatternIsImplicit where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (e ^. wrongPatternIsImplicitActual)
@@ -109,11 +112,12 @@ instance ToGenericError ExpectedExplicitArgument where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           app@(f, args) = e ^. expectedExplicitArgumentApp
@@ -143,11 +147,12 @@ instance ToGenericError PatternFunction where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (e ^. patternFunction)
@@ -167,11 +172,12 @@ instance ToGenericError TooManyArguments where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLocSpan (fromJust (nonEmpty (map snd unexpectedArgs)))
@@ -210,11 +216,12 @@ instance ToGenericError FunctionApplied where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLocSpan (fun :| map snd args)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error/Types.hs
@@ -1,7 +1,5 @@
 module Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Error.Types where
 
--- import  Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Error.Pretty
-
 import Juvix.Compiler.Internal.Extra
 import Juvix.Compiler.Internal.Pretty (fromGenericOptions)
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Error.Pretty
@@ -16,31 +14,33 @@ data WrongConstructorAppLength = WrongConstructorAppLength
 makeLenses ''WrongConstructorAppLength
 
 instance ToGenericError WrongConstructorAppLength where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = getLoc (e ^. wrongConstructorAppLength)
-      msg =
-        "The constructor"
-          <+> ppCode opts' (e ^. wrongConstructorAppLength . constrAppConstructor)
-          <+> "should have"
-          <+> arguments (e ^. wrongConstructorAppLengthExpected)
-            <> ", but has been given"
-          <+> pretty actual
-
-      actual :: Int
-      actual = length (e ^. wrongConstructorAppLength . constrAppParameters)
-      arguments :: Int -> Doc ann
-      arguments n = num <+> plural "argument" "arguments" n
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
         where
-          num
-            | n == 0 = "no"
-            | otherwise = pretty n
+          opts' = fromGenericOptions opts
+          i = getLoc (e ^. wrongConstructorAppLength)
+          msg =
+            "The constructor"
+              <+> ppCode opts' (e ^. wrongConstructorAppLength . constrAppConstructor)
+              <+> "should have"
+              <+> arguments (e ^. wrongConstructorAppLengthExpected)
+                <> ", but has been given"
+              <+> pretty actual
+
+          actual :: Int
+          actual = length (e ^. wrongConstructorAppLength . constrAppParameters)
+          arguments :: Int -> Doc ann
+          arguments n = num <+> plural "argument" "arguments" n
+            where
+              num
+                | n == 0 = "no"
+                | otherwise = pretty n
 
 newtype LhsTooManyPatterns = LhsTooManyPatterns
   { _lhsTooManyPatternsRemaining :: NonEmpty PatternArg
@@ -49,8 +49,8 @@ newtype LhsTooManyPatterns = LhsTooManyPatterns
 makeLenses ''LhsTooManyPatterns
 
 instance ToGenericError LhsTooManyPatterns where
-  genericError _ e =
-    GenericError
+  genericError e =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,
         _genericErrorIntervals = [i]
@@ -76,25 +76,27 @@ data WrongPatternIsImplicit = WrongPatternIsImplicit
 makeLenses ''WrongPatternIsImplicit
 
 instance ToGenericError WrongPatternIsImplicit where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = getLoc (e ^. wrongPatternIsImplicitActual)
-      expec = e ^. wrongPatternIsImplicitExpected
-      found = e ^. wrongPatternIsImplicitActual . patternArgIsImplicit
-      pat = e ^. wrongPatternIsImplicitActual
-      msg =
-        "Expected an"
-          <+> pretty expec
-          <+> "pattern but found an"
-          <+> pretty found
-          <+> "pattern:"
-          <+> ppCode opts' pat
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          i = getLoc (e ^. wrongPatternIsImplicitActual)
+          expec = e ^. wrongPatternIsImplicitExpected
+          found = e ^. wrongPatternIsImplicitActual . patternArgIsImplicit
+          pat = e ^. wrongPatternIsImplicitActual
+          msg =
+            "Expected an"
+              <+> pretty expec
+              <+> "pattern but found an"
+              <+> pretty found
+              <+> "pattern:"
+              <+> ppCode opts' pat
 
 data ExpectedExplicitArgument = ExpectedExplicitArgument
   { _expectedExplicitArgumentApp :: (Expression, [(IsImplicit, Expression)]),
@@ -104,30 +106,32 @@ data ExpectedExplicitArgument = ExpectedExplicitArgument
 makeLenses ''ExpectedExplicitArgument
 
 instance ToGenericError ExpectedExplicitArgument where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      app@(f, args) = e ^. expectedExplicitArgumentApp
-      idx = e ^. expectedExplicitArgumentIx
-      arg :: Expression
-      arg = snd (toList args !! idx)
-      i = getLoc arg
-      msg =
-        "Expected an explicit argument as the"
-          <+> ordinal (succ idx)
-          <+> "argument of"
-          <+> ppCode opts' f
-          <+> "but found"
-          <+> ppArg opts' Implicit arg
-            <> "."
-            <> softline
-            <> "In the application"
-          <+> ppApp opts' app
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          app@(f, args) = e ^. expectedExplicitArgumentApp
+          idx = e ^. expectedExplicitArgumentIx
+          arg :: Expression
+          arg = snd (toList args !! idx)
+          i = getLoc arg
+          msg =
+            "Expected an explicit argument as the"
+              <+> ordinal (succ idx)
+              <+> "argument of"
+              <+> ppCode opts' f
+              <+> "but found"
+              <+> ppArg opts' Implicit arg
+                <> "."
+                <> softline
+                <> "In the application"
+              <+> ppApp opts' app
 
 newtype PatternFunction = PatternFunction
   { _patternFunction :: ConstructorApp
@@ -136,19 +140,21 @@ newtype PatternFunction = PatternFunction
 makeLenses ''PatternFunction
 
 instance ToGenericError PatternFunction where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = getLoc (e ^. patternFunction)
-      msg =
-        "Invalid pattern"
-          <+> ppCode opts' (e ^. patternFunction) <> "."
-          <+> "Function types cannot be pattern matched"
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          i = getLoc (e ^. patternFunction)
+          msg =
+            "Invalid pattern"
+              <+> ppCode opts' (e ^. patternFunction) <> "."
+              <+> "Function types cannot be pattern matched"
 
 data TooManyArguments = TooManyArguments
   { _tooManyArgumentsApp :: (Expression, [(IsImplicit, Expression)]),
@@ -158,38 +164,40 @@ data TooManyArguments = TooManyArguments
 makeLenses ''TooManyArguments
 
 instance ToGenericError TooManyArguments where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = getLocSpan (fromJust (nonEmpty (map snd unexpectedArgs)))
-      (fun, args) = e ^. tooManyArgumentsApp
-      numUnexpected :: Int
-      numUnexpected = e ^. tooManyArgumentsUnexpected
-      unexpectedArgs :: [(IsImplicit, Expression)]
-      unexpectedArgs = reverse . take numUnexpected . reverse $ args
-      ppUnexpectedArgs = hsep (map (uncurry (ppArg opts')) unexpectedArgs)
-      app :: Expression
-      app = foldApplication fun args
-      msg =
-        "Too many arguments in the application"
-          <+> ppCode opts' app <> "."
-          <+> "The last"
-          <+> numArguments
-            <> ", namely"
-          <+> ppUnexpectedArgs
-            <> ","
-          <+> wasNotExpected
-      numArguments :: Doc ann
-      numArguments = plural "argument" (pretty numUnexpected <+> "arguments") numUnexpected
-      wasNotExpected :: Doc ann
-      wasNotExpected
-        | numUnexpected == 1 = "was not expected"
-        | otherwise = "were not expected"
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          i = getLocSpan (fromJust (nonEmpty (map snd unexpectedArgs)))
+          (fun, args) = e ^. tooManyArgumentsApp
+          numUnexpected :: Int
+          numUnexpected = e ^. tooManyArgumentsUnexpected
+          unexpectedArgs :: [(IsImplicit, Expression)]
+          unexpectedArgs = reverse . take numUnexpected . reverse $ args
+          ppUnexpectedArgs = hsep (map (uncurry (ppArg opts')) unexpectedArgs)
+          app :: Expression
+          app = foldApplication fun args
+          msg =
+            "Too many arguments in the application"
+              <+> ppCode opts' app <> "."
+              <+> "The last"
+              <+> numArguments
+                <> ", namely"
+              <+> ppUnexpectedArgs
+                <> ","
+              <+> wasNotExpected
+          numArguments :: Doc ann
+          numArguments = plural "argument" (pretty numUnexpected <+> "arguments") numUnexpected
+          wasNotExpected :: Doc ann
+          wasNotExpected
+            | numUnexpected == 1 = "was not expected"
+            | otherwise = "were not expected"
 
 data FunctionApplied = FunctionApplied
   { _functionAppliedFunction :: Function,
@@ -199,19 +207,21 @@ data FunctionApplied = FunctionApplied
 makeLenses ''FunctionApplied
 
 instance ToGenericError FunctionApplied where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = getLocSpan (fun :| map snd args)
-      args = e ^. functionAppliedArguments
-      fun = ExpressionFunction (e ^. functionAppliedFunction)
-      msg =
-        "A function type cannot be applied."
-          <> softline
-          <> "In the application"
-          <+> ppApp opts' (fun, args)
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          i = getLocSpan (fun :| map snd args)
+          args = e ^. functionAppliedArguments
+          fun = ExpressionFunction (e ^. functionAppliedFunction)
+          msg =
+            "A function type cannot be applied."
+              <> softline
+              <> "In the application"
+              <+> ppApp opts' (fun, args)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
@@ -24,15 +24,15 @@ data TypeCheckerError
   | ErrNoPositivity NoPositivity
 
 instance ToGenericError TypeCheckerError where
-  genericError :: GenericOptions -> TypeCheckerError -> GenericError
-  genericError opts = \case
-    ErrWrongConstructorType e -> genericError opts e
-    ErrWrongReturnType e -> genericError opts e
-    ErrArity e -> genericError opts e
-    ErrWrongType e -> genericError opts e
-    ErrUnsolvedMeta e -> genericError opts e
-    ErrExpectedFunctionType e -> genericError opts e
-    ErrTooManyArgumentsIndType e -> genericError opts e
-    ErrTooFewArgumentsIndType e -> genericError opts e
-    ErrImpracticalPatternMatching e -> genericError opts e
-    ErrNoPositivity e -> genericError opts e
+  genericError :: Member (Reader GenericOptions) r => TypeCheckerError -> Sem r GenericError
+  genericError = \case
+    ErrWrongConstructorType e -> genericError e
+    ErrWrongReturnType e -> genericError e
+    ErrArity e -> genericError e
+    ErrWrongType e -> genericError e
+    ErrUnsolvedMeta e -> genericError e
+    ErrExpectedFunctionType e -> genericError e
+    ErrTooManyArgumentsIndType e -> genericError e
+    ErrTooFewArgumentsIndType e -> genericError e
+    ErrImpracticalPatternMatching e -> genericError e
+    ErrNoPositivity e -> genericError e

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
@@ -24,15 +24,15 @@ data TypeCheckerError
   | ErrNoPositivity NoPositivity
 
 instance ToGenericError TypeCheckerError where
-  genericError :: TypeCheckerError -> GenericError
-  genericError = \case
-    ErrWrongConstructorType e -> genericError e
-    ErrWrongReturnType e -> genericError e
-    ErrArity e -> genericError e
-    ErrWrongType e -> genericError e
-    ErrUnsolvedMeta e -> genericError e
-    ErrExpectedFunctionType e -> genericError e
-    ErrTooManyArgumentsIndType e -> genericError e
-    ErrTooFewArgumentsIndType e -> genericError e
-    ErrImpracticalPatternMatching e -> genericError e
-    ErrNoPositivity e -> genericError e
+  genericError :: GenericOptions -> TypeCheckerError -> GenericError
+  genericError opts = \case
+    ErrWrongConstructorType e -> genericError opts e
+    ErrWrongReturnType e -> genericError opts e
+    ErrArity e -> genericError opts e
+    ErrWrongType e -> genericError opts e
+    ErrUnsolvedMeta e -> genericError opts e
+    ErrExpectedFunctionType e -> genericError opts e
+    ErrTooManyArgumentsIndType e -> genericError opts e
+    ErrTooFewArgumentsIndType e -> genericError opts e
+    ErrImpracticalPatternMatching e -> genericError opts e
+    ErrNoPositivity e -> genericError opts e

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Pretty.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Pretty.hs
@@ -9,10 +9,6 @@ import Juvix.Compiler.Internal.Pretty.Base qualified as Micro
 import Juvix.Data.CodeAnn
 import Juvix.Prelude
 
--- I don't see much benefit in changing this function to use effects instead of
--- an options argument, because it is used only in the error messages in
--- Analysis/*. Changing it makes sense only if we rewrite all error message
--- creation to use monadic style, and I don't see the benefit of it.
 ppCode :: Micro.PrettyCode c => Micro.Options -> c -> Doc Ann
 ppCode opts = runPP opts . Micro.ppCode
 

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Pretty.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Pretty.hs
@@ -9,23 +9,23 @@ import Juvix.Compiler.Internal.Pretty.Base qualified as Micro
 import Juvix.Data.CodeAnn
 import Juvix.Prelude
 
-ppCode :: Micro.PrettyCode c => c -> Doc Ann
-ppCode = runPP . Micro.ppCode
+ppCode :: Micro.PrettyCode c => Micro.Options -> c -> Doc Ann
+ppCode opts = runPP opts . Micro.ppCode
 
-ppAtom :: (Micro.PrettyCode c, HasAtomicity c) => c -> Doc Ann
-ppAtom = runPP . Micro.ppCodeAtom
+ppAtom :: (Micro.PrettyCode c, HasAtomicity c) => Micro.Options -> c -> Doc Ann
+ppAtom opts = runPP opts . Micro.ppCodeAtom
 
-runPP :: Sem '[Reader Micro.Options] (Doc Micro.Ann) -> Doc Ann
-runPP = highlight_ . run . runReader Micro.defaultOptions
+runPP :: Micro.Options -> Sem '[Reader Micro.Options] (Doc Micro.Ann) -> Doc Ann
+runPP opts = highlight_ . run . runReader opts
 
 highlight_ :: Doc Ann -> Doc Ann
 highlight_ = annotate AnnCode
 
-ppApp :: (Expression, [(IsImplicit, Expression)]) -> Doc Ann
-ppApp (fun, args) =
-  hsep (ppAtom fun : map (uncurry ppArg) args)
+ppApp :: Micro.Options -> (Expression, [(IsImplicit, Expression)]) -> Doc Ann
+ppApp opts (fun, args) =
+  hsep (ppAtom opts fun : map (uncurry (ppArg opts)) args)
 
-ppArg :: IsImplicit -> Expression -> Doc Ann
-ppArg im arg = case im of
-  Implicit -> braces (ppCode arg)
-  Explicit -> ppAtom arg
+ppArg :: Micro.Options -> IsImplicit -> Expression -> Doc Ann
+ppArg opts im arg = case im of
+  Implicit -> braces (ppCode opts arg)
+  Explicit -> ppAtom opts arg

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Pretty.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Pretty.hs
@@ -9,6 +9,10 @@ import Juvix.Compiler.Internal.Pretty.Base qualified as Micro
 import Juvix.Data.CodeAnn
 import Juvix.Prelude
 
+-- I don't see much benefit in changing this function to use effects instead of
+-- an options argument, because it is used only in the error messages in
+-- Analysis/*. Changing it makes sense only if we rewrite all error message
+-- creation to use monadic style, and I don't see the benefit of it.
 ppCode :: Micro.PrettyCode c => Micro.Options -> c -> Doc Ann
 ppCode opts = runPP opts . Micro.ppCode
 

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -18,26 +18,28 @@ data WrongConstructorType = WrongConstructorType
 makeLenses ''WrongConstructorType
 
 instance ToGenericError WrongConstructorType where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      ctorName = e ^. wrongCtorTypeName
-      i = getLoc ctorName
-      msg =
-        "The constructor"
-          <+> ppCode opts' ctorName
-          <+> "belongs to the inductive type:"
-            <> line
-            <> indent' (ppCode opts' (e ^. wrongCtorTypeActual))
-            <> line
-            <> "but is expected to belong to the inductive type:"
-            <> line
-            <> indent' (ppCode opts' (e ^. wrongCtorTypeExpected))
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          ctorName = e ^. wrongCtorTypeName
+          i = getLoc ctorName
+          msg =
+            "The constructor"
+              <+> ppCode opts' ctorName
+              <+> "belongs to the inductive type:"
+                <> line
+                <> indent' (ppCode opts' (e ^. wrongCtorTypeActual))
+                <> line
+                <> "but is expected to belong to the inductive type:"
+                <> line
+                <> indent' (ppCode opts' (e ^. wrongCtorTypeExpected))
 
 data WrongReturnType = WrongReturnType
   { _wrongReturnTypeConstructorName :: Name,
@@ -48,28 +50,30 @@ data WrongReturnType = WrongReturnType
 makeLenses ''WrongReturnType
 
 instance ToGenericError WrongReturnType where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = j,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i, j]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      ctorName = e ^. wrongReturnTypeConstructorName
-      i = getLoc ctorName
-      ty = e ^. wrongReturnTypeActual
-      j = getLoc ty
-      msg =
-        "The constructor"
-          <+> ppCode opts' ctorName
-          <+> "has the wrong return type:"
-            <> line
-            <> indent' (ppCode opts' ty)
-            <> line
-            <> "but is expected to have type:"
-            <> line
-            <> indent' (ppCode opts' (e ^. wrongReturnTypeExpected))
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = j,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i, j]
+          }
+        where
+          opts' = fromGenericOptions opts
+          ctorName = e ^. wrongReturnTypeConstructorName
+          i = getLoc ctorName
+          ty = e ^. wrongReturnTypeActual
+          j = getLoc ty
+          msg =
+            "The constructor"
+              <+> ppCode opts' ctorName
+              <+> "has the wrong return type:"
+                <> line
+                <> indent' (ppCode opts' ty)
+                <> line
+                <> "but is expected to have type:"
+                <> line
+                <> indent' (ppCode opts' (e ^. wrongReturnTypeExpected))
 
 newtype UnsolvedMeta = UnsolvedMeta
   { _unsolvedMeta :: Hole
@@ -78,8 +82,8 @@ newtype UnsolvedMeta = UnsolvedMeta
 makeLenses ''UnsolvedMeta
 
 instance ToGenericError UnsolvedMeta where
-  genericError _ e =
-    GenericError
+  genericError e =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = ppOutput msg,
         _genericErrorIntervals = [i]
@@ -100,39 +104,41 @@ data WrongConstructorAppArgs = WrongConstructorAppArgs
 makeLenses ''WrongConstructorAppArgs
 
 instance ToGenericError WrongConstructorAppArgs where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = getLoc (e ^. wrongCtorAppApp . constrAppConstructor)
-      msg =
-        "The constructor:"
-          <+> ctorName
-          <+> "is being matched against"
-          <+> numPats
-            <> ":"
-            <> line
-            <> indent' (ppCode opts' (e ^. wrongCtorAppApp))
-            <> line
-            <> "but is expected to be matched against"
-          <+> numTypes
-          <+> "with the following types:"
-            <> line
-            <> indent' (hsep (ctorName : (ppCode opts' <$> (e ^. wrongCtorAppTypes))))
-      numPats :: Doc ann
-      numPats = pat (length (e ^. wrongCtorAppApp . constrAppParameters))
-      numTypes :: Doc ann
-      numTypes = pat (length (e ^. wrongCtorAppTypes))
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          i = getLoc (e ^. wrongCtorAppApp . constrAppConstructor)
+          msg =
+            "The constructor:"
+              <+> ctorName
+              <+> "is being matched against"
+              <+> numPats
+                <> ":"
+                <> line
+                <> indent' (ppCode opts' (e ^. wrongCtorAppApp))
+                <> line
+                <> "but is expected to be matched against"
+              <+> numTypes
+              <+> "with the following types:"
+                <> line
+                <> indent' (hsep (ctorName : (ppCode opts' <$> (e ^. wrongCtorAppTypes))))
+          numPats :: Doc ann
+          numPats = pat (length (e ^. wrongCtorAppApp . constrAppParameters))
+          numTypes :: Doc ann
+          numTypes = pat (length (e ^. wrongCtorAppTypes))
 
-      ctorName :: Doc Ann
-      ctorName = ppCode opts' (e ^. wrongCtorAppApp . constrAppConstructor)
+          ctorName :: Doc Ann
+          ctorName = ppCode opts' (e ^. wrongCtorAppApp . constrAppConstructor)
 
-      pat :: Int -> Doc ann
-      pat n = pretty n <+> plural "pattern" "patterns" n
+          pat :: Int -> Doc ann
+          pat n = pretty n <+> plural "pattern" "patterns" n
 
 -- | the type of an expression does not match the inferred type
 data WrongType = WrongType
@@ -144,32 +150,34 @@ data WrongType = WrongType
 makeLenses ''WrongType
 
 instance ToGenericError WrongType where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = either getLoc getLoc (e ^. wrongTypeThing)
-      msg =
-        "The"
-          <+> thing
-          <+> either (ppCode opts') (ppCode opts') subjectThing
-          <+> "has type:"
-            <> line
-            <> indent' (ppCode opts' (e ^. wrongTypeActual))
-            <> line
-            <> "but is expected to have type:"
-            <> line
-            <> indent' (ppCode opts' (e ^. wrongTypeExpected))
-      thing :: Doc a
-      thing = case subjectThing of
-        Left {} -> "expression"
-        Right {} -> "pattern"
-      subjectThing :: Either Expression Pattern
-      subjectThing = e ^. wrongTypeThing
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          i = either getLoc getLoc (e ^. wrongTypeThing)
+          msg =
+            "The"
+              <+> thing
+              <+> either (ppCode opts') (ppCode opts') subjectThing
+              <+> "has type:"
+                <> line
+                <> indent' (ppCode opts' (e ^. wrongTypeActual))
+                <> line
+                <> "but is expected to have type:"
+                <> line
+                <> indent' (ppCode opts' (e ^. wrongTypeExpected))
+          thing :: Doc a
+          thing = case subjectThing of
+            Left {} -> "expression"
+            Right {} -> "pattern"
+          subjectThing :: Either Expression Pattern
+          subjectThing = e ^. wrongTypeThing
 
 -- | The left hand expression of a function application is not
 -- a function type.
@@ -182,31 +190,33 @@ data ExpectedFunctionType = ExpectedFunctionType
 makeLenses ''ExpectedFunctionType
 
 instance ToGenericError ExpectedFunctionType where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      i = getLoc (e ^. expectedFunctionTypeExpression)
-      msg =
-        "Type error near"
-          <+> pretty (getLoc subjectExpr)
-            <> "."
-            <> line
-            <> "In the expression:"
-            <> line
-            <> indent' (ppCode opts' (e ^. expectedFunctionTypeExpression))
-            <> line
-            <> "the expression"
-          <+> ppCode opts' (e ^. expectedFunctionTypeApp)
-          <+> "is expected to have a function type but has type:"
-            <> line
-            <> indent' (ppCode opts' (e ^. expectedFunctionTypeType))
-      subjectExpr :: Expression
-      subjectExpr = e ^. expectedFunctionTypeExpression
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          i = getLoc (e ^. expectedFunctionTypeExpression)
+          msg =
+            "Type error near"
+              <+> pretty (getLoc subjectExpr)
+                <> "."
+                <> line
+                <> "In the expression:"
+                <> line
+                <> indent' (ppCode opts' (e ^. expectedFunctionTypeExpression))
+                <> line
+                <> "the expression"
+              <+> ppCode opts' (e ^. expectedFunctionTypeApp)
+              <+> "is expected to have a function type but has type:"
+                <> line
+                <> indent' (ppCode opts' (e ^. expectedFunctionTypeType))
+          subjectExpr :: Expression
+          subjectExpr = e ^. expectedFunctionTypeExpression
 
 data WrongNumberArgumentsIndType = WrongNumberArgumentsIndType
   { _wrongNumberArgumentsIndTypeActualType :: Expression,
@@ -217,34 +227,36 @@ data WrongNumberArgumentsIndType = WrongNumberArgumentsIndType
 makeLenses ''WrongNumberArgumentsIndType
 
 instance ToGenericError WrongNumberArgumentsIndType where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      ty = e ^. wrongNumberArgumentsIndTypeActualType
-      i = getLoc ty
-      expectedNumArgs = e ^. wrongNumberArgumentsIndTypeExpectedNumArgs
-      actualNumArgs = e ^. wrongNumberArgumentsIndTypeActualNumArgs
-      msg =
-        "The type"
-          <+> ppCode opts' ty
-          <+> "expects"
-          <+> ( if
-                    | expectedNumArgs == 0 -> "no arguments"
-                    | expectedNumArgs == 1 -> "one argument"
-                    | otherwise -> pretty expectedNumArgs <+> "arguments"
-              )
-            <> ", but"
-          <+> ( if
-                    | actualNumArgs == 0 -> "no argument is"
-                    | actualNumArgs == 1 -> "only one argument is"
-                    | otherwise -> pretty actualNumArgs <+> "arguments are"
-              )
-          <+> "given"
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          ty = e ^. wrongNumberArgumentsIndTypeActualType
+          i = getLoc ty
+          expectedNumArgs = e ^. wrongNumberArgumentsIndTypeExpectedNumArgs
+          actualNumArgs = e ^. wrongNumberArgumentsIndTypeActualNumArgs
+          msg =
+            "The type"
+              <+> ppCode opts' ty
+              <+> "expects"
+              <+> ( if
+                        | expectedNumArgs == 0 -> "no arguments"
+                        | expectedNumArgs == 1 -> "one argument"
+                        | otherwise -> pretty expectedNumArgs <+> "arguments"
+                  )
+                <> ", but"
+              <+> ( if
+                        | actualNumArgs == 0 -> "no argument is"
+                        | actualNumArgs == 1 -> "only one argument is"
+                        | otherwise -> pretty actualNumArgs <+> "arguments are"
+                  )
+              <+> "given"
 
 newtype ImpracticalPatternMatching = ImpracticalPatternMatching
   { _impracticalPatternMatchingType :: Expression
@@ -253,21 +265,23 @@ newtype ImpracticalPatternMatching = ImpracticalPatternMatching
 makeLenses ''ImpracticalPatternMatching
 
 instance ToGenericError ImpracticalPatternMatching where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      ty = e ^. impracticalPatternMatchingType
-      i = getLoc ty
-      msg =
-        "The type"
-          <+> ppCode opts' ty
-          <+> "is not an inductive data type."
-          <+> "Therefore, pattern-matching is not available here"
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = i,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i]
+          }
+        where
+          opts' = fromGenericOptions opts
+          ty = e ^. impracticalPatternMatchingType
+          i = getLoc ty
+          msg =
+            "The type"
+              <+> ppCode opts' ty
+              <+> "is not an inductive data type."
+              <+> "Therefore, pattern-matching is not available here"
 
 data NoPositivity = NoPositivity
   { _noStrictPositivityType :: Name,
@@ -278,23 +292,25 @@ data NoPositivity = NoPositivity
 makeLenses ''NoPositivity
 
 instance ToGenericError NoPositivity where
-  genericError opts e =
-    GenericError
-      { _genericErrorLoc = j,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i, j]
-      }
+  genericError e = ask >>= generr
     where
-      opts' = fromGenericOptions opts
-      ty = e ^. noStrictPositivityType
-      ctor = e ^. noStrictPositivityConstructor
-      arg = e ^. noStrictPositivityArgument
-      i = getLoc ty
-      j = getLoc arg
-      msg =
-        "The type"
-          <+> ppCode opts' ty
-          <+> "is not strictly positive."
-            <> line
-            <> "It appears at a negative position in one of the arguments of the constructor"
-          <+> ppCode opts' ctor <> "."
+      generr opts =
+        return GenericError
+          { _genericErrorLoc = j,
+            _genericErrorMessage = ppOutput msg,
+            _genericErrorIntervals = [i, j]
+          }
+        where
+          opts' = fromGenericOptions opts
+          ty = e ^. noStrictPositivityType
+          ctor = e ^. noStrictPositivityConstructor
+          arg = e ^. noStrictPositivityArgument
+          i = getLoc ty
+          j = getLoc arg
+          msg =
+            "The type"
+              <+> ppCode opts' ty
+              <+> "is not strictly positive."
+                <> line
+                <> "It appears at a negative position in one of the arguments of the constructor"
+              <+> ppCode opts' ctor <> "."

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -21,11 +21,12 @@ instance ToGenericError WrongConstructorType where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           ctorName = e ^. wrongCtorTypeName
@@ -53,11 +54,12 @@ instance ToGenericError WrongReturnType where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = j,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i, j]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = j,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i, j]
+            }
         where
           opts' = fromGenericOptions opts
           ctorName = e ^. wrongReturnTypeConstructorName
@@ -83,11 +85,12 @@ makeLenses ''UnsolvedMeta
 
 instance ToGenericError UnsolvedMeta where
   genericError e =
-    return GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = ppOutput msg,
-        _genericErrorIntervals = [i]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = ppOutput msg,
+          _genericErrorIntervals = [i]
+        }
     where
       i = getLoc (e ^. unsolvedMeta)
       msg :: Doc a
@@ -107,11 +110,12 @@ instance ToGenericError WrongConstructorAppArgs where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (e ^. wrongCtorAppApp . constrAppConstructor)
@@ -153,11 +157,12 @@ instance ToGenericError WrongType where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = either getLoc getLoc (e ^. wrongTypeThing)
@@ -193,11 +198,12 @@ instance ToGenericError ExpectedFunctionType where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           i = getLoc (e ^. expectedFunctionTypeExpression)
@@ -230,11 +236,12 @@ instance ToGenericError WrongNumberArgumentsIndType where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           ty = e ^. wrongNumberArgumentsIndTypeActualType
@@ -268,11 +275,12 @@ instance ToGenericError ImpracticalPatternMatching where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = i,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
         where
           opts' = fromGenericOptions opts
           ty = e ^. impracticalPatternMatchingType
@@ -295,11 +303,12 @@ instance ToGenericError NoPositivity where
   genericError e = ask >>= generr
     where
       generr opts =
-        return GenericError
-          { _genericErrorLoc = j,
-            _genericErrorMessage = ppOutput msg,
-            _genericErrorIntervals = [i, j]
-          }
+        return
+          GenericError
+            { _genericErrorLoc = j,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i, j]
+            }
         where
           opts' = fromGenericOptions opts
           ty = e ^. noStrictPositivityType

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -96,10 +96,10 @@ upToMiniC = upToInternalReachability >=> C.fromInternal
 runIOEither :: Sem PipelineEff a -> IO (Either JuvixError a)
 runIOEither = runM . runError . runBuiltins . runNameIdGen . mapError (JuvixError @FilesError) . runFilesIO
 
-runIO :: Sem PipelineEff a -> IO a
-runIO = runIOEither >=> mayThrow
+runIO :: GenericOptions -> Sem PipelineEff a -> IO a
+runIO opts = runIOEither >=> mayThrow
   where
     mayThrow :: Either JuvixError r -> IO r
     mayThrow = \case
-      Left err -> printErrorAnsiSafe err >> exitFailure
+      Left err -> printErrorAnsiSafe opts err >> exitFailure
       Right r -> return r

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -103,3 +103,6 @@ runIO opts = runIOEither >=> mayThrow
     mayThrow = \case
       Left err -> printErrorAnsiSafe opts err >> exitFailure
       Right r -> return r
+
+runIO' :: Sem PipelineEff a -> IO a
+runIO' = runIO defaultGenericOptions

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -101,7 +101,7 @@ runIO opts = runIOEither >=> mayThrow
   where
     mayThrow :: Either JuvixError r -> IO r
     mayThrow = \case
-      Left err -> printErrorAnsiSafe opts err >> exitFailure
+      Left err -> runM $ runReader opts $ printErrorAnsiSafe err >> embed exitFailure
       Right r -> return r
 
 runIO' :: Sem PipelineEff a -> IO a

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -15,7 +15,7 @@ data EntryPoint = EntryPoint
     _entryPointNoStdlib :: Bool,
     _entryPointPackage :: Package,
     _entryPointStdin :: Maybe Text,
-    _entryPointPrettyOptions :: GenericOptions,
+    _entryPointGenericOptions :: GenericOptions,
     _entryPointModulePaths :: NonEmpty FilePath
   }
   deriving stock (Eq, Show)
@@ -29,7 +29,7 @@ defaultEntryPoint mainFile =
       _entryPointNoStdlib = False,
       _entryPointStdin = Nothing,
       _entryPointPackage = emptyPackage,
-      _entryPointPrettyOptions = defaultGenericOptions,
+      _entryPointGenericOptions = defaultGenericOptions,
       _entryPointModulePaths = pure mainFile
     }
 

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -15,6 +15,7 @@ data EntryPoint = EntryPoint
     _entryPointNoStdlib :: Bool,
     _entryPointPackage :: Package,
     _entryPointStdin :: Maybe Text,
+    _entryPointPrettyOptions :: GenericOptions,
     _entryPointModulePaths :: NonEmpty FilePath
   }
   deriving stock (Eq, Show)
@@ -28,6 +29,7 @@ defaultEntryPoint mainFile =
       _entryPointNoStdlib = False,
       _entryPointStdin = Nothing,
       _entryPointPackage = emptyPackage,
+      _entryPointPrettyOptions = defaultGenericOptions,
       _entryPointModulePaths = pure mainFile
     }
 

--- a/src/Juvix/Data/Effect/Files/Error.hs
+++ b/src/Juvix/Data/Effect/Files/Error.hs
@@ -15,8 +15,8 @@ data FilesError = FilesError
   deriving stock (Show)
 
 instance ToGenericError FilesError where
-  genericError _ FilesError {..} =
-    GenericError
+  genericError FilesError {..} =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = AnsiText (pretty @_ @AnsiStyle msg),
         _genericErrorIntervals = [i]

--- a/src/Juvix/Data/Effect/Files/Error.hs
+++ b/src/Juvix/Data/Effect/Files/Error.hs
@@ -15,7 +15,7 @@ data FilesError = FilesError
   deriving stock (Show)
 
 instance ToGenericError FilesError where
-  genericError FilesError {..} =
+  genericError _ FilesError {..} =
     GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = AnsiText (pretty @_ @AnsiStyle msg),

--- a/src/Juvix/Data/Effect/Files/Error.hs
+++ b/src/Juvix/Data/Effect/Files/Error.hs
@@ -16,11 +16,12 @@ data FilesError = FilesError
 
 instance ToGenericError FilesError where
   genericError FilesError {..} =
-    return GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = AnsiText (pretty @_ @AnsiStyle msg),
-        _genericErrorIntervals = [i]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = AnsiText (pretty @_ @AnsiStyle msg),
+          _genericErrorIntervals = [i]
+        }
     where
       i :: Interval
       i =

--- a/src/Juvix/Data/Error.hs
+++ b/src/Juvix/Data/Error.hs
@@ -13,7 +13,7 @@ data JuvixError
   = forall a. (ToGenericError a, Typeable a) => JuvixError a
 
 instance ToGenericError JuvixError where
-  genericError (JuvixError e) = genericError e
+  genericError opts (JuvixError e) = genericError opts e
 
 fromJuvixError :: Typeable a => JuvixError -> Maybe a
 fromJuvixError (JuvixError e) = cast e

--- a/src/Juvix/Data/Error.hs
+++ b/src/Juvix/Data/Error.hs
@@ -13,7 +13,7 @@ data JuvixError
   = forall a. (ToGenericError a, Typeable a) => JuvixError a
 
 instance ToGenericError JuvixError where
-  genericError opts (JuvixError e) = genericError opts e
+  genericError (JuvixError e) = genericError e
 
 fromJuvixError :: Typeable a => JuvixError -> Maybe a
 fromJuvixError (JuvixError e) = cast e

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -57,8 +57,8 @@ render ansi endChar err = do
   let header = genericErrorHeader g
   let helper f x = (f . layoutPretty defaultLayoutOptions) (header <> x <> lastChar)
   if
-    | ansi -> return $ helper Ansi.renderStrict (toAnsiDoc gMsg)
-    | otherwise -> return $ helper renderStrict (toTextDoc gMsg)
+      | ansi -> return $ helper Ansi.renderStrict (toAnsiDoc gMsg)
+      | otherwise -> return $ helper renderStrict (toTextDoc gMsg)
   where
     lastChar :: Doc a
     lastChar

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -19,6 +19,7 @@ data GenericError = GenericError
 newtype GenericOptions = GenericOptions
   { _showNameIds :: Bool
   }
+  deriving stock (Eq, Show)
 
 makeLenses ''GenericError
 makeLenses ''GenericOptions

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -17,13 +17,14 @@ data GenericError = GenericError
   }
 
 newtype GenericOptions = GenericOptions
-  { _optShowNameIds :: Bool
+  { _showNameIds :: Bool
   }
 
 makeLenses ''GenericError
+makeLenses ''GenericOptions
 
 defaultGenericOptions :: GenericOptions
-defaultGenericOptions = GenericOptions {_optShowNameIds = False}
+defaultGenericOptions = GenericOptions {_showNameIds = False}
 
 instance Pretty GenericError where
   pretty :: GenericError -> Doc a

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -22,6 +22,9 @@ newtype GenericOptions = GenericOptions
 
 makeLenses ''GenericError
 
+defaultGenericOptions :: GenericOptions
+defaultGenericOptions = GenericOptions {_optShowNameIds = False}
+
 instance Pretty GenericError where
   pretty :: GenericError -> Doc a
   pretty g = genericErrorHeader g <> pretty (g ^. genericErrorMessage)
@@ -96,3 +99,9 @@ runErrorIO opts =
   runError >=> \case
     Left err -> embed (printErrorAnsiSafe opts err >> exitFailure)
     Right a -> return a
+
+runErrorIO' ::
+  (ToGenericError a, Member (Embed IO) r) =>
+  Sem (Error a ': r) b ->
+  Sem r b
+runErrorIO' = runErrorIO defaultGenericOptions

--- a/src/Juvix/Parser/Error.hs
+++ b/src/Juvix/Parser/Error.hs
@@ -12,11 +12,12 @@ newtype ParserError = ParserError
 
 instance ToGenericError ParserError where
   genericError e =
-    return GenericError
-      { _genericErrorLoc = i,
-        _genericErrorMessage = AnsiText $ pretty @_ @AnsiStyle e,
-        _genericErrorIntervals = [i]
-      }
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = AnsiText $ pretty @_ @AnsiStyle e,
+          _genericErrorIntervals = [i]
+        }
     where
       i = getLoc e
 

--- a/src/Juvix/Parser/Error.hs
+++ b/src/Juvix/Parser/Error.hs
@@ -11,8 +11,8 @@ newtype ParserError = ParserError
   deriving stock (Show)
 
 instance ToGenericError ParserError where
-  genericError _ e =
-    GenericError
+  genericError e =
+    return GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = AnsiText $ pretty @_ @AnsiStyle e,
         _genericErrorIntervals = [i]

--- a/src/Juvix/Parser/Error.hs
+++ b/src/Juvix/Parser/Error.hs
@@ -11,7 +11,7 @@ newtype ParserError = ParserError
   deriving stock (Show)
 
 instance ToGenericError ParserError where
-  genericError e =
+  genericError _ e =
     GenericError
       { _genericErrorLoc = i,
         _genericErrorMessage = AnsiText $ pretty @_ @AnsiStyle e,

--- a/test/BackendC/Base.hs
+++ b/test/BackendC/Base.hs
@@ -32,7 +32,7 @@ wasmClangAssertionCGenOnly :: FilePath -> ((String -> IO ()) -> Assertion)
 wasmClangAssertionCGenOnly mainFile step = do
   step "C Generation"
   let entryPoint = defaultEntryPoint mainFile
-  (void . runIO) (upToMiniC entryPoint)
+  (void . runIO') (upToMiniC entryPoint)
 
 wasmClangAssertion :: WASMInfo -> FilePath -> FilePath -> ((String -> IO ()) -> Assertion)
 wasmClangAssertion WASMInfo {..} mainFile expectedFile step = do
@@ -42,7 +42,7 @@ wasmClangAssertion WASMInfo {..} mainFile expectedFile step = do
 
   step "C Generation"
   let entryPoint = defaultEntryPoint mainFile
-  p :: MiniC.MiniCResult <- runIO (upToMiniC entryPoint)
+  p :: MiniC.MiniCResult <- runIO' (upToMiniC entryPoint)
 
   expected <- TIO.readFile expectedFile
 
@@ -65,7 +65,7 @@ wasiClangAssertion stdlibMode mainFile expectedFile stdinText step = do
 
   step "C Generation"
   let entryPoint = (defaultEntryPoint mainFile) {_entryPointNoStdlib = stdlibMode == StdlibExclude}
-  p :: MiniC.MiniCResult <- runIO (upToMiniC entryPoint)
+  p :: MiniC.MiniCResult <- runIO' (upToMiniC entryPoint)
 
   expected <- TIO.readFile expectedFile
 

--- a/test/Reachability/Positive.hs
+++ b/test/Reachability/Positive.hs
@@ -36,7 +36,7 @@ testDescr PosTest {..} =
                     }
 
             step "Pipeline up to reachability"
-            p :: Micro.InternalTypedResult <- runIO (upToInternalReachability entryPoint)
+            p :: Micro.InternalTypedResult <- runIO' (upToInternalReachability entryPoint)
 
             step "Check reachability results"
             let names = concatMap getNames (p ^. Micro.resultModules)

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -49,13 +49,13 @@ testDescr PosTest {..} =
                   | otherwise = HashMap.union fs stdlibMap
 
             step "Parsing"
-            p :: Parser.ParserResult <- runIO (upToParsing entryPoint)
+            p :: Parser.ParserResult <- runIO' (upToParsing entryPoint)
 
             let p2 = head (p ^. Parser.resultModules)
 
             step "Scoping"
             s :: Scoper.ScoperResult <-
-              runIO
+              runIO'
                 ( do
                     void (entrySetup entryPoint)
                     Concrete.fromParsed p
@@ -78,18 +78,18 @@ testDescr PosTest {..} =
             step "Parsing pretty scoped"
             let fs2 = unionStdlib (HashMap.singleton entryFile scopedPretty)
             p' :: Parser.ParserResult <-
-              (runM . runErrorIO @JuvixError . runNameIdGen . runFilesPure fs2)
+              (runM . runErrorIO' @JuvixError . runNameIdGen . runFilesPure fs2)
                 (upToParsing entryPoint)
 
             step "Parsing pretty parsed"
             let fs3 = unionStdlib (HashMap.singleton entryFile parsedPretty)
             parsedPretty' :: Parser.ParserResult <-
-              (runM . runErrorIO @JuvixError . runNameIdGen . runFilesPure fs3)
+              (runM . runErrorIO' @JuvixError . runNameIdGen . runFilesPure fs3)
                 (upToParsing entryPoint)
 
             step "Scoping the scoped"
             s' :: Scoper.ScoperResult <-
-              (runM . runErrorIO @JuvixError . runNameIdGen . runFilesPure fs)
+              (runM . runErrorIO' @JuvixError . runNameIdGen . runFilesPure fs)
                 (upToScoping entryPoint)
 
             step "Checks"

--- a/test/Termination/Positive.hs
+++ b/test/Termination/Positive.hs
@@ -21,7 +21,7 @@ testDescr PosTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             let entryPoint = (defaultEntryPoint _file) {_entryPointNoStdlib = True}
-            (void . runIO) (upToInternal entryPoint)
+            (void . runIO') (upToInternal entryPoint)
         }
 
 --------------------------------------------------------------------------------
@@ -45,7 +45,7 @@ testDescrFlag N.NegTest {..} =
                       _entryPointNoStdlib = True
                     }
 
-            (void . runIO) (upToInternal entryPoint)
+            (void . runIO') (upToInternal entryPoint)
         }
 
 --------------------------------------------------------------------------------

--- a/test/TypeCheck/Positive.hs
+++ b/test/TypeCheck/Positive.hs
@@ -21,7 +21,7 @@ testDescr PosTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             let entryPoint = defaultEntryPoint _file
-            (void . runIO) (upToInternalTyped entryPoint)
+            (void . runIO') (upToInternalTyped entryPoint)
         }
 
 --------------------------------------------------------------------------------
@@ -43,7 +43,7 @@ testNoPositivityFlag N.NegTest {..} =
                     { _entryPointNoPositivity = True
                     }
 
-            (void . runIO) (upToInternal entryPoint)
+            (void . runIO') (upToInternal entryPoint)
         }
 
 negPositivityTests :: [N.NegTest]


### PR DESCRIPTION
# Description

* `Reader GenericOptions` effect added to the function `genericError` in Data/Error/GenericError.hs.
* GlobalOptions converted into GenericOptions and stored in EntryPoint in Main/getEntryPoint
* `ppCode` in Typechecking/Error/Pretty.hs still has the GenericOptions argument and I resist removing it. I don't see much benefit in changing this function to use effects instead of an options argument, because it is used only in the error messages in Analysis/*. Changing it makes sense only if we rewrite all error message creation to use monadic style, and I don't see the benefit of it. It's more readable to create an error message as an expression than do it piecewise with do-notation, and then one needs exactly the ppCode function with an GenericOptions argument. NB this ppCode just calls Micro.ppCode and runReader.
* Fixes #1215.
