### PR TITLE
Fix arity checker bug

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -382,8 +382,7 @@ checkExpression ::
   Arity ->
   Expression ->
   Sem r Expression
-checkExpression hintArity expr =
-  case expr of
+checkExpression hintArity expr = case expr of
     ExpressionIden {} -> appHelper expr []
     ExpressionApplication a -> goApp a
     ExpressionLiteral {} -> appHelper expr []

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -383,14 +383,14 @@ checkExpression ::
   Expression ->
   Sem r Expression
 checkExpression hintArity expr = case expr of
-    ExpressionIden {} -> appHelper expr []
-    ExpressionApplication a -> goApp a
-    ExpressionLiteral {} -> appHelper expr []
-    ExpressionFunction {} -> return expr
-    ExpressionUniverse {} -> return expr
-    ExpressionHole {} -> return expr
-    ExpressionSimpleLambda {} -> simplelambda
-    ExpressionLambda l -> ExpressionLambda <$> checkLambda hintArity l
+  ExpressionIden {} -> appHelper expr []
+  ExpressionApplication a -> goApp a
+  ExpressionLiteral {} -> appHelper expr []
+  ExpressionFunction {} -> return expr
+  ExpressionUniverse {} -> return expr
+  ExpressionHole {} -> return expr
+  ExpressionSimpleLambda {} -> simplelambda
+  ExpressionLambda l -> ExpressionLambda <$> checkLambda hintArity l
   where
     goApp :: Application -> Sem r Expression
     goApp = uncurry appHelper . second toList . unfoldApplication'

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Data/Types.hs
@@ -1,6 +1,7 @@
 module Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Types where
 
 import Juvix.Prelude
+import Juvix.Prelude.Pretty
 
 data Arity
   = ArityUnit
@@ -74,3 +75,32 @@ foldArity UnfoldedArity {..} = go _ufoldArityParams
           l = case a of
             ParamExplicit e -> ParamExplicit e
             ParamImplicit -> ParamImplicit
+
+instance HasAtomicity FunctionArity where
+  atomicity = const (Aggregate funFixity)
+
+instance HasAtomicity Arity where
+  atomicity = \case
+    ArityUnit -> Atom
+    ArityUnknown -> Atom
+    ArityFunction f -> atomicity f
+
+instance Pretty ArityParameter where
+  pretty = \case
+    ParamImplicit -> "{𝟙}"
+    ParamExplicit f -> pretty f
+
+instance Pretty FunctionArity where
+  pretty f@(FunctionArity l r) =
+    parensCond (atomParens (const True) (atomicity f) funFixity) (pretty l)
+      <> " → "
+      <> pretty r
+    where
+      parensCond :: Bool -> Doc a -> Doc a
+      parensCond t d = if t then parens d else d
+
+instance Pretty Arity where
+  pretty = \case
+    ArityUnit -> "𝟙"
+    ArityUnknown -> "?"
+    ArityFunction f -> pretty f

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -116,4 +116,7 @@ inductive Box (A : Type) {
 x : Box ((A : Type) → A → A);
 x := b λ {A a := a};
 
+t1 :  {A : Type} → Box ((A : Type) → A → A) → A → A;
+t1 {A} := λ {(b f) := f A};
+
 end;

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -114,6 +114,6 @@ inductive Box (A : Type) {
 };
 
 x : Box ((A : Type) → A → A);
-x := b (λ {A a := a});
+x := b λ {A a := a};
 
 end;

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -109,4 +109,11 @@ zipWith := λ {_ nil _ := nil;
 t : {A : Type} → {B : Type} → ({X : Type} → List X) → List A × List B;
 t := id {({X : Type} → List X) → _} λ { f := f {_} , f {_} };
 
+inductive Box (A : Type) {
+  b : A → Box A;
+};
+
+x : Box ((A : Type) → A → A);
+x := b (λ {A a := a});
+
 end;

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -116,7 +116,7 @@ inductive Box (A : Type) {
 x : Box ((A : Type) → A → A);
 x := b λ {A a := a};
 
-t1 :  {A : Type} → Box ((A : Type) → A → A) → A → A;
+t1 : {A : Type} → Box ((A : Type) → A → A) → A → A;
 t1 {A} := λ {(b f) := f A};
 
 end;


### PR DESCRIPTION
Depends on #1538.

The following fails to arity check:
```
inductive Box (A : Type) {
  b : A → Box A;
};

x : Box ((A : Type) → A → A);
x := b λ {A a := a};
```

The issue is that when arity checking an application, we were first checking the arguments and then adding the holes. As an unwanted consequence, the arguments could be assigned an incorrect arity. Now this is fixed

The pr also includes pretty printing for arities, which was useful during the debugging.