### PR TITLE
Keywords refactor

### DIFF
--- a/src/Juvix/Compiler/Asm/Keywords.hs
+++ b/src/Juvix/Compiler/Asm/Keywords.hs
@@ -9,8 +9,6 @@ import Juvix.Data.Keyword
 import Juvix.Data.Keyword.All
   ( kwArg,
     kwColon,
-    -- are these different?
-
     kwDollar,
     kwFalse,
     kwFun,

--- a/src/Juvix/Compiler/Asm/Keywords.hs
+++ b/src/Juvix/Compiler/Asm/Keywords.hs
@@ -1,0 +1,43 @@
+module Juvix.Compiler.Asm.Keywords
+  ( module Juvix.Compiler.Asm.Keywords,
+    module Juvix.Data.Keyword,
+    module Juvix.Data.Keyword.All,
+  )
+where
+
+import Juvix.Data.Keyword
+import Juvix.Data.Keyword.All
+  ( kwArg,
+    kwColon,
+    -- are these different?
+
+    kwDollar,
+    kwFalse,
+    kwFun,
+    kwInductive,
+    kwRightArrow,
+    kwSemicolon,
+    kwStar,
+    kwTmp,
+    kwTrue,
+    kwUnit,
+    kwVoid,
+  )
+import Juvix.Prelude
+
+allKeywordStrings :: HashSet Text
+allKeywordStrings = keywordsStrings allKeywords
+
+allKeywords :: [Keyword]
+allKeywords =
+  [ kwFun,
+    kwInductive,
+    kwColon,
+    kwSemicolon,
+    kwStar,
+    kwRightArrow,
+    kwTrue,
+    kwFalse,
+    kwArg,
+    kwTmp
+  ]

--- a/src/Juvix/Compiler/Asm/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource/Lexer.hs
@@ -35,14 +35,8 @@ number = number' integer
 string :: Member (Reader ParserParams) r => ParsecS r (Text, Interval)
 string = lexemeInterval string'
 
-keyword :: Text -> ParsecS r ()
-keyword = keyword' space
-
 kw :: Members '[Reader ParserParams] r => Keyword -> ParsecS r ()
 kw k = void $ lexeme $ kw' k
-
-keywordSymbol :: Text -> ParsecS r ()
-keywordSymbol = keywordSymbol' space
 
 identifier :: ParsecS r Text
 identifier = lexeme bareIdentifier

--- a/src/Juvix/Compiler/Asm/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource/Lexer.hs
@@ -1,10 +1,11 @@
 module Juvix.Compiler.Asm.Translation.FromSource.Lexer
   ( module Juvix.Compiler.Asm.Translation.FromSource.Lexer,
     module Juvix.Parser.Lexer,
+    module Juvix.Compiler.Asm.Keywords,
   )
 where
 
-import Juvix.Extra.Strings qualified as Str
+import Juvix.Compiler.Asm.Keywords
 import Juvix.Parser.Lexer
 import Juvix.Prelude
 import Text.Megaparsec as P hiding (sepBy1, sepEndBy1, some)
@@ -37,6 +38,9 @@ string = lexemeInterval string'
 keyword :: Text -> ParsecS r ()
 keyword = keyword' space
 
+kw :: Members '[Reader ParserParams] r => Keyword -> ParsecS r ()
+kw k = void $ lexeme $ kw' k
+
 keywordSymbol :: Text -> ParsecS r ()
 keywordSymbol = keywordSymbol' space
 
@@ -47,24 +51,10 @@ identifierL :: Member (Reader ParserParams) r => ParsecS r (Text, Interval)
 identifierL = lexemeInterval bareIdentifier
 
 bareIdentifier :: ParsecS r Text
-bareIdentifier = rawIdentifier' (`elem` specialSymbols) allKeywords
+bareIdentifier = rawIdentifier' (`elem` specialSymbols) allKeywordStrings
 
 specialSymbols :: [Char]
 specialSymbols = ":"
-
-allKeywords :: [ParsecS r ()]
-allKeywords =
-  [ kwFun,
-    kwInductive,
-    kwColon,
-    kwSemicolon,
-    kwStar,
-    kwArrow,
-    kwTrue,
-    kwFalse,
-    kwArg,
-    kwTmp
-  ]
 
 dot :: ParsecS r ()
 dot = symbol "."
@@ -98,42 +88,3 @@ braces = between (symbol "{") (symbol "}")
 
 brackets :: ParsecS r a -> ParsecS r a
 brackets = between (symbol "[") (symbol "]")
-
-kwFun :: ParsecS r ()
-kwFun = keyword Str.fun_
-
-kwInductive :: ParsecS r ()
-kwInductive = keyword Str.inductive
-
-kwColon :: ParsecS r ()
-kwColon = keyword Str.colon
-
-kwSemicolon :: ParsecS r ()
-kwSemicolon = keyword Str.semicolon
-
-kwStar :: ParsecS r ()
-kwStar = keyword Str.mul
-
-kwDollar :: ParsecS r ()
-kwDollar = keyword Str.dollar
-
-kwArrow :: ParsecS r ()
-kwArrow = keyword Str.toAscii <|> keyword Str.toUnicode
-
-kwTrue :: ParsecS r ()
-kwTrue = keyword Str.true_
-
-kwFalse :: ParsecS r ()
-kwFalse = keyword Str.false_
-
-kwUnit :: ParsecS r ()
-kwUnit = keyword Str.unit
-
-kwVoid :: ParsecS r ()
-kwVoid = keyword Str.void
-
-kwArg :: ParsecS r ()
-kwArg = keyword Str.arg_
-
-kwTmp :: ParsecS r ()
-kwTmp = keyword Str.tmp_

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -1,0 +1,85 @@
+module Juvix.Compiler.Concrete.Keywords
+  ( module Juvix.Compiler.Concrete.Keywords,
+    module Juvix.Data.Keyword,
+    module Juvix.Data.Keyword.All,
+  )
+where
+
+import Juvix.Data.Keyword
+import Juvix.Data.Keyword.All
+  ( -- reserved
+
+    -- extra
+    cBackend,
+    ghc,
+    kwAssign,
+    kwAxiom,
+    kwBuiltin,
+    kwColon,
+    kwColonOmega,
+    kwColonOne,
+    kwColonZero,
+    kwCompile,
+    kwEnd,
+    kwForeign,
+    kwHiding,
+    kwHole,
+    kwImport,
+    kwIn,
+    kwInductive,
+    kwInfix,
+    kwInfixl,
+    kwInfixr,
+    kwLambda,
+    kwLet,
+    kwMapsTo,
+    kwModule,
+    kwOpen,
+    kwPositive,
+    kwPostfix,
+    kwPublic,
+    kwRightArrow,
+    kwSemicolon,
+    kwTerminating,
+    kwType,
+    kwUsing,
+    kwWhere,
+    kwWildcard,
+  )
+import Juvix.Prelude
+
+allKeywordStrings :: HashSet Text
+allKeywordStrings = keywordsStrings allKeywords
+
+allKeywords :: [Keyword]
+allKeywords =
+  [ kwAssign,
+    kwAxiom,
+    kwColon,
+    kwColonOmega,
+    kwColonOne,
+    kwColonZero,
+    kwCompile,
+    kwEnd,
+    kwForeign,
+    kwHiding,
+    kwHole,
+    kwImport,
+    kwIn,
+    kwInductive,
+    kwInfix,
+    kwInfixl,
+    kwInfixr,
+    kwLambda,
+    kwLet,
+    kwModule,
+    kwOpen,
+    kwPostfix,
+    kwPublic,
+    kwRightArrow,
+    kwSemicolon,
+    kwType,
+    kwUsing,
+    kwWhere,
+    kwWildcard
+  ]

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -1,6 +1,8 @@
 module Juvix.Compiler.Concrete.Translation.FromSource.Lexer
   ( module Juvix.Compiler.Concrete.Translation.FromSource.Lexer,
     module Juvix.Parser.Lexer,
+    module Juvix.Data.Keyword,
+    module Juvix.Compiler.Concrete.Keywords,
   )
 where
 
@@ -9,6 +11,8 @@ import GHC.Unicode
 import Juvix.Compiler.Concrete.Data.ParsedInfoTableBuilder
 import Juvix.Compiler.Concrete.Extra hiding (Pos, space, string')
 import Juvix.Compiler.Concrete.Extra qualified as P
+import Juvix.Compiler.Concrete.Keywords
+import Juvix.Data.Keyword
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Parser.Lexer
 import Juvix.Prelude
@@ -76,57 +80,18 @@ judocStart = P.chunk Str.judocStart >> hspace
 judocEmptyLine :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
 judocEmptyLine = lexeme (void (P.try (judocStart >> P.newline)))
 
--- | We use the ascii version in the label so it shows in the error messages.
-keywordUnicode :: Members '[Reader ParserParams, InfoTableBuilder] r => Text -> Text -> ParsecS r ()
-keywordUnicode ascii unic = P.label (unpack ascii) (keyword ascii <|> keyword unic)
-
-keyword :: Members '[Reader ParserParams, InfoTableBuilder] r => Text -> ParsecS r ()
-keyword kw = do
-  l <- keywordL' space kw
-  lift (registerKeyword l)
+kw :: Members '[Reader ParserParams, InfoTableBuilder] r => Keyword -> ParsecS r ()
+kw k = lexeme $ kw' k >>= P.lift . registerKeyword
 
 -- | Same as @identifier@ but does not consume space after it.
 bareIdentifier :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r (Text, Interval)
-bareIdentifier = interval $ rawIdentifier allKeywords
+bareIdentifier = interval (rawIdentifier allKeywordStrings)
 
 dot :: forall e m. MonadParsec e Text m => m Char
 dot = P.char '.'
 
 dottedIdentifier :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r (NonEmpty (Text, Interval))
 dottedIdentifier = lexeme $ P.sepBy1 bareIdentifier dot
-
-allKeywords :: Members '[Reader ParserParams, InfoTableBuilder] r => [ParsecS r ()]
-allKeywords =
-  [ kwAssign,
-    kwAxiom,
-    kwColon,
-    kwColonOmega,
-    kwColonOne,
-    kwColonZero,
-    kwCompile,
-    kwEnd,
-    kwForeign,
-    kwHiding,
-    kwHole,
-    kwImport,
-    kwIn,
-    kwInductive,
-    kwInfix,
-    kwInfixl,
-    kwInfixr,
-    kwLambda,
-    kwLet,
-    kwModule,
-    kwOpen,
-    kwPostfix,
-    kwPublic,
-    kwRightArrow,
-    kwSemicolon,
-    kwType,
-    kwUsing,
-    kwWhere,
-    kwWildcard
-  ]
 
 lbrace :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
 lbrace = symbol "{"
@@ -145,108 +110,3 @@ parens = between lparen rparen
 
 braces :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r a -> ParsecS r a
 braces = between (symbol "{") (symbol "}")
-
-kwBuiltin :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwBuiltin = keyword Str.builtin
-
-kwAssign :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwAssign = keyword Str.assignAscii
-
-kwAxiom :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwAxiom = keyword Str.axiom
-
-kwColon :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwColon = keyword Str.colon
-
-kwColonOmega :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwColonOmega = keywordUnicode Str.colonOmegaAscii Str.colonOmegaUnicode
-
-kwColonOne :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwColonOne = keyword Str.colonOne
-
-kwColonZero :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwColonZero = keyword Str.colonZero
-
-kwCompile :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwCompile = keyword Str.compile
-
-kwEnd :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwEnd = keyword Str.end
-
-kwHiding :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwHiding = keyword Str.hiding
-
-kwImport :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwImport = keyword Str.import_
-
-kwForeign :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwForeign = keyword Str.foreign_
-
-kwIn :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwIn = keyword Str.in_
-
-kwInductive :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwInductive = keyword Str.inductive
-
-kwInfix :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwInfix = keyword Str.infix_
-
-kwInfixl :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwInfixl = keyword Str.infixl_
-
-kwInfixr :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwInfixr = keyword Str.infixr_
-
-kwLambda :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwLambda = keywordUnicode Str.lambdaAscii Str.lambdaUnicode
-
-kwLet :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwLet = keyword Str.let_
-
-kwMapsTo :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwMapsTo = keywordUnicode Str.mapstoAscii Str.mapstoUnicode
-
-kwModule :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwModule = keyword Str.module_
-
-kwOpen :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwOpen = keyword Str.open
-
-kwPostfix :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwPostfix = keyword Str.postfix
-
-kwPublic :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwPublic = keyword Str.public
-
-kwRightArrow :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwRightArrow = keywordUnicode Str.toAscii Str.toUnicode
-
-kwSemicolon :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwSemicolon = keyword Str.semicolon
-
-kwType :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwType = keyword Str.type_
-
-kwTerminating :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwTerminating = keyword Str.terminating
-
-kwPositive :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwPositive = keyword Str.positive
-
-kwUsing :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwUsing = keyword Str.using
-
-kwWhere :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwWhere = keyword Str.where_
-
-kwHole :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwHole = keyword Str.underscore
-
-kwWildcard :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-kwWildcard = keyword Str.underscore
-
-ghc :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-ghc = keyword Str.ghc
-
-cBackend :: Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r ()
-cBackend = keyword Str.cBackend

--- a/src/Juvix/Compiler/Core/Keywords.hs
+++ b/src/Juvix/Compiler/Core/Keywords.hs
@@ -1,0 +1,80 @@
+module Juvix.Compiler.Core.Keywords
+  ( module Juvix.Compiler.Core.Keywords,
+    module Juvix.Data.Keyword,
+    module Juvix.Data.Keyword.All,
+  )
+where
+
+import Juvix.Data.Keyword
+import Juvix.Data.Keyword.All
+  ( kwAssign,
+    kwBind,
+    kwCase,
+    kwComma,
+    kwConstr,
+    kwDef,
+    kwDiv,
+    kwElse,
+    kwEq,
+    kwFail,
+    kwGe,
+    kwGt,
+    kwIf,
+    kwIn,
+    kwLe,
+    kwLet,
+    kwLetRec,
+    kwLt,
+    kwMatch,
+    kwMinus,
+    kwMod,
+    kwMul,
+    kwOf,
+    kwPlus,
+    kwRightArrow,
+    kwSemicolon,
+    kwSeq,
+    kwThen,
+    kwTrace,
+    kwWildcard,
+    kwWith,
+  )
+import Juvix.Prelude
+
+allKeywordStrings :: HashSet Text
+allKeywordStrings = keywordsStrings allKeywords
+
+allKeywords :: [Keyword]
+allKeywords =
+  [ kwAssign,
+    kwLet,
+    kwLetRec,
+    kwIn,
+    kwConstr,
+    kwCase,
+    kwOf,
+    kwMatch,
+    kwWith,
+    kwIf,
+    kwThen,
+    kwElse,
+    kwDef,
+    kwRightArrow,
+    kwSemicolon,
+    kwComma,
+    kwWildcard,
+    kwPlus,
+    kwMinus,
+    kwMul,
+    kwDiv,
+    kwMod,
+    kwEq,
+    kwLt,
+    kwLe,
+    kwGt,
+    kwGe,
+    kwBind,
+    kwSeq,
+    kwTrace,
+    kwFail
+  ]

--- a/src/Juvix/Compiler/Core/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource/Lexer.hs
@@ -1,9 +1,11 @@
 module Juvix.Compiler.Core.Translation.FromSource.Lexer
   ( module Juvix.Compiler.Core.Translation.FromSource.Lexer,
     module Juvix.Parser.Lexer,
+    module Juvix.Compiler.Core.Keywords,
   )
 where
 
+import Juvix.Compiler.Core.Keywords
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Parser.Lexer
 import Juvix.Prelude
@@ -22,6 +24,9 @@ lexemeInterval = lexeme . interval
 symbol :: Text -> ParsecS r ()
 symbol = void . L.symbol space
 
+kw :: Members '[Reader ParserParams] r => Keyword -> ParsecS r ()
+kw = void . lexeme . kw'
+
 decimal :: (Member (Reader ParserParams) r, Num n) => ParsecS r (n, Interval)
 decimal = lexemeInterval L.decimal
 
@@ -34,9 +39,6 @@ number = number' integer
 string :: Member (Reader ParserParams) r => ParsecS r (Text, Interval)
 string = lexemeInterval string'
 
-keyword :: Text -> ParsecS r ()
-keyword = keyword' space
-
 keywordSymbol :: Text -> ParsecS r ()
 keywordSymbol = keywordSymbol' space
 
@@ -48,42 +50,7 @@ identifierL = lexemeInterval bareIdentifier
 
 -- | Same as @identifier@ but does not consume space after it.
 bareIdentifier :: ParsecS r Text
-bareIdentifier = rawIdentifier allKeywords
-
-allKeywords :: [ParsecS r ()]
-allKeywords =
-  [ kwAssign,
-    kwLet,
-    kwLetRec,
-    kwIn,
-    kwConstr,
-    kwCase,
-    kwOf,
-    kwMatch,
-    kwWith,
-    kwIf,
-    kwThen,
-    kwElse,
-    kwDef,
-    kwRightArrow,
-    kwSemicolon,
-    kwComma,
-    kwWildcard,
-    kwPlus,
-    kwMinus,
-    kwMul,
-    kwDiv,
-    kwMod,
-    kwEq,
-    kwLt,
-    kwLe,
-    kwGt,
-    kwGe,
-    kwBind,
-    kwSeq,
-    kwTrace,
-    kwFail
-  ]
+bareIdentifier = rawIdentifier allKeywordStrings
 
 symbolAt :: ParsecS r ()
 symbolAt = symbol Str.at_
@@ -108,96 +75,3 @@ parens = between lparen rparen
 
 braces :: ParsecS r a -> ParsecS r a
 braces = between (symbol "{") (symbol "}")
-
-kwAssign :: ParsecS r ()
-kwAssign = keyword Str.assignAscii
-
-kwLet :: ParsecS r ()
-kwLet = keyword Str.let_
-
-kwLetRec :: ParsecS r ()
-kwLetRec = keyword Str.letrec_
-
-kwIn :: ParsecS r ()
-kwIn = keyword Str.in_
-
-kwConstr :: ParsecS r ()
-kwConstr = keyword Str.constr
-
-kwCase :: ParsecS r ()
-kwCase = keyword Str.case_
-
-kwOf :: ParsecS r ()
-kwOf = keyword Str.of_
-
-kwMatch :: ParsecS r ()
-kwMatch = keyword Str.match_
-
-kwWith :: ParsecS r ()
-kwWith = keyword Str.with_
-
-kwIf :: ParsecS r ()
-kwIf = keyword Str.if_
-
-kwThen :: ParsecS r ()
-kwThen = keyword Str.then_
-
-kwElse :: ParsecS r ()
-kwElse = keyword Str.else_
-
-kwDef :: ParsecS r ()
-kwDef = keyword Str.def
-
-kwRightArrow :: ParsecS r ()
-kwRightArrow = keyword Str.toUnicode <|> keyword Str.toAscii
-
-kwSemicolon :: ParsecS r ()
-kwSemicolon = keyword Str.semicolon
-
-kwComma :: ParsecS r ()
-kwComma = keywordSymbol Str.comma
-
-kwWildcard :: ParsecS r ()
-kwWildcard = keyword Str.underscore
-
-kwPlus :: ParsecS r ()
-kwPlus = keyword Str.plus
-
-kwMinus :: ParsecS r ()
-kwMinus = keyword Str.minus
-
-kwMul :: ParsecS r ()
-kwMul = keyword Str.mul
-
-kwDiv :: ParsecS r ()
-kwDiv = keyword Str.div
-
-kwMod :: ParsecS r ()
-kwMod = keyword Str.mod
-
-kwEq :: ParsecS r ()
-kwEq = keyword Str.equal
-
-kwLt :: ParsecS r ()
-kwLt = keyword Str.less
-
-kwLe :: ParsecS r ()
-kwLe = keyword Str.lessEqual
-
-kwGt :: ParsecS r ()
-kwGt = keyword Str.greater
-
-kwGe :: ParsecS r ()
-kwGe = keyword Str.greaterEqual
-
-kwBind :: ParsecS r ()
-kwBind = keyword Str.bind
-
-kwSeq :: ParsecS r ()
-kwSeq = keyword Str.seq_
-
-kwTrace :: ParsecS r ()
-kwTrace = keyword Str.trace_
-
-kwFail :: ParsecS r ()
-kwFail = keyword Str.fail_

--- a/src/Juvix/Compiler/Core/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource/Lexer.hs
@@ -39,9 +39,6 @@ number = number' integer
 string :: Member (Reader ParserParams) r => ParsecS r (Text, Interval)
 string = lexemeInterval string'
 
-keywordSymbol :: Text -> ParsecS r ()
-keywordSymbol = keywordSymbol' space
-
 identifier :: ParsecS r Text
 identifier = lexeme bareIdentifier
 

--- a/src/Juvix/Data/Keyword.hs
+++ b/src/Juvix/Data/Keyword.hs
@@ -1,0 +1,33 @@
+module Juvix.Data.Keyword where
+
+import Data.HashSet qualified as HashSet
+import Juvix.Prelude
+import Juvix.Prelude.Pretty
+
+data Keyword = Keyword
+  { _keywordAscii :: Text,
+    _keywordUnicode :: Maybe Text
+  }
+
+makeLenses ''Keyword
+
+instance Pretty Keyword where
+  pretty k = maybe (pretty (k ^. keywordAscii)) pretty (k ^. keywordUnicode)
+
+keywordsStrings :: [Keyword] -> HashSet Text
+keywordsStrings = HashSet.fromList . concatMap keywordStrings
+
+keywordStrings :: Keyword -> [Text]
+keywordStrings Keyword {..} = maybe id (:) _keywordUnicode [_keywordAscii]
+
+asciiKw :: Text -> Keyword
+asciiKw _keywordAscii = Keyword {_keywordUnicode = Nothing, ..}
+
+isReservedChar :: Char -> Bool
+isReservedChar = (`elem` reservedSymbols)
+
+hasReservedChar :: Text -> Bool
+hasReservedChar = any isReservedChar . unpack
+
+reservedSymbols :: [Char]
+reservedSymbols = ";(){}.@\"[]"

--- a/src/Juvix/Data/Keyword.hs
+++ b/src/Juvix/Data/Keyword.hs
@@ -30,4 +30,4 @@ hasReservedChar :: Text -> Bool
 hasReservedChar = any isReservedChar . unpack
 
 reservedSymbols :: [Char]
-reservedSymbols = ";(){}.@\"[]"
+reservedSymbols = ";(){}.@\"[]\\"

--- a/src/Juvix/Data/Keyword.hs
+++ b/src/Juvix/Data/Keyword.hs
@@ -24,10 +24,11 @@ keywordStrings :: Keyword -> [Text]
 keywordStrings Keyword {..} = maybe id (:) _keywordUnicode [_keywordAscii]
 
 mkKw :: Text -> Maybe Text -> Keyword
-mkKw _keywordAscii _keywordUnicode = Keyword {
-  _keywordHasReserved = hasReservedChar _keywordAscii,
-  ..
-  }
+mkKw _keywordAscii _keywordUnicode =
+  Keyword
+    { _keywordHasReserved = hasReservedChar _keywordAscii,
+      ..
+    }
 
 asciiKw :: Text -> Keyword
 asciiKw ascii = mkKw ascii Nothing

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -1,0 +1,216 @@
+module Juvix.Data.Keyword.All
+  ( module Juvix.Data.Keyword,
+    module Juvix.Data.Keyword.All,
+  )
+where
+
+import Juvix.Data.Keyword
+import Juvix.Extra.Strings qualified as Str
+import Juvix.Prelude
+
+kwBuiltin :: Keyword
+kwBuiltin = asciiKw Str.builtin
+
+kwAssign :: Keyword
+kwAssign = asciiKw Str.assignAscii
+
+kwAxiom :: Keyword
+kwAxiom = asciiKw Str.axiom
+
+kwColon :: Keyword
+kwColon = asciiKw Str.colon
+
+kwColonOmega :: Keyword
+kwColonOmega = Keyword Str.colonOmegaAscii (Just Str.colonOmegaUnicode)
+
+kwColonOne :: Keyword
+kwColonOne = asciiKw Str.colonOne
+
+kwColonZero :: Keyword
+kwColonZero = asciiKw Str.colonZero
+
+kwCompile :: Keyword
+kwCompile = asciiKw Str.compile
+
+kwEnd :: Keyword
+kwEnd = asciiKw Str.end
+
+kwHiding :: Keyword
+kwHiding = asciiKw Str.hiding
+
+kwImport :: Keyword
+kwImport = asciiKw Str.import_
+
+kwForeign :: Keyword
+kwForeign = asciiKw Str.foreign_
+
+kwIn :: Keyword
+kwIn = asciiKw Str.in_
+
+kwInductive :: Keyword
+kwInductive = asciiKw Str.inductive
+
+kwInfix :: Keyword
+kwInfix = asciiKw Str.infix_
+
+kwInfixl :: Keyword
+kwInfixl = asciiKw Str.infixl_
+
+kwInfixr :: Keyword
+kwInfixr = asciiKw Str.infixr_
+
+kwLambda :: Keyword
+kwLambda = Keyword Str.lambdaAscii (Just Str.lambdaUnicode)
+
+kwLet :: Keyword
+kwLet = asciiKw Str.let_
+
+kwMapsTo :: Keyword
+kwMapsTo = Keyword Str.mapstoAscii (Just Str.mapstoUnicode)
+
+kwModule :: Keyword
+kwModule = asciiKw Str.module_
+
+kwOpen :: Keyword
+kwOpen = asciiKw Str.open
+
+kwPostfix :: Keyword
+kwPostfix = asciiKw Str.postfix
+
+kwPublic :: Keyword
+kwPublic = asciiKw Str.public
+
+kwRightArrow :: Keyword
+kwRightArrow = Keyword Str.toAscii (Just Str.toUnicode)
+
+kwSemicolon :: Keyword
+kwSemicolon = asciiKw Str.semicolon
+
+kwType :: Keyword
+kwType = asciiKw Str.type_
+
+kwTerminating :: Keyword
+kwTerminating = asciiKw Str.terminating
+
+kwPositive :: Keyword
+kwPositive = asciiKw Str.positive
+
+kwUsing :: Keyword
+kwUsing = asciiKw Str.using
+
+kwWhere :: Keyword
+kwWhere = asciiKw Str.where_
+
+kwHole :: Keyword
+kwHole = asciiKw Str.underscore
+
+kwWildcard :: Keyword
+kwWildcard = asciiKw Str.underscore
+
+ghc :: Keyword
+ghc = asciiKw Str.ghc
+
+cBackend :: Keyword
+cBackend = asciiKw Str.cBackend
+
+kwLetRec :: Keyword
+kwLetRec = asciiKw Str.letrec_
+
+kwConstr :: Keyword
+kwConstr = asciiKw Str.constr
+
+kwCase :: Keyword
+kwCase = asciiKw Str.case_
+
+kwOf :: Keyword
+kwOf = asciiKw Str.of_
+
+kwMatch :: Keyword
+kwMatch = asciiKw Str.match_
+
+kwWith :: Keyword
+kwWith = asciiKw Str.with_
+
+kwIf :: Keyword
+kwIf = asciiKw Str.if_
+
+kwThen :: Keyword
+kwThen = asciiKw Str.then_
+
+kwElse :: Keyword
+kwElse = asciiKw Str.else_
+
+kwDef :: Keyword
+kwDef = asciiKw Str.def
+
+kwComma :: Keyword
+kwComma = asciiKw Str.comma
+
+kwPlus :: Keyword
+kwPlus = asciiKw Str.plus
+
+kwMinus :: Keyword
+kwMinus = asciiKw Str.minus
+
+kwMul :: Keyword
+kwMul = asciiKw Str.mul
+
+kwDiv :: Keyword
+kwDiv = asciiKw Str.div
+
+kwMod :: Keyword
+kwMod = asciiKw Str.mod
+
+kwEq :: Keyword
+kwEq = asciiKw Str.equal
+
+kwLt :: Keyword
+kwLt = asciiKw Str.less
+
+kwLe :: Keyword
+kwLe = asciiKw Str.lessEqual
+
+kwGt :: Keyword
+kwGt = asciiKw Str.greater
+
+kwGe :: Keyword
+kwGe = asciiKw Str.greaterEqual
+
+kwBind :: Keyword
+kwBind = asciiKw Str.bind
+
+kwSeq :: Keyword
+kwSeq = asciiKw Str.seq_
+
+kwTrace :: Keyword
+kwTrace = asciiKw Str.trace_
+
+kwFail :: Keyword
+kwFail = asciiKw Str.fail_
+
+kwFun :: Keyword
+kwFun = asciiKw Str.fun_
+
+kwStar :: Keyword
+kwStar = asciiKw Str.mul
+
+kwTrue :: Keyword
+kwTrue = asciiKw Str.true_
+
+kwFalse :: Keyword
+kwFalse = asciiKw Str.false_
+
+kwArg :: Keyword
+kwArg = asciiKw Str.arg_
+
+kwTmp :: Keyword
+kwTmp = asciiKw Str.tmp_
+
+kwUnit :: Keyword
+kwUnit = asciiKw Str.unit
+
+kwVoid :: Keyword
+kwVoid = asciiKw Str.void
+
+kwDollar :: Keyword
+kwDollar = asciiKw Str.dollar

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -59,7 +59,7 @@ kwInfixr :: Keyword
 kwInfixr = asciiKw Str.infixr_
 
 kwLambda :: Keyword
-kwLambda = unicodeKw  Str.lambdaAscii Str.lambdaUnicode
+kwLambda = unicodeKw Str.lambdaAscii Str.lambdaUnicode
 
 kwLet :: Keyword
 kwLet = asciiKw Str.let_

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -6,7 +6,6 @@ where
 
 import Juvix.Data.Keyword
 import Juvix.Extra.Strings qualified as Str
-import Juvix.Prelude
 
 kwBuiltin :: Keyword
 kwBuiltin = asciiKw Str.builtin
@@ -21,7 +20,7 @@ kwColon :: Keyword
 kwColon = asciiKw Str.colon
 
 kwColonOmega :: Keyword
-kwColonOmega = Keyword Str.colonOmegaAscii (Just Str.colonOmegaUnicode)
+kwColonOmega = unicodeKw Str.colonOmegaAscii Str.colonOmegaUnicode
 
 kwColonOne :: Keyword
 kwColonOne = asciiKw Str.colonOne
@@ -60,13 +59,13 @@ kwInfixr :: Keyword
 kwInfixr = asciiKw Str.infixr_
 
 kwLambda :: Keyword
-kwLambda = Keyword Str.lambdaAscii (Just Str.lambdaUnicode)
+kwLambda = unicodeKw  Str.lambdaAscii Str.lambdaUnicode
 
 kwLet :: Keyword
 kwLet = asciiKw Str.let_
 
 kwMapsTo :: Keyword
-kwMapsTo = Keyword Str.mapstoAscii (Just Str.mapstoUnicode)
+kwMapsTo = unicodeKw Str.mapstoAscii Str.mapstoUnicode
 
 kwModule :: Keyword
 kwModule = asciiKw Str.module_
@@ -81,7 +80,7 @@ kwPublic :: Keyword
 kwPublic = asciiKw Str.public
 
 kwRightArrow :: Keyword
-kwRightArrow = Keyword Str.toAscii (Just Str.toUnicode)
+kwRightArrow = unicodeKw Str.toAscii Str.toUnicode
 
 kwSemicolon :: Keyword
 kwSemicolon = asciiKw Str.semicolon

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -3,9 +3,11 @@
 module Juvix.Parser.Lexer where
 
 import Control.Monad.Trans.Class (lift)
+import Data.HashSet qualified as HashSet
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import GHC.Unicode
+import Juvix.Data.Keyword
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
 import Text.Megaparsec as P hiding (sepBy1, sepEndBy1, some)
@@ -64,6 +66,7 @@ number' int mn mx = do
 string' :: ParsecS r Text
 string' = pack <$> (char '"' >> manyTill L.charLiteral (char '"'))
 
+-- {-# DEPRECATED use kw' #-}
 keyword' :: ParsecS r () -> Text -> ParsecS r ()
 keyword' spc kw =
   P.try $ do
@@ -84,25 +87,49 @@ keywordSymbol' spc kw = do
     void $ P.chunk kw
     spc
 
-rawIdentifier :: [ParsecS r ()] -> ParsecS r Text
-rawIdentifier allKeywords = rawIdentifier' (const False) allKeywords
+-- | The caller is responsible of consuming space after it
+kw' :: forall r. Member (Reader ParserParams) r => Keyword -> ParsecS r Interval
+kw' k@Keyword {..} = P.label (unpack _keywordAscii) helper
+  where
+    helper :: ParsecS r Interval
+    helper
+      | hasReservedChar _keywordAscii || maybe False hasReservedChar _keywordUnicode =
+          onlyInterval
+            ( P.chunk _keywordAscii
+                <|> maybe empty P.chunk _keywordUnicode
+            )
+      | otherwise = P.try $ do
+          (w, i) <- interval morpheme
+          unless (w `elem` keywordStrings k) (failure Nothing (Set.singleton (Label (fromJust $ nonEmpty $ unpack _keywordAscii))))
+          return i
 
-rawIdentifier' :: (Char -> Bool) -> [ParsecS r ()] -> ParsecS r Text
-rawIdentifier' excludedTailChar allKeywords = do
-  notFollowedBy (choice allKeywords)
-  h <- P.satisfy validFirstChar
-  t <- P.takeWhileP Nothing (validTailChar .&&. not . excludedTailChar)
-  return (Text.cons h t)
+rawIdentifier' :: (Char -> Bool) -> HashSet Text -> ParsecS r Text
+rawIdentifier' excludedTailChar allKeywords = label "<identifier>" $ P.try $ do
+  w <- morpheme' excludedTailChar
+  when (w `HashSet.member` allKeywords) empty
+  return w
+
+rawIdentifier :: HashSet Text -> ParsecS r Text
+rawIdentifier = rawIdentifier' (const False)
 
 validTailChar :: Char -> Bool
-validTailChar c =
-  isAlphaNum c || (validFirstChar c && notElem c delimiterSymbols)
+validTailChar =
+  (`notElem` reservedSymbols)
+    .&&. (isAlphaNum .||. (validFirstChar .&&. (`notElem` delimiterSymbols)))
+
+-- | A word that does not contain reserved symbols. It may be an identifier or a keyword.
+morpheme' :: (Char -> Bool) -> ParsecS r Text
+morpheme' excludedTailChar = do
+  h <- P.satisfy validFirstChar
+  t <- P.takeWhileP Nothing (validTailChar .&&. not . excludedTailChar)
+  let iden = Text.cons h t
+  return iden
+
+morpheme :: ParsecS r Text
+morpheme = morpheme' (const False)
 
 delimiterSymbols :: [Char]
 delimiterSymbols = ","
-
-reservedSymbols :: [Char]
-reservedSymbols = "@\";(){}[]."
 
 validFirstChar :: Char -> Bool
 validFirstChar c = not (isNumber c || isSpace c || (c `elem` reservedSymbols))

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -66,27 +66,6 @@ number' int mn mx = do
 string' :: ParsecS r Text
 string' = pack <$> (char '"' >> manyTill L.charLiteral (char '"'))
 
--- {-# DEPRECATED use kw' #-}
-keyword' :: ParsecS r () -> Text -> ParsecS r ()
-keyword' spc kw =
-  P.try $ do
-    P.chunk kw
-    notFollowedBy (satisfy validTailChar)
-    spc
-
-keywordL' :: Member (Reader ParserParams) r => ParsecS r () -> Text -> ParsecS r Interval
-keywordL' spc kw = P.try $ do
-  i <- onlyInterval (P.chunk kw)
-  notFollowedBy (satisfy validTailChar)
-  spc
-  return i
-
-keywordSymbol' :: ParsecS r () -> Text -> ParsecS r ()
-keywordSymbol' spc kw = do
-  P.try $ do
-    void $ P.chunk kw
-    spc
-
 -- | The caller is responsible of consuming space after it
 kw' :: forall r. Member (Reader ParserParams) r => Keyword -> ParsecS r Interval
 kw' k@Keyword {..} = P.label (unpack _keywordAscii) helper


### PR DESCRIPTION
The goal of this PR is to refactor lexers (Concrete/Core/Asm) so that they can share the functionality related to keywords.

Also, it removes the use of `notFollowedBy` in identifier/keyword parsing