### PR TITLE
Add CanonicalProjection

### DIFF
--- a/app/Commands/Dev/Core.hs
+++ b/app/Commands/Dev/Core.hs
@@ -1,6 +1,7 @@
 module Commands.Dev.Core where
 
 import Juvix.Compiler.Core.Data.TransformationId.Parser
+import Juvix.Compiler.Core.Pretty.Options qualified as Core
 import Juvix.Prelude hiding (Doc)
 import Options.Applicative
 
@@ -25,6 +26,18 @@ data CoreReadOptions = CoreReadOptions
 makeLenses ''CoreReplOptions
 makeLenses ''CoreEvalOptions
 makeLenses ''CoreReadOptions
+
+instance CanonicalProjection CoreReplOptions Core.Options where
+  project c =
+    Core.defaultOptions
+      { Core._optShowDeBruijnIndices = c ^. coreReplShowDeBruijn
+      }
+
+instance CanonicalProjection CoreReadOptions Core.Options where
+  project c =
+    Core.defaultOptions
+      { Core._optShowDeBruijnIndices = c ^. coreReadShowDeBruijn
+      }
 
 defaultCoreEvalOptions :: CoreEvalOptions
 defaultCoreEvalOptions =

--- a/app/Commands/Dev/Scope.hs
+++ b/app/Commands/Dev/Scope.hs
@@ -20,9 +20,9 @@ parseScope = do
       )
   pure ScopeOptions {..}
 
-mkScopePrettyOptions :: GlobalOptions -> ScopeOptions -> Scoper.Options
-mkScopePrettyOptions g ScopeOptions {..} =
-  Scoper.defaultOptions
-    { Scoper._optShowNameIds = g ^. globalShowNameIds,
-      Scoper._optInlineImports = _scopeInlineImports
-    }
+instance CanonicalProjection (GlobalOptions, ScopeOptions) Scoper.Options where
+  project (g, ScopeOptions {..}) =
+    Scoper.defaultOptions
+      { Scoper._optShowNameIds = g ^. globalShowNameIds,
+        Scoper._optInlineImports = _scopeInlineImports
+      }

--- a/app/Commands/Dev/Termination.hs
+++ b/app/Commands/Dev/Termination.hs
@@ -3,7 +3,7 @@ module Commands.Dev.Termination where
 import Control.Monad.Extra
 import Data.Text qualified as Text
 import GlobalOptions
-import Juvix.Compiler.Abstract.Pretty.Base qualified as A
+import Juvix.Compiler.Abstract.Pretty.Base qualified as Abstract
 import Juvix.Prelude hiding (Doc)
 import Options.Applicative
 
@@ -13,7 +13,7 @@ data TerminationCommand
 
 data CallsOptions = CallsOptions
   { _callsFunctionNameFilter :: Maybe (NonEmpty Text),
-    _callsShowDecreasingArgs :: A.ShowDecrArgs
+    _callsShowDecreasingArgs :: Abstract.ShowDecrArgs
   }
 
 newtype CallGraphOptions = CallGraphOptions
@@ -40,17 +40,17 @@ parseCalls = do
       decrArgsParser
       ( long "show-decreasing-args"
           <> short 'd'
-          <> value A.ArgRel
+          <> value Abstract.ArgRel
           <> help "possible values: argument, relation, both"
       )
   pure CallsOptions {..}
   where
-    decrArgsParser :: ReadM A.ShowDecrArgs
+    decrArgsParser :: ReadM Abstract.ShowDecrArgs
     decrArgsParser = eitherReader $ \s ->
       case map toLower s of
-        "argument" -> return A.OnlyArg
-        "relation" -> return A.OnlyRel
-        "both" -> return A.ArgRel
+        "argument" -> return Abstract.OnlyArg
+        "relation" -> return Abstract.OnlyRel
+        "both" -> return Abstract.ArgRel
         _ -> Left "bad argument"
 
 parseCallGraph :: Parser CallGraphOptions
@@ -91,9 +91,9 @@ parseTerminationCommand =
             (CallGraph <$> parseCallGraph)
             (progDesc "Compute the complete call graph of a .juvix file")
 
-callsPrettyOptions :: GlobalOptions -> CallsOptions -> A.Options
-callsPrettyOptions GlobalOptions {..} CallsOptions {..} =
-  A.defaultOptions
-    { A._optShowNameIds = _globalShowNameIds,
-      A._optShowDecreasingArgs = _callsShowDecreasingArgs
-    }
+instance CanonicalProjection (GlobalOptions, CallsOptions) Abstract.Options where
+  project (GlobalOptions {..}, CallsOptions {..}) =
+    Abstract.defaultOptions
+      { Abstract._optShowNameIds = _globalShowNameIds,
+        Abstract._optShowDecreasingArgs = _callsShowDecreasingArgs
+      }

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -4,6 +4,8 @@ module GlobalOptions
 where
 
 import Commands.Extra
