### PR TITLE
Detect nested patterns as smaller in the termination checker

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Data/SizeInfo.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Data/SizeInfo.hs
@@ -1,13 +1,12 @@
 module Juvix.Compiler.Internal.Translation.FromAbstract.Analysis.Termination.Data.SizeInfo where
 
-import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Abstract.Extra
 import Juvix.Prelude
 
 -- | i = SizeInfo [v] ⇔ v is smaller than argument i of the caller function.
 -- Indexes are 0 based
 data SizeInfo = SizeInfo
-  { _sizeSmaller :: HashMap VarName Int,
+  { _sizeSmaller :: [[Pattern]],
     _sizeEqual :: [Pattern]
   }
 
@@ -21,15 +20,12 @@ emptySizeInfo =
     }
 
 mkSizeInfo :: [PatternArg] -> SizeInfo
-mkSizeInfo ps = SizeInfo {..}
+mkSizeInfo args = SizeInfo {..}
   where
-    ps' :: [Pattern]
-    ps' = map (^. patternArgPattern) (filter (not . isBrace) ps)
+    ps :: [Pattern]
+    ps = map (^. patternArgPattern) (filter (not . isBrace) args)
     isBrace :: PatternArg -> Bool
     isBrace = (== Implicit) . (^. patternArgIsImplicit)
-    _sizeEqual = map (^. patternArgPattern) ps
-    _sizeSmaller :: HashMap VarName Int
-    _sizeSmaller =
-      HashMap.fromList
-        [ (v, i) | (i, p) <- zip [0 ..] ps', v <- p ^.. smallerPatternVariables
-        ]
+    _sizeEqual = ps
+    _sizeSmaller :: [[Pattern]]
+    _sizeSmaller = map (^.. patternSubCosmos) ps

--- a/test/Termination/Positive.hs
+++ b/test/Termination/Positive.hs
@@ -53,6 +53,7 @@ testDescrFlag N.NegTest {..} =
 tests :: [PosTest]
 tests =
   [ PosTest "Ackerman nice def. is terminating" "." "Ack.juvix",
+    PosTest "Fibonacci with nested pattern" "." "Fib.juvix",
     PosTest "Recursive functions on Lists" "." "Data/List.juvix"
   ]
 

--- a/tests/positive/Termination/Fib.juvix
+++ b/tests/positive/Termination/Fib.juvix
@@ -1,0 +1,18 @@
+module Fib;
+
+inductive Nat {
+  zero : Nat;
+  suc : Nat → Nat;
+};
+
+infixl 6 +;
++ : Nat → Nat → Nat;
++ zero b ≔ b;
++ (suc a) b ≔ suc (a + b);
+
+fib : Nat -> Nat;
+fib zero := zero;
+fib (suc (zero)) := suc zero;
+fib (suc (suc n)) := fib (suc n) + fib n;
+
+end;


### PR DESCRIPTION
Closes #1462.

Previous to this pr only nested variables were detected to be smaller than the pattern. So if a pattern was `suc (suc n)` the variable `n` were detected to be smaller. After this pr, `suc n` is also detected to be smaller.