### PR TITLE
Refactor Node datatype

### DIFF
--- a/src/Juvix/Compiler/Core/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTable.hs
@@ -9,7 +9,7 @@ data InfoTable = InfoTable
     -- `_identMap` is needed only for REPL
     _identMap :: HashMap Text (Either Symbol Tag),
     _infoMain :: Maybe Symbol,
-    _infoIdents :: HashMap Symbol IdentInfo,
+    _infoIdentifiers :: HashMap Symbol IdentifierInfo,
     _infoInductives :: HashMap Name InductiveInfo,
     _infoConstructors :: HashMap Tag ConstructorInfo,
     _infoAxioms :: HashMap Name AxiomInfo
@@ -21,20 +21,20 @@ emptyInfoTable =
     { _identContext = mempty,
       _identMap = mempty,
       _infoMain = Nothing,
-      _infoIdents = mempty,
+      _infoIdentifiers = mempty,
       _infoInductives = mempty,
       _infoConstructors = mempty,
       _infoAxioms = mempty
     }
 
-data IdentInfo = IdentInfo
-  { _identName :: Name,
-    _identSymbol :: Symbol,
-    _identType :: Type,
-    -- _identArgsNum will be used often enough to justify avoiding recomputation
-    _identArgsNum :: Int,
-    _identArgsInfo :: [ArgumentInfo],
-    _identIsExported :: Bool
+data IdentifierInfo = IdentifierInfo
+  { _identifierName :: Name,
+    _identifierSymbol :: Symbol,
+    _identifierType :: Type,
+    -- _identifierArgsNum will be used often enough to justify avoiding recomputation
+    _identifierArgsNum :: Int,
+    _identifierArgsInfo :: [ArgumentInfo],
+    _identifierIsExported :: Bool
   }
 
 data ArgumentInfo = ArgumentInfo
@@ -70,7 +70,7 @@ data AxiomInfo = AxiomInfo
   }
 
 makeLenses ''InfoTable
-makeLenses ''IdentInfo
+makeLenses ''IdentifierInfo
 makeLenses ''ArgumentInfo
 makeLenses ''InductiveInfo
 makeLenses ''ConstructorInfo

--- a/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
@@ -7,7 +7,7 @@ import Juvix.Compiler.Core.Language
 data InfoTableBuilder m a where
   FreshSymbol :: InfoTableBuilder m Symbol
   FreshTag :: InfoTableBuilder m Tag
-  RegisterIdent :: IdentInfo -> InfoTableBuilder m ()
+  RegisterIdent :: IdentifierInfo -> InfoTableBuilder m ()
   RegisterConstructor :: ConstructorInfo -> InfoTableBuilder m ()
   RegisterIdentNode :: Symbol -> Node -> InfoTableBuilder m ()
   SetIdentArgsInfo :: Symbol -> [ArgumentInfo] -> InfoTableBuilder m ()
@@ -44,7 +44,7 @@ makeLenses ''BuilderState
 initBuilderState :: InfoTable -> BuilderState
 initBuilderState tab =
   BuilderState
