### PR TITLE
JuvixReg

### DIFF
--- a/src/Juvix/Compiler/Asm/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Asm/Data/InfoTable.hs
@@ -1,6 +1,12 @@
-module Juvix.Compiler.Asm.Data.InfoTable where
+module Juvix.Compiler.Asm.Data.InfoTable
+  ( module Juvix.Compiler.Asm.Data.InfoTable,
+    module Juvix.Compiler.Asm.Language.Rep,
+    module Juvix.Compiler.Asm.Language.Type,
+  )
+where
 
 import Juvix.Compiler.Asm.Language
+import Juvix.Compiler.Asm.Language.Rep
 import Juvix.Compiler.Asm.Language.Type
 
 data InfoTable = InfoTable
@@ -44,30 +50,6 @@ data InductiveInfo = InductiveInfo
     _inductiveKind :: Type,
     _inductiveConstructors :: [ConstructorInfo]
   }
-
--- | Memory representation of a constructor.
-data MemRep
-  = -- | Standard representation of a constructor: [tag, field 0, .., field n]
-    MemRepConstr
-  | -- | A constructor with zero fields (arguments) can be represented as an
-    -- unboxed tag.
-    MemRepTag
-  | -- | If a constructor is the only non-zero-field constructor in its inductive
-    -- type, then it can be represented as a tagless tuple (the tag is not needed
-    -- to distinguish from other unboxed tag constructors)
-    MemRepTuple
-  | -- | If a zero-field constructor is the only constructor in its inductive
-    -- type, then it's a unit and can be omitted altogether.
-    MemRepUnit
-  | -- | If a constructor has exactly one field and there are no other
-    -- constructors in its inductive type (in Haskell, such types are
-    -- "newtypes"), then it can be unpacked and represented by the value of its
-    -- field. If the tags are globally unique, this can be applied even if there
-    -- are other constructors, as long as no two unpacked fields have the same
-    -- type or an untagged representation (we can't distinguish between tuples
-    -- representing constructors of different inductive types because they have
-    -- no tag).
-    MemRepUnpacked
 
 makeLenses ''InfoTable
 makeLenses ''FunctionInfo

--- a/src/Juvix/Compiler/Asm/Error.hs
+++ b/src/Juvix/Compiler/Asm/Error.hs
@@ -3,6 +3,7 @@ module Juvix.Compiler.Asm.Error where
 import Juvix.Compiler.Asm.Language
 import Juvix.Data.PPOutput
 import Text.Megaparsec.Pos qualified as M
+import Text.Show
 
 data AsmError = AsmError
   { _asmErrorLoc :: Maybe Location,
@@ -29,6 +30,9 @@ instance ToGenericError AsmError where
 
 instance Pretty AsmError where
   pretty (AsmError {..}) = pretty _asmErrorMsg
+
+instance Show AsmError where
+  show (AsmError {..}) = fromText _asmErrorMsg
 
 instance HasLoc AsmError where
   getLoc (AsmError {..}) = fromMaybe defaultLoc _asmErrorLoc

--- a/src/Juvix/Compiler/Asm/Extra.hs
+++ b/src/Juvix/Compiler/Asm/Extra.hs
@@ -28,9 +28,7 @@ validateCode tab args = void . recurse sig args
         }
 
 validateFunction :: Member (Error AsmError) r => InfoTable -> FunctionInfo -> Sem r ()
-validateFunction tab fi = validateCode tab args (fi ^. functionCode)
-  where
-    args = HashMap.fromList $ zip [0 ..] (typeArgs (fi ^. functionType))
+validateFunction tab fi = validateCode tab (argumentsFromFunctionInfo fi) (fi ^. functionCode)
 
 validateInfoTable :: Member (Error AsmError) r => InfoTable -> Sem r ()
 validateInfoTable tab = mapM_ (validateFunction tab) (HashMap.elems (tab ^. infoFunctions))

--- a/src/Juvix/Compiler/Asm/Extra/Memory.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Memory.hs
@@ -8,7 +8,6 @@ import Juvix.Compiler.Asm.Error
 import Juvix.Compiler.Asm.Extra.Base
 import Juvix.Compiler.Asm.Extra.Type
 import Juvix.Compiler.Asm.Language
-import Juvix.Compiler.Asm.Language.Type
 import Juvix.Compiler.Asm.Pretty
 import Safe (atMay)
 

--- a/src/Juvix/Compiler/Asm/Extra/Memory.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Memory.hs
@@ -13,6 +13,11 @@ import Safe (atMay)
 
 type Arguments = HashMap Offset Type
 
+argumentsFromFunctionInfo :: FunctionInfo -> Arguments
+argumentsFromFunctionInfo fi =
+  HashMap.fromList $
+    zip [0 ..] (take (fi ^. functionArgsNum) (typeArgs (fi ^. functionType)))
+
 -- | A static representation of JuvixAsm memory providing type information for
 -- memory locations.
 data Memory = Memory
@@ -39,11 +44,17 @@ pushValueStack ty = over memoryValueStack (Stack.push ty)
 popValueStack :: Int -> Memory -> Memory
 popValueStack n = iterateN n (over memoryValueStack Stack.pop)
 
