### PR TITLE
Core/Extra/Recursors/Collector bugfix

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/Recursors/Collector.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Collector.hs
@@ -20,7 +20,7 @@ binderInfoCollector :: Collector (Int, [Info]) (BinderList Info)
 binderInfoCollector =
   Collector
     BL.empty
-    (\(k, bi) c -> if k == 0 then c else BL.prepend bi c)
+    (\(k, bi) c -> if k == 0 then c else BL.prepend (reverse bi) c)
 
 binderNumCollector :: Collector (Int, [Info]) Index
 binderNumCollector = Collector 0 (\(k, _) c -> c + k)


### PR DESCRIPTION
# Description

The BinderInfos for multiple binders are stored according to their order in Node (top-down), but when added to BinderList they should be in reverse order for de Bruijn indexing (bottom-up). We haven't noticed this so far, because Lambda always introduces only one binder. CaseBranch and LetRec may introduce many binders.
