### PR TITLE
Disallow tab characters as spaces

### DIFF
--- a/examples/milestone/Collatz/Collatz.juvix
+++ b/examples/milestone/Collatz/Collatz.juvix
@@ -11,7 +11,7 @@ div2 zero ≔ just zero;
 div2 (suc (suc n)) ≔ mapMaybe suc (div2 n);
 div2 _ ≔ nothing;
 
-collatzNext : ℕ → ℕ;
+collatzNext : ℕ → ℕ;
 collatzNext n ≔ fromMaybe (suc (3 * n)) (div2 n);
 
 collatz : ℕ → ℕ;

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -1,6 +1,5 @@
 -- | This module contains lexing functions common to all parsers in the pipeline
 -- (Juvix, JuvixCore, JuvixAsm).
-
 module Juvix.Parser.Lexer where
 
 import Control.Monad.Trans.Class (lift)
@@ -27,8 +26,8 @@ parseFailure off str = P.parseError $ P.FancyError off (Set.singleton (P.ErrorFa
 space1 :: (MonadParsec e s m, Token s ~ Char) => m ()
 space1 = void $ takeWhile1P (Just "white space (only spaces and newlines allowed)") isWhiteSpace
   where
-  isWhiteSpace :: Char -> Bool
-  isWhiteSpace = (`elem` [' ', '\n'])
+    isWhiteSpace :: Char -> Bool
+    isWhiteSpace = (`elem` [' ', '\n'])
 
 space' :: forall r. Bool -> (forall a. ParsecS r a -> ParsecS r ()) -> ParsecS r ()
 space' judoc comment_ = L.space space1 lineComment block

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import Arity qualified
 import BackendC qualified
 import Base
 import Core qualified
+import Parsing qualified
 import Reachability qualified
 import Scope qualified
 import Termination qualified
@@ -21,7 +22,8 @@ fastTests :: TestTree
 fastTests =
   testGroup
     "Juvix fast tests"
-    [ Scope.allTests,
+    [ Parsing.allTests,
+      Scope.allTests,
       Termination.allTests,
       Arity.allTests,
       TypeCheck.allTests,

--- a/test/Parsing.hs
+++ b/test/Parsing.hs
@@ -1,0 +1,10 @@
+module Parsing
+  ( allTests,
+  )
+where
+
+import Base
+import Parsing.Negative qualified as N
+
+allTests :: TestTree
+allTests = testGroup "Parsing tests" [N.allTests]

--- a/test/Parsing/Negative.hs
+++ b/test/Parsing/Negative.hs
@@ -4,7 +4,6 @@ import Base
 import Juvix.Compiler.Pipeline
 import Juvix.Parser.Error
 
-
 root :: FilePath
 root = "tests/negative"
 

--- a/test/Parsing/Negative.hs
+++ b/test/Parsing/Negative.hs
@@ -1,0 +1,45 @@
+module Parsing.Negative where
+
+import Base
+import Juvix.Compiler.Pipeline
+import Juvix.Parser.Error
+
+
+root :: FilePath
+root = "tests/negative"
+
+data NegTest = NegTest
+  { _name :: String,
+    _relDir :: FilePath,
+    _file :: FilePath
+  }
+
+testDescr :: NegTest -> TestDescr
+testDescr NegTest {..} =
+  let tRoot = root </> _relDir
+   in TestDescr
+        { _testName = _name,
+          _testRoot = tRoot,
+          _testAssertion = Single $ do
+            let entryPoint = defaultEntryPoint _file
+            res <- runIOEither (upToParsing entryPoint)
+            case mapLeft fromJuvixError res of
+              Left (Just (_ :: ParserError)) -> return ()
+              Left Nothing -> assertFailure "The parser did not find an error."
+              Right _ -> assertFailure "An error ocurred but it was not in the parser."
+        }
+
+allTests :: TestTree
+allTests =
+  testGroup
+    "Parsing negative tests"
+    ( map (mkTest . testDescr) scoperErrorTests
+    )
+
+scoperErrorTests :: [NegTest]
+scoperErrorTests =
+  [ NegTest
+      "Tab character"
+      "."
+      "Tab.juvix"
+  ]

--- a/tests/negative/Tab.juvix
+++ b/tests/negative/Tab.juvix
@@ -1,0 +1,3 @@
+module 	Tab;
+
+end;


### PR DESCRIPTION
The use of tab characters as spaces would be too hard to properly handle in the current implementation of semantic highlighting for both emacs and vscode. For this reason, we have decided to forbid tab characters. This PR implements this change.

Closes #1464 