+valueStackHeight :: Memory -> Int
+valueStackHeight mem = length (mem ^. memoryValueStack)
+
 pushTempStack :: Type -> Memory -> Memory
 pushTempStack ty = over memoryTempStack (Stack.push ty)
 
 popTempStack :: Int -> Memory -> Memory
 popTempStack n = iterateN n (over memoryTempStack Stack.pop)
+
+tempStackHeight :: Memory -> Int
+tempStackHeight mem = length (mem ^. memoryTempStack)
 
 -- | Read value stack at index `n` from the top.
 topValueStack :: Int -> Memory -> Maybe Type

--- a/src/Juvix/Compiler/Asm/Extra/Recursors.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Recursors.hs
@@ -1,6 +1,6 @@
 module Juvix.Compiler.Asm.Extra.Recursors
   ( module Juvix.Compiler.Asm.Extra.Recursors,
-    Arguments,
+    module Juvix.Compiler.Asm.Extra.Memory,
   )
 where
 
@@ -22,6 +22,9 @@ data RecursorSig r a = RecursorSig
   }
 
 makeLenses ''RecursorSig
+
+recurseFun :: Member (Error AsmError) r => RecursorSig r a -> FunctionInfo -> Sem r [a]
+recurseFun sig fi = recurse sig (argumentsFromFunctionInfo fi) (fi ^. functionCode)
 
 recurse :: Member (Error AsmError) r => RecursorSig r a -> Arguments -> Code -> Sem r [a]
 recurse sig args = fmap snd . recurse' sig (mkMemory args)

--- a/src/Juvix/Compiler/Asm/Extra/Recursors.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Recursors.hs
@@ -11,7 +11,6 @@ import Juvix.Compiler.Asm.Extra.Base
 import Juvix.Compiler.Asm.Extra.Memory
 import Juvix.Compiler.Asm.Extra.Type
 import Juvix.Compiler.Asm.Language
-import Juvix.Compiler.Asm.Language.Type
 import Juvix.Compiler.Asm.Pretty
 
 -- | Recursor signature. Contains read-only recursor parameters.

--- a/src/Juvix/Compiler/Asm/Extra/Type.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Type.hs
@@ -4,7 +4,6 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Juvix.Compiler.Asm.Data.InfoTable
 import Juvix.Compiler.Asm.Error
 import Juvix.Compiler.Asm.Language
-import Juvix.Compiler.Asm.Language.Type
 import Juvix.Compiler.Asm.Pretty
 
 mkTypeInteger :: Type

--- a/src/Juvix/Compiler/Asm/Language/Rep.hs
+++ b/src/Juvix/Compiler/Asm/Language/Rep.hs
@@ -1,0 +1,66 @@
+module Juvix.Compiler.Asm.Language.Rep where
+
+-- | Memory representation of a constructor.
+data MemRep
+  = -- | Standard representation of a constructor: [tag, field 0, .., field n]
+    MemRepConstr
+  | -- | A constructor with zero fields (arguments) can be represented as an
+    -- unboxed tag.
+    MemRepTag
+  | -- | If a constructor is the only non-zero-field constructor in its inductive
+    -- type, then it can be represented as a tagless tuple (the tag is not needed
+    -- to distinguish from other unboxed tag constructors)
+    MemRepTuple
+  | -- | If a zero-field constructor is the only constructor in its inductive
+    -- type, then it's a unit and can be omitted altogether.
+    MemRepUnit
+  | -- | If a constructor has exactly one field and there are no other
+    -- constructors in its inductive type (in Haskell, such types are
+    -- "newtypes"), then it can be unpacked and represented by the value of its
+    -- field. If the tags are globally unique, this can be applied even if there
+    -- are other constructors, as long as no two unpacked fields have the same
+    -- type or an untagged representation (we can't distinguish between tuples
+    -- representing constructors of different inductive types because they have
+    -- no tag). The argument is the representation of the wrapped value.
+    MemRepUnpacked ValRep
+
+-- | Representation of values.
+data ValRep
+  = -- | Unboxed integer or pointer to boxed integer.
+    ValRepInteger
+  | -- | Unboxed boolean.
+    ValRepBool
+  | -- | Pointer to string.
+    ValRepString
+  | -- | Raw word with arbitrary bit pattern.
+    ValRepWord
+  | -- | Constructor of an inductive type with a given representation.
+    ValRepInd IndRep
+
+-- | Representation of an inductive type.
+data IndRep
+  = -- | Standard representation of an inductive type: all constructors have
+    -- MemRepConstr representation.
+    IndRepStandard
+  | -- | All constructors have MemRepTag representation.
+    IndRepEnum
+  | -- | All constructors have MemRepTag representation, except one which has
+    -- MemRepTuple representation.
+    IndRepEnumRecord
+  | -- | The inductive type has one constructor with MemRepUnpacked
+    -- representation and one or more constructors with MemRepTag
+    -- representation. There are no other constructors. See @IndRepNewtype@.
+    IndRepEnumMaybe ValRep
+  | -- | The inductive type has one constructor with MemRepTuple representation.
+    -- There are no other constructors.
+    IndRepRecord
+  | -- | The inductive type has one constructor with MemRepUnit representation.
+    -- There are no other constructors.
+    IndRepUnit
+  | -- | The inductive type has one constructor with MemRepUnpacked
+    -- representation. There are no other constructors. The argument is the
+    -- representation of the wrapped value.
+    IndRepNewtype ValRep
+  | -- | The constructors can have any representation as long as there is no
+    -- ambiguity arising from unpacking.
+    IndRepMixed

