### PR TITLE
Add softlines between applications and hang definitions

### DIFF
--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -94,6 +94,9 @@ hsepMaybe l
 indent' :: Doc ann -> Doc ann
 indent' = indent 2
 
+hang' :: Doc ann -> Doc ann
+hang' = hang 2
+
 ordinal :: Int -> Doc a
 ordinal = \case
   1 -> "first"


### PR DESCRIPTION
Closes #1577.

The important change is this:
```diff
 ppCode (Application l r) = do
     l' <- ppLeftExpression appFixity l
     r' <- ppRightExpression appFixity r
-    return $ l' <+> r'
+    return $ l' <> softline <> r'
```

The layout algorithm will insert a newline when the line goes above 80 characters.
After this change, the example code showed in #1577 displays thus:
```
  playMove : Maybe Nat → GameState → GameState;
  playMove nothing (state b p _) := state b p (continue
    "\nInvalid number, try again\n");
  playMove (just k) (state (board s) player e) := if (not (elem (==) k
    (possibleMoves (flatten s)))) (state (board s) player (continue
    "\nThe square is already occupied, try again\n")) (checkState (state (board
    (map (map (replace player k)) s)) (switch player) noError));
```