-    { _stateNextSymbol = fromIntegral $ HashMap.size (tab ^. infoIdents),
+    { _stateNextSymbol = fromIntegral $ HashMap.size (tab ^. infoIdentifiers),
       _stateNextUserTag = fromIntegral $ HashMap.size (tab ^. infoConstructors),
       _stateInfoTable = tab
     }
@@ -66,16 +66,16 @@ runInfoTableBuilder tab =
         s <- get
         return (UserTag (s ^. stateNextUserTag - 1))
       RegisterIdent ii -> do
-        modify' (over stateInfoTable (over infoIdents (HashMap.insert (ii ^. identSymbol) ii)))
-        modify' (over stateInfoTable (over identMap (HashMap.insert (ii ^. (identName . nameText)) (Left (ii ^. identSymbol)))))
+        modify' (over stateInfoTable (over infoIdentifiers (HashMap.insert (ii ^. identifierSymbol) ii)))
+        modify' (over stateInfoTable (over identMap (HashMap.insert (ii ^. (identifierName . nameText)) (Left (ii ^. identifierSymbol)))))
       RegisterConstructor ci -> do
         modify' (over stateInfoTable (over infoConstructors (HashMap.insert (ci ^. constructorTag) ci)))
         modify' (over stateInfoTable (over identMap (HashMap.insert (ci ^. (constructorName . nameText)) (Right (ci ^. constructorTag)))))
       RegisterIdentNode sym node ->
         modify' (over stateInfoTable (over identContext (HashMap.insert sym node)))
       SetIdentArgsInfo sym argsInfo -> do
-        modify' (over stateInfoTable (over infoIdents (HashMap.adjust (set identArgsInfo argsInfo) sym)))
-        modify' (over stateInfoTable (over infoIdents (HashMap.adjust (set identArgsNum (length argsInfo)) sym)))
+        modify' (over stateInfoTable (over infoIdentifiers (HashMap.adjust (set identifierArgsInfo argsInfo) sym)))
+        modify' (over stateInfoTable (over infoIdentifiers (HashMap.adjust (set identifierArgsNum (length argsInfo)) sym)))
       GetIdent txt -> do
         s <- get
         return $ HashMap.lookup txt (s ^. (stateInfoTable . identMap))

--- a/src/Juvix/Compiler/Core/Extra.hs
+++ b/src/Juvix/Compiler/Core/Extra.hs
@@ -10,7 +10,6 @@ import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Core.Extra.Base
 import Juvix.Compiler.Core.Extra.Info
 import Juvix.Compiler.Core.Extra.Recursors
-import Juvix.Compiler.Core.Info qualified as Info
 import Juvix.Compiler.Core.Language
 
 isClosed :: Node -> Bool
@@ -23,8 +22,8 @@ freeVars :: SimpleFold Node Index
 freeVars f = ufoldAN' reassemble go
   where
     go k = \case
-      Var i idx
-        | idx >= k -> Var i <$> f (idx - k)
+      NVar (Var i idx)
+        | idx >= k -> mkVar i <$> f (idx - k)
       n -> pure n
 
 getIdents :: Node -> HashSet Symbol
@@ -34,14 +33,14 @@ nodeIdents :: Traversal' Node Symbol
 nodeIdents f = umapLeaves go
   where
     go = \case
-      Ident i d -> Ident i <$> f d
+      NIdt (Ident i d) -> mkIdent i <$> f d
       n -> pure n
 
 countFreeVarOccurrences :: Index -> Node -> Int
 countFreeVarOccurrences idx = gatherN go 0
   where
     go k acc = \case
-      Var _ idx' | idx' == idx + k -> acc + 1
+      NVar (Var _ idx') | idx' == idx + k -> acc + 1
       _ -> acc
 
 -- | increase all free variable indices by a given value
@@ -50,7 +49,7 @@ shift 0 = id
 shift m = umapN go
   where
     go k n = case n of
-      Var i idx | idx >= k -> Var i (idx + m)
+      NVar (Var i idx) | idx >= k -> mkVar i (idx + m)
       _ -> n
 
 -- | substitute a term t for the free variable with de Bruijn index 0, avoiding
@@ -60,8 +59,8 @@ subst :: Node -> Node -> Node
 subst t = umapN go
   where
     go k n = case n of
-      Var _ idx | idx == k -> shift k t
-      Var i idx | idx > k -> Var i (idx - 1)
+      NVar (Var _ idx) | idx == k -> shift k t
+      NVar (Var i idx) | idx > k -> mkVar i (idx - 1)
       _ -> n
 
 -- | reduce all beta redexes present in a term and the ones created immediately
@@ -71,12 +70,12 @@ developBeta = umap go
   where
     go :: Node -> Node
     go n = case n of
-      App _ (Lambda _ body) arg -> subst arg body
+      NApp (App _ (NLam (Lambda _ body)) arg) -> subst arg body
       _ -> n
 
 etaExpand :: Int -> Node -> Node
 etaExpand 0 n = n
-etaExpand k n = mkLambdas k (mkApp (shift k n) (map (Var Info.empty) (reverse [0 .. k - 1])))
+etaExpand k n = mkLambdas' k (mkApps' (shift k n) (map mkVar' (reverse [0 .. k - 1])))
 
 -- | substitution of all free variables for values in an environment
 substEnv :: Env -> Node -> Node
@@ -85,7 +84,7 @@ substEnv env
   | otherwise = umapN go
   where
     go k n = case n of
-      Var _ idx | idx >= k -> env !! (idx - k)
+      NVar (Var _ idx) | idx >= k -> env !! (idx - k)
       _ -> n
 
 convertClosures :: Node -> Node
@@ -93,7 +92,7 @@ convertClosures = umap go
   where
     go :: Node -> Node
     go n = case n of
-      Closure i env b -> substEnv env (Lambda i b)
+      Closure i env b -> substEnv env (mkLambda i b)
       _ -> n
 
 convertRuntimeNodes :: Node -> Node

--- a/src/Juvix/Compiler/Core/Extra.hs
+++ b/src/Juvix/Compiler/Core/Extra.hs
@@ -3,11 +3,13 @@ module Juvix.Compiler.Core.Extra
     module Juvix.Compiler.Core.Extra.Base,
     module Juvix.Compiler.Core.Extra.Recursors,
     module Juvix.Compiler.Core.Extra.Info,
+    module Juvix.Compiler.Core.Extra.Equality,
   )
 where
 
 import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Core.Extra.Base
+import Juvix.Compiler.Core.Extra.Equality
 import Juvix.Compiler.Core.Extra.Info
 import Juvix.Compiler.Core.Extra.Recursors
 import Juvix.Compiler.Core.Language
@@ -92,7 +94,7 @@ convertClosures = umap go
   where
     go :: Node -> Node
     go n = case n of
-      Closure i env b -> substEnv env (mkLambda i b)
+      Closure env (Lambda i b) -> substEnv env (mkLambda i b)
       _ -> n
 
 convertRuntimeNodes :: Node -> Node

--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -60,7 +60,7 @@ mkLet' = mkLet Info.empty
 mkCase :: Info -> Node -> [CaseBranch] -> Maybe Node -> Node
 mkCase i v bs def = NCase (Case i v bs def)
 
-mkCase':: Node -> [CaseBranch] -> Maybe Node -> Node
+mkCase' :: Node -> [CaseBranch] -> Maybe Node -> Node
 mkCase' = mkCase Info.empty
 
 mkIf :: Info -> Node -> Node -> Node -> Node

--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -173,41 +173,41 @@ destruct = \case
   NLam (Lambda i b) -> NodeDetails i [b] [1] [fetchBinderInfo i] (\i' args' -> mkLambda i' (hd args'))
   NLet (Let i v b) -> NodeDetails i [v, b] [0, 1] [[], fetchBinderInfo i] (\i' args' -> mkLet i' (hd args') (args' !! 1))
   NCase (Case i v bs Nothing) ->
-    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs in
-    NodeDetails
-      i
-      (v : map (\(CaseBranch _ _ br) -> br) bs)
-      (0 : branchBinderNums)
-      ([] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
-      ( \i' args' ->
-          mkCase
-            i'
-            (hd args')
-            ( zipWithExact
-                (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
-                bs
-                (tl args')
-            )
-            Nothing
-      )
+    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs
+     in NodeDetails
+          i
+          (v : map (\(CaseBranch _ _ br) -> br) bs)
+          (0 : branchBinderNums)
+          ([] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
+          ( \i' args' ->
+              mkCase
+                i'
+                (hd args')
+                ( zipWithExact
+                    (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
+                    bs
+                    (tl args')
+                )
+                Nothing
+          )
   NCase (Case i v bs (Just def)) ->
-    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs in
-    NodeDetails
-      i
-      (v : def : map (\(CaseBranch _ _ br) -> br) bs)
-      (0 : 0 : branchBinderNums)
-      ([] : [] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
-      ( \i' args' ->
-          mkCase
-            i'
-            (hd args')
-            ( zipWithExact
-                (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
-                bs
-                (tl (tl args'))
-            )
-            (Just (hd (tl args')))
-      )
+    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs
+     in NodeDetails
+          i
+          (v : def : map (\(CaseBranch _ _ br) -> br) bs)
+          (0 : 0 : branchBinderNums)
+          ([] : [] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
+          ( \i' args' ->
+              mkCase
+                i'
+                (hd args')
+                ( zipWithExact
+                    (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
+                    bs
+                    (tl (tl args'))
+                )
+                (Just (hd (tl args')))
+          )
   NPi (Pi i ty b) ->
     NodeDetails i [ty, b] [0, 1] [[], fetchBinderInfo i] (\i' args' -> mkPi i' (hd args') (args' !! 1))
   NUniv (Univ i l) ->

--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -7,60 +7,136 @@ import Juvix.Compiler.Core.Info.BinderInfo
 import Juvix.Compiler.Core.Language
 
 {------------------------------------------------------------------------}
+{- Node constructors -}
+
+mkVar :: Info -> Index -> Node
+mkVar i idx = NVar (Var i idx)
+
+mkVar' :: Index -> Node
+mkVar' = mkVar Info.empty
+
+mkIdent :: Info -> Symbol -> Node
+mkIdent i sym = NIdt (Ident i sym)
+
+mkIdent' :: Symbol -> Node
+mkIdent' = mkIdent Info.empty
+
+mkConstant :: Info -> ConstantValue -> Node
+mkConstant i cv = NCst (Constant i cv)
+
+mkConstant' :: ConstantValue -> Node
+mkConstant' = mkConstant Info.empty
+
+mkApp :: Info -> Node -> Node -> Node
+mkApp i l r = NApp (App i l r)
+
+mkApp' :: Node -> Node -> Node
+mkApp' = mkApp Info.empty
+
+mkBuiltinApp :: Info -> BuiltinOp -> [Node] -> Node
+mkBuiltinApp i op args = NBlt (BuiltinApp i op args)
+
+mkBuiltinApp' :: BuiltinOp -> [Node] -> Node
+mkBuiltinApp' = mkBuiltinApp Info.empty
+
+mkConstr :: Info -> Tag -> [Node] -> Node
+mkConstr i tag args = NCtr (Constr i tag args)
+
+mkConstr' :: Tag -> [Node] -> Node
+mkConstr' = mkConstr Info.empty
+
+mkLambda :: Info -> Node -> Node
+mkLambda i b = NLam (Lambda i b)
+
+mkLambda' :: Node -> Node
+mkLambda' = mkLambda Info.empty
+
+mkLet :: Info -> Node -> Node -> Node
+mkLet i v b = NLet (Let i v b)
+
+mkLet' :: Node -> Node -> Node
+mkLet' = mkLet Info.empty
+
+mkCase :: Info -> Node -> [CaseBranch] -> Maybe Node -> Node
+mkCase i v bs def = NCase (Case i v bs def)
+
+mkCase':: Node -> [CaseBranch] -> Maybe Node -> Node
+mkCase' = mkCase Info.empty
+
+mkIf :: Info -> Node -> Node -> Node -> Node
+mkIf i v b1 b2 = mkCase i v [CaseBranch (BuiltinTag TagTrue) 0 b1] (Just b2)
+
+mkIf' :: Node -> Node -> Node -> Node
+mkIf' = mkIf Info.empty
+
+{------------------------------------------------------------------------}
+{- Type constructors -}
+
+mkPi :: Info -> Type -> Type -> Type
+mkPi i ty b = NPi (Pi i ty b)
+
+mkPi' :: Type -> Type -> Type
+mkPi' = mkPi Info.empty
+
+mkUniv :: Info -> Int -> Type
+mkUniv i l = NUniv (Univ i l)
+
+mkUniv' :: Int -> Type
+mkUniv' = mkUniv Info.empty
+
+mkTypeConstr :: Info -> Symbol -> [Type] -> Type
+mkTypeConstr i sym args = NTyp (TypeConstr i sym args)
+
+mkTypeConstr' :: Symbol -> [Type] -> Type
+mkTypeConstr' = mkTypeConstr Info.empty
+
+{------------------------------------------------------------------------}
 {- functions on Type -}
 
 -- unfold a type into the target and the arguments (left-to-right)
 unfoldType' :: Type -> (Type, [(Info, Type)])
 unfoldType' ty = case ty of
-  Pi i l r -> let (tgt, args) = unfoldType' r in (tgt, (i, l) : args)
+  NPi (Pi i l r) -> let (tgt, args) = unfoldType' r in (tgt, (i, l) : args)
   _ -> (ty, [])
 
 {------------------------------------------------------------------------}
 {- functions on Node -}
-mkIdent :: Symbol -> Node
-mkIdent = Ident Info.empty
 
-mkVar :: Index -> Node
-mkVar = Var Info.empty
+mkApps :: Node -> [(Info, Node)] -> Node
+mkApps = foldl' (\acc (i, n) -> mkApp i acc n)
 
-mkIf :: Info -> Node -> Node -> Node -> Node
-mkIf i v b1 b2 = Case i v [CaseBranch (BuiltinTag TagTrue) 0 b1] (Just b2)
+mkApps' :: Node -> [Node] -> Node
+mkApps' = foldl' mkApp'
 
-mkApp' :: Node -> [(Info, Node)] -> Node
-mkApp' = foldl' (\acc (i, n) -> App i acc n)
-
-mkApp :: Node -> [Node] -> Node
-mkApp = foldl' (App Info.empty)
-
-unfoldApp' :: Node -> (Node, [(Info, Node)])
-unfoldApp' = go []
+unfoldApps :: Node -> (Node, [(Info, Node)])
+unfoldApps = go []
   where
     go :: [(Info, Node)] -> Node -> (Node, [(Info, Node)])
     go acc n = case n of
-      App i l r -> go ((i, r) : acc) l
+      NApp (App i l r) -> go ((i, r) : acc) l
       _ -> (n, acc)
 
-unfoldApp :: Node -> (Node, [Node])
-unfoldApp = second (map snd) . unfoldApp'
+unfoldApps' :: Node -> (Node, [Node])
+unfoldApps' = second (map snd) . unfoldApps
 
-mkLambdas' :: [Info] -> Node -> Node
-mkLambdas' is n = foldr Lambda n is
+mkLambdas :: [Info] -> Node -> Node
+mkLambdas is n = foldl' (flip mkLambda) n is
 
-mkLambdas :: Int -> Node -> Node
-mkLambdas k
+mkLambdas' :: Int -> Node -> Node
+mkLambdas' k
   | k < 0 = impossible
-  | otherwise = mkLambdas' (replicate k Info.empty)
+  | otherwise = mkLambdas (replicate k Info.empty)
 
-unfoldLambdas' :: Node -> ([Info], Node)
-unfoldLambdas' = go []
+unfoldLambdas :: Node -> ([Info], Node)
+unfoldLambdas = go []
   where
     go :: [Info] -> Node -> ([Info], Node)
     go acc n = case n of
-      Lambda i b -> go (i : acc) b
+      NLam (Lambda i b) -> go (i : acc) b
       _ -> (acc, n)
 
-unfoldLambdas :: Node -> (Int, Node)
-unfoldLambdas = first length . unfoldLambdas'
+unfoldLambdas' :: Node -> (Int, Node)
+unfoldLambdas' = first length . unfoldLambdas
 
 -- `NodeDetails` is a convenience datatype which provides the most commonly needed
 -- information about a node in a generic fashion.
@@ -88,56 +164,56 @@ makeLenses ''NodeDetails
 -- implement more high-level accessors and recursors.
 destruct :: Node -> NodeDetails
 destruct = \case
-  Var i idx -> NodeDetails i [] [] [] (\i' _ -> Var i' idx)
-  Ident i sym -> NodeDetails i [] [] [] (\i' _ -> Ident i' sym)
-  Constant i c -> NodeDetails i [] [] [] (\i' _ -> Constant i' c)
-  App i l r -> NodeDetails i [l, r] [0, 0] [[], []] (\i' args' -> App i' (hd args') (args' !! 1))
-  BuiltinApp i op args -> NodeDetails i args (map (const 0) args) (map (const []) args) (`BuiltinApp` op)
-  Constr i tag args -> NodeDetails i args (map (const 0) args) (map (const []) args) (`Constr` tag)
-  Lambda i b -> NodeDetails i [b] [1] [fetchBinderInfo i] (\i' args' -> Lambda i' (hd args'))
-  Let i v b -> NodeDetails i [v, b] [0, 1] [[], fetchBinderInfo i] (\i' args' -> Let i' (hd args') (args' !! 1))
-  Case i v bs Nothing ->
-    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs
-     in NodeDetails
-          i
-          (v : map (\(CaseBranch _ _ br) -> br) bs)
-          (0 : branchBinderNums)
-          ([] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
-          ( \i' args' ->
-              Case
-                i'
-                (hd args')
-                ( zipWithExact
-                    (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
-                    bs
-                    (tl args')
-                )
-                Nothing
-          )
-  Case i v bs (Just def) ->
-    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs
-     in NodeDetails
-          i
-          (v : def : map (\(CaseBranch _ _ br) -> br) bs)
-          (0 : 0 : branchBinderNums)
-          ([] : [] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
-          ( \i' args' ->
-              Case
-                i'
-                (hd args')
-                ( zipWithExact
-                    (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
-                    bs
-                    (tl (tl args'))
-                )
-                (Just (hd (tl args')))
-          )
-  Pi i ty b ->
-    NodeDetails i [ty, b] [0, 1] [[], fetchBinderInfo i] (\i' args' -> Pi i' (hd args') (args' !! 1))
-  Univ i l ->
-    NodeDetails i [] [] [] (\i' _ -> Univ i' l)
-  TypeConstr i sym args ->
-    NodeDetails i args (map (const 0) args) (map (const []) args) (`TypeConstr` sym)
+  NVar (Var i idx) -> NodeDetails i [] [] [] (\i' _ -> mkVar i' idx)
+  NIdt (Ident i sym) -> NodeDetails i [] [] [] (\i' _ -> mkIdent i' sym)
+  NCst (Constant i c) -> NodeDetails i [] [] [] (\i' _ -> mkConstant i' c)
+  NApp (App i l r) -> NodeDetails i [l, r] [0, 0] [[], []] (\i' args' -> mkApp i' (hd args') (args' !! 1))
+  NBlt (BuiltinApp i op args) -> NodeDetails i args (map (const 0) args) (map (const []) args) (`mkBuiltinApp` op)
+  NCtr (Constr i tag args) -> NodeDetails i args (map (const 0) args) (map (const []) args) (`mkConstr` tag)
+  NLam (Lambda i b) -> NodeDetails i [b] [1] [fetchBinderInfo i] (\i' args' -> mkLambda i' (hd args'))
+  NLet (Let i v b) -> NodeDetails i [v, b] [0, 1] [[], fetchBinderInfo i] (\i' args' -> mkLet i' (hd args') (args' !! 1))
+  NCase (Case i v bs Nothing) ->
+    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs in
+    NodeDetails
+      i
+      (v : map (\(CaseBranch _ _ br) -> br) bs)
+      (0 : branchBinderNums)
+      ([] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
+      ( \i' args' ->
+          mkCase
+            i'
+            (hd args')
+            ( zipWithExact
+                (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
+                bs
+                (tl args')
+            )
+            Nothing
+      )
+  NCase (Case i v bs (Just def)) ->
+    let branchBinderNums = map (\(CaseBranch _ k _) -> k) bs in
+    NodeDetails
+      i
+      (v : def : map (\(CaseBranch _ _ br) -> br) bs)
+      (0 : 0 : branchBinderNums)
+      ([] : [] : fetchCaseBinderInfo i (map (`replicate` Info.empty) branchBinderNums))
+      ( \i' args' ->
+          mkCase
+            i'
+            (hd args')
+            ( zipWithExact
+                (\(CaseBranch tag k _) br' -> CaseBranch tag k br')
+                bs
+                (tl (tl args'))
+            )
+            (Just (hd (tl args')))
+      )
+  NPi (Pi i ty b) ->
+    NodeDetails i [ty, b] [0, 1] [[], fetchBinderInfo i] (\i' args' -> mkPi i' (hd args') (args' !! 1))
+  NUniv (Univ i l) ->
+    NodeDetails i [] [] [] (\i' _ -> mkUniv i' l)
+  NTyp (TypeConstr i sym args) ->
+    NodeDetails i args (map (const 0) args) (map (const []) args) (`mkTypeConstr` sym)
   Closure i env b ->
     NodeDetails
       i

--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -93,7 +93,7 @@ mkTypeConstr' = mkTypeConstr Info.empty
 {------------------------------------------------------------------------}
 {- functions on Type -}
 
--- unfold a type into the target and the arguments (left-to-right)
+-- | Unfold a type into the target and the arguments (left-to-right)
 unfoldType' :: Type -> (Type, [(Info, Type)])
 unfoldType' ty = case ty of
   NPi (Pi i l r) -> let (tgt, args) = unfoldType' r in (tgt, (i, l) : args)
@@ -138,7 +138,7 @@ unfoldLambdas = go []
 unfoldLambdas' :: Node -> (Int, Node)
 unfoldLambdas' = first length . unfoldLambdas
 
--- `NodeDetails` is a convenience datatype which provides the most commonly needed
+-- | `NodeDetails` is a convenience datatype which provides the most commonly needed
 -- information about a node in a generic fashion.
 data NodeDetails = NodeDetails
   { -- `nodeInfo` is the info associated with the node,
@@ -214,13 +214,13 @@ destruct = \case
     NodeDetails i [] [] [] (\i' _ -> mkUniv i' l)
   NTyp (TypeConstr i sym args) ->
     NodeDetails i args (map (const 0) args) (map (const []) args) (`mkTypeConstr` sym)
-  Closure i env b ->
+  Closure env (Lambda i b) ->
     NodeDetails
       i
       (b : env)
       (1 : map (const 0) env)
       (fetchBinderInfo i : map (const []) env)
-      (\i' args' -> Closure i' (tl args') (hd args'))
+      (\i' args' -> Closure (tl args') (Lambda i' (hd args')))
   where
     fetchBinderInfo :: Info -> [Info]
     fetchBinderInfo i = [getInfoBinder i]

--- a/src/Juvix/Compiler/Core/Extra/Equality.hs
+++ b/src/Juvix/Compiler/Core/Extra/Equality.hs
@@ -11,6 +11,6 @@ structEq (NCtr (Constr _ tag1 args1)) (NCtr (Constr _ tag2 args2)) =
   where
     argsEq :: [Node] -> [Node] -> Bool
     argsEq [] [] = True
-    argsEq (x:xs) (y:ys) | structEq x y = argsEq xs ys
+    argsEq (x : xs) (y : ys) | structEq x y = argsEq xs ys
     argsEq _ _ = False
 structEq x y = x == y

--- a/src/Juvix/Compiler/Core/Extra/Equality.hs
+++ b/src/Juvix/Compiler/Core/Extra/Equality.hs
@@ -1,0 +1,16 @@
+module Juvix.Compiler.Core.Extra.Equality where
+
+import Juvix.Compiler.Core.Language
+
+-- | Structural equality on Nodes. Semantically the same as `==` but slightly
+-- optimised. Used mostly in the evaluator.
+structEq :: Node -> Node -> Bool
+structEq (NCst (Constant _ v1)) (NCst (Constant _ v2)) = v1 == v2
+structEq (NCtr (Constr _ tag1 args1)) (NCtr (Constr _ tag2 args2)) =
+  tag1 == tag2 && argsEq args1 args2
+  where
+    argsEq :: [Node] -> [Node] -> Bool
+    argsEq [] [] = True
+    argsEq (x:xs) (y:ys) | structEq x y = argsEq xs ys
+    argsEq _ _ = False
+structEq x y = x == y

--- a/src/Juvix/Compiler/Core/Info/FreeVarsInfo.hs
+++ b/src/Juvix/Compiler/Core/Info/FreeVarsInfo.hs
@@ -22,7 +22,7 @@ computeFreeVarsInfo = umapN go
   where
     go :: Index -> Node -> Node
     go k n = case n of
-      Var i idx | idx >= k -> Var (Info.insert fvi i) idx
+      NVar (Var i idx) | idx >= k -> mkVar (Info.insert fvi i) idx
         where
           fvi = FreeVarsInfo (HashMap.singleton (idx - k) 1)
       _ -> modifyInfo (Info.insert fvi) n

--- a/src/Juvix/Compiler/Core/Info/IdentInfo.hs
+++ b/src/Juvix/Compiler/Core/Info/IdentInfo.hs
@@ -22,7 +22,7 @@ computeIdentInfo = umap go
   where
     go :: Node -> Node
     go n = case n of
-      Ident i sym -> Ident (Info.insert fvi i) sym
+      NIdt (Ident i sym) -> mkIdent (Info.insert fvi i) sym
         where
           fvi = IdentInfo (HashMap.singleton sym 1)
       _ -> modifyInfo (Info.insert fvi) n

--- a/src/Juvix/Compiler/Core/Language.hs
+++ b/src/Juvix/Compiler/Core/Language.hs
@@ -18,55 +18,87 @@ import Juvix.Compiler.Core.Language.Base
 {---------------------------------------------------------------------------------}
 {- Program tree datatype -}
 
+-- De Bruijn index of a locally bound variable.
+data Var = Var {_varInfo :: !Info, _varIndex :: !Index}
+
+-- Global identifier of a function (with corresponding `Node` in the global
+-- context).
+data Ident = Ident {_identInfo :: !Info, _identSymbol :: !Symbol}
+
+data Constant = Constant {_constantInfo :: !Info, _constantValue :: !ConstantValue}
+
+data App = App {_appInfo :: !Info, _appLeft :: !Node, _appRight :: !Node}
+
+-- A builtin application. A builtin has no corresponding Node. It is treated
+-- specially by the evaluator and the code generator. For example, basic
+-- arithmetic operations go into `Builtin`. The number of arguments supplied
+-- must be equal to the number of arguments expected by the builtin
+-- operation (this simplifies evaluation and code generation). If you need
+-- partial application, eta-expand with lambdas, e.g., eta-expand `(+) 2` to
+-- `\x -> (+) 2 x`. See Transformation/Eta.hs.
+data BuiltinApp = BuiltinApp
+  { _builtinAppInfo :: !Info,
+    _builtinAppOp :: !BuiltinOp,
+    _builtinAppArgs :: ![Node]
+  }
+
+-- A data constructor application. The number of arguments supplied must be
+-- equal to the number of arguments expected by the constructor.
+data Constr = Constr
+  { _constrInfo :: !Info,
+    _constrTag :: !Tag,
+    _constrArgs :: ![Node]
+  }
+
+data Lambda = Lambda {_lambdaInfo :: !Info, _lambdaBody :: !Node}
+
+-- `let x := value in body` is not reducible to lambda + application for the purposes
+-- of ML-polymorphic / dependent type checking or code generation!
+data Let = Let {_letInfo :: !Info, _letValue :: !Node, _letBody :: !Node}
+
+-- One-level case matching on the tag of a data constructor: `Case value
+-- branches default`. `Case` is lazy: only the selected branch is evaluated.
+data Case = Case
+  { _caseInfo :: !Info,
+    _caseValue :: !Node,
+    _caseBranches :: ![CaseBranch],
+    _caseDefault :: !(Maybe Node)
+  }
+
+-- Dependent Pi-type. Compilation-time only. Pi implicitly introduces a binder
+-- in the body, exactly like Lambda. So `Pi info ty body` is `Pi x : ty .
+-- body` in more familiar notation, but references to `x` in `body` are via de
+-- Bruijn index. For example, Pi A : Type . A -> A translates to (omitting
+-- Infos): Pi (Univ level) (Pi (Var 0) (Var 1)).
+data Pi = Pi {_piInfo :: !Info, _piType :: !Type, _piBody :: !Type}
+
+-- Universe. Compilation-time only.
+data Univ = Univ {_univInfo :: !Info, _univLevel :: !Int}
+
+-- Type constructor application. Compilation-time only.
+data TypeConstr = TypeConstr
+  { _typeConstrInfo :: !Info,
+    _typeConstrSymbol :: !Symbol,
+    _typeConstrArgs :: ![Type]
+  }
+
 -- `Node` is the type of nodes in the program tree. The nodes themselves
 -- contain only runtime-relevant information. Runtime-irrelevant annotations
 -- (including all type information) are stored in the infos associated with each
 -- node.
 data Node
-  = -- De Bruijn index of a locally bound variable.
-    Var {_varInfo :: !Info, _varIndex :: !Index}
-  | -- Global identifier of a function (with corresponding `Node` in the global
-    -- context).
-    Ident {_identInfo :: !Info, _identSymbol :: !Symbol}
-  | Constant {_constantInfo :: !Info, _constantValue :: !ConstantValue}
-  | App {_appInfo :: !Info, _appLeft :: !Node, _appRight :: !Node}
-  | -- A builtin application. A builtin has no corresponding Node. It is treated
-    -- specially by the evaluator and the code generator. For example, basic
-    -- arithmetic operations go into `Builtin`. The number of arguments supplied
-    -- must be equal to the number of arguments expected by the builtin
-    -- operation (this simplifies evaluation and code generation). If you need
-    -- partial application, eta-expand with lambdas, e.g., eta-expand `(+) 2` to
-    -- `\x -> (+) 2 x`. See Transformation/Eta.hs.
-    BuiltinApp {_builtinInfo :: !Info, _builtinOp :: !BuiltinOp, _builtinArgs :: ![Node]}
-  | -- A data constructor application. The number of arguments supplied must be
-    -- equal to the number of arguments expected by the constructor.
-    Constr
-      { _constrInfo :: !Info,
-        _constrTag :: !Tag,
-        _constrArgs :: ![Node]
-      }
-  | Lambda {_lambdaInfo :: !Info, _lambdaBody :: !Node}
-  | -- `let x := value in body` is not reducible to lambda + application for the purposes
-    -- of ML-polymorphic / dependent type checking or code generation!
-    Let {_letInfo :: !Info, _letValue :: !Node, _letBody :: !Node}
-  | -- One-level case matching on the tag of a data constructor: `Case value
-    -- branches default`. `Case` is lazy: only the selected branch is evaluated.
-    Case
-      { _caseInfo :: !Info,
-        _caseValue :: !Node,
-        _caseBranches :: ![CaseBranch],
-        _caseDefault :: !(Maybe Node)
-      }
-  | -- Dependent Pi-type. Compilation-time only. Pi implicitly introduces a binder
-    -- in the body, exactly like Lambda. So `Pi info ty body` is `Pi x : ty .
-    -- body` in more familiar notation, but references to `x` in `body` are via de
-    -- Bruijn index. For example, Pi A : Type . A -> A translates to (omitting
-    -- Infos): Pi (Univ level) (Pi (Var 0) (Var 1)).
-    Pi {_piInfo :: !Info, _piType :: !Type, _piBody :: !Type}
-  | -- Universe. Compilation-time only.
-    Univ {_univInfo :: !Info, _univLevel :: !Int}
-  | -- Type constructor application. Compilation-time only.
-    TypeConstr {_typeConstrInfo :: !Info, _typeConstrSymbol :: !Symbol, _typeConstrArgs :: ![Type]}
+  = NVar {-# UNPACK #-} !Var
+  | NIdt {-# UNPACK #-} !Ident
+  | NCst {-# UNPACK #-} !Constant
+  | NApp {-# UNPACK #-} !App
+  | NBlt {-# UNPACK #-} !BuiltinApp
+  | NCtr {-# UNPACK #-} !Constr
+  | NLam {-# UNPACK #-} !Lambda
+  | NLet {-# UNPACK #-} !Let
+  | NCase {-# UNPACK #-} !Case
+  | NPi {-# UNPACK #-} !Pi
+  | NUniv {-# UNPACK #-} !Univ
+  | NTyp {-# UNPACK #-} !TypeConstr
   | -- Evaluation only: `Closure env body`
     Closure
       { _closureInfo :: !Info,
@@ -84,7 +116,7 @@ data ConstantValue
   deriving stock (Eq)
 
 -- Other things we might need in the future:
--- - ConstFloat
+-- - ConstFloat or ConstFixedPoint
 
 -- `CaseBranch tag argsNum branch`
 -- - `argsNum` is the number of arguments of the constructor tagged with `tag`,
@@ -110,20 +142,20 @@ type Type = Node
 
 instance HasAtomicity Node where
   atomicity = \case
-    Var {} -> Atom
-    Ident {} -> Atom
-    Constant {} -> Atom
-    App {} -> Aggregate appFixity
-    BuiltinApp {..} | null _builtinArgs -> Atom
-    BuiltinApp {} -> Aggregate lambdaFixity
-    Constr {..} | null _constrArgs -> Atom
-    Constr {} -> Aggregate lambdaFixity
-    Lambda {} -> Aggregate lambdaFixity
-    Let {} -> Aggregate lambdaFixity
-    Case {} -> Aggregate lambdaFixity
-    Pi {} -> Aggregate lambdaFixity
-    Univ {} -> Atom
-    TypeConstr {} -> Aggregate appFixity
+    NVar {} -> Atom
+    NIdt {} -> Atom
+    NCst {} -> Atom
+    NApp {} -> Aggregate appFixity
+    NBlt BuiltinApp {..} | null _builtinAppArgs -> Atom
+    NBlt BuiltinApp {} -> Aggregate lambdaFixity
+    NCtr Constr {..} | null _constrArgs -> Atom
+    NCtr Constr {} -> Aggregate lambdaFixity
+    NLam Lambda {} -> Aggregate lambdaFixity
+    NLet Let {} -> Aggregate lambdaFixity
+    NCase Case {} -> Aggregate lambdaFixity
+    NPi Pi {} -> Aggregate lambdaFixity
+    NUniv Univ {} -> Atom
+    NTyp TypeConstr {} -> Aggregate appFixity
     Closure {} -> Aggregate lambdaFixity
 
 lambdaFixity :: Fixity
@@ -131,17 +163,30 @@ lambdaFixity = Fixity (PrecNat 0) (Unary AssocPostfix)
 
 instance Eq Node where
   (==) :: Node -> Node -> Bool
-  Var _ idx1 == Var _ idx2 = idx1 == idx2
-  Ident _ sym1 == Ident _ sym2 = sym1 == sym2
-  Constant _ v1 == Constant _ v2 = v1 == v2
-  App _ l1 r1 == App _ l2 r2 = l1 == l2 && r1 == r2
-  BuiltinApp _ op1 args1 == BuiltinApp _ op2 args2 = op1 == op2 && args1 == args2
-  Constr _ tag1 args1 == Constr _ tag2 args2 = tag1 == tag2 && args1 == args2
-  Lambda _ b1 == Lambda _ b2 = b1 == b2
-  Let _ v1 b1 == Let _ v2 b2 = v1 == v2 && b1 == b2
-  Case _ v1 bs1 def1 == Case _ v2 bs2 def2 = v1 == v2 && bs1 == bs2 && def1 == def2
-  Pi _ ty1 b1 == Pi _ ty2 b2 = ty1 == ty2 && b1 == b2
-  Univ _ l1 == Univ _ l2 = l1 == l2
-  TypeConstr _ sym1 args1 == TypeConstr _ sym2 args2 = sym1 == sym2 && args1 == args2
+  NVar (Var _ idx1) == NVar (Var _ idx2) = idx1 == idx2
+  NIdt (Ident _ sym1) == NIdt (Ident _ sym2) = sym1 == sym2
+  NCst (Constant _ v1) == NCst (Constant _ v2) = v1 == v2
+  NApp (App _ l1 r1) == NApp (App _ l2 r2) = l1 == l2 && r1 == r2
+  NBlt (BuiltinApp _ op1 args1) == NBlt (BuiltinApp _ op2 args2) = op1 == op2 && args1 == args2
+  NCtr (Constr _ tag1 args1) == NCtr (Constr _ tag2 args2) = tag1 == tag2 && args1 == args2
+  NLam (Lambda _ b1) == NLam (Lambda _ b2) = b1 == b2
+  NLet (Let _ v1 b1) == NLet (Let _ v2 b2) = v1 == v2 && b1 == b2
+  NCase (Case _ v1 bs1 def1) == NCase (Case _ v2 bs2 def2) = v1 == v2 && bs1 == bs2 && def1 == def2
+  NPi (Pi _ ty1 b1) == NPi (Pi _ ty2 b2) = ty1 == ty2 && b1 == b2
+  NUniv (Univ _ l1) == NUniv (Univ _ l2) = l1 == l2
+  NTyp (TypeConstr _ sym1 args1) == NTyp (TypeConstr _ sym2 args2) = sym1 == sym2 && args1 == args2
   Closure _ env1 b1 == Closure _ env2 b2 = env1 == env2 && b1 == b2
   _ == _ = False
+
+makeLenses ''Var
+makeLenses ''Ident
+makeLenses ''Constant
+makeLenses ''App
+makeLenses ''BuiltinApp
+makeLenses ''Constr
+makeLenses ''Let
+makeLenses ''Case
+makeLenses ''Pi
+makeLenses ''Univ
+makeLenses ''TypeConstr
+makeLenses ''CaseBranch

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -64,7 +64,7 @@ instance PrettyCode Tag where
 
 instance PrettyCode Node where
   ppCode node = case node of
-    Var {..} ->
+    NVar Var {..} ->
       case Info.lookup kNameInfo _varInfo of
         Just ni -> do
           showDeBruijn <- asks (^. optShowDeBruijnIndices)
@@ -73,31 +73,31 @@ instance PrettyCode Node where
             then return $ n <> kwDeBruijnVar <> pretty _varIndex
             else return n
         Nothing -> return $ kwDeBruijnVar <> pretty _varIndex
-    Ident {..} ->
+    NIdt Ident {..} ->
       case Info.lookup kNameInfo _identInfo of
         Just ni -> ppCode (ni ^. NameInfo.infoName)
         Nothing -> return $ kwUnnamedIdent <> pretty _identSymbol
-    Constant _ (ConstInteger int) ->
+    NCst (Constant _ (ConstInteger int)) ->
       return $ annotate AnnLiteralInteger (pretty int)
-    Constant _ (ConstString txt) ->
+    NCst (Constant _ (ConstString txt)) ->
       return $ annotate AnnLiteralString (pretty (show txt :: String))
-    App {..} -> do
+    NApp App {..} -> do
       l' <- ppLeftExpression appFixity _appLeft
       r' <- ppRightExpression appFixity _appRight
       return $ l' <+> r'
-    BuiltinApp {..} -> do
-      args' <- mapM (ppRightExpression appFixity) _builtinArgs
-      op' <- ppCode _builtinOp
+    NBlt BuiltinApp {..} -> do
+      args' <- mapM (ppRightExpression appFixity) _builtinAppArgs
+      op' <- ppCode _builtinAppOp
       return $ foldl' (<+>) op' args'
-    Constr {..} -> do
+    NCtr Constr {..} -> do
       args' <- mapM (ppRightExpression appFixity) _constrArgs
       n' <-
         case Info.lookup kNameInfo _constrInfo of
           Just ni -> ppCode (ni ^. NameInfo.infoName)
           Nothing -> ppCode _constrTag
       return $ foldl' (<+>) n' args'
-    Lambda {} -> do
-      let (infos, body) = unfoldLambdas' node
+    NLam Lambda {} -> do
+      let (infos, body) = unfoldLambdas node
       pplams <- mapM ppLam infos
       b <- ppCode body
       return $ foldl' (flip (<+>)) b pplams
@@ -109,7 +109,7 @@ instance PrettyCode Node where
               n <- ppCode name
               return $ kwLambda <> n
             Nothing -> return $ kwLambda <> kwQuestion
-    Let {..} -> do
+    NLet Let {..} -> do
       n' <-
         case getInfoName (getInfoBinder _letInfo) of
           Just name -> ppCode name
@@ -117,7 +117,7 @@ instance PrettyCode Node where
       v' <- ppCode _letValue
       b' <- ppCode _letBody
       return $ kwLet <+> n' <+> kwAssign <+> v' <+> kwIn <+> b'
-    Case {..} -> do
+    NCase Case {..} -> do
       bns <-
         case Info.lookup kCaseBinderInfo _caseInfo of
           Just ci -> mapM (mapM (maybe (return kwQuestion) ppCode . getInfoName)) (ci ^. infoBranchBinders)
@@ -137,7 +137,7 @@ instance PrettyCode Node where
           Nothing -> return bs'
       let bss = bracesIndent $ align $ concatWith (\a b -> a <> kwSemicolon <> line <> b) bs''
       return $ kwCase <+> v <+> kwOf <+> bss
-    Pi {..} ->
+    NPi Pi {..} ->
       case getInfoName $ getInfoBinder _piInfo of
         Just name -> do
           n <- ppCode name
@@ -146,9 +146,9 @@ instance PrettyCode Node where
         Nothing -> do
           b <- ppCode _piBody
           return $ kwLambda <> kwQuestion <+> b
-    Univ {..} ->
+    NUniv Univ {..} ->
       return $ kwType <+> pretty _univLevel
-    TypeConstr {..} -> do
+    NTyp TypeConstr {..} -> do
       args' <- mapM (ppRightExpression appFixity) _typeConstrArgs
       n' <-
         case Info.lookup kNameInfo _typeConstrInfo of
@@ -156,7 +156,7 @@ instance PrettyCode Node where
           Nothing -> return $ kwUnnamedIdent <> pretty _typeConstrSymbol
       return $ foldl' (<+>) n' args'
     Closure {..} ->
-      ppCode (substEnv _closureEnv (Lambda _closureInfo _closureBody))
+      ppCode (substEnv _closureEnv (mkLambda _closureInfo _closureBody))
 
 instance PrettyCode a => PrettyCode (NonEmpty a) where
   ppCode x = do

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -155,8 +155,8 @@ instance PrettyCode Node where
           Just ni -> ppCode (ni ^. NameInfo.infoName)
           Nothing -> return $ kwUnnamedIdent <> pretty _typeConstrSymbol
       return $ foldl' (<+>) n' args'
-    Closure {..} ->
-      ppCode (substEnv _closureEnv (mkLambda _closureInfo _closureBody))
+    Closure env l@Lambda {} ->
+      ppCode (substEnv env (NLam l))
 
 instance PrettyCode a => PrettyCode (NonEmpty a) where
   ppCode x = do

--- a/src/Juvix/Compiler/Core/Transformation/Eta.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Eta.hs
@@ -13,9 +13,9 @@ etaExpandBuiltins = umap go
   where
     go :: Node -> Node
     go n = case n of
-      BuiltinApp {..}
-        | builtinOpArgsNum _builtinOp > length _builtinArgs ->
-            etaExpand (builtinOpArgsNum _builtinOp - length _builtinArgs) n
+      NBlt BuiltinApp {..}
+        | builtinOpArgsNum _builtinAppOp > length _builtinAppArgs ->
+            etaExpand (builtinOpArgsNum _builtinAppOp - length _builtinAppArgs) n
       _ -> n
 
 etaExpandConstrs :: (Tag -> Int) -> Node -> Node
@@ -23,7 +23,7 @@ etaExpandConstrs argsNum = umap go
   where
     go :: Node -> Node
     go n = case n of
-      Constr {..}
+      NCtr Constr {..}
         | k > length _constrArgs ->
             etaExpand (k - length _constrArgs) n
         where
@@ -35,10 +35,10 @@ squashApps = dmap go
   where
     go :: Node -> Node
     go n =
-      let (l, args) = unfoldApp n
+      let (l, args) = unfoldApps' n
        in case l of
-            Constr i tag args' -> Constr i tag (args' ++ args)
-            BuiltinApp i op args' -> BuiltinApp i op (args' ++ args)
+            NCtr (Constr i tag args') -> mkConstr i tag (args' ++ args)
+            NBlt (BuiltinApp i op args') -> mkBuiltinApp i op (args' ++ args)
             _ -> n
 
 etaExpandApps :: InfoTable -> Node -> Node


### PR DESCRIPTION
# Description

Refactoring of the Node datatype. Introduces a separate datatype for each constructor containing all constructor arguments. Node helper constructor functions added in Core/Extra/Base.hs: mkVar, mkIdent, mkApp, ...
