### PR TITLE
Restructure recursors and add some lens interfaces

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -17,6 +17,11 @@ unfoldType' ty = case ty of
 
 {------------------------------------------------------------------------}
 {- functions on Node -}
+mkIdent :: Symbol -> Node
+mkIdent = Ident Info.empty
+
+mkVar :: Index -> Node
+mkVar = Var Info.empty
 
 mkIf :: Info -> Node -> Node -> Node -> Node
 mkIf i v b1 b2 = Case i v [CaseBranch (BuiltinTag TagTrue) 0 b1] (Just b2)
@@ -42,7 +47,9 @@ mkLambdas' :: [Info] -> Node -> Node
 mkLambdas' is n = foldr Lambda n is
 
 mkLambdas :: Int -> Node -> Node
-mkLambdas k = mkLambdas' (replicate k Info.empty)
+mkLambdas k
+  | k < 0 = impossible
+  | otherwise = mkLambdas' (replicate k Info.empty)
 
 unfoldLambdas' :: Node -> ([Info], Node)
 unfoldLambdas' = go []
@@ -152,6 +159,11 @@ destruct = \case
 
     tl :: [a] -> [a]
     tl = List.tail
+
+reassemble :: Node -> [Node] -> Node
+reassemble n = (d ^. nodeReassemble) (d ^. nodeInfo)
+  where
+    d = destruct n
 
 children :: Node -> [Node]
 children = (^. nodeChildren) . destruct

--- a/src/Juvix/Compiler/Core/Extra/Recursors.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors.hs
@@ -1,180 +1,49 @@
 module Juvix.Compiler.Core.Extra.Recursors
   ( module Juvix.Compiler.Core.Extra.Recursors,
-    BinderList,
+    module Juvix.Compiler.Core.Extra.Recursors.Applicative,
+    module Juvix.Compiler.Core.Extra.Recursors.Collector,
+    module Juvix.Compiler.Core.Extra.Recursors.Monadic,
   )
 where
 
 import Data.Functor.Identity
