### PR TITLE
Add a github action to build a static linux binary

### DIFF
--- a/.github/workflows/linux-static-binary.yaml
+++ b/.github/workflows/linux-static-binary.yaml
@@ -1,0 +1,41 @@
+name: Build Linux static binary
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'the repository ref to build'
+        required: true
+        default: 'main'
+
+jobs:
+  build:
+    name: Build static binary
+    runs-on: ubuntu-latest
+    container: ghcr.io/paulcadman/ghc-alpine:9.2.4
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: create ~/.local/bin
+        run: mkdir -p "$HOME/.local/bin"
+        shell: bash
+
+      - name: Add ~/.local/bin to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: build Juvix
+        run: stack install --system-ghc --ghc-options='-split-sections -optl-static'
+
+      - run: echo "HOME=$HOME" >> $GITHUB_ENV
+        shell: bash
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: juvix-linux_x86_64-${{ github.event.inputs.ref }}
+          path: ${{ env.HOME }}/.local/bin/juvix

--- a/docker/Dockerfile-ghc-alpine-9.2.4
+++ b/docker/Dockerfile-ghc-alpine-9.2.4
@@ -1,0 +1,28 @@
+FROM alpine:3.12
+
+RUN apk upgrade --no-cache &&\
+    apk add --no-cache curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz gzip tar perl git bash sudo binutils-gold lld &&\
+    apk add --no-cache zlib zlib-dev zlib-static gmp gmp-dev ncurses-static xz
+
+RUN curl https://downloads.haskell.org/~ghc/8.10-latest/ghc-8.10.2-x86_64-alpine3.10-linux-integer-simple.tar.xz -OL
+
+RUN tar xf ghc-8.10.2-x86_64-alpine3.10-linux-integer-simple.tar.xz
+
+RUN cd ghc-8.10.2-x86_64-unknown-linux && ./configure --prefix /opt && make install
+
+RUN curl https://downloads.haskell.org/~ghc/9.2.4/ghc-9.2.4-src.tar.xz -OL
+
+RUN tar xf ghc-9.2.4-src.tar.xz
+
+WORKDIR /ghc-9.2.4
+
+RUN GHC=/opt/bin/ghc ./configure --prefix /usr/local
+
+RUN make -j
+RUN make install
+
+WORKDIR /
+
+RUN curl https://get.haskellstack.org/stable/linux-x86_64.tar.gz -OL
+RUN tar xf linux-x86_64.tar.gz
+RUN cp stack-2.7.5-linux-x86_64/stack /usr/local/bin


### PR DESCRIPTION
This uses a custom docker image build using Dockerfile-ghc-alpine-9.2.4

The prebuilt ghcup binary distributions of GHC 9.2.x are broken, so we have to build our own, see https://gitlab.haskell.org/ghc/ghc/-/issues/20266

Closes https://github.com/anoma/juvix/issues/1469