--- a/src/Juvix/Compiler/Asm/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Asm/Pretty/Base.hs
@@ -11,7 +11,6 @@ import Juvix.Compiler.Asm.Data.InfoTable
 import Juvix.Compiler.Asm.Extra.Base
 import Juvix.Compiler.Asm.Interpreter.Base
 import Juvix.Compiler.Asm.Interpreter.RuntimeState
-import Juvix.Compiler.Asm.Language.Type
 import Juvix.Compiler.Asm.Pretty.Options
 import Juvix.Compiler.Core.Pretty.Base qualified as Core
 import Juvix.Data.CodeAnn

--- a/src/Juvix/Compiler/Asm/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromCore.hs
@@ -5,7 +5,6 @@ import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Asm.Data.InfoTable
 import Juvix.Compiler.Asm.Extra.Base
 import Juvix.Compiler.Asm.Language
-import Juvix.Compiler.Asm.Language.Type
 import Juvix.Compiler.Core.Data.BinderList qualified as BL
 import Juvix.Compiler.Core.Data.Stripped.InfoTable qualified as Core
 import Juvix.Compiler.Core.Language.Stripped qualified as Core

--- a/src/Juvix/Compiler/Asm/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromCore.hs
@@ -32,7 +32,9 @@ genCode infoTable fi =
           _functionSymbol = fi ^. Core.functionSymbol,
           _functionArgsNum = fi ^. Core.functionArgsNum,
           _functionType = convertType (fi ^. Core.functionArgsNum) (fi ^. Core.functionType),
-          _functionCode = code
+          _functionCode = code,
+          _functionMaxTempStackHeight = -1, -- computed later
+          _functionMaxValueStackHeight = -1
         }
   where
     unimplemented :: forall a. a

--- a/src/Juvix/Compiler/Asm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource.hs
@@ -71,7 +71,8 @@ declareBuiltins = do
             _inductiveSymbol = sym,
             _inductiveLocation = Just i,
             _inductiveKind = TyDynamic,
-            _inductiveConstructors = constrs
+            _inductiveConstructors = constrs,
+            _inductiveRepresentation = IndRepStandard
           }
       )
   lift $ mapM_ registerConstr constrs
@@ -115,7 +116,9 @@ statementFunction = do
             _functionLocation = Just i,
             _functionCode = [],
             _functionArgsNum = length argtys,
-            _functionType = mkTypeFun argtys (fromMaybe TyDynamic mrty)
+            _functionType = mkTypeFun argtys (fromMaybe TyDynamic mrty),
+            _functionMaxValueStackHeight = -1, -- computed later
+            _functionMaxTempStackHeight = -1
           }
   lift $ registerFunction fi0
   mcode <- (kw kwSemicolon $> Nothing) <|> optional (braces parseCode)
@@ -153,7 +156,8 @@ statementInductive = do
             _inductiveLocation = Just i,
             _inductiveSymbol = sym,
             _inductiveKind = TyDynamic,
-            _inductiveConstructors = []
+            _inductiveConstructors = [],
+            _inductiveRepresentation = IndRepStandard
           }
   lift $ registerInductive ii
   ctrs <- braces $ P.sepEndBy (constrDecl sym) (kw kwSemicolon)

--- a/src/Juvix/Compiler/Asm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource.hs
@@ -11,7 +11,6 @@ import Juvix.Compiler.Asm.Data.InfoTableBuilder
 import Juvix.Compiler.Asm.Extra.Base
 import Juvix.Compiler.Asm.Extra.Type
 import Juvix.Compiler.Asm.Language
-import Juvix.Compiler.Asm.Language.Type
 import Juvix.Compiler.Asm.Translation.FromSource.Lexer
 import Juvix.Parser.Error
 import Text.Megaparsec qualified as P

--- a/src/Juvix/Compiler/Reg/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Reg/Data/InfoTable.hs
@@ -1,13 +1,6 @@
-module Juvix.Compiler.Asm.Data.InfoTable
-  ( module Juvix.Compiler.Asm.Data.InfoTable,
-    module Juvix.Compiler.Asm.Language.Rep,
-    module Juvix.Compiler.Asm.Language.Type,
-  )
-where
+module Juvix.Compiler.Reg.Data.InfoTable where
 
