### PR TITLE
Add lambda expressions to internal and add typechecking support

### DIFF
--- a/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
@@ -126,6 +126,15 @@ goExpression p e = case e of
     goExpression p r
   ExpressionLiteral {} -> return ()
   ExpressionHole {} -> return ()
+  where
+  goLambda :: Lambda -> Sem r ()
+  goLambda (Lambda clauses) = mapM_ goClause clauses
+    where
+    goClause :: LambdaClause -> Sem r ()
+    goClause (LambdaClause {..}) = do
+      goExpression p _lambdaBody
+      mapM_ (goPattern p) _lambdaParameters
+
 
 goFunctionParameter :: Member (State DependencyGraph) r => Name -> FunctionParameter -> Sem r ()
 goFunctionParameter p param = goExpression p (param ^. paramType)

--- a/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
@@ -126,6 +126,7 @@ goExpression p e = case e of
     goExpression p r
   ExpressionLiteral {} -> return ()
   ExpressionHole {} -> return ()
+  ExpressionLambda l -> goLambda l
   where
   goLambda :: Lambda -> Sem r ()
   goLambda (Lambda clauses) = mapM_ goClause clauses

--- a/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Abstract/Extra/DependencyBuilder.hs
@@ -128,14 +128,13 @@ goExpression p e = case e of
   ExpressionHole {} -> return ()
   ExpressionLambda l -> goLambda l
   where
-  goLambda :: Lambda -> Sem r ()
-  goLambda (Lambda clauses) = mapM_ goClause clauses
-    where
-    goClause :: LambdaClause -> Sem r ()
-    goClause (LambdaClause {..}) = do
-      goExpression p _lambdaBody
-      mapM_ (goPattern p) _lambdaParameters
-
+    goLambda :: Lambda -> Sem r ()
+    goLambda (Lambda clauses) = mapM_ goClause clauses
+      where
+        goClause :: LambdaClause -> Sem r ()
+        goClause (LambdaClause {..}) = do
+          goExpression p _lambdaBody
+          mapM_ (goPattern p) _lambdaParameters
 
 goFunctionParameter :: Member (State DependencyGraph) r => Name -> FunctionParameter -> Sem r ()
 goFunctionParameter p param = goExpression p (param ^. paramType)

--- a/src/Juvix/Compiler/Abstract/Extra/Functions.hs
+++ b/src/Juvix/Compiler/Abstract/Extra/Functions.hs
@@ -146,6 +146,10 @@ matchExpressions = go
         goApp ia ib
       (ExpressionApplication {}, _) -> err
       (_, ExpressionApplication {}) -> err
+      (ExpressionLambda ia, ExpressionLambda ib) ->
+        goLambda ia ib
+      (ExpressionLambda {}, _) -> err
+      (_, ExpressionLambda {}) -> err
       (ExpressionUniverse ia, ExpressionUniverse ib) ->
         unless (ia == ib) err
       (ExpressionUniverse {}, _) -> err
@@ -163,6 +167,8 @@ matchExpressions = go
     addIfFreeVar va vb = whenM (isSoftFreeVar va) (addName va vb)
     err :: Sem r a
     err = throw @Text "Expression missmatch"
+    goLambda :: Lambda -> Lambda -> Sem r ()
+    goLambda = error "TODO not implemented yet"
     goApp :: Application -> Application -> Sem r ()
     goApp (Application al ar aim) (Application bl br bim) = do
       unless (aim == bim) err

--- a/src/Juvix/Compiler/Abstract/Language.hs
+++ b/src/Juvix/Compiler/Abstract/Language.hs
@@ -139,7 +139,7 @@ newtype Lambda = Lambda
   deriving stock (Eq, Show)
 
 data LambdaClause = LambdaClause
