### PR TITLE
Stripped version of Core Node datatype

### DIFF
--- a/src/Juvix/Compiler/Core/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTable.hs
@@ -10,7 +10,7 @@ data InfoTable = InfoTable
     _identMap :: HashMap Text IdentKind,
     _infoMain :: Maybe Symbol,
     _infoIdentifiers :: HashMap Symbol IdentifierInfo,
-    _infoInductives :: HashMap Name InductiveInfo,
+    _infoInductives :: HashMap Symbol InductiveInfo,
     _infoConstructors :: HashMap Tag ConstructorInfo,
     _infoAxioms :: HashMap Name AxiomInfo
   }
@@ -57,7 +57,8 @@ data ConstructorInfo = ConstructorInfo
   { _constructorName :: Name,
     _constructorTag :: Tag,
     _constructorType :: Type,
-    _constructorArgsNum :: Int
+    _constructorArgsNum :: Int,
+    _constructorInductive :: Symbol
   }
 
 data ParameterInfo = ParameterInfo

--- a/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
@@ -5,16 +5,16 @@ import Juvix.Compiler.Core.Language.Stripped
 data InfoTable = InfoTable
   { _infoMain :: Maybe Symbol,
     _infoFunctions :: HashMap Symbol FunctionInfo,
-    _infoInductives :: HashMap Name InductiveInfo,
+    _infoInductives :: HashMap Symbol InductiveInfo,
     _infoConstructors :: HashMap Tag ConstructorInfo
   }
 
 data FunctionInfo = FunctionInfo
   { _functionName :: Maybe Name,
     _functionSymbol :: Symbol,
-    -- _functionNode has `_functionArgsNum` free variables corresponding to the
+    -- _functionBody has `_functionArgsNum` free variables corresponding to the
     -- function arguments
-    _functionNode :: Node,
+    _functionBody :: Node,
     _functionType :: Type,
     -- a function can have 0 arguments
     _functionArgsNum :: Int,
@@ -31,8 +31,7 @@ data InductiveInfo = InductiveInfo
   { _inductiveName :: Name,
     _inductiveKind :: Type,
     _inductiveConstructors :: [ConstructorInfo],
-    _inductiveParams :: [ParameterInfo],
-    _inductivePositive :: Bool
+    _inductiveParams :: [ParameterInfo]
   }
 
 data ConstructorInfo = ConstructorInfo

--- a/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
@@ -1,0 +1,55 @@
+module Juvix.Compiler.Core.Data.Stripped.InfoTable where
+
+import Juvix.Compiler.Core.Language.Stripped
+
+data InfoTable = InfoTable {
+  _infoMain :: Maybe Symbol,
+  _infoFunctions :: HashMap Symbol FunctionInfo,
+  _infoInductives :: HashMap Name InductiveInfo,
+  _infoConstructors :: HashMap Tag ConstructorInfo
+}
+
+data FunctionInfo = FunctionInfo
+  { _functionName :: Maybe Name,
+    _functionSymbol :: Symbol,
+    -- _functionNode has `_functionArgsNum` free variables corresponding to the
+    -- function arguments
+    _functionNode :: Node,
+    _functionType :: Type,
+    -- a function can have 0 arguments
+    _functionArgsNum :: Int,
+    _functionArgsInfo :: [ArgumentInfo],
+    _functionIsExported :: Bool
+  }
+
+data ArgumentInfo = ArgumentInfo
+  { _argumentName :: Maybe Name,
+    _argumentType :: Type
+  }
+
+data InductiveInfo = InductiveInfo
+  { _inductiveName :: Name,
+    _inductiveKind :: Type,
+    _inductiveConstructors :: [ConstructorInfo],
+    _inductiveParams :: [ParameterInfo],
+    _inductivePositive :: Bool
+  }
+
+data ConstructorInfo = ConstructorInfo
+  { _constructorName :: Maybe Name,
+    _constructorTag :: Tag,
+    _constructorType :: Type
+  }
+
+data ParameterInfo = ParameterInfo
+  { _paramName :: Maybe Name,
+    _paramKind :: Type,
+    _paramIsImplicit :: Bool
+  }
+
+makeLenses ''InfoTable
+makeLenses ''FunctionInfo
+makeLenses ''ArgumentInfo
+makeLenses ''InductiveInfo
+makeLenses ''ConstructorInfo
+makeLenses ''ParameterInfo

--- a/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
@@ -2,12 +2,12 @@ module Juvix.Compiler.Core.Data.Stripped.InfoTable where
 
 import Juvix.Compiler.Core.Language.Stripped
 
-data InfoTable = InfoTable {
-  _infoMain :: Maybe Symbol,
-  _infoFunctions :: HashMap Symbol FunctionInfo,
-  _infoInductives :: HashMap Name InductiveInfo,
-  _infoConstructors :: HashMap Tag ConstructorInfo
-}
+data InfoTable = InfoTable
+  { _infoMain :: Maybe Symbol,
+    _infoFunctions :: HashMap Symbol FunctionInfo,
+    _infoInductives :: HashMap Name InductiveInfo,
+    _infoConstructors :: HashMap Tag ConstructorInfo
+  }
 
 data FunctionInfo = FunctionInfo
   { _functionName :: Maybe Name,

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -82,10 +82,7 @@ eval !ctx !env0 = convertRuntimeNodes . eval' env0
 
     branch :: Node -> Env -> [Node] -> Tag -> Maybe Node -> [CaseBranch] -> Node
     branch n !env !args !tag !def = \case
-      (CaseBranch tag' _ b) : _
-        | tag' == tag ->
-            let !env' = revAppend args env
-             in eval' env' b
+      (CaseBranch _ tag' _ b) : _ | tag' == tag -> eval' (revAppend args env) b
       _ : bs' -> branch n env args tag def bs'
       [] -> case def of
         Just b -> eval' env b

--- a/src/Juvix/Compiler/Core/Extra/Stripped/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Stripped/Base.hs
@@ -1,0 +1,36 @@
+module Juvix.Compiler.Core.Extra.Stripped.Base where
+
+import Juvix.Compiler.Core.Language.Stripped
+
+{------------------------------------------------------------------------}
+{- Stripped Node constructors -}
+
+mkVar :: VarInfo -> Index -> Node
+mkVar i idx = NVar (Var i idx)
+
+mkVar' :: Index -> Node
+mkVar' = mkVar (VarInfo Nothing TyDynamic)
+
+mkIdent :: IdentInfo -> Symbol -> Node
+mkIdent i sym = NIdt (Ident i sym)
+
+mkIdent' :: Symbol -> Node
+mkIdent' = mkIdent (IdentInfo Nothing TyDynamic)
+
+mkConstant :: ConstantValue -> Node
+mkConstant cv = NCst (Constant () cv)
+
+mkApps :: Fun -> [Node] -> Node
+mkApps l r = NApp (Apps () l r)
+
+mkBuiltinApp :: BuiltinOp -> [Node] -> Node
+mkBuiltinApp op args = NBlt (BuiltinApp () op args)
+
+mkConstr :: Tag -> [Node] -> Node
+mkConstr tag args = NCtr (Constr () tag args)
+
+mkLet :: Node -> Node -> Node
+mkLet v b = NLet (Let () v b)
+
+mkCase :: Node -> [CaseBranch] -> Maybe Node -> Node
+mkCase v bs def = NCase (Case () v bs def)

--- a/src/Juvix/Compiler/Core/Extra/Stripped/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Stripped/Base.hs
@@ -29,8 +29,8 @@ mkBuiltinApp op args = NBlt (BuiltinApp () op args)
 mkConstr :: ConstrInfo -> Tag -> [Node] -> Node
 mkConstr i tag args = NCtr (Constr i tag args)
 
-mkConstr' :: Tag -> [Node] -> Node
-mkConstr' = mkConstr (ConstrInfo Nothing TyDynamic)
+mkConstr' :: Symbol -> Tag -> [Node] -> Node
+mkConstr' sym = mkConstr (ConstrInfo Nothing TyDynamic sym)
 
 mkLet :: LetInfo -> Node -> Node -> Node
 mkLet i v b = NLet (Let i v b)

--- a/src/Juvix/Compiler/Core/Extra/Stripped/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Stripped/Base.hs
@@ -26,11 +26,17 @@ mkApps l r = NApp (Apps () l r)
 mkBuiltinApp :: BuiltinOp -> [Node] -> Node
 mkBuiltinApp op args = NBlt (BuiltinApp () op args)
 
-mkConstr :: Tag -> [Node] -> Node
-mkConstr tag args = NCtr (Constr () tag args)
+mkConstr :: ConstrInfo -> Tag -> [Node] -> Node
+mkConstr i tag args = NCtr (Constr i tag args)
 
-mkLet :: Node -> Node -> Node
-mkLet v b = NLet (Let () v b)
+mkConstr' :: Tag -> [Node] -> Node
+mkConstr' = mkConstr (ConstrInfo Nothing TyDynamic)
+
+mkLet :: LetInfo -> Node -> Node -> Node
+mkLet i v b = NLet (Let i v b)
+
+mkLet' :: Node -> Node -> Node
+mkLet' = mkLet (LetInfo Nothing TyDynamic)
 
 mkCase :: Node -> [CaseBranch] -> Maybe Node -> Node
 mkCase v bs def = NCase (Case () v bs def)

--- a/src/Juvix/Compiler/Core/Info/BinderInfo.hs
+++ b/src/Juvix/Compiler/Core/Info/BinderInfo.hs
@@ -19,17 +19,8 @@ instance IsInfo BindersInfo
 kBindersInfo :: Key BindersInfo
 kBindersInfo = Proxy
 
-newtype CaseBinderInfo = CaseBinderInfo
-  { _infoBranchBinders :: [[Info]]
-  }
-
-instance IsInfo CaseBinderInfo
-
-kCaseBinderInfo :: Key CaseBinderInfo
-kCaseBinderInfo = Proxy
-
 makeLenses ''BinderInfo
-makeLenses ''CaseBinderInfo
+makeLenses ''BindersInfo
 
 getInfoBinder :: Info -> Info
 getInfoBinder i =
@@ -42,3 +33,6 @@ getInfoBinders n i =
   case Info.lookup kBindersInfo i of
     Just (BindersInfo {..}) -> _infoBinders
     Nothing -> replicate n Info.empty
+
+setInfoBinders :: [Info] -> Info -> Info
+setInfoBinders = Info.insert . BindersInfo

--- a/src/Juvix/Compiler/Core/Info/BranchInfo.hs
+++ b/src/Juvix/Compiler/Core/Info/BranchInfo.hs
@@ -1,5 +1,6 @@
 module Juvix.Compiler.Core.Info.BranchInfo where
 
+import Juvix.Compiler.Core.Info qualified as Info
 import Juvix.Compiler.Core.Language.Base
 
 newtype BranchInfo = BranchInfo
@@ -11,14 +12,12 @@ instance IsInfo BranchInfo
 kBranchInfo :: Key BranchInfo
 kBranchInfo = Proxy
 
-newtype CaseBranchInfo = CaseBranchInfo
-  { _infoBranches :: [BranchInfo]
-  }
-
-instance IsInfo CaseBranchInfo
-
-kCaseBranchInfo :: Key CaseBranchInfo
-kCaseBranchInfo = Proxy
-
 makeLenses ''BranchInfo
-makeLenses ''CaseBranchInfo
+
+getInfoTagName :: Info -> Maybe Name
+getInfoTagName i = case Info.lookup kBranchInfo i of
+  Just BranchInfo {..} -> Just _infoTagName
+  Nothing -> Nothing
+
+setInfoTagName :: Name -> Info -> Info
+setInfoTagName = Info.insert . BranchInfo

--- a/src/Juvix/Compiler/Core/Language.hs
+++ b/src/Juvix/Compiler/Core/Language.hs
@@ -32,7 +32,7 @@ type instance FLet 'Main = Let' Info Node
 
 type instance FLetRec 'Main = LetRec' Info Node
 
-type instance FCase 'Main = Case' Info Node
+type instance FCase 'Main = Case' Info Info Node
 
 type instance FPi 'Main = Pi' Info Node
 
@@ -72,7 +72,7 @@ type TypeConstr = FTypeConstr 'Main
 
 type Dynamic = FDynamic 'Main
 
-type CaseBranch = CaseBranch' Node
+type CaseBranch = CaseBranch' Info Node
 
 {---------------------------------------------------------------------------------}
 

--- a/src/Juvix/Compiler/Core/Language.hs
+++ b/src/Juvix/Compiler/Core/Language.hs
@@ -15,35 +15,35 @@ import Juvix.Compiler.Core.Language.Nodes
 {---------------------------------------------------------------------------------}
 {- Program tree datatype -}
 
-type instance FVar 'Core = Var' Info
-type instance FIdent 'Core = Ident' Info
-type instance FConstant 'Core = Constant' Info
-type instance FApp 'Core = App' Info Node
-type instance FBuiltinApp 'Core = BuiltinApp' Info Node
-type instance FConstr 'Core = Constr' Info Node
-type instance FLambda 'Core = Lambda' Info Node
-type instance FLet 'Core = Let' Info Node
-type instance FLetRec 'Core = LetRec' Info Node
-type instance FCase 'Core = Case' Info Node
-type instance FPi 'Core = Pi' Info Node
-type instance FUniv 'Core = Univ' Info
-type instance FTypeConstr 'Core = TypeConstr' Info Node
-type instance FDynamic 'Core = Dynamic' Info
+type instance FVar 'Main = Var' Info
+type instance FIdent 'Main = Ident' Info
+type instance FConstant 'Main = Constant' Info
+type instance FApp 'Main = App' Info Node
+type instance FBuiltinApp 'Main = BuiltinApp' Info Node
+type instance FConstr 'Main = Constr' Info Node
+type instance FLambda 'Main = Lambda' Info Node
+type instance FLet 'Main = Let' Info Node
+type instance FLetRec 'Main = LetRec' Info Node
+type instance FCase 'Main = Case' Info Node
+type instance FPi 'Main = Pi' Info Node
+type instance FUniv 'Main = Univ' Info
+type instance FTypeConstr 'Main = TypeConstr' Info Node
+type instance FDynamic 'Main = Dynamic' Info
 
-type Var = FVar 'Core
-type Ident = FIdent 'Core
-type Constant = FConstant 'Core
-type App = FApp 'Core
-type BuiltinApp = FBuiltinApp 'Core
-type Constr = FConstr 'Core
-type Lambda = FLambda 'Core
-type Let = FLet 'Core
-type LetRec = FLetRec 'Core
-type Case = FCase 'Core
-type Pi = FPi 'Core
-type Univ = FUniv 'Core
-type TypeConstr = FTypeConstr 'Core
-type Dynamic = FDynamic 'Core
+type Var = FVar 'Main
+type Ident = FIdent 'Main
+type Constant = FConstant 'Main
+type App = FApp 'Main
+type BuiltinApp = FBuiltinApp 'Main
+type Constr = FConstr 'Main
+type Lambda = FLambda 'Main
+type Let = FLet 'Main
+type LetRec = FLetRec 'Main
+type Case = FCase 'Main
+type Pi = FPi 'Main
+type Univ = FUniv 'Main
+type TypeConstr = FTypeConstr 'Main
+type Dynamic = FDynamic 'Main
 
 type CaseBranch = CaseBranch' Node
 

--- a/src/Juvix/Compiler/Core/Language.hs
+++ b/src/Juvix/Compiler/Core/Language.hs
@@ -14,63 +14,33 @@ import Juvix.Compiler.Core.Language.Nodes
 
 {---------------------------------------------------------------------------------}
 
-type instance FVar 'Main = Var' Info
+type Var = Var' Info
 
-type instance FIdent 'Main = Ident' Info
+type Ident = Ident' Info
 
-type instance FConstant 'Main = Constant' Info
+type Constant = Constant' Info
 
-type instance FApp 'Main = App' Info Node
+type App = App' Info Node
 
-type instance FBuiltinApp 'Main = BuiltinApp' Info Node
+type BuiltinApp = BuiltinApp' Info Node
 
-type instance FConstr 'Main = Constr' Info Node
+type Constr = Constr' Info Node
 
-type instance FLambda 'Main = Lambda' Info Node
+type Lambda = Lambda' Info Node
 
-type instance FLet 'Main = Let' Info Node
+type Let = Let' Info Node
 
-type instance FLetRec 'Main = LetRec' Info Node
+type LetRec = LetRec' Info Node
 
-type instance FCase 'Main = Case' Info Info Node
+type Case = Case' Info Info Node
 
-type instance FPi 'Main = Pi' Info Node
+type Pi = Pi' Info Node
 
-type instance FUniv 'Main = Univ' Info
+type Univ = Univ' Info
 
-type instance FTypeConstr 'Main = TypeConstr' Info Node
+type TypeConstr = TypeConstr' Info Node
 
-type instance FDynamic 'Main = Dynamic' Info
-
-{---------------------------------------------------------------------------------}
-
-type Var = FVar 'Main
-
-type Ident = FIdent 'Main
-
-type Constant = FConstant 'Main
-
-type App = FApp 'Main
-
-type BuiltinApp = FBuiltinApp 'Main
-
-type Constr = FConstr 'Main
-
-type Lambda = FLambda 'Main
-
-type Let = FLet 'Main
-
-type LetRec = FLetRec 'Main
-
-type Case = FCase 'Main
-
-type Pi = FPi 'Main
-
-type Univ = FUniv 'Main
-
-type TypeConstr = FTypeConstr 'Main
-
-type Dynamic = FDynamic 'Main
+type Dynamic = Dynamic' Info
 
 type CaseBranch = CaseBranch' Info Node
 

--- a/src/Juvix/Compiler/Core/Language.hs
+++ b/src/Juvix/Compiler/Core/Language.hs
@@ -76,9 +76,6 @@ data Node
 -- - laziness annotations (converting these to closure/thunk creation should be
 --   done further down the pipeline)
 
--- Other things we might need in the future:
--- - ConstFloat or ConstFixedPoint
-
 -- A node (term) is closed if it has no free variables, i.e., no de Bruijn
 -- indices pointing outside the term.
 

--- a/src/Juvix/Compiler/Core/Language.hs
+++ b/src/Juvix/Compiler/Core/Language.hs
@@ -13,39 +13,68 @@ import Juvix.Compiler.Core.Language.Base
 import Juvix.Compiler.Core.Language.Nodes
 
 {---------------------------------------------------------------------------------}
-{- Program tree datatype -}
 
 type instance FVar 'Main = Var' Info
+
 type instance FIdent 'Main = Ident' Info
+
 type instance FConstant 'Main = Constant' Info
+
 type instance FApp 'Main = App' Info Node
+
 type instance FBuiltinApp 'Main = BuiltinApp' Info Node
+
 type instance FConstr 'Main = Constr' Info Node
+
 type instance FLambda 'Main = Lambda' Info Node
+
 type instance FLet 'Main = Let' Info Node
+
 type instance FLetRec 'Main = LetRec' Info Node
+
 type instance FCase 'Main = Case' Info Node
+
 type instance FPi 'Main = Pi' Info Node
+
 type instance FUniv 'Main = Univ' Info
+
 type instance FTypeConstr 'Main = TypeConstr' Info Node
+
 type instance FDynamic 'Main = Dynamic' Info
 
+{---------------------------------------------------------------------------------}
+
 type Var = FVar 'Main
+
 type Ident = FIdent 'Main
+
 type Constant = FConstant 'Main
+
 type App = FApp 'Main
+
 type BuiltinApp = FBuiltinApp 'Main
+
 type Constr = FConstr 'Main
+
 type Lambda = FLambda 'Main
+
 type Let = FLet 'Main
+
 type LetRec = FLetRec 'Main
+
 type Case = FCase 'Main
+
 type Pi = FPi 'Main
+
 type Univ = FUniv 'Main
+
 type TypeConstr = FTypeConstr 'Main
+
 type Dynamic = FDynamic 'Main
 
 type CaseBranch = CaseBranch' Node
+
+{---------------------------------------------------------------------------------}
 
 -- | `Node` is the type of nodes in the program tree. The nodes themselves
 -- contain only runtime-relevant information. Runtime-irrelevant annotations

--- a/src/Juvix/Compiler/Core/Language/Base.hs
+++ b/src/Juvix/Compiler/Core/Language/Base.hs
@@ -5,10 +5,7 @@ module Juvix.Compiler.Core.Language.Base
     module Juvix.Compiler.Core.Language.Builtins,
     module Juvix.Prelude,
     module Juvix.Compiler.Abstract.Data.Name,
-    Location,
-    Symbol,
-    Tag (..),
-    Index,
+    module Juvix.Compiler.Core.Language.Base,
   )
 where
 

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -1,7 +1,7 @@
 module Juvix.Compiler.Core.Language.Nodes where
 
-import Juvix.Compiler.Core.Language.Base
 import Data.Kind qualified as GHC
+import Juvix.Compiler.Core.Language.Base
 
 data Stage = Main | Stripped
 
@@ -38,6 +38,11 @@ data App' i a = App {_appInfo :: i, _appLeft :: !a, _appRight :: !a}
 
 type FApp :: Stage -> GHC.Type
 type family FApp s
+
+data Apps' f i a = Apps {_appsInfo :: i, _appsFun :: !f, _appsArgs :: ![a]}
+
+type FApps :: Stage -> GHC.Type
+type family FApps s
 
 -- | A builtin application. A builtin has no corresponding Node. It is treated
 -- specially by the evaluator and the code generator. For example, basic
@@ -157,6 +162,9 @@ instance HasAtomicity (Constant' i) where
 instance HasAtomicity (App' i a) where
   atomicity _ = Aggregate appFixity
 
+instance HasAtomicity (Apps' f i a) where
+  atomicity _ = Aggregate appFixity
+
 instance HasAtomicity (BuiltinApp' i a) where
   atomicity BuiltinApp {..}
     | null _builtinAppArgs = Atom
@@ -205,6 +213,9 @@ instance Eq (Constant' i) where
 
 instance Eq a => Eq (App' i a) where
   (App _ l1 r1) == (App _ l2 r2) = l1 == l2 && r1 == r2
+
+instance (Eq f, Eq a) => Eq (Apps' f i a) where
+  (Apps _ op1 args1) == (Apps _ op2 args2) = op1 == op2 && args1 == args2
 
 instance Eq a => Eq (BuiltinApp' i a) where
   (BuiltinApp _ op1 args1) == (BuiltinApp _ op2 args2) = op1 == op2 && args1 == args2

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -19,6 +19,9 @@ data ConstantValue
   | ConstString !Text
   deriving stock (Eq)
 
+-- Other things we might need in the future:
+-- - ConstFloat or ConstFixedPoint
+
 data App' i a = App {_appInfo :: i, _appLeft :: !a, _appRight :: !a}
 
 data Apps' f i a = Apps {_appsInfo :: i, _appsFun :: !f, _appsArgs :: ![a]}

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -3,7 +3,10 @@ module Juvix.Compiler.Core.Language.Nodes where
 import Juvix.Compiler.Core.Language.Base
 import Data.Kind qualified as GHC
 
-data Stage = Core | Stripped
+data Stage = Main | Stripped
+
+type FNode :: Stage -> GHC.Type
+type family FNode s
 
 {-------------------------------------------------------------------}
 {- Polymorphic Node types -}
@@ -138,6 +141,9 @@ newtype Dynamic' i = Dynamic {_dynamicInfo :: i}
 
 type FDynamic :: Stage -> GHC.Type
 type family FDynamic s
+
+{-------------------------------------------------------------------}
+{- Typeclass instances -}
 
 instance HasAtomicity (Var' i) where
   atomicity _ = Atom

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -1,0 +1,246 @@
+module Juvix.Compiler.Core.Language.Nodes where
+
+import Juvix.Compiler.Core.Language.Base
+import Data.Kind qualified as GHC
+
+data Stage = Core | Stripped
+
+{-------------------------------------------------------------------}
+{- Polymorphic Node types -}
+
+-- | De Bruijn index of a locally bound variable.
+data Var' i = Var {_varInfo :: i, _varIndex :: !Index}
+
+type FVar :: Stage -> GHC.Type
+type family FVar s
+
+-- | Global identifier of a function (with corresponding `Node` in the global
+-- context).
+data Ident' i = Ident {_identInfo :: i, _identSymbol :: !Symbol}
+
+type FIdent :: Stage -> GHC.Type
+type family FIdent s
+
+data Constant' i = Constant {_constantInfo :: i, _constantValue :: !ConstantValue}
+
+type FConstant :: Stage -> GHC.Type
+type family FConstant s
+
+data ConstantValue
+  = ConstInteger !Integer
+  | ConstString !Text
+  deriving stock (Eq)
+
+data App' i a = App {_appInfo :: i, _appLeft :: !a, _appRight :: !a}
+
+type FApp :: Stage -> GHC.Type
+type family FApp s
+
+-- | A builtin application. A builtin has no corresponding Node. It is treated
+-- specially by the evaluator and the code generator. For example, basic
+-- arithmetic operations go into `Builtin`. The number of arguments supplied
+-- must be equal to the number of arguments expected by the builtin operation
+-- (this simplifies evaluation and code generation). If you need partial
+-- application, eta-expand with lambdas, e.g., eta-expand `(+) 2` to `\x -> (+)
+-- 2 x`. See Transformation/Eta.hs.
+data BuiltinApp' i a = BuiltinApp
+  { _builtinAppInfo :: i,
+    _builtinAppOp :: !BuiltinOp,
+    _builtinAppArgs :: ![a]
+  }
+
+type FBuiltinApp :: Stage -> GHC.Type
+type family FBuiltinApp s
+
+-- | A data constructor application. The number of arguments supplied must be
+-- equal to the number of arguments expected by the constructor.
+data Constr' i a = Constr
+  { _constrInfo :: i,
+    _constrTag :: !Tag,
+    _constrArgs :: ![a]
+  }
+
+type FConstr :: Stage -> GHC.Type
+type family FConstr s
+
+data Lambda' i a = Lambda {_lambdaInfo :: i, _lambdaBody :: !a}
+
+type FLambda :: Stage -> GHC.Type
+type family FLambda s
+
+-- | `let x := value in body` is not reducible to lambda + application for the
+-- purposes of ML-polymorphic / dependent type checking or code generation!
+data Let' i a = Let {_letInfo :: i, _letValue :: !a, _letBody :: !a}
+
+type FLet :: Stage -> GHC.Type
+type family FLet s
+
+-- | Represents a block of mutually recursive local definitions. Both in the
+-- body and in the values `length _letRecValues` implicit binders are introduced
+-- which hold the functions/values being defined.
+data LetRec' i a = LetRec
+  { _letRecInfo :: i,
+    _letRecValues :: !(NonEmpty a),
+    _letRecBody :: !a
+  }
+
+type FLetRec :: Stage -> GHC.Type
+type family FLetRec s
+
+-- | One-level case matching on the tag of a data constructor: `Case value
+-- branches default`. `Case` is lazy: only the selected branch is evaluated.
+data Case' i a = Case
+  { _caseInfo :: i,
+    _caseValue :: !a,
+    _caseBranches :: ![CaseBranch' a],
+    _caseDefault :: !(Maybe a)
+  }
+
+type FCase :: Stage -> GHC.Type
+type family FCase s
+
+-- | `CaseBranch tag argsNum branch`
+-- - `argsNum` is the number of arguments of the constructor tagged with `tag`,
+--   equal to the number of implicit binders above `branch`
+data CaseBranch' a = CaseBranch {_caseTag :: !Tag, _caseBindersNum :: !Int, _caseBranch :: !a}
+  deriving stock (Eq)
+
+-- | Dependent Pi-type. Compilation-time only. Pi implicitly introduces a binder
+-- in the body, exactly like Lambda. So `Pi info ty body` is `Pi x : ty .
+-- body` in more familiar notation, but references to `x` in `body` are via de
+-- Bruijn index. For example, Pi A : GHC.Type . A -> A translates to (omitting
+-- Infos): Pi (Univ level) (Pi (Var 0) (Var 1)).
+data Pi' i a = Pi {_piInfo :: i, _piType :: !a, _piBody :: !a}
+
+type FPi :: Stage -> GHC.Type
+type family FPi s
+
+-- | Universe. Compilation-time only.
+data Univ' i = Univ {_univInfo :: i, _univLevel :: !Int}
+
+type FUniv :: Stage -> GHC.Type
+type family FUniv s
+
+-- | GHC.Type constructor application. Compilation-time only.
+data TypeConstr' i a = TypeConstr
+  { _typeConstrInfo :: i,
+    _typeConstrSymbol :: !Symbol,
+    _typeConstrArgs :: ![a]
+  }
+
+type FTypeConstr :: Stage -> GHC.Type
+type family FTypeConstr s
+
+-- | Dynamic type. A Node with a dynamic type has an unknown type. Useful
+-- for transformations that introduce partial type information, e.g., one can
+-- have types `* -> *` and `* -> * -> Nat` where `*` is the dynamic type.
+newtype Dynamic' i = Dynamic {_dynamicInfo :: i}
+
+type FDynamic :: Stage -> GHC.Type
+type family FDynamic s
+
+instance HasAtomicity (Var' i) where
+  atomicity _ = Atom
+
+instance HasAtomicity (Ident' i) where
+  atomicity _ = Atom
+
+instance HasAtomicity (Constant' i) where
+  atomicity _ = Atom
+
+instance HasAtomicity (App' i a) where
+  atomicity _ = Aggregate appFixity
+
+instance HasAtomicity (BuiltinApp' i a) where
+  atomicity BuiltinApp {..}
+    | null _builtinAppArgs = Atom
+    | otherwise = Aggregate lambdaFixity
+
+instance HasAtomicity (Constr' i a) where
+  atomicity Constr {..}
+    | null _constrArgs = Atom
+    | otherwise = Aggregate lambdaFixity
+
+instance HasAtomicity (Lambda' i a) where
+  atomicity _ = Aggregate lambdaFixity
+
+instance HasAtomicity (Let' i a) where
+  atomicity _ = Aggregate lambdaFixity
+
+instance HasAtomicity (LetRec' i a) where
+  atomicity _ = Aggregate lambdaFixity
+
+instance HasAtomicity (Case' i a) where
+  atomicity _ = Aggregate lambdaFixity
+
+instance HasAtomicity (Pi' i a) where
+  atomicity _ = Aggregate lambdaFixity
+
+instance HasAtomicity (Univ' i) where
+  atomicity _ = Atom
+
+instance HasAtomicity (TypeConstr' i a) where
+  atomicity _ = Aggregate lambdaFixity
+
+instance HasAtomicity (Dynamic' i) where
+  atomicity _ = Atom
+
+lambdaFixity :: Fixity
+lambdaFixity = Fixity (PrecNat 0) (Unary AssocPostfix)
+
+instance Eq (Var' i) where
+  (Var _ idx1) == (Var _ idx2) = idx1 == idx2
+
+instance Eq (Ident' i) where
+  (Ident _ sym1) == (Ident _ sym2) = sym1 == sym2
+
+instance Eq (Constant' i) where
+  (Constant _ v1) == (Constant _ v2) = v1 == v2
+
+instance Eq a => Eq (App' i a) where
+  (App _ l1 r1) == (App _ l2 r2) = l1 == l2 && r1 == r2
+
+instance Eq a => Eq (BuiltinApp' i a) where
+  (BuiltinApp _ op1 args1) == (BuiltinApp _ op2 args2) = op1 == op2 && args1 == args2
+
+instance Eq a => Eq (Constr' i a) where
+  (Constr _ tag1 args1) == (Constr _ tag2 args2) = tag1 == tag2 && args1 == args2
+
+instance Eq a => Eq (Lambda' i a) where
+  (Lambda _ b1) == (Lambda _ b2) = b1 == b2
+
+instance Eq a => Eq (Let' i a) where
+  (Let _ v1 b1) == (Let _ v2 b2) = v1 == v2 && b1 == b2
+
+instance Eq a => Eq (LetRec' i a) where
+  (LetRec _ vs1 b1) == (LetRec _ vs2 b2) = vs1 == vs2 && b1 == b2
+
+instance Eq a => Eq (Case' i a) where
+  (Case _ v1 bs1 def1) == (Case _ v2 bs2 def2) = v1 == v2 && bs1 == bs2 && def1 == def2
+
+instance Eq a => Eq (Pi' i a) where
+  (Pi _ ty1 b1) == (Pi _ ty2 b2) = ty1 == ty2 && b1 == b2
+
+instance Eq (Univ' i) where
+  (Univ _ l1) == (Univ _ l2) = l1 == l2
+
+instance Eq a => Eq (TypeConstr' i a) where
+  (TypeConstr _ sym1 args1) == (TypeConstr _ sym2 args2) = sym1 == sym2 && args1 == args2
+
+instance Eq (Dynamic' i) where
+  (Dynamic _) == (Dynamic _) = True
+
+makeLenses ''Var'
+makeLenses ''Ident'
+makeLenses ''Constant'
+makeLenses ''App'
+makeLenses ''BuiltinApp'
+makeLenses ''Constr'
+makeLenses ''Let'
+makeLenses ''LetRec'
+makeLenses ''Case'
+makeLenses ''Pi'
+makeLenses ''Univ'
+makeLenses ''TypeConstr'
+makeLenses ''Dynamic'
+makeLenses ''CaseBranch'

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -1,17 +1,6 @@
 module Juvix.Compiler.Core.Language.Nodes where
 
-import Data.Kind qualified as GHC
 import Juvix.Compiler.Core.Language.Base
-
-data Stage
-  = Main
-  | Stripped
-  deriving stock (Eq, Show)
-
-$(genSingletons [''Stage])
-
-type FNode :: Stage -> GHC.Type
-type family FNode s = res | res -> s
 
 {-------------------------------------------------------------------}
 {- Polymorphic Node types -}
@@ -19,20 +8,11 @@ type family FNode s = res | res -> s
 -- | De Bruijn index of a locally bound variable.
 data Var' i = Var {_varInfo :: i, _varIndex :: !Index}
 
-type FVar :: Stage -> GHC.Type
-type family FVar s = res | res -> s
-
 -- | Global identifier of a function (with corresponding `Node` in the global
 -- context).
 data Ident' i = Ident {_identInfo :: i, _identSymbol :: !Symbol}
 
-type FIdent :: Stage -> GHC.Type
-type family FIdent s = res | res -> s
-
 data Constant' i = Constant {_constantInfo :: i, _constantValue :: !ConstantValue}
-
-type FConstant :: Stage -> GHC.Type
-type family FConstant s = res | res -> s
 
 data ConstantValue
   = ConstInteger !Integer
@@ -41,13 +21,7 @@ data ConstantValue
 
 data App' i a = App {_appInfo :: i, _appLeft :: !a, _appRight :: !a}
 
-type FApp :: Stage -> GHC.Type
-type family FApp s = res | res -> s
-
 data Apps' f i a = Apps {_appsInfo :: i, _appsFun :: !f, _appsArgs :: ![a]}
-
-type FApps :: Stage -> GHC.Type
-type family FApps s = res | res -> s
 
 -- | A builtin application. A builtin has no corresponding Node. It is treated
 -- specially by the evaluator and the code generator. For example, basic
@@ -62,9 +36,6 @@ data BuiltinApp' i a = BuiltinApp
     _builtinAppArgs :: ![a]
   }
 
-type FBuiltinApp :: Stage -> GHC.Type
-type family FBuiltinApp s = res | res -> s
-
 -- | A data constructor application. The number of arguments supplied must be
 -- equal to the number of arguments expected by the constructor.
 data Constr' i a = Constr
@@ -73,20 +44,11 @@ data Constr' i a = Constr
     _constrArgs :: ![a]
   }
 
-type FConstr :: Stage -> GHC.Type
-type family FConstr s = res | res -> s
-
 data Lambda' i a = Lambda {_lambdaInfo :: i, _lambdaBody :: !a}
-
-type FLambda :: Stage -> GHC.Type
-type family FLambda s = res | res -> s
 
 -- | `let x := value in body` is not reducible to lambda + application for the
 -- purposes of ML-polymorphic / dependent type checking or code generation!
 data Let' i a = Let {_letInfo :: i, _letValue :: !a, _letBody :: !a}
-
-type FLet :: Stage -> GHC.Type
-type family FLet s = res | res -> s
 
 -- | Represents a block of mutually recursive local definitions. Both in the
 -- body and in the values `length _letRecValues` implicit binders are introduced
@@ -97,9 +59,6 @@ data LetRec' i a = LetRec
     _letRecBody :: !a
   }
 
-type FLetRec :: Stage -> GHC.Type
-type family FLetRec s
-
 -- | One-level case matching on the tag of a data constructor: `Case value
 -- branches default`. `Case` is lazy: only the selected branch is evaluated.
 data Case' i bi a = Case
@@ -108,9 +67,6 @@ data Case' i bi a = Case
     _caseBranches :: ![CaseBranch' bi a],
     _caseDefault :: !(Maybe a)
   }
-
-type FCase :: Stage -> GHC.Type
-type family FCase s = res | res -> s
 
 -- | `CaseBranch tag argsNum branch`
 -- - `argsNum` is the number of arguments of the constructor tagged with `tag`,
@@ -129,14 +85,8 @@ data CaseBranch' i a = CaseBranch
 -- Infos): Pi (Univ level) (Pi (Var 0) (Var 1)).
 data Pi' i a = Pi {_piInfo :: i, _piType :: !a, _piBody :: !a}
 
-type FPi :: Stage -> GHC.Type
-type family FPi s = res | res -> s
-
 -- | Universe. Compilation-time only.
 data Univ' i = Univ {_univInfo :: i, _univLevel :: !Int}
-
-type FUniv :: Stage -> GHC.Type
-type family FUniv s = res | res -> s
 
 -- | GHC.Type constructor application. Compilation-time only.
 data TypeConstr' i a = TypeConstr
@@ -145,16 +95,10 @@ data TypeConstr' i a = TypeConstr
     _typeConstrArgs :: ![a]
   }
 
-type FTypeConstr :: Stage -> GHC.Type
-type family FTypeConstr s = res | res -> s
-
 -- | Dynamic type. A Node with a dynamic type has an unknown type. Useful
 -- for transformations that introduce partial type information, e.g., one can
 -- have types `* -> *` and `* -> * -> Nat` where `*` is the dynamic type.
 newtype Dynamic' i = Dynamic {_dynamicInfo :: i}
-
-type FDynamic :: Stage -> GHC.Type
-type family FDynamic s
 
 {-------------------------------------------------------------------}
 {- Typeclass instances -}

--- a/src/Juvix/Compiler/Core/Language/Stripped.hs
+++ b/src/Juvix/Compiler/Core/Language/Stripped.hs
@@ -43,44 +43,24 @@ data CaseBranchInfo = CaseBranchInfo
 
 {---------------------------------------------------------------------------------}
 
-type instance FVar 'Stripped = Var' VarInfo
+type Var = Var' VarInfo
 
-type instance FIdent 'Stripped = Ident' IdentInfo
+type Ident = Ident' IdentInfo
 
-type instance FConstant 'Stripped = Constant' ()
+type Constant = Constant' ()
 
-type instance FApps 'Stripped = Apps' Fun () Node
+type Apps = Apps' Fun () Node
 
 data Fun = FunVar Var | FunIdent Ident
   deriving stock (Eq)
 
-type instance FBuiltinApp 'Stripped = BuiltinApp' () Node
+type BuiltinApp = BuiltinApp' () Node
 
-type instance FConstr 'Stripped = Constr' ConstrInfo Node
+type Constr = Constr' ConstrInfo Node
 
-type instance FLet 'Stripped = Let' LetInfo Node
+type Let = Let' LetInfo Node
 
-type instance FCase 'Stripped = Case' () CaseBranchInfo Node
-
-type instance FNode 'Stripped = Node
-
-{---------------------------------------------------------------------------------}
-
-type Var = FVar 'Stripped
-
-type Ident = FIdent 'Stripped
-
-type Constant = FConstant 'Stripped
-
-type Apps = FApps 'Stripped
-
-type BuiltinApp = FBuiltinApp 'Stripped
-
-type Constr = FConstr 'Stripped
-
-type Let = FLet 'Stripped
-
-type Case = FCase 'Stripped
+type Case = Case' () CaseBranchInfo Node
 
 type CaseBranch = CaseBranch' CaseBranchInfo Node
 

--- a/src/Juvix/Compiler/Core/Language/Stripped.hs
+++ b/src/Juvix/Compiler/Core/Language/Stripped.hs
@@ -26,7 +26,8 @@ data IdentInfo = IdentInfo
 
 data ConstrInfo = ConstrInfo
   { _constrInfoName :: Maybe Name,
-    _constrInfoType :: Type
+    _constrInfoType :: Type,
+    _constrInfoInductive :: Symbol
   }
 
 data LetInfo = LetInfo

--- a/src/Juvix/Compiler/Core/Language/Stripped.hs
+++ b/src/Juvix/Compiler/Core/Language/Stripped.hs
@@ -1,0 +1,47 @@
+module Juvix.Compiler.Core.Language.Stripped where
+
+import Juvix.Compiler.Core.Language.Base
+import Juvix.Compiler.Core.Language.Nodes
+
+{---------------------------------------------------------------------------------}
+{- Stripped program tree datatype -}
+
+type instance FVar 'Stripped = Var' Info
+type instance FIdent 'Stripped = Ident' Info
+type instance FConstant 'Stripped = Constant' Info
+type instance FApp 'Stripped = App' Info Node
+type instance FBuiltinApp 'Stripped = BuiltinApp' Info Node
+type instance FConstr 'Stripped = Constr' Info Node
+type instance FLet 'Stripped = Let' Info Node
+type instance FCase 'Stripped = Case' Info Node
+
+type Var = FVar 'Stripped
+type Ident = FIdent 'Stripped
+type Constant = FConstant 'Stripped
+type App = FApp 'Stripped
+type BuiltinApp = FBuiltinApp 'Stripped
+type Constr = FConstr 'Stripped
+type Let = FLet 'Stripped
+type Case = FCase 'Stripped
+
+data Node
+  = NVar Var
+  | NIdt Ident
+  | NCst Constant
+  | NApp App
+  | NBlt BuiltinApp
+  | NCtr Constr
+  | NLet Let
+  | NCase Case
+  deriving stock (Eq)
+
+instance HasAtomicity Node where
+  atomicity = \case
+    NVar x -> atomicity x
+    NIdt x -> atomicity x
+    NCst x -> atomicity x
+    NApp x -> atomicity x
+    NBlt x -> atomicity x
+    NCtr x -> atomicity x
+    NLet x -> atomicity x
+    NCase x -> atomicity x

--- a/src/Juvix/Compiler/Core/Language/Stripped.hs
+++ b/src/Juvix/Compiler/Core/Language/Stripped.hs
@@ -16,7 +16,7 @@ import Juvix.Compiler.Core.Language.Stripped.Type
 
 data VarInfo = VarInfo
   { _varInfoName :: Maybe Name,
-    _varInfoType :: Type
+    _varInfoType :: Type -- TyDynamic if not available
   }
 
 data IdentInfo = IdentInfo
@@ -24,8 +24,22 @@ data IdentInfo = IdentInfo
     _identInfoType :: Type
   }
 
-data Fun = FunVar Var | FunIdent Ident
-  deriving stock (Eq)
+data ConstrInfo = ConstrInfo
+  { _constrInfoName :: Maybe Name,
+    _constrInfoType :: Type
+  }
+
+data LetInfo = LetInfo
+  { _letInfoBinderName :: Maybe Name,
+    _letInfoBinderType :: Type
+  }
+
+data CaseBranchInfo = CaseBranchInfo
+  { _caseBranchInfoBinderNames :: [Maybe Name],
+    _caseBranchInfoBinderTypes :: [Type],
+    _caseBranchInfoConstrName :: Maybe Name,
+    _caseBranchInfoConstrType :: Type
+  }
 
 {---------------------------------------------------------------------------------}
 
@@ -37,13 +51,16 @@ type instance FConstant 'Stripped = Constant' ()
 
 type instance FApps 'Stripped = Apps' Fun () Node
 
+data Fun = FunVar Var | FunIdent Ident
+  deriving stock (Eq)
+
 type instance FBuiltinApp 'Stripped = BuiltinApp' () Node
 
-type instance FConstr 'Stripped = Constr' () Node
+type instance FConstr 'Stripped = Constr' ConstrInfo Node
 
-type instance FLet 'Stripped = Let' () Node
+type instance FLet 'Stripped = Let' LetInfo Node
 
-type instance FCase 'Stripped = Case' () Node
+type instance FCase 'Stripped = Case' () CaseBranchInfo Node
 
 type instance FNode 'Stripped = Node
 
@@ -65,7 +82,7 @@ type Let = FLet 'Stripped
 
 type Case = FCase 'Stripped
 
-type CaseBranch = CaseBranch' Node
+type CaseBranch = CaseBranch' CaseBranchInfo Node
 
 {---------------------------------------------------------------------------------}
 
@@ -90,3 +107,9 @@ instance HasAtomicity Node where
     NCtr x -> atomicity x
     NLet x -> atomicity x
     NCase x -> atomicity x
+
+makeLenses ''VarInfo
+makeLenses ''IdentInfo
+makeLenses ''ConstrInfo
+makeLenses ''LetInfo
+makeLenses ''CaseBranchInfo

--- a/src/Juvix/Compiler/Core/Language/Stripped.hs
+++ b/src/Juvix/Compiler/Core/Language/Stripped.hs
@@ -1,34 +1,79 @@
-module Juvix.Compiler.Core.Language.Stripped where
+module Juvix.Compiler.Core.Language.Stripped
+  ( module Juvix.Compiler.Core.Language.Base,
+    module Juvix.Compiler.Core.Language.Nodes,
+    module Juvix.Compiler.Core.Language.Stripped.Type,
+    module Juvix.Compiler.Core.Language.Stripped,
+  )
+where
+
+{- Stripped program tree datatype -}
 
 import Juvix.Compiler.Core.Language.Base
 import Juvix.Compiler.Core.Language.Nodes
+import Juvix.Compiler.Core.Language.Stripped.Type
 
 {---------------------------------------------------------------------------------}
-{- Stripped program tree datatype -}
 
-type instance FVar 'Stripped = Var' Info
-type instance FIdent 'Stripped = Ident' Info
-type instance FConstant 'Stripped = Constant' Info
-type instance FApp 'Stripped = App' Info Node
-type instance FBuiltinApp 'Stripped = BuiltinApp' Info Node
-type instance FConstr 'Stripped = Constr' Info Node
-type instance FLet 'Stripped = Let' Info Node
-type instance FCase 'Stripped = Case' Info Node
+data VarInfo = VarInfo
+  { _varInfoName :: Maybe Name,
+    _varInfoType :: Type
+  }
+
+data IdentInfo = IdentInfo
+  { _identInfoName :: Maybe Name,
+    _identInfoType :: Type
+  }
+
+data Fun = FunVar Var | FunIdent Ident
+  deriving stock (Eq)
+
+{---------------------------------------------------------------------------------}
+
+type instance FVar 'Stripped = Var' VarInfo
+
+type instance FIdent 'Stripped = Ident' IdentInfo
+
+type instance FConstant 'Stripped = Constant' ()
+
+type instance FApps 'Stripped = Apps' Fun () Node
+
+type instance FBuiltinApp 'Stripped = BuiltinApp' () Node
+
+type instance FConstr 'Stripped = Constr' () Node
+
+type instance FLet 'Stripped = Let' () Node
+
+type instance FCase 'Stripped = Case' () Node
+
+type instance FNode 'Stripped = Node
+
+{---------------------------------------------------------------------------------}
 
 type Var = FVar 'Stripped
+
 type Ident = FIdent 'Stripped
+
 type Constant = FConstant 'Stripped
-type App = FApp 'Stripped
+
+type Apps = FApps 'Stripped
+
 type BuiltinApp = FBuiltinApp 'Stripped
+
 type Constr = FConstr 'Stripped
+
 type Let = FLet 'Stripped
+
 type Case = FCase 'Stripped
+
+type CaseBranch = CaseBranch' Node
+
+{---------------------------------------------------------------------------------}
 
 data Node
   = NVar Var
   | NIdt Ident
   | NCst Constant
-  | NApp App
+  | NApp Apps
   | NBlt BuiltinApp
   | NCtr Constr
   | NLet Let

--- a/src/Juvix/Compiler/Core/Language/Stripped/Type.hs
+++ b/src/Juvix/Compiler/Core/Language/Stripped/Type.hs
@@ -1,0 +1,44 @@
+module Juvix.Compiler.Core.Language.Stripped.Type where
+
+import Juvix.Compiler.Core.Language.Base
+
+data Type = TyDynamic | TyApp TypeApp | TyFun TypeFun
+  deriving stock (Eq)
+
+data TypeApp = TypeApp
+  { _typeAppSymbol :: Symbol,
+    _typeAppArgs :: [Type]
+  }
+  deriving stock (Eq)
+
+data TypeFun = TypeFun
+  { _typeFunLeft :: Type,
+    _typeFunRight :: Type
+  }
+  deriving stock (Eq)
+
+makeLenses ''TypeApp
+makeLenses ''TypeFun
+
+unfoldType :: Type -> (Type, [Type])
+unfoldType = \case
+  TyFun (TypeFun l r) ->
+    let (tgt, args) = unfoldType r
+     in (tgt, l : args)
+  ty -> (ty, [])
+
+-- argument types
+typeArgs :: Type -> [Type]
+typeArgs = snd . unfoldType
+
+-- target type
+typeTarget :: Type -> Type
+typeTarget = fst . unfoldType
+
+targetIsDynamic :: Type -> Bool
+targetIsDynamic ty = typeTarget ty == TyDynamic
+
+-- the number of arguments is statically determinable only if the target is not
+-- Dynamic
+typeArgsNum :: Type -> Int
+typeArgsNum = length . typeArgs

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -13,6 +13,7 @@ import Juvix.Compiler.Core.Info.BinderInfo
 import Juvix.Compiler.Core.Info.BranchInfo as BranchInfo
 import Juvix.Compiler.Core.Info.NameInfo as NameInfo
 import Juvix.Compiler.Core.Language
+import Juvix.Compiler.Core.Language.Stripped qualified as Stripped
 import Juvix.Compiler.Core.Pretty.Options
 import Juvix.Data.CodeAnn
 import Juvix.Extra.Strings qualified as Str
@@ -81,41 +82,118 @@ instance PrettyCode InfoTable where
             body' <- ppCode n
             return (kwDef <+> sym' <+> kwAssign <+> body')
 
+-- unfortunately, type classes don't work well with type synonyms, so we cannot
+-- write a generic instance of PrettyCode for FVar
+ppCodeVar :: forall s r. (SingI s, Member (Reader Options) r) => FVar s -> Sem r (Doc Ann)
+ppCodeVar v =
+  let name :: Maybe Name = case sing :: SStage s of
+        SMain -> getInfoName (v ^. varInfo)
+        SStripped -> v ^. (varInfo . Stripped.varInfoName)
+      idx :: Index = case sing :: SStage s of
+        SMain -> v ^. varIndex
+        SStripped -> v ^. varIndex
+   in case name of
+        Just nm -> do
+          showDeBruijn <- asks (^. optShowDeBruijnIndices)
+          n <- ppCode nm
+          if showDeBruijn
+            then return $ n <> kwDeBruijnVar <> pretty idx
+            else return n
+        Nothing -> return $ kwDeBruijnVar <> pretty idx
+
+ppCodeIdent :: forall s r. (SingI s, Member (Reader Options) r) => FIdent s -> Sem r (Doc Ann)
+ppCodeIdent idt =
+  let name :: Maybe Name = case sing :: SStage s of
+        SMain -> getInfoName (idt ^. identInfo)
+        SStripped -> idt ^. (identInfo . Stripped.identInfoName)
+      sym :: Symbol = case sing :: SStage s of
+        SMain -> idt ^. identSymbol
+        SStripped -> idt ^. identSymbol
+   in case name of
+        Just nm -> ppCode nm
+        Nothing -> return $ kwUnnamedIdent <> pretty sym
+
+instance PrettyCode (Constant' i) where
+  ppCode = \case
+    Constant _ (ConstInteger int) ->
+      return $ annotate AnnLiteralInteger (pretty int)
+    Constant _ (ConstString txt) ->
+      return $ annotate AnnLiteralString (pretty (show txt :: String))
+
+instance (PrettyCode a, HasAtomicity a) => PrettyCode (App' i a) where
+  ppCode App {..} = do
+    l' <- ppLeftExpression appFixity _appLeft
+    r' <- ppRightExpression appFixity _appRight
+    return $ l' <+> r'
+
+instance PrettyCode Stripped.Fun where
+  ppCode = \case
+    Stripped.FunVar x -> ppCodeVar x
+    Stripped.FunIdent x -> ppCodeIdent x
+
+instance (PrettyCode f, PrettyCode a, HasAtomicity a) => PrettyCode (Apps' f i a) where
+  ppCode Apps {..} = do
+    args' <- mapM (ppRightExpression appFixity) _appsArgs
+    n' <- ppCode _appsFun
+    return $ foldl' (<+>) n' args'
+
+instance (PrettyCode a, HasAtomicity a) => PrettyCode (BuiltinApp' i a) where
+  ppCode BuiltinApp {..} = do
+    args' <- mapM (ppRightExpression appFixity) _builtinAppArgs
+    op' <- ppCode _builtinAppOp
+    return $ foldl' (<+>) op' args'
+
+ppCodeConstr :: forall s r. (SingI s, Member (Reader Options) r) => FConstr s -> Sem r (Doc Ann)
+ppCodeConstr c = do
+  let name :: Maybe Name = case sing :: SStage s of
+        SMain -> getInfoName (c ^. constrInfo)
+        SStripped -> c ^. (constrInfo . Stripped.constrInfoName)
+  let tag :: Tag = case sing :: SStage s of
+        SMain -> c ^. constrTag
+        SStripped -> c ^. constrTag
+  args' :: [Doc Ann] <- case sing :: SStage s of
+    SMain -> mapM (ppRightExpression appFixity) (c ^. constrArgs)
+    SStripped -> mapM (ppRightExpression appFixity) (c ^. constrArgs)
+  n' <- case name of
+    Just nm -> ppCode nm
+    Nothing -> ppCode tag
+  return $ foldl' (<+>) n' args'
+
+ppCodeLet' :: (PrettyCode a, Member (Reader Options) r) => Maybe Name -> Let' i a -> Sem r (Doc Ann)
+ppCodeLet' name lt = do
+  n' <- case name of
+    Just nm -> ppCode nm
+    Nothing -> return kwQuestion
+  v' <- ppCode (lt ^. letValue)
+  b' <- ppCode (lt ^. letBody)
+  return $ kwLet <+> n' <+> kwAssign <+> v' <+> kwIn <+> b'
+
+ppCodeCase' :: (PrettyCode a, Member (Reader Options) r) => [[Maybe Name]] -> [Maybe Name] -> Case' i bi a -> Sem r (Doc Ann)
+ppCodeCase' branchBinderNames branchTagNames Case {..} = do
+  let branchTags = map (\(CaseBranch _ tag _ _) -> tag) _caseBranches
+  let branchBodies = map (\(CaseBranch _ _ _ b) -> b) _caseBranches
+  bns <- mapM (mapM (maybe (return kwQuestion) ppCode)) branchBinderNames
+  cns <- zipWithM (\tag -> maybe (ppCode tag) ppCode) branchTags branchTagNames
+  v <- ppCode _caseValue
+  bs' <- sequence $ zipWith3Exact (\cn bn br -> ppCode br >>= \br' -> return $ foldl' (<+>) cn bn <+> kwMapsto <+> br') cns bns branchBodies
+  bs'' <-
+    case _caseDefault of
+      Just def -> do
+        d' <- ppCode def
+        return $ bs' ++ [kwDefault <+> kwMapsto <+> d']
+      Nothing -> return bs'
+  let bss = bracesIndent $ align $ concatWith (\a b -> a <> kwSemicolon <> line <> b) bs''
+  return $ kwCase <+> v <+> kwOf <+> bss
+
 instance PrettyCode Node where
   ppCode :: forall r. Member (Reader Options) r => Node -> Sem r (Doc Ann)
   ppCode node = case node of
-    NVar Var {..} ->
-      case Info.lookup kNameInfo _varInfo of
-        Just ni -> do
-          showDeBruijn <- asks (^. optShowDeBruijnIndices)
-          n <- ppCode (ni ^. NameInfo.infoName)
-          if showDeBruijn
-            then return $ n <> kwDeBruijnVar <> pretty _varIndex
-            else return n
-        Nothing -> return $ kwDeBruijnVar <> pretty _varIndex
-    NIdt Ident {..} ->
-      case Info.lookup kNameInfo _identInfo of
-        Just ni -> ppCode (ni ^. NameInfo.infoName)
-        Nothing -> return $ kwUnnamedIdent <> pretty _identSymbol
-    NCst (Constant _ (ConstInteger int)) ->
-      return $ annotate AnnLiteralInteger (pretty int)
-    NCst (Constant _ (ConstString txt)) ->
-      return $ annotate AnnLiteralString (pretty (show txt :: String))
-    NApp App {..} -> do
-      l' <- ppLeftExpression appFixity _appLeft
-      r' <- ppRightExpression appFixity _appRight
-      return $ l' <+> r'
-    NBlt BuiltinApp {..} -> do
-      args' <- mapM (ppRightExpression appFixity) _builtinAppArgs
-      op' <- ppCode _builtinAppOp
-      return $ foldl' (<+>) op' args'
-    NCtr Constr {..} -> do
-      args' <- mapM (ppRightExpression appFixity) _constrArgs
-      n' <-
-        case Info.lookup kNameInfo _constrInfo of
-          Just ni -> ppCode (ni ^. NameInfo.infoName)
-          Nothing -> ppCode _constrTag
-      return $ foldl' (<+>) n' args'
+    NVar x -> ppCodeVar x
+    NIdt x -> ppCodeIdent x
+    NCst x -> ppCode x
+    NApp x -> ppCode x
+    NBlt x -> ppCode x
+    NCtr x -> ppCodeConstr x
     NLam Lambda {} -> do
       let (infos, body) = unfoldLambdas node
       pplams <- mapM ppLam infos
@@ -129,14 +207,9 @@ instance PrettyCode Node where
               n <- ppCode name
               return $ kwLambda <> n
             Nothing -> return $ kwLambda <> kwQuestion
-    NLet Let {..} -> do
-      n' <-
-        case getInfoName (getInfoBinder _letInfo) of
-          Just name -> ppCode name
-          Nothing -> return kwQuestion
-      v' <- ppCode _letValue
-      b' <- ppCode _letBody
-      return $ kwLet <+> n' <+> kwAssign <+> v' <+> kwIn <+> b'
+    NLet x ->
+      let name = getInfoName (getInfoBinder (x ^. letInfo))
+       in ppCodeLet' name x
     NRec LetRec {..} -> do
       let n = length _letRecValues
       ns <- mapM getName (getInfoBinders n _letRecInfo)
@@ -158,26 +231,10 @@ instance PrettyCode Node where
           case getInfoName i of
             Just name -> ppCode name
             Nothing -> return kwQuestion
-    NCase Case {..} -> do
-      bns <-
-        case Info.lookup kCaseBinderInfo _caseInfo of
-          Just ci -> mapM (mapM (maybe (return kwQuestion) ppCode . getInfoName)) (ci ^. infoBranchBinders)
-          Nothing -> mapM (\(CaseBranch _ n _) -> replicateM n (return kwQuestion)) _caseBranches
-      cns <-
-        case Info.lookup kCaseBranchInfo _caseInfo of
-          Just ci -> mapM (ppCode . (^. BranchInfo.infoTagName)) (ci ^. infoBranches)
-          Nothing -> mapM (\(CaseBranch tag _ _) -> ppCode tag) _caseBranches
-      let bs = map (\(CaseBranch _ _ br) -> br) _caseBranches
-      v <- ppCode _caseValue
-      bs' <- sequence $ zipWith3Exact (\cn bn br -> ppCode br >>= \br' -> return $ foldl' (<+>) cn bn <+> kwMapsto <+> br') cns bns bs
-      bs'' <-
-        case _caseDefault of
-          Just def -> do
-            d' <- ppCode def
-            return $ bs' ++ [kwDefault <+> kwMapsto <+> d']
-          Nothing -> return bs'
-      let bss = bracesIndent $ align $ concatWith (\a b -> a <> kwSemicolon <> line <> b) bs''
-      return $ kwCase <+> v <+> kwOf <+> bss
+    NCase x@Case {..} ->
+      let branchBinderNames = map (\(CaseBranch bi _ k _) -> map getInfoName (getInfoBinders k bi)) _caseBranches
+          branchTagNames = map (\(CaseBranch bi _ _ _) -> getInfoTagName bi) _caseBranches
+       in ppCodeCase' branchBinderNames branchTagNames x
     NPi Pi {..} ->
       case getInfoName $ getInfoBinder _piInfo of
         Just name -> do
@@ -199,6 +256,22 @@ instance PrettyCode Node where
     NDyn {} -> return kwDynamic
     Closure env l@Lambda {} ->
       ppCode (substEnv env (NLam l))
+
+instance PrettyCode Stripped.Node where
+  ppCode = \case
+    Stripped.NVar x -> ppCodeVar x
+    Stripped.NIdt x -> ppCodeIdent x
+    Stripped.NCst x -> ppCode x
+    Stripped.NApp x -> ppCode x
+    Stripped.NBlt x -> ppCode x
+    Stripped.NCtr x -> ppCodeConstr x
+    Stripped.NLet x ->
+      let name = x ^. (letInfo . Stripped.letInfoBinderName)
+       in ppCodeLet' name x
+    Stripped.NCase x@Stripped.Case {..} ->
+      let branchBinderNames = map (\(Stripped.CaseBranch bi _ _ _) -> bi ^. Stripped.caseBranchInfoBinderNames) _caseBranches
+          branchTagNames = map (\(Stripped.CaseBranch bi _ _ _) -> bi ^. Stripped.caseBranchInfoConstrName) _caseBranches
+       in ppCodeCase' branchBinderNames branchTagNames x
 
 instance PrettyCode a => PrettyCode (NonEmpty a) where
   ppCode x = do

--- a/src/Juvix/Compiler/Core/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource.hs
@@ -72,13 +72,15 @@ declareBuiltinConstr ::
   Interval ->
   Sem r ()
 declareBuiltinConstr btag nameTxt i = do
+  sym <- freshSymbol
   name <- freshName KNameConstructor nameTxt i
   registerConstructor
     ( ConstructorInfo
         { _constructorName = name,
           _constructorTag = BuiltinTag btag,
           _constructorType = mkDynamic',
-          _constructorArgsNum = builtinConstrArgsNum btag
+          _constructorArgsNum = builtinConstrArgsNum btag,
+          _constructorInductive = sym
         }
     )
 
@@ -187,13 +189,15 @@ statementConstr = do
     Nothing ->
       return ()
   tag <- lift freshTag
+  sym <- lift freshSymbol
   name <- lift $ freshName KNameConstructor txt i
   let info =
         ConstructorInfo
           { _constructorName = name,
             _constructorTag = tag,
             _constructorType = mkDynamic',
-            _constructorArgsNum = argsNum
+            _constructorArgsNum = argsNum,
+            _constructorInductive = sym
           }
   lift $ registerConstructor info
 

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Core.Translation.Stripped.FromMain where
+module Juvix.Compiler.Core.Translation.Stripped.FromCore where
 
 import Juvix.Compiler.Core.Data.InfoTable
 import Juvix.Compiler.Core.Data.Stripped.InfoTable qualified as Stripped

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromMain.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromMain.hs
@@ -1,10 +1,10 @@
 module Juvix.Compiler.Core.Translation.Stripped.FromMain where
 
 import Juvix.Compiler.Core.Data.InfoTable
-import Juvix.Compiler.Core.Language
-import Juvix.Compiler.Core.Language.Stripped qualified as Stripped
 import Juvix.Compiler.Core.Data.Stripped.InfoTable qualified as Stripped
 import Juvix.Compiler.Core.Extra.Stripped.Base qualified as Stripped
+import Juvix.Compiler.Core.Language
+import Juvix.Compiler.Core.Language.Stripped qualified as Stripped
 
 fromMain :: InfoTable -> Stripped.InfoTable
 fromMain = error "not yet implemented"

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromMain.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromMain.hs
@@ -1,0 +1,13 @@
+module Juvix.Compiler.Core.Translation.Stripped.FromMain where
+
+import Juvix.Compiler.Core.Data.InfoTable
+import Juvix.Compiler.Core.Language
+import Juvix.Compiler.Core.Language.Stripped qualified as Stripped
+import Juvix.Compiler.Core.Data.Stripped.InfoTable qualified as Stripped
+import Juvix.Compiler.Core.Extra.Stripped.Base qualified as Stripped
+
+fromMain :: InfoTable -> Stripped.InfoTable
+fromMain = error "not yet implemented"
+
+translateNode :: Node -> Stripped.Node
+translateNode _ = Stripped.mkVar' 0


### PR DESCRIPTION
The Stripped.Node datatype specifies precisely the format of Nodes needed for compilation to JuvixAsm.

Ultimately, I didn't use type families for two reasons.
1. Most importantly, they don't work with the UNPACK pragma. The compiler gives an error.
2. They don't seem to be very useful in this particular case. I implemented pretty printing for Stripped.Node, and anything that could be done with type families could also be done in a simpler way with parametric polymorphism by abstracting one or two extra arguments to a printing function. Beyond pretty printing, we won't be having many more general functions that need to work both on Node and Stripped.Node.

The reason why type families didn't turn out very useful might be that Node and Stripped.Node have different constructors, so the top-level case needs to be handled separately anyway.