-import Juvix.Compiler.Asm.Language
-import Juvix.Compiler.Asm.Language.Rep
-import Juvix.Compiler.Asm.Language.Type
+import Juvix.Compiler.Reg.Language
 
 data InfoTable = InfoTable
   { _infoFunctions :: HashMap Symbol FunctionInfo,
@@ -20,13 +13,9 @@ data FunctionInfo = FunctionInfo
   { _functionName :: Text,
     _functionLocation :: Maybe Location,
     _functionSymbol :: Symbol,
-    -- | `_functionArgsNum` may be different from `length (typeArgs
-    -- (_functionType))` only if it is 0 (the "function" takes zero arguments)
-    -- and the result is a function.
     _functionArgsNum :: Int,
-    _functionType :: Type,
-    _functionMaxValueStackHeight :: Int,
-    _functionMaxTempStackHeight :: Int,
+    _functionStackVarsNum :: Int,
+    _functionTempVarsNum :: Int,
     _functionCode :: Code
   }
 
@@ -34,13 +23,7 @@ data ConstructorInfo = ConstructorInfo
   { _constructorName :: Text,
     _constructorLocation :: Maybe Location,
     _constructorTag :: Tag,
-    -- | `_constructorArgsNum` should always be equal to `length (typeArgs
-    -- (_constructorType))`. It is stored separately mainly for the benefit of
-    -- the interpreter (so it does not have to recompute it every time).
     _constructorArgsNum :: Int,
-    -- | Constructor types are assumed to be fully uncurried, i.e., `uncurryType
-    -- _constructorType == _constructorType`
-    _constructorType :: Type,
     _constructorInductive :: Symbol,
     _constructorRepresentation :: MemRep
   }
@@ -49,7 +32,6 @@ data InductiveInfo = InductiveInfo
   { _inductiveName :: Text,
     _inductiveLocation :: Maybe Location,
     _inductiveSymbol :: Symbol,
-    _inductiveKind :: Type,
     _inductiveConstructors :: [ConstructorInfo],
     _inductiveRepresentation :: IndRep
   }

--- a/src/Juvix/Compiler/Reg/Language.hs
+++ b/src/Juvix/Compiler/Reg/Language.hs
@@ -1,0 +1,160 @@
+module Juvix.Compiler.Reg.Language
+  ( module Juvix.Compiler.Reg.Language,
+    module Juvix.Compiler.Reg.Language.Base,
+  )
+where
+
+import Juvix.Compiler.Reg.Language.Base
+
+data Type
+  = -- | Unboxed integer or pointer to boxed integer.
+    TyInteger
+  | -- | Unboxed boolean.
+    TyBool
+  | -- | Pointer to a string.
+    TyString
+  | -- | A raw word with arbitrary bit pattern.
+    TyWord
+  | -- | A pointer to a constructor.
+    TyPtr
+
+data Value
+  = ConstInt Integer
+  | ConstBool Bool
+  | ConstString Text
+  | ConstUnit
+  | ConstVoid
+  | CRef ConstrField
+  | VRef VarRef
+
+type Index = Int
+
+-- | Reference to a constructor field (argument).
+data ConstrField = ConstrField
+  { -- | Tag of the constructor being referenced.
+    _constrFieldTag :: Tag,
+    -- | Memory representation of the constructor.
+    _constrFieldMemRep :: MemRep,
+    -- | Location where the data is stored.
+    _constrFieldRef :: VarRef,
+    _constrFieldIndex :: Index
+  }
+
+data VarGroup = VarGroupArgs | VarGroupStack | VarGroupTemp
+
+data VarRef = VarRef
+  { _varRefGroup :: VarGroup,
+    _varRefIndex :: Index,
+    _varRefType :: Type
+  }
+
+data Instruction
+  = Binop BinaryOp
+  | Assign InstrAssign
+  | Trace InstrTrace
+  | Dump
+  | Failure InstrFailure
+  | Alloc InstrAlloc
+  | AllocClosure InstrAllocClosure
+  | ExtendClosure InstrExtendClosure
+  | Call InstrCall
+  | CallClosures InstrCallClosures
+  | Return
+  | Branch InstrBranch
+  | Case InstrCase
+
+type Code = [Instruction]
+
+data BinaryOp = BinaryOp
+  { _binaryOpCode :: Opcode,
+    _binaryOpResult :: VarRef,
+    _binaryOpArg1 :: Value,
+    _binaryOpArg2 :: Value
+  }
+
+data Opcode
+  = OpIntAdd
+  | OpIntSub
+  | OpIntMul
+  | OpIntDiv
+  | OpIntMod
+  | OpIntLt
+  | OpIntLe
+  | OpEq
+
+data InstrAssign = InstrAssign
+  { _instrAssignResult :: VarRef,
+    _instrAssignValue :: Value
+  }
+
+newtype InstrTrace = InstrTrace
+  { _instrTraceValue :: Value
+  }
+
+newtype InstrFailure = InstrFailure
+  { _instrFailure :: Value
+  }
+
+data InstrAlloc = InstrAlloc
+  { _instrAllocResult :: VarRef,
+    _instrAllocTag :: Tag,
+    _instrAllocMemRep :: MemRep,
+    _instrAllocArgs :: [Value],
+    _instrAllocLiveVars :: [VarRef]
+  }
+
+data InstrAllocClosure = InstrAllocClosure
+  { _instrAllocClosureResult :: VarRef,
+    _instrAllocClosureSymbol :: Symbol,
+    _instrAllocClosureExpectedArgsNum :: Int,
+    _instrAllocClosureArgs :: [Value],
+    _instrAllocClosureLiveVars :: [VarRef]
+  }
+
+data InstrExtendClosure = InstrExtendClosure
+  { _instrExtendClosureResult :: VarRef,
+    _instrExtendClosureArgs :: [Value],
+    _instrExtendClosureLiveVars :: [VarRef]
+  }
+
+data CallType = CallFun Symbol | CallClosure VarRef
+
+data InstrCall = InstrCall
+  { _instrCallResult :: VarRef,
+    _instrCallType :: CallType,
+    _instrCallIsTail :: Bool,
+    _instrCallArgs :: [Value],
+    -- | Variables live at the point of the call. If the call is not
+    -- tail-recursive, live variables need to be saved before the call and
+    -- restored after it.
+    _instrCallLiveVars :: [VarRef]
+  }
+
+data InstrCallClosures = InstrCallClosures
+  { _instrCallClosuresResult :: VarRef,
+    _instrCallClosuresClosure :: VarRef,
+    _instrCallClosuresIsTail :: Bool,
+    _instrCallClosuresArgs :: [Value],
+    _instrCallClosuresLiveVars :: [VarRef]
+  }
+
+data InstrBranch = InstrBranch
+  { _instrBranchValue :: Value,
+    _instrBranchTrue :: Code,
+    _instrBranchFalse :: Code
+  }
+
+data InstrCase = InstrCase
+  { _instrCaseValue :: Value,
+    _instrCaseInductive :: Symbol,
+    _instrCaseIndRep :: IndRep,
+    _instrCaseBranches :: [CaseBranch],
+    _instrCaseDefault :: Maybe Code
+  }
+
+data CaseBranch = CaseBranch
+  { _caseBranchTag :: Tag,
+    -- | Memory representation of the constructor corresponding to the branch.
+    _caseBranchMemRep :: MemRep,
+    _caseBranchCode :: Code
+  }

--- a/src/Juvix/Compiler/Reg/Language.hs
+++ b/src/Juvix/Compiler/Reg/Language.hs
@@ -6,18 +6,6 @@ where
 
 import Juvix.Compiler.Reg.Language.Base
 
-data Type
-  = -- | Unboxed integer or pointer to boxed integer.
-    TyInteger
-  | -- | Unboxed boolean.
-    TyBool
-  | -- | Pointer to a string.
-    TyString
-  | -- | A raw word with arbitrary bit pattern.
-    TyWord
-  | -- | A pointer to a constructor.
-    TyPtr
-
 data Value
   = ConstInt Integer
   | ConstBool Bool
@@ -44,12 +32,12 @@ data VarGroup = VarGroupArgs | VarGroupStack | VarGroupTemp
 
 data VarRef = VarRef
   { _varRefGroup :: VarGroup,
-    _varRefIndex :: Index,
-    _varRefType :: Type
+    _varRefIndex :: Index
   }
 
 data Instruction
-  = Binop BinaryOp
+  = Nop -- no operation
+  | Binop BinaryOp
   | Assign InstrAssign
   | Trace InstrTrace
   | Dump
@@ -113,6 +101,7 @@ data InstrAllocClosure = InstrAllocClosure
 
 data InstrExtendClosure = InstrExtendClosure
   { _instrExtendClosureResult :: VarRef,
+    _instrExtendClosureValue :: VarRef,
     _instrExtendClosureArgs :: [Value],
     _instrExtendClosureLiveVars :: [VarRef]
   }
@@ -132,8 +121,8 @@ data InstrCall = InstrCall
 
 data InstrCallClosures = InstrCallClosures
   { _instrCallClosuresResult :: VarRef,
-    _instrCallClosuresClosure :: VarRef,
     _instrCallClosuresIsTail :: Bool,
+    _instrCallClosuresValue :: VarRef,
     _instrCallClosuresArgs :: [Value],
     _instrCallClosuresLiveVars :: [VarRef]
   }

--- a/src/Juvix/Compiler/Reg/Language/Base.hs
+++ b/src/Juvix/Compiler/Reg/Language/Base.hs
@@ -5,4 +5,4 @@ module Juvix.Compiler.Reg.Language.Base
 where
 
 import Juvix.Compiler.Asm.Language.Rep
-import Juvix.Compiler.Core.Language.Base hiding (Index, BuiltinOp(..))
+import Juvix.Compiler.Core.Language.Base hiding (BuiltinOp (..), Index)

--- a/src/Juvix/Compiler/Reg/Language/Base.hs
+++ b/src/Juvix/Compiler/Reg/Language/Base.hs
@@ -1,0 +1,8 @@
+module Juvix.Compiler.Reg.Language.Base
+  ( module Juvix.Compiler.Core.Language.Base,
+    module Juvix.Compiler.Asm.Language.Rep,
+  )
+where
+
+import Juvix.Compiler.Asm.Language.Rep
+import Juvix.Compiler.Core.Language.Base hiding (Index, BuiltinOp(..))

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -1,7 +1,276 @@
 module Juvix.Compiler.Reg.Translation.FromAsm where
 
+import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Asm.Data.InfoTable qualified as Asm
+import Juvix.Compiler.Asm.Error qualified as Asm
+import Juvix.Compiler.Asm.Extra.Recursors qualified as Asm
 import Juvix.Compiler.Asm.Language qualified as Asm
+import Juvix.Compiler.Reg.Data.InfoTable
 import Juvix.Compiler.Reg.Language
 
-fromAsm :: Asm.Code -> Code
-fromAsm = undefined
+fromAsm :: Asm.InfoTable -> InfoTable
+fromAsm tab =
+  InfoTable
+    { _infoFunctions = HashMap.map convertFun (tab ^. Asm.infoFunctions),
+      _infoConstrs = HashMap.map convertConstr (tab ^. Asm.infoConstrs),
+      _infoInductives = HashMap.map convertInductive (tab ^. Asm.infoInductives),
+      _infoMainFunction = tab ^. Asm.infoMainFunction
+    }
+  where
+    convertFun :: Asm.FunctionInfo -> FunctionInfo
+    convertFun fi =
+      FunctionInfo
+        { _functionName = fi ^. Asm.functionName,
+          _functionLocation = fi ^. Asm.functionLocation,
+          _functionSymbol = fi ^. Asm.functionSymbol,
+          _functionArgsNum = fi ^. Asm.functionArgsNum,
+          _functionStackVarsNum = fi ^. Asm.functionMaxValueStackHeight,
+          _functionTempVarsNum = fi ^. Asm.functionMaxTempStackHeight,
+          _functionCode = fromAsmFun tab fi
+        }
+
+    convertConstr :: Asm.ConstructorInfo -> ConstructorInfo
+    convertConstr ci =
+      ConstructorInfo
+        { _constructorName = ci ^. Asm.constructorName,
+          _constructorLocation = ci ^. Asm.constructorLocation,
+          _constructorTag = ci ^. Asm.constructorTag,
+          _constructorArgsNum = ci ^. Asm.constructorArgsNum,
+          _constructorInductive = ci ^. Asm.constructorInductive,
+          _constructorRepresentation = ci ^. Asm.constructorRepresentation
+        }
+
+    convertInductive :: Asm.InductiveInfo -> InductiveInfo
+    convertInductive ii =
+      InductiveInfo
+        { _inductiveName = ii ^. Asm.inductiveName,
+          _inductiveLocation = ii ^. Asm.inductiveLocation,
+          _inductiveSymbol = ii ^. Asm.inductiveSymbol,
+          _inductiveConstructors = map convertConstr (ii ^. Asm.inductiveConstructors),
+          _inductiveRepresentation = ii ^. Asm.inductiveRepresentation
+        }
+
+fromAsmFun ::
+  Asm.InfoTable ->
+  Asm.FunctionInfo ->
+  Code
+fromAsmFun tab fi =
+  case run $ runError $ Asm.recurseFun sig fi of
+    Left err -> error (show err)
+    Right code -> code
+  where
+    sig :: Asm.RecursorSig (Error Asm.AsmError ': r) Instruction
+    sig =
+      Asm.RecursorSig
+        { _recursorInfoTable = tab,
+          _recurseInstr = fromAsmInstr tab,
+          _recurseBranch = fromAsmBranch,
+          _recurseCase = fromAsmCase tab
+        }
+
+fromAsmInstr ::
+  Asm.InfoTable ->
+  Asm.Memory ->
+  Asm.CmdInstr ->
+  Sem r Instruction
+fromAsmInstr tab mem Asm.CmdInstr {..} =
+  case _cmdInstrInstruction of
+    Asm.IntAdd -> return $ mkBinop OpIntAdd
+    Asm.IntSub -> return $ mkBinop OpIntSub
+    Asm.IntMul -> return $ mkBinop OpIntMul
+    Asm.IntDiv -> return $ mkBinop OpIntDiv
+    Asm.IntMod -> return $ mkBinop OpIntMod
+    Asm.IntLt -> return $ mkBinop OpIntLt
+    Asm.IntLe -> return $ mkBinop OpIntLe
+    Asm.ValEq -> return $ mkBinop OpEq
+    Asm.Push val -> return $ mkAssign (VarRef VarGroupStack (n + 1)) (mkValue val)
+    Asm.Pop -> return Nop
+    Asm.PushTemp ->
+      return $
+        mkAssign
+          (VarRef VarGroupTemp (Asm.tempStackHeight mem))
+          (VRef $ VarRef VarGroupStack n)
+    Asm.PopTemp -> return Nop
+    Asm.Trace -> return $ Trace $ InstrTrace (VRef $ VarRef VarGroupStack n)
+    Asm.Dump -> return Dump
+    Asm.Failure -> return $ Failure $ InstrFailure (VRef $ VarRef VarGroupStack n)
+    Asm.AllocConstr tag -> return $ mkAlloc tag
+    Asm.AllocClosure x -> return $ mkAllocClosure x
+    Asm.ExtendClosure x -> return $ mkExtendClosure x
+    Asm.Call x -> return $ mkCall False x
+    Asm.TailCall x -> return $ mkCall True x
+    Asm.CallClosures x -> return $ mkCallClosures False x
+    Asm.TailCallClosures x -> return $ mkCallClosures True x
+    Asm.Return -> return Return
+  where
+    -- `n` is the index of the top of the value stack *before* executing the
+    -- instruction
+    n :: Int
+    n = Asm.valueStackHeight mem - 1
+
+    -- Live variables *after* executing the instruction. TODO: proper liveness
+    -- analysis in JuvixAsm.
+    liveVars :: Int -> [VarRef]
+    liveVars k =
+      map (VarRef VarGroupStack) [0 .. n - k]
+        ++ map (VarRef VarGroupTemp) [0 .. Asm.tempStackHeight mem]
+        ++ map (VarRef VarGroupArgs) [0 .. (mem ^. Asm.memoryArgsNum)]
+
+    getArgs :: Int -> Int -> [Value]
+    getArgs s k = map (\i -> VRef $ VarRef VarGroupStack (n - i)) [s .. (s + k - 1)]
+
+    mkBinop :: Opcode -> Instruction
+    mkBinop op =
+      Binop
+        ( BinaryOp
+            { _binaryOpCode = op,
+              _binaryOpResult = VarRef VarGroupStack n,
+              _binaryOpArg1 = VRef $ VarRef VarGroupStack n,
+              _binaryOpArg2 = VRef $ VarRef VarGroupStack (n - 1)
+            }
+        )
+
+    mkAssign :: VarRef -> Value -> Instruction
+    mkAssign tgt src = Assign (InstrAssign tgt src)
+
+    mkValue :: Asm.Value -> Value
+    mkValue = \case
+      Asm.ConstInt v -> ConstInt v
+      Asm.ConstBool v -> ConstBool v
+      Asm.ConstString v -> ConstString v
+      Asm.ConstUnit -> ConstUnit
+      Asm.ConstVoid -> ConstVoid
+      Asm.Ref mv -> case mv of
+        Asm.DRef dref -> VRef $ mkVar dref
+        Asm.ConstrRef Asm.Field {..} ->
+          CRef $
+            ConstrField
+              { _constrFieldTag = _fieldTag,
+                _constrFieldRef = mkVar _fieldRef,
+                _constrFieldIndex = _fieldOffset,
+                _constrFieldMemRep = ci ^. Asm.constructorRepresentation
+              }
+          where
+            ci = fromJust impossible $ HashMap.lookup _fieldTag (tab ^. Asm.infoConstrs)
+
+    mkVar :: Asm.DirectRef -> VarRef
+    mkVar = \case
+      Asm.StackRef -> VarRef VarGroupStack n
+      Asm.ArgRef idx -> VarRef VarGroupArgs idx
+      Asm.TempRef idx -> VarRef VarGroupTemp idx
+
+    mkAlloc :: Tag -> Instruction
+    mkAlloc tag =
+      Alloc $
+        InstrAlloc
+          { _instrAllocTag = tag,
+            _instrAllocResult = VarRef VarGroupStack n,
+            _instrAllocArgs = getArgs 0 (ci ^. Asm.constructorArgsNum),
+            _instrAllocMemRep = ci ^. Asm.constructorRepresentation,
+            _instrAllocLiveVars = liveVars (ci ^. Asm.constructorArgsNum)
+          }
+      where
+        ci = fromJust impossible $ HashMap.lookup tag (tab ^. Asm.infoConstrs)
+
+    mkAllocClosure :: Asm.InstrAllocClosure -> Instruction
+    mkAllocClosure Asm.InstrAllocClosure {..} =
+      AllocClosure $
+        InstrAllocClosure
+          { _instrAllocClosureSymbol = fi ^. Asm.functionSymbol,
+            _instrAllocClosureResult = VarRef VarGroupStack n,
+            _instrAllocClosureExpectedArgsNum = fi ^. Asm.functionArgsNum,
+            _instrAllocClosureArgs = getArgs 0 _allocClosureArgsNum,
+            _instrAllocClosureLiveVars = liveVars _allocClosureArgsNum
+          }
+      where
+        fi = fromJust impossible $ HashMap.lookup _allocClosureFunSymbol (tab ^. Asm.infoFunctions)
+
+    mkExtendClosure :: Asm.InstrExtendClosure -> Instruction
+    mkExtendClosure Asm.InstrExtendClosure {..} =
+      ExtendClosure $
+        InstrExtendClosure
+          { _instrExtendClosureResult = VarRef VarGroupStack n,
+            _instrExtendClosureValue = VarRef VarGroupStack n,
+            _instrExtendClosureArgs = getArgs 1 _extendClosureArgsNum,
+            _instrExtendClosureLiveVars = liveVars (_extendClosureArgsNum + 1)
+          }
+
+    mkCall :: Bool -> Asm.InstrCall -> Instruction
+    mkCall isTail Asm.InstrCall {..} =
+      Call $
+        InstrCall
+          { _instrCallResult = VarRef VarGroupStack n,
+            _instrCallType = ct,
+            _instrCallIsTail = isTail,
+            _instrCallArgs = getArgs s _callArgsNum,
+            _instrCallLiveVars = liveVars (_callArgsNum + s)
+          }
+      where
+        ct = case _callType of
+          Asm.CallFun f -> CallFun f
+          Asm.CallClosure -> CallClosure (VarRef VarGroupStack n)
+        s = case _callType of
+          Asm.CallFun {} -> 0
+          Asm.CallClosure -> 1
+
+    mkCallClosures :: Bool -> Asm.InstrCallClosures -> Instruction
+    mkCallClosures isTail Asm.InstrCallClosures {..} =
+      CallClosures $
+        InstrCallClosures
+          { _instrCallClosuresResult = VarRef VarGroupStack n,
+            _instrCallClosuresValue = VarRef VarGroupStack n,
+            _instrCallClosuresIsTail = isTail,
+            _instrCallClosuresArgs = getArgs 1 _callClosuresArgsNum,
+            _instrCallClosuresLiveVars = liveVars _callClosuresArgsNum
+          }
+
+fromAsmBranch ::
+  Asm.Memory ->
+  Asm.CmdBranch ->
+  Code ->
+  Code ->
+  Sem r Instruction
+fromAsmBranch mem Asm.CmdBranch {} codeTrue codeFalse =
+  return $
+    Branch $
+      InstrBranch
+        { _instrBranchValue = VRef $ VarRef VarGroupStack (Asm.valueStackHeight mem - 1),
+          _instrBranchTrue = codeTrue,
+          _instrBranchFalse = codeFalse
+        }
+
+fromAsmCase ::
+  Asm.InfoTable ->
+  Asm.Memory ->
+  Asm.CmdCase ->
+  [Code] ->
+  Maybe Code ->
+  Sem r Instruction
+fromAsmCase tab mem Asm.CmdCase {..} brs def =
+  return $
+    Case $
+      InstrCase
+        { _instrCaseValue = VRef $ VarRef VarGroupStack (Asm.valueStackHeight mem - 1),
+          _instrCaseInductive = _cmdCaseInductive,
+          _instrCaseIndRep = ii ^. inductiveRepresentation,
+          _instrCaseBranches =
+            zipWithExact
+              ( \br code ->
+                  let tag = br ^. Asm.caseBranchTag
+                      ci =
+                        fromJust impossible $
+                          HashMap.lookup tag (tab ^. Asm.infoConstrs)
+                   in CaseBranch
+                        { _caseBranchTag = tag,
+                          _caseBranchMemRep = ci ^. constructorRepresentation,
+                          _caseBranchCode = code
+                        }
+              )
+              _cmdCaseBranches
+              brs,
+          _instrCaseDefault = def
+        }
+  where
+    ii =
+      fromJust impossible $
+        HashMap.lookup _cmdCaseInductive (tab ^. Asm.infoInductives)

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -1,0 +1,7 @@
+module Juvix.Compiler.Reg.Translation.FromAsm where
+
+import Juvix.Compiler.Asm.Language qualified as Asm
+import Juvix.Compiler.Reg.Language
+
+fromAsm :: Asm.Code -> Code
+fromAsm = undefined

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -75,14 +75,7 @@ fromAsmInstr ::
   Sem r Instruction
 fromAsmInstr tab mem Asm.CmdInstr {..} =
   case _cmdInstrInstruction of
-    Asm.IntAdd -> return $ mkBinop OpIntAdd
-    Asm.IntSub -> return $ mkBinop OpIntSub
-    Asm.IntMul -> return $ mkBinop OpIntMul
-    Asm.IntDiv -> return $ mkBinop OpIntDiv
-    Asm.IntMod -> return $ mkBinop OpIntMod
-    Asm.IntLt -> return $ mkBinop OpIntLt
-    Asm.IntLe -> return $ mkBinop OpIntLe
-    Asm.ValEq -> return $ mkBinop OpEq
+    Asm.Binop op -> return $ mkBinop (mkOpcode op)
     Asm.Push val -> return $ mkAssign (VarRef VarGroupStack (n + 1)) (mkValue val)
     Asm.Pop -> return Nop
     Asm.PushTemp ->
@@ -129,6 +122,17 @@ fromAsmInstr tab mem Asm.CmdInstr {..} =
               _binaryOpArg2 = VRef $ VarRef VarGroupStack (n - 1)
             }
         )
+
+    mkOpcode :: Asm.Opcode -> Opcode
+    mkOpcode = \case
+      Asm.IntAdd -> OpIntAdd
+      Asm.IntSub -> OpIntSub
+      Asm.IntMul -> OpIntMul
+      Asm.IntDiv -> OpIntDiv
+      Asm.IntMod -> OpIntMod
+      Asm.IntLt -> OpIntLt
+      Asm.IntLe -> OpIntLe
+      Asm.ValEq -> OpEq
 
     mkAssign :: VarRef -> Value -> Instruction
     mkAssign tgt src = Assign (InstrAssign tgt src)


### PR DESCRIPTION
# Description

JuvixReg is a "register machine" representation of JuvixAsm. The translation from JuvixAsm to C / LLVM is straightforward. JuvixReg provides an intermediate data structure which makes it clear what is needed for a translation from JuvixAsm to a variable/register-based language.

# Checklist:

- [x] Code datatype
- [x] Translation from JuvixAsm