+import Juvix.Compiler.Abstract.Pretty.Options qualified as Abstract
+import Juvix.Compiler.Internal.Pretty.Options qualified as Internal
 import Juvix.Data.Error.GenericError qualified as E
 import Juvix.Prelude
 import Options.Applicative hiding (hidden)
@@ -21,6 +23,18 @@ data GlobalOptions = GlobalOptions
   deriving stock (Eq, Show)
 
 makeLenses ''GlobalOptions
+
+instance CanonicalProjection GlobalOptions Internal.Options where
+  project g =
+    Internal.Options
+      { Internal._optShowNameIds = g ^. globalShowNameIds
+      }
+
+instance CanonicalProjection GlobalOptions Abstract.Options where
+  project g =
+    Abstract.defaultOptions
+      { Abstract._optShowNameIds = g ^. globalShowNameIds
+      }
 
 defaultGlobalOptions :: GlobalOptions
 defaultGlobalOptions =

--- a/src/Juvix/Compiler/Abstract/Pretty.hs
+++ b/src/Juvix/Compiler/Abstract/Pretty.hs
@@ -12,8 +12,8 @@ import Juvix.Prelude
 ppOutDefault :: PrettyCode c => c -> AnsiText
 ppOutDefault = AnsiText . PPOutput . doc defaultOptions
 
-ppOut :: PrettyCode c => Options -> c -> AnsiText
-ppOut o = AnsiText . PPOutput . doc o
+ppOut :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> AnsiText
+ppOut o = AnsiText . PPOutput . doc (project o)
 
 ppTrace :: PrettyCode c => c -> Text
 ppTrace = toAnsiText True . ppOutDefault

--- a/src/Juvix/Compiler/Concrete/Pretty.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty.hs
@@ -13,5 +13,5 @@ import Juvix.Prelude
 ppOutDefault :: PrettyCode c => c -> AnsiText
 ppOutDefault = AnsiText . PPOutput . doc defaultOptions
 
-ppOut :: PrettyCode c => Options -> c -> AnsiText
-ppOut o = AnsiText . PPOutput . doc o
+ppOut :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> AnsiText
+ppOut o = AnsiText . PPOutput . doc (project o)

--- a/src/Juvix/Compiler/Core/Pretty.hs
+++ b/src/Juvix/Compiler/Core/Pretty.hs
@@ -15,11 +15,11 @@ import Prettyprinter.Render.Terminal qualified as Ansi
 ppOutDefault :: PrettyCode c => c -> AnsiText
 ppOutDefault = AnsiText . PPOutput . doc defaultOptions
 
-ppOut :: PrettyCode c => Options -> c -> AnsiText
-ppOut o = AnsiText . PPOutput . doc o
+ppOut :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> AnsiText
+ppOut o = AnsiText . PPOutput . doc (project o)
 
-ppTrace' :: PrettyCode c => Options -> c -> Text
-ppTrace' opts = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc opts
+ppTrace' :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> Text
+ppTrace' opts = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc (project opts)
 
 ppTrace :: PrettyCode c => c -> Text
 ppTrace = ppTrace' defaultOptions

--- a/src/Juvix/Compiler/Internal/Pretty.hs
+++ b/src/Juvix/Compiler/Internal/Pretty.hs
@@ -15,8 +15,8 @@ import Prettyprinter.Render.Terminal qualified as Ansi
 ppOutDefault :: PrettyCode c => c -> AnsiText
 ppOutDefault = AnsiText . PPOutput . doc defaultOptions
 
-ppOut :: PrettyCode c => Options -> c -> AnsiText
-ppOut o = AnsiText . PPOutput . doc o
+ppOut :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> AnsiText
+ppOut o = AnsiText . PPOutput . doc (project o)
 
 ppTrace :: PrettyCode c => c -> Text
 ppTrace = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc defaultOptions

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -330,3 +330,9 @@ allElements = [minBound .. maxBound]
 
 readerState :: forall a r x. (Member (State a) r) => Sem (Reader a ': r) x -> Sem r x
 readerState m = get >>= (`runReader` m)
+
+class CanonicalProjection a b where
+  project :: a -> b
+
+instance CanonicalProjection a a where
+  project = id


### PR DESCRIPTION
This pr adds this class:
```
class CanonicalProjection a b where
  project :: a -> b
```
It is meant to be used for records types that have an obvious projection into another record. E.g.
```
instance CanonicalProjection GlobalOptions Internal.Options where
  project g =
    Internal.Options
      { Internal._optShowNameIds = g ^. globalShowNameIds
      }
```

I have updated the pretty printing functions that expect options to accept anything that has a canonical projection into the options.

The benefit is that the callsites can usually be simplified since you do not need to do an adhoc projection or remember the name of the projection if it exists.

```diff
-                  let ppOpts =
-                        Internal.defaultOptions
-                          { Internal._optShowNameIds = globalOpts ^. globalShowNameIds
-                          }
-                  App.renderStdOut (Internal.ppOut ppOpts micro)
+                  App.renderStdOut (Internal.ppOut globalOpts micro)
```

We have discussed this with @paulcadman and we have a small preference to have this. It'd be nice to know the opinion of @lukaszcz 