-  { _lambdaParameters :: NonEmpty Pattern,
+  { _lambdaParameters :: NonEmpty PatternArg,
     _lambdaBody :: Expression
   }
   deriving stock (Eq, Show)

--- a/src/Juvix/Compiler/Abstract/Language.hs
+++ b/src/Juvix/Compiler/Abstract/Language.hs
@@ -108,7 +108,7 @@ data Expression
   | ExpressionFunction Function
   | ExpressionLiteral LiteralLoc
   | ExpressionHole Hole
-  ---  ExpressionLambda Lambda not supported yet
+  | ExpressionLambda Lambda
   deriving stock (Eq, Show)
 
 instance HasAtomicity Expression where
@@ -119,6 +119,7 @@ instance HasAtomicity Expression where
     ExpressionApplication a -> atomicity a
     ExpressionFunction f -> atomicity f
     ExpressionLiteral f -> atomicity f
+    ExpressionLambda l -> atomicity l
 
 data Application = Application
   { _appLeft :: Expression,
@@ -129,6 +130,9 @@ data Application = Application
 
 instance HasAtomicity Application where
   atomicity = const (Aggregate appFixity)
+
+instance HasAtomicity Lambda where
+  atomicity = const Atom
 
 newtype Lambda = Lambda
   {_lambdaClauses :: [LambdaClause]}

--- a/src/Juvix/Compiler/Abstract/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Abstract/Pretty/Base.hs
@@ -120,10 +120,10 @@ instance PrettyCode ConstructorApp where
   ppCode (ConstructorApp ctr args) = do
     ctr' <- ppCode ctr
     if
-      | null args -> do
-          args' <- hsep <$> mapM ppCode args
-          return (parens (ctr' <+> args'))
-      | otherwise -> return ctr'
+        | null args -> do
+            args' <- hsep <$> mapM ppCode args
+            return (parens (ctr' <+> args'))
+        | otherwise -> return ctr'
 
 instance PrettyCode Pattern where
   ppCode = \case

--- a/src/Juvix/Compiler/Abstract/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Abstract/Pretty/Base.hs
@@ -97,6 +97,41 @@ instance PrettyCode Application where
 instance PrettyCode Universe where
   ppCode (Universe n _) = return $ kwType <+?> (pretty <$> n)
 
+instance PrettyCode PatternArg where
+  ppCode a = do
+    p <- ppCode (a ^. patternArgPattern)
+    return (bracesIf (Implicit == a ^. patternArgIsImplicit) p)
+
+instance PrettyCode LambdaClause where
+  ppCode LambdaClause {..} = do
+    lambdaParameters' <- hsep . toList <$> mapM ppCode _lambdaParameters
+    lambdaBody' <- ppCode _lambdaBody
+    return $ lambdaParameters' <+> kwAssign <+> lambdaBody'
+
+instance PrettyCode Lambda where
+  ppCode Lambda {..} = do
+    lambdaClauses' <- ppBlock _lambdaClauses
+    return $ kwLambda <+> lambdaClauses'
+
+ppBlock :: (PrettyCode a, Members '[Reader Options] r, Traversable t) => t a -> Sem r (Doc Ann)
+ppBlock items = bracesIndent . vsep . toList <$> mapM (fmap endSemicolon . ppCode) items
+
+instance PrettyCode ConstructorApp where
+  ppCode (ConstructorApp ctr args) = do
+    ctr' <- ppCode ctr
+    if
+      | null args -> do
+          args' <- hsep <$> mapM ppCode args
+          return (parens (ctr' <+> args'))
+      | otherwise -> return ctr'
+
+instance PrettyCode Pattern where
+  ppCode = \case
+    PatternVariable v -> ppCode v
+    PatternWildcard {} -> return kwWildcard
+    PatternEmpty {} -> return $ parens mempty
+    PatternConstructorApp constr -> ppCode constr
+
 instance PrettyCode Expression where
   ppCode e = case e of
     ExpressionIden i -> ppCode i
@@ -105,6 +140,7 @@ instance PrettyCode Expression where
     ExpressionFunction f -> ppCode f
     ExpressionLiteral l -> ppSCode l
     ExpressionHole h -> ppSCode h
+    ExpressionLambda l -> ppCode l
 
 instance PrettyCode Usage where
   ppCode u = return $ case u of

--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -356,11 +356,11 @@ goExpression = \case
 goLambda :: forall r. Member (Error ScoperError) r => Lambda 'Scoped -> Sem r Abstract.Lambda
 goLambda (Lambda cl) = Abstract.Lambda <$> mapM goClause cl
   where
-  goClause :: LambdaClause 'Scoped -> Sem r Abstract.LambdaClause
-  goClause (LambdaClause ps b) = do
-    ps' <- mapM goPatternArg ps
-    b' <- goExpression b
-    return (Abstract.LambdaClause ps' b')
+    goClause :: LambdaClause 'Scoped -> Sem r Abstract.LambdaClause
+    goClause (LambdaClause ps b) = do
+      ps' <- mapM goPatternArg ps
+      b' <- goExpression b
+      return (Abstract.LambdaClause ps' b')
 
 goUniverse :: Universe -> Universe
 goUniverse = id

--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -314,7 +314,7 @@ goExpression = \case
   ExpressionInfixApplication ia -> Abstract.ExpressionApplication <$> goInfix ia
   ExpressionPostfixApplication pa -> Abstract.ExpressionApplication <$> goPostfix pa
   ExpressionLiteral l -> return (Abstract.ExpressionLiteral l)
-  ExpressionLambda {} -> unsupported "Lambda"
+  ExpressionLambda l -> Abstract.ExpressionLambda <$> goLambda l
   ExpressionBraces b -> throw (ErrAppLeftImplicit (AppLeftImplicit b))
   ExpressionLetBlock {} -> unsupported "Let Block"
   ExpressionUniverse uni -> return (Abstract.ExpressionUniverse (goUniverse uni))
@@ -352,6 +352,15 @@ goExpression = \case
           l'' = Abstract.ExpressionApplication (Abstract.Application op' l' Explicit)
       r' <- goExpression r
       return (Abstract.Application l'' r' Explicit)
+
+goLambda :: forall r. Member (Error ScoperError) r => Lambda 'Scoped -> Sem r Abstract.Lambda
+goLambda (Lambda cl) = Abstract.Lambda <$> mapM goClause cl
+  where
+  goClause :: LambdaClause 'Scoped -> Sem r Abstract.LambdaClause
+  goClause (LambdaClause ps b) = do
+    ps' <- mapM goPatternArg ps
+    b' <- goExpression b
+    return (Abstract.LambdaClause ps' b')
 
 goUniverse :: Universe -> Universe
 goUniverse = id

--- a/src/Juvix/Compiler/Backend/C/Data/Base.hs
+++ b/src/Juvix/Compiler/Backend/C/Data/Base.hs
@@ -95,6 +95,7 @@ goType t = case t ^. Micro.unpolyType of
   Micro.ExpressionApplication a -> goType (mkPolyType' (fst (Micro.unfoldApplication a)))
   Micro.ExpressionLiteral {} -> impossible
   Micro.ExpressionHole {} -> impossible
+  Micro.ExpressionSimpleLambda {} -> impossible
   Micro.ExpressionLambda {} -> impossible
   where
     getMicroType :: Micro.Iden -> Sem r CDeclType

--- a/src/Juvix/Compiler/Backend/C/Data/Closure.hs
+++ b/src/Juvix/Compiler/Backend/C/Data/Closure.hs
@@ -74,6 +74,7 @@ genClosureExpression funArgTyps = \case
   Micro.ExpressionFunction {} -> impossible
   Micro.ExpressionHole {} -> impossible
   Micro.ExpressionUniverse {} -> impossible
+  Micro.ExpressionSimpleLambda {} -> impossible
   Micro.ExpressionLambda {} -> impossible
   where
     exprApplication :: Micro.Application -> Sem r [ClosureInfo]

--- a/src/Juvix/Compiler/Backend/C/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Backend/C/Translation/FromInternal.hs
@@ -381,6 +381,7 @@ goExpression = \case
   Micro.ExpressionFunction {} -> impossible
   Micro.ExpressionHole {} -> impossible
   Micro.ExpressionUniverse {} -> impossible
+  Micro.ExpressionSimpleLambda {} -> impossible
   Micro.ExpressionLambda {} -> impossible
 
 goIden :: Members '[Reader PatternInfoTable, Builtins, Reader Micro.InfoTable] r => Micro.Iden -> Sem r Expression

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -707,8 +707,8 @@ deriving stock instance
   Ord (Lambda s)
 
 data LambdaClause (s :: Stage) = LambdaClause
-  { lambdaParameters :: NonEmpty (PatternType s),
-    lambdaBody :: ExpressionType s
+  { _lambdaParameters :: NonEmpty (PatternType s),
+    _lambdaBody :: ExpressionType s
   }
 
 deriving stock instance

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1017,12 +1017,12 @@ checkLambdaClause ::
   LambdaClause 'Parsed ->
   Sem r (LambdaClause 'Scoped)
 checkLambdaClause LambdaClause {..} = do
-  lambdaParameters' <- mapM checkParsePatternAtom lambdaParameters
-  lambdaBody' <- withBindCurrentGroup (checkParseExpressionAtoms lambdaBody)
+  lambdaParameters' <- mapM checkParsePatternAtom _lambdaParameters
+  lambdaBody' <- withBindCurrentGroup (checkParseExpressionAtoms _lambdaBody)
   return
     LambdaClause
-      { lambdaParameters = lambdaParameters',
-        lambdaBody = lambdaBody'
+      { _lambdaParameters = lambdaParameters',
+        _lambdaBody = lambdaBody'
       }
 
 scopedVar ::

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -471,9 +471,9 @@ whereClause =
 
 lambdaClause :: Members '[Reader ParserParams, InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (LambdaClause 'Parsed)
 lambdaClause = do
-  lambdaParameters <- P.some patternAtom
+  _lambdaParameters <- P.some patternAtom
   kwAssign
-  lambdaBody <- parseExpressionAtoms
+  _lambdaBody <- parseExpressionAtoms
   return LambdaClause {..}
 
 lambda :: Members '[Reader ParserParams, InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (Lambda 'Parsed)

--- a/src/Juvix/Compiler/Internal/Data/LocalVars.hs
+++ b/src/Juvix/Compiler/Internal/Data/LocalVars.hs
@@ -9,6 +9,9 @@ data LocalVars = LocalVars
     _localTyMap :: HashMap VarName VarName
   }
 
+instance Semigroup LocalVars where
+  (LocalVars a b) <> (LocalVars a' b') = LocalVars (a <> a') (b <> b')
+
 makeLenses ''LocalVars
 
 addType :: VarName -> Expression -> LocalVars -> LocalVars

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -165,10 +165,10 @@ mkPolyType = fmap PolyType . go
         ty' <- go ty
         return (ExpressionSimpleLambda (SimpleLambda v ty' b'))
       where
-      goClause :: LambdaClause -> Maybe LambdaClause
-      goClause (LambdaClause ps b) = do
-        b' <- go b
-        return (LambdaClause ps b')
+        goClause :: LambdaClause -> Maybe LambdaClause
+        goClause (LambdaClause ps b) = do
+          b' <- go b
+          return (LambdaClause ps b')
 
 class HasExpressions a where
   leafExpressions :: Traversal' a Expression

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -110,14 +110,14 @@ data SimpleLambda = SimpleLambda
   }
   deriving stock (Eq, Generic)
 
-newtype Lambda = Lambda {
-  _lambdaClauses :: NonEmpty LambdaClause
+newtype Lambda = Lambda
+  { _lambdaClauses :: NonEmpty LambdaClause
   }
   deriving stock (Eq, Generic)
 
-data LambdaClause = LambdaClause {
-  _lambdaPatterns :: NonEmpty Pattern, -- only explicit patterns are allowed
-  _lambdaBody :: Expression -- only explicit patterns are allowed,
+data LambdaClause = LambdaClause
+  { _lambdaPatterns :: NonEmpty Pattern, -- only explicit patterns are allowed
+    _lambdaBody :: Expression -- only explicit patterns are allowed,
   }
   deriving stock (Eq, Generic)
 

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -92,6 +92,7 @@ data Expression
   | ExpressionLiteral LiteralLoc
   | ExpressionHole Hole
   | ExpressionUniverse SmallUniverse
+  | ExpressionSimpleLambda SimpleLambda
   | ExpressionLambda Lambda
   deriving stock (Eq, Generic)
 
@@ -102,14 +103,29 @@ data Example = Example
     _exampleExpression :: Expression
   }
 
-data Lambda = Lambda
-  { _lambdaVar :: VarName,
-    _lambdaVarType :: Expression,
-    _lambdaBody :: Expression
+data SimpleLambda = SimpleLambda
+  { _slambdaVar :: VarName,
+    _slambdaVarType :: Expression,
+    _slambdaBody :: Expression
+  }
+  deriving stock (Eq, Generic)
+
+newtype Lambda = Lambda {
+  _lambdaClauses :: NonEmpty LambdaClause
+  }
+  deriving stock (Eq, Generic)
+
+data LambdaClause = LambdaClause {
+  _lambdaPatterns :: NonEmpty Pattern, -- only explicit patterns are allowed
+  _lambdaBody :: Expression -- only explicit patterns are allowed,
   }
   deriving stock (Eq, Generic)
 
 instance Hashable Lambda
+
+instance Hashable LambdaClause
+
+instance Hashable SimpleLambda
 
 data Application = Application
   { _appLeft :: Expression,
@@ -131,16 +147,25 @@ data ConstructorApp = ConstructorApp
   { _constrAppConstructor :: Name,
     _constrAppParameters :: [PatternArg]
   }
+  deriving stock (Eq, Generic)
+
+instance Hashable ConstructorApp
 
 data PatternArg = PatternArg
   { _patternArgIsImplicit :: IsImplicit,
     _patternArgPattern :: Pattern
   }
+  deriving stock (Eq, Generic)
+
+instance Hashable PatternArg
 
 data Pattern
   = PatternVariable VarName
   | PatternConstructorApp ConstructorApp
   | PatternWildcard Wildcard
+  deriving stock (Eq, Generic)
+
+instance Hashable Pattern
 
 newtype InductiveParameter = InductiveParameter
   { _inductiveParamName :: VarName
@@ -192,6 +217,7 @@ makeLenses ''ModuleBody
 makeLenses ''Application
 makeLenses ''TypedExpression
 makeLenses ''Function
+makeLenses ''SimpleLambda
 makeLenses ''Lambda
 makeLenses ''FunctionParameter
 makeLenses ''InductiveParameter
@@ -200,6 +226,9 @@ makeLenses ''ConstructorApp
 
 instance HasAtomicity Application where
   atomicity = const (Aggregate appFixity)
+
+instance HasAtomicity SimpleLambda where
+  atomicity = const Atom
 
 instance HasAtomicity Lambda where
   atomicity = const Atom
@@ -212,6 +241,7 @@ instance HasAtomicity Expression where
     ExpressionHole {} -> Atom
     ExpressionUniverse u -> atomicity u
     ExpressionFunction f -> atomicity f
+    ExpressionSimpleLambda l -> atomicity l
     ExpressionLambda l -> atomicity l
 
 instance HasAtomicity Function where
@@ -249,8 +279,14 @@ instance HasLoc Function where
 instance HasLoc Application where
   getLoc (Application l r _) = getLoc l <> getLoc r
 
+instance HasLoc SimpleLambda where
+  getLoc l = getLoc (l ^. slambdaVar) <> getLoc (l ^. slambdaBody)
+
+instance HasLoc LambdaClause where
+  getLoc (LambdaClause ps e) = getLocSpan ps <> getLoc e
+
 instance HasLoc Lambda where
-  getLoc l = getLoc (l ^. lambdaVar) <> getLoc (l ^. lambdaBody)
+  getLoc l = getLocSpan (l ^. lambdaClauses)
 
 instance HasLoc Expression where
   getLoc = \case
@@ -260,6 +296,7 @@ instance HasLoc Expression where
     ExpressionHole h -> getLoc h
     ExpressionUniverse u -> getLoc u
     ExpressionFunction u -> getLoc u
+    ExpressionSimpleLambda l -> getLoc l
     ExpressionLambda l -> getLoc l
 
 instance HasLoc Iden where

--- a/src/Juvix/Compiler/Internal/Pretty.hs
+++ b/src/Juvix/Compiler/Internal/Pretty.hs
@@ -19,4 +19,4 @@ ppOut :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> AnsiText
 ppOut o = AnsiText . PPOutput . doc (project o)
 
 ppTrace :: PrettyCode c => c -> Text
-ppTrace = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc defaultOptions
+ppTrace = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc traceOptions

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -73,7 +73,7 @@ instance PrettyCode Expression where
 
 instance PrettyCode LambdaClause where
   ppCode LambdaClause {..} = do
-    lambdaParameters' <- hsep <$> mapM ppCode _lambdaPatterns
+    lambdaParameters' <- hsep <$> mapM ppCodeAtom _lambdaPatterns
     lambdaBody' <- ppCode _lambdaBody
     return $ lambdaParameters' <+> kwAssign <+> lambdaBody'
 
@@ -163,9 +163,9 @@ instance PrettyCode FunctionDef where
 instance PrettyCode FunctionClause where
   ppCode c = do
     funName <- ppCode (c ^. clauseName)
-    clausePatterns' <- mapM ppCodeAtom (c ^. clausePatterns)
+    clausePatterns' <- hsepMaybe <$> mapM ppCodeAtom (c ^. clausePatterns)
     clauseBody' <- ppCode (c ^. clauseBody)
-    return $ funName <+> hsep clausePatterns' <+> kwAssign <+> clauseBody'
+    return $ funName <+?> clausePatterns' <+> kwAssign <+> clauseBody'
 
 instance PrettyCode Backend where
   ppCode = \case

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -40,10 +40,10 @@ instance PrettyCode Iden where
     IdenAxiom a -> ppCode a
     IdenInductive a -> ppCode a
 
-instance PrettyCode Lambda where
+instance PrettyCode SimpleLambda where
   ppCode l = do
-    b' <- ppCode (l ^. lambdaBody)
-    v' <- ppCode (l ^. lambdaVar)
+    b' <- ppCode (l ^. slambdaBody)
+    v' <- ppCode (l ^. slambdaVar)
     return $ kwLambda <+> braces (v' <+> kwAssign <+> b')
 
 instance PrettyCode Application where
@@ -68,7 +68,19 @@ instance PrettyCode Expression where
     ExpressionFunction f -> ppCode f
     ExpressionUniverse u -> ppCode u
     ExpressionLiteral l -> return (pretty l)
+    ExpressionSimpleLambda l -> ppCode l
     ExpressionLambda l -> ppCode l
+
+instance PrettyCode LambdaClause where
+  ppCode LambdaClause {..} = do
+    lambdaParameters' <- hsep <$> mapM ppCode _lambdaPatterns
+    lambdaBody' <- ppCode _lambdaBody
+    return $ lambdaParameters' <+> kwAssign <+> lambdaBody'
+
+instance PrettyCode Lambda where
+  ppCode Lambda {..} = do
+    lambdaClauses' <- ppBlock _lambdaClauses
+    return $ kwLambda <+> lambdaClauses'
 
 instance PrettyCode BackendItem where
   ppCode BackendItem {..} = do

--- a/src/Juvix/Compiler/Internal/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Options.hs
@@ -12,6 +12,12 @@ defaultOptions =
     { _optShowNameIds = False
     }
 
+traceOptions :: Options
+traceOptions =
+  Options
+    { _optShowNameIds = True
+    }
+
 makeLenses ''Options
 
 fromGenericOptions :: GenericOptions -> Options

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -232,6 +232,23 @@ goType e = case e of
   Abstract.ExpressionFunction f -> ExpressionFunction <$> goFunction f
   Abstract.ExpressionLiteral {} -> unsupported "literals in types"
   Abstract.ExpressionHole h -> return (ExpressionHole h)
+  Abstract.ExpressionLambda {} -> unsupported "lambda in types"
+
+goLambda :: forall r. Abstract.Lambda -> Sem r Lambda
+goLambda (Abstract.Lambda cl) = case nonEmpty cl of
+  Nothing -> unsupported "empty lambda"
+  Just cl' -> Lambda <$> mapM goClause cl'
+  where
+  goClause :: Abstract.LambdaClause -> Sem r LambdaClause
+  goClause (Abstract.LambdaClause ps b) = do
+    ps' <- mapM (goPattern . explicit) ps
+    b' <- goExpression b
+    return (LambdaClause ps' b')
+    where
+    explicit :: Abstract.PatternArg -> Abstract.Pattern
+    explicit (Abstract.PatternArg i p) = case i of
+      Explicit -> p
+      _ -> unsupported "implicit patterns in lambda"
 
 goApplication :: Abstract.Application -> Sem r Application
 goApplication (Abstract.Application f x i) = do
@@ -266,6 +283,7 @@ goExpression e = case e of
   Abstract.ExpressionUniverse {} -> unsupported "universes in expression"
   Abstract.ExpressionFunction f -> ExpressionFunction <$> goExpressionFunction f
   Abstract.ExpressionApplication a -> ExpressionApplication <$> goApplication a
+  Abstract.ExpressionLambda l -> ExpressionLambda <$> goLambda l
   Abstract.ExpressionLiteral l -> return (ExpressionLiteral l)
   Abstract.ExpressionHole h -> return (ExpressionHole h)
 
@@ -333,6 +351,7 @@ viewConstructorType = \case
     return ([], ExpressionApplication a')
   Abstract.ExpressionUniverse u -> return ([], smallUniverseE (getLoc u))
   Abstract.ExpressionLiteral {} -> unsupported "literal in a type"
+  Abstract.ExpressionLambda {} -> unsupported "lambda in a constructor type"
   where
     viewFunctionType :: Abstract.Function -> Sem r (NonEmpty Expression, Expression)
     viewFunctionType (Abstract.Function p r) = do

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -219,15 +219,15 @@ isSmallType e = case e of
 isSmallUni :: Universe -> Bool
 isSmallUni u = 0 == fromMaybe 0 (u ^. universeLevel)
 
-goTypeUniverse :: Universe -> Expression
-goTypeUniverse u
-  | isSmallUni u = smallUniverseE (getLoc u)
+goUniverse :: Universe -> SmallUniverse
+goUniverse u
+  | isSmallUni u = SmallUniverse (getLoc u)
   | otherwise = unsupported "big universes"
 
 goType :: Abstract.Expression -> Sem r Expression
 goType e = case e of
   Abstract.ExpressionIden i -> return (ExpressionIden (goTypeIden i))
-  Abstract.ExpressionUniverse u -> return (goTypeUniverse u)
+  Abstract.ExpressionUniverse u -> return (ExpressionUniverse (goUniverse u))
   Abstract.ExpressionApplication a -> ExpressionApplication <$> goTypeApplication a
   Abstract.ExpressionFunction f -> ExpressionFunction <$> goFunction f
   Abstract.ExpressionLiteral {} -> unsupported "literals in types"
@@ -280,7 +280,7 @@ goExpressionFunction f = do
 goExpression :: Abstract.Expression -> Sem r Expression
 goExpression e = case e of
   Abstract.ExpressionIden i -> return (ExpressionIden (goIden i))
-  Abstract.ExpressionUniverse {} -> unsupported "universes in expression"
+  Abstract.ExpressionUniverse u -> return (ExpressionUniverse (goUniverse u))
   Abstract.ExpressionFunction f -> ExpressionFunction <$> goExpressionFunction f
   Abstract.ExpressionApplication a -> ExpressionApplication <$> goApplication a
   Abstract.ExpressionLambda l -> ExpressionLambda <$> goLambda l

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -239,16 +239,16 @@ goLambda (Abstract.Lambda cl) = case nonEmpty cl of
   Nothing -> unsupported "empty lambda"
   Just cl' -> Lambda <$> mapM goClause cl'
   where
-  goClause :: Abstract.LambdaClause -> Sem r LambdaClause
-  goClause (Abstract.LambdaClause ps b) = do
-    ps' <- mapM (goPattern . explicit) ps
-    b' <- goExpression b
-    return (LambdaClause ps' b')
-    where
-    explicit :: Abstract.PatternArg -> Abstract.Pattern
-    explicit (Abstract.PatternArg i p) = case i of
-      Explicit -> p
-      _ -> unsupported "implicit patterns in lambda"
+    goClause :: Abstract.LambdaClause -> Sem r LambdaClause
+    goClause (Abstract.LambdaClause ps b) = do
+      ps' <- mapM (goPattern . explicit) ps
+      b' <- goExpression b
+      return (LambdaClause ps' b')
+      where
+        explicit :: Abstract.PatternArg -> Abstract.Pattern
+        explicit (Abstract.PatternArg i p) = case i of
+          Explicit -> p
+          _ -> unsupported "implicit patterns in lambda"
 
 goApplication :: Abstract.Application -> Sem r Application
 goApplication (Abstract.Application f x i) = do

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Checker.hs
@@ -90,10 +90,20 @@ checkExpression e =
     Nothing -> case e of
       ExpressionApplication a -> checkApplication a
       ExpressionFunction f -> checkFunction f
+      ExpressionLambda l -> checkLambda l
       ExpressionIden {} -> return ()
       ExpressionHole {} -> return ()
       ExpressionUniverse {} -> return ()
       ExpressionLiteral {} -> return ()
+
+checkLambda :: forall r.
+  Members '[State CallMap, Reader FunctionRef, Reader InfoTable, Reader SizeInfo] r =>
+  Lambda ->
+  Sem r ()
+checkLambda (Lambda cl) = mapM_ checkClause cl
+  where
+  checkClause :: LambdaClause -> Sem r ()
+  checkClause LambdaClause {..} = checkExpression _lambdaBody
 
 checkApplication ::
   Members '[State CallMap, Reader FunctionRef, Reader InfoTable, Reader SizeInfo] r =>

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Checker.hs
@@ -96,14 +96,15 @@ checkExpression e =
       ExpressionUniverse {} -> return ()
       ExpressionLiteral {} -> return ()
 
-checkLambda :: forall r.
+checkLambda ::
+  forall r.
   Members '[State CallMap, Reader FunctionRef, Reader InfoTable, Reader SizeInfo] r =>
   Lambda ->
   Sem r ()
 checkLambda (Lambda cl) = mapM_ checkClause cl
   where
-  checkClause :: LambdaClause -> Sem r ()
-  checkClause LambdaClause {..} = checkExpression _lambdaBody
+    checkClause :: LambdaClause -> Sem r ()
+    checkClause LambdaClause {..} = checkExpression _lambdaBody
 
 checkApplication ::
   Members '[State CallMap, Reader FunctionRef, Reader InfoTable, Reader SizeInfo] r =>

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -148,7 +148,8 @@ arityLiteral (WithLoc _ l) = case l of
 arityUniverse :: Arity
 arityUniverse = ArityUnit
 
--- | currently we do not try to infer lambda arity
+-- | currently we do not try to infer lambda arity.
+-- Since lambdas cannot yet have implicit arguments, this is fine.
 arityLambda :: Lambda -> Arity
 arityLambda = const ArityUnknown
 

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -323,7 +323,6 @@ typeArity = go
 
     goIden :: Iden -> Sem r Arity
     goIden = \case
-      -- IdenVar v -> getLocalArity v -- does not work!
       IdenVar {} -> return ArityUnknown
       IdenInductive {} -> return ArityUnit
       IdenFunction {} -> return ArityUnknown -- we need normalization to determine the arity

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -86,8 +86,8 @@ checkFunctionClause ari cl = do
     name = cl ^. clauseName
     loc = getLoc name
 
-lambda :: a
-lambda = error "lambda expressions are not supported by the arity checker"
+simplelambda :: a
+simplelambda = error "simple lambda expressions are not supported by the arity checker"
 
 withEmptyLocalVars :: Sem (Reader LocalVars : r) a -> Sem r a
 withEmptyLocalVars = runReader emptyLocalVars
@@ -104,7 +104,7 @@ guessArity = \case
   ExpressionApplication a -> appHelper a
   ExpressionIden i -> idenHelper i
   ExpressionUniverse {} -> return arityUniverse
-  ExpressionSimpleLambda {} -> lambda
+  ExpressionSimpleLambda {} -> simplelambda
   ExpressionLambda {} -> return ArityUnknown
   where
     idenHelper :: Iden -> Sem r Arity
@@ -319,7 +319,7 @@ typeArity = go
       ExpressionHole {} -> return ArityUnknown
       ExpressionLambda {} -> return ArityUnknown
       ExpressionUniverse {} -> return ArityUnit
-      ExpressionSimpleLambda {} -> lambda
+      ExpressionSimpleLambda {} -> simplelambda
 
     goIden :: Iden -> Sem r Arity
     goIden = \case
@@ -374,7 +374,7 @@ checkExpression hintArity expr = case expr of
   ExpressionFunction {} -> return expr
   ExpressionUniverse {} -> return expr
   ExpressionHole {} -> return expr
-  ExpressionSimpleLambda {} -> lambda
+  ExpressionSimpleLambda {} -> simplelambda
   ExpressionLambda l -> ExpressionLambda <$> checkLambda hintArity l
   where
     goApp :: Application -> Sem r Expression
@@ -387,7 +387,7 @@ checkExpression hintArity expr = case expr of
         ExpressionIden i -> idenArity i >>= helper (getLoc i)
         ExpressionLiteral l -> helper (getLoc l) (arityLiteral l)
         ExpressionUniverse l -> helper (getLoc l) arityUniverse
-        ExpressionSimpleLambda {} -> lambda
+        ExpressionSimpleLambda {} -> simplelambda
         ExpressionFunction f ->
           throw
             ( ErrFunctionApplied

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/LocalVars.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/LocalVars.hs
@@ -12,7 +12,10 @@ newtype LocalVars = LocalVars
 makeLenses ''LocalVars
 
 addArity :: Member (State LocalVars) r => VarName -> Arity -> Sem r ()
-addArity v t = modify (over localArities (HashMap.insert v t))
+addArity v t = modify (withArity v t)
+
+withArity :: VarName -> Arity -> LocalVars -> LocalVars
+withArity v t = over localArities (HashMap.insert v t)
 
 getLocalArity :: Member (Reader LocalVars) r => VarName -> Sem r Arity
 getLocalArity v = fromJust <$> asks (^. localArities . at v)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/LocalVars.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/LocalVars.hs
@@ -8,6 +8,7 @@ import Juvix.Prelude
 newtype LocalVars = LocalVars
   { _localArities :: HashMap VarName Arity
   }
+  deriving newtype (Semigroup, Monoid)
 
 makeLenses ''LocalVars
 
@@ -18,10 +19,7 @@ withArity :: VarName -> Arity -> LocalVars -> LocalVars
 withArity v t = over localArities (HashMap.insert v t)
 
 getLocalArity :: Member (Reader LocalVars) r => VarName -> Sem r Arity
-getLocalArity v = fromJust <$> asks (^. localArities . at v)
+getLocalArity v = fromMaybe ArityUnknown <$> asks (^. localArities . at v)
 
 emptyLocalVars :: LocalVars
-emptyLocalVars =
-  LocalVars
-    { _localArities = mempty
-    }
+emptyLocalVars = mempty

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Types.hs
@@ -14,30 +14,59 @@ data FunctionArity = FunctionArity
   }
   deriving stock (Eq)
 
+data ArityRest =
+  ArityRestUnit
+  | ArityRestUnknown
+  deriving stock (Eq)
+
+data UnfoldedArity = UnfoldedArity {
+  _ufoldArityParams :: [ArityParameter],
+  _ufoldArityRest :: ArityRest
+  }
+  deriving stock (Eq)
+
 data ArityParameter
   = ParamExplicit Arity
   | ParamImplicit
   deriving stock (Eq)
+
+makeLenses ''UnfoldedArity
 
 arityParameter :: ArityParameter -> Arity
 arityParameter = \case
   ParamImplicit -> ArityUnit
   ParamExplicit a -> a
 
-unfoldArity :: Arity -> [ArityParameter]
-unfoldArity = go
+arityCommonPrefix :: Arity -> Arity -> [ArityParameter]
+arityCommonPrefix p1 p2 = commonPrefix u1 u2
   where
-    go :: Arity -> [ArityParameter]
-    go = \case
-      ArityUnit -> []
-      ArityUnknown -> []
-      ArityFunction (FunctionArity l r) -> l : unfoldArity r
+  u1 = unfoldArity p1
+  u2 = unfoldArity p2
 
-foldArity :: [ArityParameter] -> Arity
-foldArity = go
+unfoldArity' :: Arity -> UnfoldedArity
+unfoldArity' = \case
+  ArityUnit -> UnfoldedArity {
+    _ufoldArityParams = [],
+    _ufoldArityRest = ArityRestUnit
+    }
+  ArityUnknown -> UnfoldedArity {
+    _ufoldArityParams = [],
+    _ufoldArityRest = ArityRestUnknown
+    }
+  ArityFunction (FunctionArity l r) ->
+    over ufoldArityParams (l :) (unfoldArity' r)
+
+unfoldArity :: Arity -> [ArityParameter]
+unfoldArity = (^. ufoldArityParams) . unfoldArity'
+
+foldArity :: UnfoldedArity -> Arity
+foldArity UnfoldedArity {..} = go _ufoldArityParams
   where
+    go :: [ArityParameter] -> Arity
     go = \case
-      [] -> ArityUnit
+      [] -> case _ufoldArityRest of
+        ArityRestUnit -> ArityUnit
+        ArityRestUnknown -> ArityUnknown
       (a : as) -> ArityFunction (FunctionArity l (go as))
         where
           l = case a of

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Types.hs
@@ -14,14 +14,14 @@ data FunctionArity = FunctionArity
   }
   deriving stock (Eq)
 
-data ArityRest =
-  ArityRestUnit
+data ArityRest
+  = ArityRestUnit
   | ArityRestUnknown
   deriving stock (Eq)
 
-data UnfoldedArity = UnfoldedArity {
-  _ufoldArityParams :: [ArityParameter],
-  _ufoldArityRest :: ArityRest
+data UnfoldedArity = UnfoldedArity
+  { _ufoldArityParams :: [ArityParameter],
+    _ufoldArityRest :: ArityRest
   }
   deriving stock (Eq)
 
@@ -40,19 +40,21 @@ arityParameter = \case
 arityCommonPrefix :: Arity -> Arity -> [ArityParameter]
 arityCommonPrefix p1 p2 = commonPrefix u1 u2
   where
-  u1 = unfoldArity p1
-  u2 = unfoldArity p2
+    u1 = unfoldArity p1
+    u2 = unfoldArity p2
 
 unfoldArity' :: Arity -> UnfoldedArity
 unfoldArity' = \case
-  ArityUnit -> UnfoldedArity {
-    _ufoldArityParams = [],
-    _ufoldArityRest = ArityRestUnit
-    }
-  ArityUnknown -> UnfoldedArity {
-    _ufoldArityParams = [],
-    _ufoldArityRest = ArityRestUnknown
-    }
+  ArityUnit ->
+    UnfoldedArity
+      { _ufoldArityParams = [],
+        _ufoldArityRest = ArityRestUnit
+      }
+  ArityUnknown ->
+    UnfoldedArity
+      { _ufoldArityParams = [],
+        _ufoldArityRest = ArityRestUnknown
+      }
   ArityFunction (FunctionArity l r) ->
     over ufoldArityParams (l :) (unfoldArity' r)
 

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
@@ -67,12 +67,19 @@ checkStrictlyPositiveOccurrences ty ctorName name recLimit ref =
       ExpressionLiteral {} -> return ()
       ExpressionHole {} -> return ()
       ExpressionUniverse {} -> return ()
+      ExpressionSimpleLambda l -> helperSimpleLambda l
       ExpressionLambda l -> helperLambda l
       where
-        helperLambda :: Lambda -> Sem r ()
-        helperLambda (Lambda _ lamVarTy lamBody) = do
+        helperSimpleLambda :: SimpleLambda -> Sem r ()
+        helperSimpleLambda (SimpleLambda _ lamVarTy lamBody) = do
           helper inside lamVarTy
           helper inside lamBody
+
+        helperLambda :: Lambda -> Sem r ()
+        helperLambda (Lambda cl) = mapM_ goClause cl
+          where
+          goClause :: LambdaClause -> Sem r ()
+          goClause (LambdaClause _ b) = helper inside b
 
         helperIden :: Iden -> Sem r ()
         helperIden = \case

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
@@ -78,8 +78,8 @@ checkStrictlyPositiveOccurrences ty ctorName name recLimit ref =
         helperLambda :: Lambda -> Sem r ()
         helperLambda (Lambda cl) = mapM_ goClause cl
           where
-          goClause :: LambdaClause -> Sem r ()
-          goClause (LambdaClause _ b) = helper inside b
+            goClause :: LambdaClause -> Sem r ()
+            goClause (LambdaClause _ b) = helper inside b
 
         helperIden :: Iden -> Sem r ()
         helperIden = \case

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -618,31 +618,6 @@ inferExpression' e = case e of
           ExpressionHole h -> do
             fun <- ExpressionFunction <$> holeRefineToFunction h
             helper (set typedType fun l')
-          -- OLD
-          -- When we have have an application with a hole on the left: '_@1 x'
-          -- We assume that it is a type application and thus 'x' must be a type.
-          -- Not sure if this is always desirable.
-          ExpressionHole h -> do
-            q <- queryMetavar h
-            case q of
-              Just ty -> helper (set typedType ty l')
-              Nothing -> do
-                -- TODO INCORRECT
-                r' <- checkExpression (smallUniverseE (getLoc h)) r
-                h' <- freshHole (getLoc h)
-                let fun = Function (unnamedParameter r') (ExpressionHole h')
-                whenJustM (matchTypes (ExpressionHole h) (ExpressionFunction fun)) impossible
-                return
-                  TypedExpression
-                    { _typedType = ExpressionHole h',
-                      _typedExpression =
-                        ExpressionApplication
-                          Application
-                            { _appLeft = l' ^. typedExpression,
-                              _appRight = r',
-                              _appImplicit = iapp
-                            }
-                    }
           _ -> throw tyErr
             where
               tyErr :: TypeCheckerError

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -497,7 +497,7 @@ inferExpression' e = case e of
   ExpressionFunction f -> goFunction f
   ExpressionHole h -> inferHole h
   ExpressionUniverse u -> goUniverse u
-  ExpressionLambda l -> goLambda l
+  ExpressionSimpleLambda l -> goSimpleLambda l
   where
     inferHole :: Hole -> Sem r TypedExpression
     inferHole h = do
@@ -508,8 +508,8 @@ inferExpression' e = case e of
             _typedType = ExpressionUniverse (SmallUniverse (getLoc h))
           }
 
-    goLambda :: Lambda -> Sem r TypedExpression
-    goLambda (Lambda v ty b) = do
+    goSimpleLambda :: SimpleLambda -> Sem r TypedExpression
+    goSimpleLambda (SimpleLambda v ty b) = do
       b' <- inferExpression' b
       let smallUni = smallUniverseE (getLoc ty)
       ty' <- checkExpression smallUni ty
@@ -517,7 +517,7 @@ inferExpression' e = case e of
       return
         TypedExpression
           { _typedType = ExpressionFunction fun,
-            _typedExpression = ExpressionLambda (Lambda v ty' (b' ^. typedExpression))
+            _typedExpression = ExpressionSimpleLambda (SimpleLambda v ty' (b' ^. typedExpression))
           }
 
     goUniverse :: SmallUniverse -> Sem r TypedExpression

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -11,8 +11,7 @@ import Juvix.Prelude
 data WrongConstructorType = WrongConstructorType
   { _wrongCtorTypeName :: Name,
     _wrongCtorTypeExpected :: InductiveName,
-    _wrongCtorTypeActual :: InductiveName,
-    _wrongCtorTypeFunName :: Name
+    _wrongCtorTypeActual :: InductiveName
   }
 
 makeLenses ''WrongConstructorType

--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -201,6 +201,9 @@ braces = enclose kwBraceL kwBraceR
 parens :: Doc Ann -> Doc Ann
 parens = enclose kwParenL kwParenR
 
+bracesIf :: Bool -> Doc Ann -> Doc Ann
+bracesIf t = if t then braces else id
+
 implicitDelim :: IsImplicit -> Doc Ann -> Doc Ann
 implicitDelim = \case
   Implicit -> braces
@@ -217,6 +220,9 @@ parensCond t d = if t then parens d else d
 
 bracesCond :: Bool -> Doc Ann -> Doc Ann
 bracesCond t d = if t then braces d else d
+
+endSemicolon :: Doc Ann -> Doc Ann
+endSemicolon x = x <> kwSemicolon
 
 ppStringLit :: Text -> Doc Ann
 ppStringLit = annotate AnnLiteralString . doubleQuotes . escaped

--- a/src/Juvix/Data/Loc.hs
+++ b/src/Juvix/Data/Loc.hs
@@ -64,8 +64,9 @@ instance Hashable Interval
 class HasLoc t where
   getLoc :: t -> Interval
 
+-- | The items are assumed to be in order with respect to their location.
 getLocSpan :: HasLoc t => NonEmpty t -> Interval
-getLocSpan = foldr1 (<>) . fmap getLoc
+getLocSpan l = getLoc (head l) <> getLoc (last l)
 
 -- | Assumes the file is the same
 instance Semigroup Interval where

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -244,11 +244,11 @@ map' f (h : t) =
 commonPrefix :: forall a. Eq a => [a] -> [a] -> [a]
 commonPrefix a b = reverse (go [] a b)
   where
-  go :: [a] -> [a] -> [a] -> [a]
-  go ac x y = case (x, y) of
-    (x' : xs, y' : ys)
-     | x' == y' -> go (x' : ac) xs ys
-    _ -> ac
+    go :: [a] -> [a] -> [a] -> [a]
+    go ac x y = case (x, y) of
+      (x' : xs, y' : ys)
+        | x' == y' -> go (x' : ac) xs ys
+      _ -> ac
 
 --------------------------------------------------------------------------------
 -- NonEmpty

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -240,6 +240,16 @@ map' f (h : t) =
    in let !vs = map' f t
        in v : vs
 
+-- | longest common prefix
+commonPrefix :: forall a. Eq a => [a] -> [a] -> [a]
+commonPrefix a b = reverse (go [] a b)
+  where
+  go :: [a] -> [a] -> [a] -> [a]
+  go ac x y = case (x, y) of
+    (x' : xs, y' : ys)
+     | x' == y' -> go (x' : ac) xs ys
+    _ -> ac
+
 --------------------------------------------------------------------------------
 -- NonEmpty
 --------------------------------------------------------------------------------

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,7 +8,7 @@ import Parsing qualified
 import Reachability qualified
 import Scope qualified
 import Termination qualified
-import TypeCheck qualified
+import Typecheck qualified
 
 slowTests :: TestTree
 slowTests =
@@ -26,7 +26,7 @@ fastTests =
       Scope.allTests,
       Termination.allTests,
       Arity.allTests,
-      TypeCheck.allTests,
+      Typecheck.allTests,
       Reachability.allTests
     ]
 

--- a/test/TypeCheck.hs
+++ b/test/TypeCheck.hs
@@ -1,8 +1,0 @@
-module TypeCheck (allTests) where
-
-import Base
-import TypeCheck.Negative qualified as N
-import TypeCheck.Positive qualified as P
-
-allTests :: TestTree
-allTests = testGroup "Type checker tests" [P.allTests, N.allTests]

--- a/test/Typecheck.hs
+++ b/test/Typecheck.hs
@@ -1,0 +1,8 @@
+module Typecheck (allTests) where
+
+import Base
+import Typecheck.Negative qualified as N
+import Typecheck.Positive qualified as P
+
+allTests :: TestTree
+allTests = testGroup "Type checker tests" [P.allTests, N.allTests]

--- a/test/Typecheck/Negative.hs
+++ b/test/Typecheck/Negative.hs
@@ -1,4 +1,4 @@
-module TypeCheck.Negative where
+module Typecheck.Negative where
 
 import Base
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Error

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -1,8 +1,8 @@
-module TypeCheck.Positive where
+module Typecheck.Positive where
 
 import Base
 import Juvix.Compiler.Pipeline
-import TypeCheck.Negative qualified as N
+import Typecheck.Negative qualified as N
 
 data PosTest = PosTest
   { _name :: String,
@@ -155,6 +155,10 @@ tests =
       "Import a builtin multiple times"
       "BuiltinsMultiImport"
       "Input.juvix",
+    PosTest
+      "Basic lambda functions"
+      "Internal"
+      "Lambda.juvix",
     PosTest
       "open import a builtin multiple times"
       "BuiltinsMultiOpenImport"

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -1,0 +1,114 @@
+module Lambda;
+
+infixr 9 ∘;
+∘ : {A : Type} → {B : Type} → {C : Type} → (B → C) → (A → B) → A → C;
+∘ {_} {B} {_} := λ {f g x ≔ f (g x)};
+
+inductive Nat {
+  zero : Nat;
+  suc : Nat → Nat;
+};
+
+infixr 2 ×;
+infixr 4 ,;
+inductive × (A : Type) (B : Type) {
+  , : A → B → A × B;
+};
+
+id : {A : Type} → A → A;
+id {A} := λ {a := a};
+
+id' : (A : Type) → A → A;
+id' := λ {A a := a};
+
+id'' : (A : Type) → A → A;
+id'' := λ {A := λ {a := a}};
+
+uncurry : {A : Type} → {B : Type} → {C : Type} → (A → B → C) → A × B → C;
+uncurry {A} {B} {C} := λ {f (a, b) := f a b};
+
+inductive Box (A : Type) {
+  box : A → Box A;
+};
+
+idB : {A : Type} → A → A;
+idB {A} a ≔ λ { a := a} a;
+
+mapB : {A : Type} → (A → A) → A → A;
+mapB {A} ≔ λ { f a := f a};
+
+terminating add : Nat → Nat → Nat;
+add := λ {zero n := n; (suc n) := λ {m := suc (add n m) }};
+
+fst : {A : Type} → {B : Type} → A × B → A;
+fst {_} {_} := λ {(a, _) ≔ a};
+
+swap : {A : Type} → {B : Type} → A × B → B × A;
+swap {_} {_} := λ {(a, b) ≔ b, a};
+
+first : {A : Type} → {B : Type} → {A' : Type} → (A → A') → A × B → A' × B;
+first {_} {_} {_} := λ {f (a, b) ≔ f a, b};
+
+second : {A : Type} → {B : Type} → {B' : Type} → (B → B') → A × B → A × B';
+second f (a , b) ≔ a , f b;
+
+both : {A : Type} → {B : Type} → (A → B) → A × A → B × B;
+both {_} {_} := λ {f (a, b) ≔ f a, f b};
+
+infixr 5 ∷;
+inductive List (a : Type) {
+  nil : List a;
+  ∷ : a → List a → List a;
+};
+
+terminating
+map : {A : Type} → {B : Type} → (A → B) → List A → List B;
+map {_} {_} := λ {f nil ≔ nil;
+                  f (x ∷ xs) ≔ f x ∷ map f xs};
+
+pairEval : {A : Type} → {B : Type} → (A → B) × A → B;
+pairEval {_} {_} := λ {(f, x) ≔ f x};
+
+terminating
+foldr : {A : Type} → {B : Type} → (A → B → B) → B → List A → B;
+foldr {_} {_} := λ {_ z nil ≔ z;
+                    f z (h ∷ hs) ≔ f h (foldr f z hs)};
+
+terminating
+foldl : {A : Type} → {B : Type} → (B → A → B) → B → List A → B;
+foldl {_} {_} := λ {f z nil ≔ z ;
+    f z (h ∷ hs) ≔ foldl f (f z h) hs};
+
+inductive Bool {
+  true : Bool;
+  false : Bool;
+};
+
+if : {A : Type} → Bool → A → A → A;
+if true a _ ≔ a;
+if false _ b ≔ b;
+
+terminating
+filter : {A : Type} → (A → Bool) → List A → List A;
+filter {_} := λ {_ nil ≔ nil;
+   f (h ∷ hs) ≔ if (f h)
+     (h ∷ filter f hs)
+     (filter f hs)};
+
+terminating
+partition : {A : Type} → (A → Bool) → List A → List A × List A;
+partition {_} := λ {_ nil ≔ nil, nil;
+    f (x ∷ xs) ≔ (if (f x) first second) ((∷) x) (partition f xs)};
+
+terminating
+zipWith : {A : Type} → {B : Type} → {C : Type} → (_ → _ → _) → List A → List B → List C;
+zipWith {_} {_} {_} := λ {_ nil _ := nil;
+    _ _ nil := nil;
+    f (x ∷ xs) (y ∷ ys) := f x y ∷ zipWith f xs ys
+   };
+
+t : {A : Type} → {B : Type} → ({X : Type} → List X) → List A × List B;
+t {A} {B} := id {({X : Type} → List X) → _} λ { f ≔ f {A} , f {B}};
+
+
+end;

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -13,7 +13,7 @@ inductive × (A : Type) (B : Type) {
 
 infixr 9 ∘;
 ∘ : {A : Type} → {B : Type} → {C : Type} → (B → C) → (A → B) → A → C;
-∘ {_} {B} {_} := λ {f g x ≔ f (g x)};
+∘ {_} {B} {_} := λ {f g x := f (g x)};
 
 id : {A : Type} → A → A;
 id := λ {a := a};
@@ -40,43 +40,43 @@ terminating add : Nat → Nat → Nat;
 add := λ {zero n := n; (suc n) := λ {m := suc (add n m) }};
 
 fst : {A : Type} → {B : Type} → A × B → A;
-fst {_} := λ {(a, _) ≔ a};
+fst {_} := λ {(a, _) := a};
 
 swap : {A : Type} → {B : Type} → A × B → B × A;
-swap {_} {_} := λ {(a, b) ≔ b, a};
+swap {_} {_} := λ {(a, b) := b, a};
 
 first : {A : Type} → {B : Type} → {A' : Type} → (A → A') → A × B → A' × B;
-first := λ {f (a, b) ≔ f a, b};
+first := λ {f (a, b) := f a, b};
 
 second : {A : Type} → {B : Type} → {B' : Type} → (B → B') → A × B → A × B';
-second f (a , b) ≔ a , f b;
+second f (a , b) := a , f b;
 
 both : {A : Type} → {B : Type} → (A → B) → A × A → B × B;
-both {_} {B} := λ {f (a, b) ≔ f a, f b};
+both {_} {B} := λ {f (a, b) := f a, f b};
 
-infixr 5 ∷;
+infixr 5 ::;
 inductive List (a : Type) {
   nil : List a;
-  ∷ : a → List a → List a;
+  :: : a → List a → List a;
 };
 
 terminating
 map : {A : Type} → {B : Type} → (A → B) → List A → List B;
-map {_} := λ {f nil ≔ nil;
-                  f (x ∷ xs) ≔ f x ∷ map f xs};
+map {_} := λ {f nil := nil;
+              f (x :: xs) := f x :: map f xs};
 
 pairEval : {A : Type} → {B : Type} → (A → B) × A → B;
-pairEval := λ {(f, x) ≔ f x};
+pairEval := λ {(f, x) := f x};
 
 terminating
 foldr : {A : Type} → {B : Type} → (A → B → B) → B → List A → B;
-foldr := λ {_ z nil ≔ z;
-                    f z (h ∷ hs) ≔ f h (foldr f z hs)};
+foldr := λ {_ z nil := z;
+            f z (h :: hs) := f h (foldr f z hs)};
 
 terminating
 foldl : {A : Type} → {B : Type} → (B → A → B) → B → List A → B;
-foldl := λ {f z nil ≔ z ;
-    f z (h ∷ hs) ≔ foldl f (f z h) hs};
+foldl := λ {f z nil := z;
+            f z (h :: hs) := foldl f (f z h) hs};
 
 inductive Bool {
   true : Bool;
@@ -84,29 +84,29 @@ inductive Bool {
 };
 
 if : {A : Type} → Bool → A → A → A;
-if := λ {true a _ ≔ a;
-    false _ b ≔ b};
+if := λ {true a _ := a;
+         false _ b := b};
 
 terminating
 filter : {A : Type} → (A → Bool) → List A → List A;
-filter := λ {_ nil ≔ nil;
-   f (h ∷ hs) ≔ if (f h)
-     (h ∷ filter f hs)
-     (filter f hs)};
+filter := λ {_ nil := nil;
+             f (h :: hs) := if (f h)
+                            (h :: filter f hs)
+                            (filter f hs)};
 
 terminating
 partition : {A : Type} → (A → Bool) → List A → List A × List A;
-partition := λ {_ nil ≔ nil, nil;
-    f (x ∷ xs) ≔ (if (f x) first second) ((∷) x) (partition f xs)};
+partition := λ {_ nil := nil, nil;
+                f (x :: xs) := (if (f x) first second) ((::) x) (partition f xs)};
 
 terminating
 zipWith : {A : Type} → {B : Type} → {C : Type} → (_ → _ → _) → List A → List B → List C;
 zipWith := λ {_ nil _ := nil;
-    _ _ nil := nil;
-    f (x ∷ xs) (y ∷ ys) := f x y ∷ zipWith f xs ys
-   };
+              _ _ nil := nil;
+              f (x :: xs) (y :: ys) := f x y :: zipWith f xs ys
+             };
 
 t : {A : Type} → {B : Type} → ({X : Type} → List X) → List A × List B;
-t := id {({X : Type} → List X) → _} λ { f ≔ f {_} , f {_} };
+t := id {({X : Type} → List X) → _} λ { f := f {_} , f {_} };
 
 end;

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -1,9 +1,5 @@
 module Lambda;
 
-infixr 9 ∘;
-∘ : {A : Type} → {B : Type} → {C : Type} → (B → C) → (A → B) → A → C;
-∘ {_} {B} {_} := λ {f g x ≔ f (g x)};
-
 inductive Nat {
   zero : Nat;
   suc : Nat → Nat;
@@ -15,8 +11,15 @@ inductive × (A : Type) (B : Type) {
   , : A → B → A × B;
 };
 
+infixr 9 ∘;
+∘ : {A : Type} → {B : Type} → {C : Type} → (B → C) → (A → B) → A → C;
+∘ {_} {B} {_} := λ {f g x ≔ f (g x)};
+
 id : {A : Type} → A → A;
-id {A} := λ {a := a};
+id := λ {a := a};
+
+id2 : {A : Type} → {B : Type} → A → A;
+id2 := λ {a := a};
 
 id' : (A : Type) → A → A;
 id' := λ {A a := a};
@@ -25,35 +28,31 @@ id'' : (A : Type) → A → A;
 id'' := λ {A := λ {a := a}};
 
 uncurry : {A : Type} → {B : Type} → {C : Type} → (A → B → C) → A × B → C;
-uncurry {A} {B} {C} := λ {f (a, b) := f a b};
-
-inductive Box (A : Type) {
-  box : A → Box A;
-};
+uncurry := λ {f (a, b) := f a b};
 
 idB : {A : Type} → A → A;
-idB {A} a ≔ λ { a := a} a;
+idB a ≔ λ { a := a} a;
 
 mapB : {A : Type} → (A → A) → A → A;
-mapB {A} ≔ λ { f a := f a};
+mapB ≔ λ { f a := f a};
 
 terminating add : Nat → Nat → Nat;
 add := λ {zero n := n; (suc n) := λ {m := suc (add n m) }};
 
 fst : {A : Type} → {B : Type} → A × B → A;
-fst {_} {_} := λ {(a, _) ≔ a};
+fst {_} := λ {(a, _) ≔ a};
 
 swap : {A : Type} → {B : Type} → A × B → B × A;
 swap {_} {_} := λ {(a, b) ≔ b, a};
 
 first : {A : Type} → {B : Type} → {A' : Type} → (A → A') → A × B → A' × B;
-first {_} {_} {_} := λ {f (a, b) ≔ f a, b};
+first := λ {f (a, b) ≔ f a, b};
 
 second : {A : Type} → {B : Type} → {B' : Type} → (B → B') → A × B → A × B';
 second f (a , b) ≔ a , f b;
 
 both : {A : Type} → {B : Type} → (A → B) → A × A → B × B;
-both {_} {_} := λ {f (a, b) ≔ f a, f b};
+both {_} {B} := λ {f (a, b) ≔ f a, f b};
 
 infixr 5 ∷;
 inductive List (a : Type) {
@@ -63,20 +62,20 @@ inductive List (a : Type) {
 
 terminating
 map : {A : Type} → {B : Type} → (A → B) → List A → List B;
-map {_} {_} := λ {f nil ≔ nil;
+map {_} := λ {f nil ≔ nil;
                   f (x ∷ xs) ≔ f x ∷ map f xs};
 
 pairEval : {A : Type} → {B : Type} → (A → B) × A → B;
-pairEval {_} {_} := λ {(f, x) ≔ f x};
+pairEval := λ {(f, x) ≔ f x};
 
 terminating
 foldr : {A : Type} → {B : Type} → (A → B → B) → B → List A → B;
-foldr {_} {_} := λ {_ z nil ≔ z;
+foldr := λ {_ z nil ≔ z;
                     f z (h ∷ hs) ≔ f h (foldr f z hs)};
 
 terminating
 foldl : {A : Type} → {B : Type} → (B → A → B) → B → List A → B;
-foldl {_} {_} := λ {f z nil ≔ z ;
+foldl := λ {f z nil ≔ z ;
     f z (h ∷ hs) ≔ foldl f (f z h) hs};
 
 inductive Bool {
@@ -85,30 +84,29 @@ inductive Bool {
 };
 
 if : {A : Type} → Bool → A → A → A;
-if true a _ ≔ a;
-if false _ b ≔ b;
+if := λ {true a _ ≔ a;
+    false _ b ≔ b};
 
 terminating
 filter : {A : Type} → (A → Bool) → List A → List A;
-filter {_} := λ {_ nil ≔ nil;
+filter := λ {_ nil ≔ nil;
    f (h ∷ hs) ≔ if (f h)
      (h ∷ filter f hs)
      (filter f hs)};
 
 terminating
 partition : {A : Type} → (A → Bool) → List A → List A × List A;
-partition {_} := λ {_ nil ≔ nil, nil;
+partition := λ {_ nil ≔ nil, nil;
     f (x ∷ xs) ≔ (if (f x) first second) ((∷) x) (partition f xs)};
 
 terminating
 zipWith : {A : Type} → {B : Type} → {C : Type} → (_ → _ → _) → List A → List B → List C;
-zipWith {_} {_} {_} := λ {_ nil _ := nil;
+zipWith := λ {_ nil _ := nil;
     _ _ nil := nil;
     f (x ∷ xs) (y ∷ ys) := f x y ∷ zipWith f xs ys
    };
 
 t : {A : Type} → {B : Type} → ({X : Type} → List X) → List A × List B;
-t {A} {B} := id {({X : Type} → List X) → _} λ { f ≔ f {A} , f {B}};
-
+t := id {({X : Type} → List X) → _} λ { f ≔ f {_} , f {_} };
 
 end;


### PR DESCRIPTION
This PR adds lambda support up to typechecking.
The changes include.
1. Lambda translation Concrete -> Abstract -> Internal.
2. Pretty printing for lambda functions in Abstract and Internal.
3. Arity checking extended to support lambda expressions.
4. typechecker extended to support lambda expressions.
5. A collection of basic tests using lambda expressions.

Limitations:
- Lambda functions cannot have implicit arguments at the moment.