### PR TITLE
Add --show-de-bruijn to `core eval` command

### DIFF
--- a/app/Commands/Dev/Core/Eval.hs
+++ b/app/Commands/Dev/Core/Eval.hs
@@ -38,12 +38,11 @@ runCommand opts = do
           | Info.member Info.kNoDisplayInfo (Core.getInfo node') ->
               return ()
         Right node' -> do
-          renderStdOut (Core.ppOut docOpts node')
+          renderStdOut (Core.ppOut opts node')
           embed (putStrLn "")
     Right (_, Nothing) -> return ()
   where
-    docOpts :: Core.Options
-    docOpts = Core.defaultOptions
+    defaultLoc :: Interval
     defaultLoc = singletonInterval (mkLoc f 0 (M.initialPos f))
     f :: FilePath
     f = opts ^. coreEvalInputFile . pathPath

--- a/app/Commands/Dev/Core/Eval/Options.hs
+++ b/app/Commands/Dev/Core/Eval/Options.hs
@@ -1,14 +1,22 @@
 module Commands.Dev.Core.Eval.Options where
 
 import CommonOptions
+import Juvix.Compiler.Core.Pretty.Options qualified as Core
 
 data CoreEvalOptions = CoreEvalOptions
   { _coreEvalNoIO :: Bool,
-    _coreEvalInputFile :: Path
+    _coreEvalInputFile :: Path,
+    _coreEvalShowDeBruijn :: Bool
   }
   deriving stock (Data)
 
 makeLenses ''CoreEvalOptions
+
+instance CanonicalProjection CoreEvalOptions Core.Options where
+  project c =
+    Core.defaultOptions
+      { Core._optShowDeBruijnIndices = c ^. coreEvalShowDeBruijn
+      }
 
 parseCoreEvalOptions :: Parser CoreEvalOptions
 parseCoreEvalOptions = do
@@ -17,5 +25,6 @@ parseCoreEvalOptions = do
       ( long "no-io"
           <> help "Don't interpret the IO effects"
       )
+  _coreEvalShowDeBruijn <- optDeBruijn
   _coreEvalInputFile <- parseInputJuvixFile
   pure CoreEvalOptions {..}


### PR DESCRIPTION
This option was removed as part of one of the cli refactors.

Fixes #1539