### PR TITLE
Stack with github actions permissions workaround

### DIFF
--- a/.github/workflows/linux-static-binary.yaml
+++ b/.github/workflows/linux-static-binary.yaml
@@ -28,6 +28,9 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
         shell: bash
 
+      - name: Stack permissions bug workaround
+        run: "chown -R $(id -un):$(id -gn) ~"
+
       - name: build Juvix
         run: stack install --system-ghc --ghc-options='-split-sections -optl-static'
 


### PR DESCRIPTION
The binary build action almost worked - https://github.com/anoma/juvix/actions/runs/2955803414

This error occurs when building with stack:

```
Run stack install --system-ghc --ghc-options='-split-sections -optl-static'
4
Preventing creation of stack root '/github/home/.stack/'. Parent directory '/github/home/' is owned by someone else.
5
Error: Process completed with exit code 1.
```

https://github.com/commercialhaskell/stack/issues/2187