-import Juvix.Compiler.Core.Data.BinderList (BinderList)
-import Juvix.Compiler.Core.Data.BinderList qualified as BL
-import Juvix.Compiler.Core.Extra.Base
-import Juvix.Compiler.Core.Info.BinderInfo
-import Juvix.Compiler.Core.Language
-
-{---------------------------------------------------------------------------------}
-{- General recursors on Node  -}
-
--- a collector collects information top-down on a single path in the program
--- tree
-data Collector a c = Collector
-  { _cEmpty :: c,
-    _cCollect :: a -> c -> c
-  }
-
-makeLenses ''Collector
-
-unitCollector :: Collector a ()
-unitCollector = Collector () (\_ _ -> ())
-
-binderInfoCollector :: Collector (Int, Maybe [BinderInfo]) (BinderList (Maybe BinderInfo))
-binderInfoCollector =
-  Collector
-    BL.empty
-    (\(k, bi) c -> if k == 0 then c else BL.prepend (map Just (fromJust bi)) c)
-
-binderNumCollector :: Collector (Int, Maybe [BinderInfo]) Index
-binderNumCollector = Collector 0 (\(k, _) c -> c + k)
-
--- `umapG` maps the nodes bottom-up, i.e., when invoking the mapper function the
--- recursive subnodes have already been mapped
-umapG ::
-  forall c m.
-  Monad m =>
-  Collector (Int, Maybe [BinderInfo]) c ->
-  (c -> Node -> m Node) ->
-  Node ->
-  m Node
-umapG coll f = go (coll ^. cEmpty)
-  where
-    go :: c -> Node -> m Node
-    go c n =
-      let ni = destruct n
-       in do
-            ns <-
-              sequence $
-                zipWith3Exact
-                  (\n' k bis -> go ((coll ^. cCollect) (k, bis) c) n')
-                  (ni ^. nodeChildren)
-                  (ni ^. nodeChildBindersNum)
-                  (ni ^. nodeChildBindersInfo)
-            f c ((ni ^. nodeReassemble) (ni ^. nodeInfo) ns)
-
-umapM :: Monad m => (Node -> m Node) -> Node -> m Node
-umapM f = umapG unitCollector (const f)
-
-umapMB :: Monad m => (BinderList (Maybe BinderInfo) -> Node -> m Node) -> Node -> m Node
-umapMB f = umapG binderInfoCollector f
-
-umapMN :: Monad m => (Index -> Node -> m Node) -> Node -> m Node
-umapMN f = umapG binderNumCollector f
-
-umap :: (Node -> Node) -> Node -> Node
-umap f n = runIdentity $ umapM (return . f) n
-
-umapB :: (BinderList (Maybe BinderInfo) -> Node -> Node) -> Node -> Node
-umapB f n = runIdentity $ umapMB (\is -> return . f is) n
-
-umapN :: (Index -> Node -> Node) -> Node -> Node
-umapN f n = runIdentity $ umapMN (\idx -> return . f idx) n
-
--- `dmapG` maps the nodes top-down
-dmapG ::
-  forall c m.
-  Monad m =>
-  Collector (Int, Maybe [BinderInfo]) c ->
-  (c -> Node -> m Node) ->
-  Node ->
-  m Node
-dmapG coll f = go (coll ^. cEmpty)
-  where
-    go :: c -> Node -> m Node
-    go c n = do
-      n' <- f c n
-      let ni = destruct n'
-      ns <-
-        sequence $
-          zipWith3Exact
-            (\n'' k bis -> go ((coll ^. cCollect) (k, bis) c) n'')
-            (ni ^. nodeChildren)
-            (ni ^. nodeChildBindersNum)
-            (ni ^. nodeChildBindersInfo)
-      return ((ni ^. nodeReassemble) (ni ^. nodeInfo) ns)
-
-dmapM :: Monad m => (Node -> m Node) -> Node -> m Node
-dmapM f = dmapG unitCollector (const f)
-
-dmapMB :: Monad m => (BinderList (Maybe BinderInfo) -> Node -> m Node) -> Node -> m Node
-dmapMB f = dmapG binderInfoCollector f
-
-dmapMN :: Monad m => (Index -> Node -> m Node) -> Node -> m Node
-dmapMN f = dmapG binderNumCollector f
+import Juvix.Compiler.Core.Extra.Recursors.Applicative
+import Juvix.Compiler.Core.Extra.Recursors.Base
+import Juvix.Compiler.Core.Extra.Recursors.Collector
+import Juvix.Compiler.Core.Extra.Recursors.Monadic
 
 dmap :: (Node -> Node) -> Node -> Node
-dmap f n = runIdentity $ dmapM (return . f) n
+dmap f = runIdentity . dmapM (return . f)
 
 dmapB :: (BinderList (Maybe BinderInfo) -> Node -> Node) -> Node -> Node
-dmapB f n = runIdentity $ dmapMB (\is -> return . f is) n
+dmapB f = runIdentity . dmapMB (\is -> return . f is)
 
 dmapN :: (Index -> Node -> Node) -> Node -> Node
-dmapN f n = runIdentity $ dmapMN (\idx -> return . f idx) n
-
--- `ufoldG` folds the tree bottom-up. The `uplus` argument combines the values -
--- it should be commutative and associative.
-ufoldG ::
-  forall c a m.
-  Monad m =>
-  Collector (Int, Maybe [BinderInfo]) c ->
-  (a -> a -> a) ->
-  (c -> Node -> m a) ->
-  Node ->
-  m a
-ufoldG coll uplus f = go (coll ^. cEmpty)
-  where
-    go :: c -> Node -> m a
-    go c n = foldr (liftM2 uplus) (f c n) mas
-      where
-        ni :: NodeDetails
-        ni = destruct n
-        mas :: [m a]
-        mas =
-          zipWith3Exact
-            (\n' k bis -> go ((coll ^. cCollect) (k, bis) c) n')
-            (ni ^. nodeChildren)
-            (ni ^. nodeChildBindersNum)
-            (ni ^. nodeChildBindersInfo)
-
-ufoldM :: Monad m => (a -> a -> a) -> (Node -> m a) -> Node -> m a
-ufoldM uplus f = ufoldG unitCollector uplus (const f)
-
-ufoldMB :: Monad m => (a -> a -> a) -> (BinderList (Maybe BinderInfo) -> Node -> m a) -> Node -> m a
-ufoldMB uplus f = ufoldG binderInfoCollector uplus f
-
-ufoldMN :: Monad m => (a -> a -> a) -> (Index -> Node -> m a) -> Node -> m a
-ufoldMN uplus f = ufoldG binderNumCollector uplus f
+dmapN f = runIdentity . dmapMN (\idx -> return . f idx)
 
 ufold :: (a -> a -> a) -> (Node -> a) -> Node -> a
