### PR TITLE
Add --allow-different-user to workflow stack command

### DIFF
--- a/.github/workflows/linux-static-binary.yaml
+++ b/.github/workflows/linux-static-binary.yaml
@@ -32,7 +32,7 @@ jobs:
         run: "chown -R $(id -un):$(id -gn) ~"
 
       - name: build Juvix
-        run: stack install --system-ghc --ghc-options='-split-sections -optl-static'
+        run: stack install --allow-different-user --system-ghc --ghc-options='-split-sections -optl-static'
 
       - run: echo "HOME=$HOME" >> $GITHUB_ENV
         shell: bash


### PR DESCRIPTION
Adds the `--allow-different-user` to GitHub workflow stack command.

I've tested this in my [fork of juvix](https://github.com/paulcadman/juvix/blob/6b54fd25df17f79053d788c5f6b5a383d595d127/.github/workflows/linux-static-binary.yaml#L35)  and it successfully builds and uploads the resulting linux binary as a build artefact, see https://github.com/paulcadman/juvix/actions/runs/2956659468