### PR TITLE
look in patterns when building the dependency graph

### DIFF
--- a/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
@@ -109,10 +109,10 @@ goPattern n p = case p ^. patternArgPattern of
   PatternEmpty -> return ()
   PatternConstructorApp a -> goApp a
   where
-  goApp :: ConstructorApp -> Sem r ()
-  goApp (ConstructorApp ctr ps) = do
-    addEdge n (ctr ^. constructorRefName)
-    mapM_ (goPattern n) ps
+    goApp :: ConstructorApp -> Sem r ()
+    goApp (ConstructorApp ctr ps) = do
+      addEdge n (ctr ^. constructorRefName)
+      mapM_ (goPattern n) ps
 
 goExpression :: forall r. Member (State DependencyGraph) r => Name -> Expression -> Sem r ()
 goExpression p e = case e of

--- a/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
@@ -98,9 +98,23 @@ goConstructorDef indName c = do
   goExpression (c ^. constructorName) (c ^. constructorType)
 
 goFunctionClause :: Member (State DependencyGraph) r => Name -> FunctionClause -> Sem r ()
-goFunctionClause p c = goExpression p (c ^. clauseBody)
+goFunctionClause p c = do
+  mapM_ (goPattern p) (c ^. clausePatterns)
+  goExpression p (c ^. clauseBody)
 
-goExpression :: Member (State DependencyGraph) r => Name -> Expression -> Sem r ()
+goPattern :: forall r. Member (State DependencyGraph) r => Name -> PatternArg -> Sem r ()
+goPattern n p = case p ^. patternArgPattern of
+  PatternVariable {} -> return ()
+  PatternWildcard {} -> return ()
+  PatternEmpty -> return ()
+  PatternConstructorApp a -> goApp a
+  where
+  goApp :: ConstructorApp -> Sem r ()
+  goApp (ConstructorApp ctr ps) = do
+    addEdge n (ctr ^. constructorRefName)
+    mapM_ (goPattern n) ps
+
+goExpression :: forall r. Member (State DependencyGraph) r => Name -> Expression -> Sem r ()
 goExpression p e = case e of
   ExpressionIden i -> addEdge p (idenName i)
   ExpressionUniverse {} -> return ()


### PR DESCRIPTION
The dependency graph is computed before holes have been inferred. Consider the following example:
```
f : _;
f true := zero;
f false := zero;
```
Unless we look at the patterns we will not know that `f` depends on `Bool`.