-ufold uplus f n = runIdentity $ ufoldM uplus (return . f) n
+ufold uplus f n = runIdentity $ ufoldA uplus (return . f) n
 
 ufoldB :: (a -> a -> a) -> (BinderList (Maybe BinderInfo) -> Node -> a) -> Node -> a
-ufoldB uplus f n = runIdentity $ ufoldMB uplus (\is -> return . f is) n
+ufoldB uplus f = runIdentity . ufoldAB uplus (\is -> return . f is)
 
 ufoldN :: (a -> a -> a) -> (Index -> Node -> a) -> Node -> a
-ufoldN uplus f n = runIdentity $ ufoldMN uplus (\idx -> return . f idx) n
-
-walk :: Monad m => (Node -> m ()) -> Node -> m ()
-walk = ufoldM mappend
-
-walkB :: Monad m => (BinderList (Maybe BinderInfo) -> Node -> m ()) -> Node -> m ()
-walkB = ufoldMB mappend
-
-walkN :: Monad m => (Index -> Node -> m ()) -> Node -> m ()
-walkN = ufoldMN mappend
+ufoldN uplus f = runIdentity . ufoldAN uplus (\idx -> return . f idx)
 
 gather :: (a -> Node -> a) -> a -> Node -> a
-gather f acc n = run $ execState acc (walk (\n' -> modify' (`f` n')) n)
+gather f acc = run . execState acc . walk (\n' -> modify' (`f` n'))
 
 gatherB :: (BinderList (Maybe BinderInfo) -> a -> Node -> a) -> a -> Node -> a
-gatherB f acc n = run $ execState acc (walkB (\is n' -> modify' (\a -> f is a n')) n)
+gatherB f acc = run . execState acc . walkB (\is n' -> modify' (\a -> f is a n'))
 
 gatherN :: (Index -> a -> Node -> a) -> a -> Node -> a
-gatherN f acc n = run $ execState acc (walkN (\idx n' -> modify' (\a -> f idx a n')) n)
+gatherN f acc = run . execState acc . walkN (\idx n' -> modify' (\a -> f idx a n'))
+
+umap :: (Node -> Node) -> Node -> Node
+umap f = runIdentity . umapM (return . f)
+
+umapB :: (BinderList (Maybe BinderInfo) -> Node -> Node) -> Node -> Node
+umapB f = runIdentity . umapMB (\is -> return . f is)
+
+umapN :: (Index -> Node -> Node) -> Node -> Node
+umapN f = runIdentity . umapMN (\idx -> return . f idx)

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Applicative.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Applicative.hs
@@ -1,0 +1,97 @@
+-- | Applicative recursors over 'Node'.
+module Juvix.Compiler.Core.Extra.Recursors.Applicative where
+
+import Juvix.Compiler.Core.Extra.Base
+import Juvix.Compiler.Core.Extra.Recursors.Base
+
+umapLeavesG ::
+  forall c f.
+  Applicative f =>
+  Collector (Int, Maybe [BinderInfo]) c ->
+  (c -> Node -> f Node) ->
+  Node ->
+  f Node
+umapLeavesG coll f = go (coll ^. cEmpty)
+  where
+    go :: c -> Node -> f Node
+    go c n
+      | null (ni ^. nodeChildren) = f c n
+      | otherwise = do
+          ns <-
+            sequenceA $
+              zipWith3Exact
+                (\n' k bis -> go ((coll ^. cCollect) (k, bis) c) n')
+                (ni ^. nodeChildren)
+                (ni ^. nodeChildBindersNum)
+                (ni ^. nodeChildBindersInfo)
+          return ((ni ^. nodeReassemble) (ni ^. nodeInfo) ns)
+      where
+        ni = destruct n
+
+ufoldG' ::
+  forall c a f.
+  Applicative f =>
+  Collector (Int, Maybe [BinderInfo]) c ->
+  (a -> [a] -> a) ->
+  (c -> Node -> f a) ->
+  Node ->
+  f a
+ufoldG' coll uplus f = go (coll ^. cEmpty)
+  where
+    go :: c -> Node -> f a
+    go c n = do
+      mas' <- sequenceA mas
+      n' <- f c n
+      pure (uplus n' mas')
+      where
+        ni :: NodeDetails
+        ni = destruct n
+        mas :: [f a]
+        mas =
+          zipWith3Exact
+            (\n' k bis -> go ((coll ^. cCollect) (k, bis) c) n')
+            (ni ^. nodeChildren)
+            (ni ^. nodeChildBindersNum)
+            (ni ^. nodeChildBindersInfo)
+
+-- `ufoldG` folds the tree bottom-up. The `uplus` argument combines the values -
+-- it should be commutative and associative.
+ufoldG ::
+  forall c a f.
+  Applicative f =>
+  Collector (Int, Maybe [BinderInfo]) c ->
+  (a -> a -> a) ->
+  (c -> Node -> f a) ->
+  Node ->
+  f a
+ufoldG coll uplus = ufoldG' coll uplus'
+  where
+    uplus' :: a -> [a] -> a
+    uplus' = foldr uplus
+
+ufoldA :: Applicative f => (a -> a -> a) -> (Node -> f a) -> Node -> f a
+ufoldA uplus f = ufoldG unitCollector uplus (const f)
+
+ufoldAB :: Applicative f => (a -> a -> a) -> (BinderList (Maybe BinderInfo) -> Node -> f a) -> Node -> f a
+ufoldAB uplus f = ufoldG binderInfoCollector uplus f
+
+ufoldAN :: Applicative f => (a -> a -> a) -> (Index -> Node -> f a) -> Node -> f a
+ufoldAN uplus f = ufoldG binderNumCollector uplus f
+
+ufoldAN' :: Applicative f => (a -> [a] -> a) -> (Index -> Node -> f a) -> Node -> f a
+ufoldAN' uplus f = ufoldG' binderNumCollector uplus f
+
+walk :: Applicative f => (Node -> f ()) -> Node -> f ()
+walk = ufoldA mappend
+
+walkN :: Applicative f => (Index -> Node -> f ()) -> Node -> f ()
+walkN = ufoldAN mappend
+
+walkB :: Applicative f => (BinderList (Maybe BinderInfo) -> Node -> f ()) -> Node -> f ()
+walkB = ufoldAB mappend
+
+umapLeavesN :: Applicative f => (Index -> Node -> f Node) -> Node -> f Node
+umapLeavesN f = umapLeavesG binderNumCollector f
+
+umapLeaves :: Applicative f => (Node -> f Node) -> Node -> f Node
+umapLeaves f = umapLeavesG unitCollector (const f)

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Base.hs
@@ -1,0 +1,12 @@
+module Juvix.Compiler.Core.Extra.Recursors.Base
+  ( module Juvix.Compiler.Core.Data.BinderList,
+    module Juvix.Compiler.Core.Language,
+    module Juvix.Compiler.Core.Info.BinderInfo,
+    module Juvix.Compiler.Core.Extra.Recursors.Collector,
+  )
+where
+
+import Juvix.Compiler.Core.Data.BinderList (BinderList)
+import Juvix.Compiler.Core.Extra.Recursors.Collector
+import Juvix.Compiler.Core.Info.BinderInfo
+import Juvix.Compiler.Core.Language

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Collector.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Collector.hs
@@ -1,7 +1,5 @@
 module Juvix.Compiler.Core.Extra.Recursors.Collector where
 
--- import Juvix.Compiler.Core.Extra.Recursors.Base
-
 import Juvix.Compiler.Core.Data.BinderList (BinderList)
 import Juvix.Compiler.Core.Data.BinderList qualified as BL
 import Juvix.Compiler.Core.Info.BinderInfo

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Collector.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Collector.hs
@@ -1,0 +1,29 @@
+module Juvix.Compiler.Core.Extra.Recursors.Collector where
+
+-- import Juvix.Compiler.Core.Extra.Recursors.Base
+
+import Juvix.Compiler.Core.Data.BinderList (BinderList)
+import Juvix.Compiler.Core.Data.BinderList qualified as BL
+import Juvix.Compiler.Core.Info.BinderInfo
+import Juvix.Compiler.Core.Language
+
+-- | a collector collects information top-down on a single path in the program
+-- tree
+data Collector a c = Collector
+  { _cEmpty :: c,
+    _cCollect :: a -> c -> c
+  }
+
+makeLenses ''Collector
+
+unitCollector :: Collector a ()
+unitCollector = Collector () (\_ _ -> ())
+
+binderInfoCollector :: Collector (Int, Maybe [BinderInfo]) (BinderList (Maybe BinderInfo))
+binderInfoCollector =
+  Collector
+    BL.empty
+    (\(k, bi) c -> if k == 0 then c else BL.prepend (map Just (fromJust bi)) c)
+
+binderNumCollector :: Collector (Int, Maybe [BinderInfo]) Index
+binderNumCollector = Collector 0 (\(k, _) c -> c + k)

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Monadic.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Monadic.hs
@@ -1,0 +1,69 @@
+module Juvix.Compiler.Core.Extra.Recursors.Monadic where
+
+import Juvix.Compiler.Core.Extra.Base
+import Juvix.Compiler.Core.Extra.Recursors.Base
+
+-- `umapG` maps the nodes bottom-up, i.e., when invoking the mapper function the
+-- recursive subnodes have already been mapped
+umapG ::
+  forall c m.
+  Monad m =>
+  Collector (Int, Maybe [BinderInfo]) c ->
+  (c -> Node -> m Node) ->
+  Node ->
+  m Node
+umapG coll f = go (coll ^. cEmpty)
+  where
+    go :: c -> Node -> m Node
+    go c n =
+      let ni = destruct n
+       in do
+            ns <-
+              sequence $
+                zipWith3Exact
+                  (\n' k bis -> go ((coll ^. cCollect) (k, bis) c) n')
+                  (ni ^. nodeChildren)
+                  (ni ^. nodeChildBindersNum)
+                  (ni ^. nodeChildBindersInfo)
+            f c ((ni ^. nodeReassemble) (ni ^. nodeInfo) ns)
+
+umapM :: Monad m => (Node -> m Node) -> Node -> m Node
+umapM f = umapG unitCollector (const f)
+
+umapMB :: Monad m => (BinderList (Maybe BinderInfo) -> Node -> m Node) -> Node -> m Node
+umapMB f = umapG binderInfoCollector f
+
+umapMN :: Monad m => (Index -> Node -> m Node) -> Node -> m Node
+umapMN f = umapG binderNumCollector f
+
+-- `dmapG` maps the nodes top-down
+dmapG ::
+  forall c m.
+  Monad m =>
+  Collector (Int, Maybe [BinderInfo]) c ->
+  (c -> Node -> m Node) ->
+  Node ->
+  m Node
+dmapG coll f = go (coll ^. cEmpty)
+  where
+    go :: c -> Node -> m Node
+    go c n = do
+      n' <- f c n
+      let ni = destruct n'
+      ns <-
+        sequence $
+          zipWith3Exact
+            (\n'' k bis -> go ((coll ^. cCollect) (k, bis) c) n'')
+            (ni ^. nodeChildren)
+            (ni ^. nodeChildBindersNum)
+            (ni ^. nodeChildBindersInfo)
+      return ((ni ^. nodeReassemble) (ni ^. nodeInfo) ns)
+
+dmapM :: Monad m => (Node -> m Node) -> Node -> m Node
+dmapM f = dmapG unitCollector (const f)
+
+dmapMB :: Monad m => (BinderList (Maybe BinderInfo) -> Node -> m Node) -> Node -> m Node
+dmapMB f = dmapG binderInfoCollector f
+
+dmapMN :: Monad m => (Index -> Node -> m Node) -> Node -> m Node
+dmapMN f = dmapG binderNumCollector f


### PR DESCRIPTION
This PR restructures the recursors in two categories: Applicative and Monadic.
In Applicative we find folds and maps to the leaves. In Monadic we find maps (top-down and bottom-up).
The advantage of having Applicative folds is that they can play well with some lens interface (e.g. `Traversal`, `SimpleFold`).
As an illustrative example, this PR implements a `SimpleFold` over free variables inside a node, and a `Traversal` over all the identifiers. One can then easily use the existing tools from the lens ecosystem to define a function to determine whether a node is closed, as shown in this PR.

Having a lens interface is not always possible, however, I think that for the cases where it is, we should try to have it.
