### PR TITLE
Fix developBeta in Core/Extra.hs

### DIFF
--- a/src/Juvix/Compiler/Core/Extra.hs
+++ b/src/Juvix/Compiler/Core/Extra.hs
@@ -56,12 +56,14 @@ shift m = umapN go
       _ -> n
 
 -- substitute a term t for the free variable with de Bruijn index 0, avoiding
--- variable capture
+-- variable capture; shifts all free variabes with de Bruijn index > 0 by -1 (as
+-- if the topmost binder was removed)
 subst :: Node -> Node -> Node
 subst t = umapN go
   where
     go k n = case n of
       Var _ idx | idx == k -> shift k t
+      Var i idx | idx > k -> Var i (idx - 1)
       _ -> n
 
 -- reduce all beta redexes present in a term and the ones created immediately


### PR DESCRIPTION
# Description

Fix a mistake in the example "developBeta" function from Core/Extra.hs. This function is not currently used anywhere and I didn't notice that I forgot to decrease free variable indices in the lambda body.
