### PR TITLE
Fix docs webapp examples CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ webapp-examples: $(WEBAPP_EXAMPLES)
 $(WEBAPP_EXAMPLES):
 	$(eval OUTPUTDIR=$(EXAMPLE_WEBAPP_OUTPUT)/$(dir $@))
 	@mkdir -p ${OUTPUTDIR}
-	@juvix compile -r standalone $(EXAMPLEMILESTONE)/$@
+	@juvix compile -t wasm -r standalone $(EXAMPLEMILESTONE)/$@
 	@cp $(dir $(EXAMPLEMILESTONE)/$@)* ${OUTPUTDIR}
 
 # -- MDBook


### PR DESCRIPTION
The default compile target is now native (https://github.com/anoma/juvix/pull/1502), so we need to pass `-t wasm` to the webapp examples build.

This fixes the docs build, e.g https://github.com/anoma/juvix/runs/8132544610?check_suite_focus=true