### PR TITLE
Properly handle top lambdas in the termination checker

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Data/SizeInfo.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Data/SizeInfo.hs
@@ -4,7 +4,7 @@ import Juvix.Compiler.Abstract.Extra
 import Juvix.Prelude
 
 -- | i = SizeInfo [v] ⇔ v is smaller than argument i of the caller function.
--- Indexes are 0 based
+-- The first (leftmost) argument has index 0
 data SizeInfo = SizeInfo
   { _sizeSmaller :: [[Pattern]],
     _sizeEqual :: [Pattern]
@@ -23,9 +23,9 @@ mkSizeInfo :: [PatternArg] -> SizeInfo
 mkSizeInfo args = SizeInfo {..}
   where
     ps :: [Pattern]
-    ps = map (^. patternArgPattern) (filter (not . isBrace) args)
-    isBrace :: PatternArg -> Bool
-    isBrace = (== Implicit) . (^. patternArgIsImplicit)
+    ps = map (^. patternArgPattern) (filter (not . isImplicit) args)
+    isImplicit :: PatternArg -> Bool
+    isImplicit = (== Implicit) . (^. patternArgIsImplicit)
     _sizeEqual = ps
     _sizeSmaller :: [[Pattern]]
     _sizeSmaller = map (^.. patternSubCosmos) ps

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Data/SizeRelation.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Data/SizeRelation.hs
@@ -1,6 +1,5 @@
 module Juvix.Compiler.Internal.Translation.FromAbstract.Analysis.Termination.Data.SizeRelation where
 
-import Data.Semiring
 import Juvix.Prelude
 import Prettyprinter
 
@@ -21,37 +20,9 @@ instance Hashable Rel
 toRel :: Rel' -> Rel
 toRel = RJust
 
-add :: Rel -> Rel -> Rel
-add RNothing b = b
-add a RNothing = a
-add (RJust a) (RJust b) = RJust (add' a b)
-
-add' :: Rel' -> Rel' -> Rel'
-add' RLe _ = RLe
-add' REq b = b
-
-mul :: Rel -> Rel -> Rel
-mul RNothing _ = RNothing
-mul _ RNothing = RNothing
-mul (RJust a) (RJust b) = RJust (mul' a b)
-
 mul' :: Rel' -> Rel' -> Rel'
 mul' REq a = a
 mul' RLe _ = RLe
-
-star_ :: Rel -> Rel
-star_ RNothing = RJust REq
-star_ (RJust RLe) = RJust RLe
-star_ (RJust REq) = RJust REq
-
-instance Semigroup Rel where
-  (<>) = add
-
-instance Semiring Rel where
-  one = RJust REq
-  zero = RNothing
-  plus = add
-  times = mul
 
 instance Pretty Rel where
   pretty r = case r of

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/FunctionCall.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/FunctionCall.hs
@@ -14,7 +14,7 @@ viewCall ::
   Expression ->
   Sem r (Maybe FunCall)
 viewCall = \case
-  ExpressionApplication (Application f _ Implicit) -> viewCall f
+  ExpressionApplication (Application f _ Implicit) -> viewCall f -- implicit arguments are ignored
   ExpressionApplication (Application f x Explicit) -> do
     c <- viewCall f
     x' <- callArg

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -36,7 +36,7 @@ idB a ≔ λ { a := a} a;
 mapB : {A : Type} → (A → A) → A → A;
 mapB ≔ λ { f a := f a};
 
-terminating add : Nat → Nat → Nat;
+add : Nat → Nat → Nat;
 add := λ {zero n := n; (suc n) := λ {m := suc (add n m) }};
 
 fst : {A : Type} → {B : Type} → A × B → A;
@@ -60,7 +60,6 @@ inductive List (a : Type) {
   :: : a → List a → List a;
 };
 
-terminating
 map : {A : Type} → {B : Type} → (A → B) → List A → List B;
 map {_} := λ {f nil := nil;
               f (x :: xs) := f x :: map f xs};
@@ -68,12 +67,10 @@ map {_} := λ {f nil := nil;
 pairEval : {A : Type} → {B : Type} → (A → B) × A → B;
 pairEval := λ {(f, x) := f x};
 
-terminating
 foldr : {A : Type} → {B : Type} → (A → B → B) → B → List A → B;
 foldr := λ {_ z nil := z;
             f z (h :: hs) := f h (foldr f z hs)};
 
-terminating
 foldl : {A : Type} → {B : Type} → (B → A → B) → B → List A → B;
 foldl := λ {f z nil := z;
             f z (h :: hs) := foldl f (f z h) hs};
@@ -87,19 +84,16 @@ if : {A : Type} → Bool → A → A → A;
 if := λ {true a _ := a;
          false _ b := b};
 
-terminating
 filter : {A : Type} → (A → Bool) → List A → List A;
 filter := λ {_ nil := nil;
              f (h :: hs) := if (f h)
                             (h :: filter f hs)
                             (filter f hs)};
 
-terminating
 partition : {A : Type} → (A → Bool) → List A → List A × List A;
 partition := λ {_ nil := nil, nil;
                 f (x :: xs) := (if (f x) first second) ((::) x) (partition f xs)};
 
-terminating
 zipWith : {A : Type} → {B : Type} → {C : Type} → (_ → _ → _) → List A → List B → List C;
 zipWith := λ {_ nil _ := nil;
               _ _ nil := nil;


### PR DESCRIPTION
Top level lambda patterns are treated as clause patterns, thus, definitions such as the following now pass the termination checker:
```
add : Nat → Nat → Nat;
add := λ {zero n := n; (suc n) := λ {m := suc (add n m)}};
```