### PR TITLE
Rename builtin natural to nat and boolean to bool

### DIFF
--- a/docs/org/language-reference/builtins.org
+++ b/docs/org/language-reference/builtins.org
@@ -6,7 +6,7 @@ Juvix has support for the built-in natural type and a few functions that are com
 1. Built-in inductive definitions.
 
    #+begin_example
-   builtin natural
+   builtin nat
    inductive Nat {
      zero : Nat;
      suc : Nat → Nat;
@@ -17,7 +17,7 @@ Juvix has support for the built-in natural type and a few functions that are com
 
    #+begin_example
    inifl 6 +;
-   builtin natural-plus
+   builtin nat-plus
    + : Nat → Nat → Nat;
    + zero b := b;
    + (suc a) b := suc (a + b);
@@ -26,6 +26,6 @@ Juvix has support for the built-in natural type and a few functions that are com
 3. Builtin axiom definitions.
 
    #+begin_example
-   builtin natural-print
+   builtin nat-print
    axiom printNat : Nat → Action;
    #+end_example

--- a/docs/org/notes/builtins.org
+++ b/docs/org/notes/builtins.org
@@ -9,7 +9,7 @@ of definitions:
 
 1. Builtin inductive definitions. For example:
    #+begin_example
-   builtin natural
+   builtin nat
    inductive Nat {
      zero : Nat;
      suc : Nat → Nat;
@@ -20,7 +20,7 @@ of definitions:
 2. Builtin function definitions. For example:
    #+begin_src text
    inifl 6 +;
-   builtin natural-plus
+   builtin nat-plus
    + : Nat → Nat → Nat;
    + zero b := b;
    + (suc a) b := suc (a + b);
@@ -28,7 +28,7 @@ of definitions:
 
 3. Builtin axiom definitions. For example:
    #+begin_src text
-   builtin natural-print
+   builtin nat-print
    axiom printNat : Nat → Action;
    #+end_src
 
@@ -40,7 +40,7 @@ collect information about the builtins that have been included in the code and
 what are the terms that refer to them. For instance, imagine that we find this
 definitions in a juvix module:
 #+begin_src text
-builtin natural
+builtin nat
 inductive MyNat {
     z : MyNat;
     s : MyNat → MyNat;

--- a/examples/milestone/ValidityPredicates/Data/Int/Ops.juvix
+++ b/examples/milestone/ValidityPredicates/Data/Int/Ops.juvix
@@ -21,24 +21,22 @@ foreign c {
    \}
 };
 
-infix 4 <';
-axiom <' : Int → Int → BackendBool;
-compile <' {
+infix 4 <;
+axiom < : Int → Int → Bool;
+compile < {
   c ↦ "lessThan";
 };
 
-infix 4 <;
-< : Int → Int → Bool;
-< i1 i2 := from-backend-bool (i1 <' i2);
-
-axiom eqInt : Int → Int → BackendBool;
+axiom eqInt : Int → Int → Bool;
 compile eqInt {
   c ↦ "eqInt";
 };
 
 infix 4 ==;
-== : Int → Int → Bool;
-== i1 i2 := from-backend-bool (eqInt i1 i2);
+axiom == : Int → Int → Bool;
+compile == {
+  c ↦ "eqInt";
+};
 
 infixl 6 -;
 axiom - : Int -> Int -> Int;

--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -243,7 +243,7 @@ registerBuiltinInductive ::
   BuiltinInductive ->
   Sem r ()
 registerBuiltinInductive d = \case
-  BuiltinNatural -> registerNaturalDef d
+  BuiltinNat -> registerNatDef d
   BuiltinBoolean -> registerBoolDef d
 
 registerBuiltinFunction ::
@@ -252,7 +252,7 @@ registerBuiltinFunction ::
   BuiltinFunction ->
   Sem r ()
 registerBuiltinFunction d = \case
-  BuiltinNaturalPlus -> registerNaturalPlus d
+  BuiltinNatPlus -> registerNatPlus d
   BuiltinBooleanIf -> registerIf d
 
 registerBuiltinAxiom ::
@@ -263,7 +263,7 @@ registerBuiltinAxiom ::
 registerBuiltinAxiom d = \case
   BuiltinIO -> registerIO d
   BuiltinIOSequence -> registerIOSequence d
-  BuiltinNaturalPrint -> registerNaturalPrint d
+  BuiltinNatPrint -> registerNatPrint d
 
 goInductive ::
   Members '[InfoTableBuilder, Builtins, Error ScoperError] r =>

--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -244,7 +244,7 @@ registerBuiltinInductive ::
   Sem r ()
 registerBuiltinInductive d = \case
   BuiltinNat -> registerNatDef d
-  BuiltinBoolean -> registerBoolDef d
+  BuiltinBool -> registerBoolDef d
 
 registerBuiltinFunction ::
   Members '[InfoTableBuilder, Error ScoperError, Builtins, NameIdGen] r =>
@@ -253,7 +253,7 @@ registerBuiltinFunction ::
   Sem r ()
 registerBuiltinFunction d = \case
   BuiltinNatPlus -> registerNatPlus d
-  BuiltinBooleanIf -> registerIf d
+  BuiltinBoolIf -> registerIf d
 
 registerBuiltinAxiom ::
   Members '[InfoTableBuilder, Error ScoperError, Builtins] r =>

--- a/src/Juvix/Compiler/Backend/C/Data/BuiltinTable.hs
+++ b/src/Juvix/Compiler/Backend/C/Data/BuiltinTable.hs
@@ -6,25 +6,25 @@ import Juvix.Prelude
 
 builtinConstructorName :: BuiltinConstructor -> Maybe Text
 builtinConstructorName = \case
-  BuiltinNaturalZero -> Just zero
-  BuiltinNaturalSuc -> Just suc
+  BuiltinNatZero -> Just zero
+  BuiltinNatSuc -> Just suc
   BuiltinBooleanTrue -> Just true_
   BuiltinBooleanFalse -> Just false_
 
 builtinInductiveName :: BuiltinInductive -> Maybe Text
 builtinInductiveName = \case
-  BuiltinNatural -> Just nat
+  BuiltinNat -> Just nat
   BuiltinBoolean -> Just bool_
 
 builtinAxiomName :: BuiltinAxiom -> Maybe Text
 builtinAxiomName = \case
-  BuiltinNaturalPrint -> Just printNat
+  BuiltinNatPrint -> Just printNat
   BuiltinIO -> Just io
   BuiltinIOSequence -> Just ioseq
 
 builtinFunctionName :: BuiltinFunction -> Maybe Text
 builtinFunctionName = \case
-  BuiltinNaturalPlus -> Just natplus
+  BuiltinNatPlus -> Just natplus
   BuiltinBooleanIf -> Just boolif
 
 builtinName :: BuiltinPrim -> Maybe Text

--- a/src/Juvix/Compiler/Backend/C/Data/BuiltinTable.hs
+++ b/src/Juvix/Compiler/Backend/C/Data/BuiltinTable.hs
@@ -8,13 +8,13 @@ builtinConstructorName :: BuiltinConstructor -> Maybe Text
 builtinConstructorName = \case
   BuiltinNatZero -> Just zero
   BuiltinNatSuc -> Just suc
-  BuiltinBooleanTrue -> Just true_
-  BuiltinBooleanFalse -> Just false_
+  BuiltinBoolTrue -> Just true_
+  BuiltinBoolFalse -> Just false_
 
 builtinInductiveName :: BuiltinInductive -> Maybe Text
 builtinInductiveName = \case
   BuiltinNat -> Just nat
-  BuiltinBoolean -> Just bool_
+  BuiltinBool -> Just bool_
 
 builtinAxiomName :: BuiltinAxiom -> Maybe Text
 builtinAxiomName = \case
@@ -25,7 +25,7 @@ builtinAxiomName = \case
 builtinFunctionName :: BuiltinFunction -> Maybe Text
 builtinFunctionName = \case
   BuiltinNatPlus -> Just natplus
-  BuiltinBooleanIf -> Just boolif
+  BuiltinBoolIf -> Just boolif
 
 builtinName :: BuiltinPrim -> Maybe Text
 builtinName = \case

--- a/src/Juvix/Compiler/Builtins.hs
+++ b/src/Juvix/Compiler/Builtins.hs
@@ -2,11 +2,11 @@ module Juvix.Compiler.Builtins
   ( module Juvix.Compiler.Builtins.Effect,
     module Juvix.Compiler.Builtins.Nat,
     module Juvix.Compiler.Builtins.IO,
-    module Juvix.Compiler.Builtins.Boolean,
+    module Juvix.Compiler.Builtins.Bool,
   )
 where
 
-import Juvix.Compiler.Builtins.Boolean
+import Juvix.Compiler.Builtins.Bool
 import Juvix.Compiler.Builtins.Effect
 import Juvix.Compiler.Builtins.IO
 import Juvix.Compiler.Builtins.Nat

--- a/src/Juvix/Compiler/Builtins.hs
+++ b/src/Juvix/Compiler/Builtins.hs
@@ -1,6 +1,6 @@
 module Juvix.Compiler.Builtins
   ( module Juvix.Compiler.Builtins.Effect,
-    module Juvix.Compiler.Builtins.Natural,
+    module Juvix.Compiler.Builtins.Nat,
     module Juvix.Compiler.Builtins.IO,
     module Juvix.Compiler.Builtins.Boolean,
   )
@@ -9,4 +9,4 @@ where
 import Juvix.Compiler.Builtins.Boolean
 import Juvix.Compiler.Builtins.Effect
 import Juvix.Compiler.Builtins.IO
-import Juvix.Compiler.Builtins.Natural
+import Juvix.Compiler.Builtins.Nat

--- a/src/Juvix/Compiler/Builtins/Base.hs
+++ b/src/Juvix/Compiler/Builtins/Base.hs
@@ -8,11 +8,11 @@ import Juvix.Prelude
 import Juvix.Prelude.Pretty
 
 data BuiltinsEnum
-  = BuiltinsNatural
+  = BuiltinsNat
   | BuiltinsZero
   | BuiltinsSuc
-  | BuiltinsNaturalPlus
-  | BuiltinsNaturalPrint
+  | BuiltinsNatPlus
+  | BuiltinsNatPrint
   | BuiltinsIO
   | BuiltinsIOSequence
   deriving stock (Show, Eq, Generic)
@@ -21,10 +21,10 @@ instance Hashable BuiltinsEnum
 
 instance Pretty BuiltinsEnum where
   pretty = \case
-    BuiltinsNatural -> Str.natural
+    BuiltinsNat -> Str.nat
     BuiltinsZero -> "zero"
     BuiltinsSuc -> "suc"
-    BuiltinsNaturalPlus -> Str.naturalPlus
-    BuiltinsNaturalPrint -> Str.naturalPrint
+    BuiltinsNatPlus -> Str.natPlus
+    BuiltinsNatPrint -> Str.natPrint
     BuiltinsIO -> Str.io
     BuiltinsIOSequence -> Str.ioSequence

--- a/src/Juvix/Compiler/Builtins/Bool.hs
+++ b/src/Juvix/Compiler/Builtins/Bool.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Builtins.Boolean where
+module Juvix.Compiler.Builtins.Bool where
 
 import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Abstract.Extra
@@ -10,7 +10,7 @@ registerBoolDef :: Member Builtins r => InductiveDef -> Sem r ()
 registerBoolDef d = do
   unless (null (d ^. inductiveParameters)) (error "Bool should have no type parameters")
   unless (isSmallUniverse' (d ^. inductiveType)) (error "Bool should be in the small universe")
-  registerBuiltin BuiltinBoolean (d ^. inductiveName)
+  registerBuiltin BuiltinBool (d ^. inductiveName)
   case d ^. inductiveConstructors of
     [c1, c2] -> registerTrue c1 >> registerFalse c2
     _ -> error "Bool should have exactly two constructors"
@@ -19,30 +19,30 @@ registerTrue :: Member Builtins r => InductiveConstructorDef -> Sem r ()
 registerTrue d@InductiveConstructorDef {..} = do
   let ctorTrue = _constructorName
       ctorTy = _constructorType
-  boolTy <- getBuiltinName (getLoc d) BuiltinBoolean
+  boolTy <- getBuiltinName (getLoc d) BuiltinBool
   unless (ctorTy === boolTy) (error $ "true has the wrong type " <> ppTrace ctorTy <> " | " <> ppTrace boolTy)
-  registerBuiltin BuiltinBooleanTrue ctorTrue
+  registerBuiltin BuiltinBoolTrue ctorTrue
 
 registerFalse :: Member Builtins r => InductiveConstructorDef -> Sem r ()
 registerFalse d@InductiveConstructorDef {..} = do
   let ctorFalse = _constructorName
       ctorTy = _constructorType
-  boolTy <- getBuiltinName (getLoc d) BuiltinBoolean
+  boolTy <- getBuiltinName (getLoc d) BuiltinBool
   unless (ctorTy === boolTy) (error $ "false has the wrong type " <> ppTrace ctorTy <> " | " <> ppTrace boolTy)
-  registerBuiltin BuiltinBooleanFalse ctorFalse
+  registerBuiltin BuiltinBoolFalse ctorFalse
 
 registerIf :: Members '[Builtins, NameIdGen] r => FunctionDef -> Sem r ()
 registerIf f = do
-  boolean <- getBuiltinName (getLoc f) BuiltinBoolean
-  true_ <- toExpression <$> getBuiltinName (getLoc f) BuiltinBooleanTrue
-  false_ <- toExpression <$> getBuiltinName (getLoc f) BuiltinBooleanFalse
+  bool <- getBuiltinName (getLoc f) BuiltinBool
+  true_ <- toExpression <$> getBuiltinName (getLoc f) BuiltinBoolTrue
+  false_ <- toExpression <$> getBuiltinName (getLoc f) BuiltinBoolFalse
   vart <- freshVar "t"
   let if_ = f ^. funDefName
       ty = f ^. funDefTypeSig
       freeTVars = HashSet.fromList [vart]
       u = ExpressionUniverse (Universe {_universeLevel = Nothing, _universeLoc = error "Universe with no location"})
-  unless (((u <>--> boolean --> vart --> vart --> vart) ==% ty) freeTVars) (error "Boolean if has the wrong type signature")
-  registerBuiltin BuiltinBooleanIf if_
+  unless (((u <>--> bool --> vart --> vart --> vart) ==% ty) freeTVars) (error "Bool if has the wrong type signature")
+  registerBuiltin BuiltinBoolIf if_
   vare <- freshVar "e"
   hole <- freshHole
   let e = toExpression vare
@@ -60,7 +60,7 @@ registerIf f = do
           | c <- toList (f ^. funDefClauses)
         ]
   case zipExactMay exClauses clauses of
-    Nothing -> error "Boolean if has the wrong number of clauses"
+    Nothing -> error "Bool if has the wrong number of clauses"
     Just z -> forM_ z $ \((exLhs, exBody), (lhs, body)) -> do
       unless (exLhs =% lhs) (error "clause lhs does not match")
       unless (exBody =% body) (error $ "clause body does not match " <> ppTrace exBody <> " | " <> ppTrace body)

--- a/src/Juvix/Compiler/Builtins/Bool.hs
+++ b/src/Juvix/Compiler/Builtins/Bool.hs
@@ -33,7 +33,7 @@ registerFalse d@InductiveConstructorDef {..} = do
 
 registerIf :: Members '[Builtins, NameIdGen] r => FunctionDef -> Sem r ()
 registerIf f = do
-  bool <- getBuiltinName (getLoc f) BuiltinBool
+  bool_ <- getBuiltinName (getLoc f) BuiltinBool
   true_ <- toExpression <$> getBuiltinName (getLoc f) BuiltinBoolTrue
   false_ <- toExpression <$> getBuiltinName (getLoc f) BuiltinBoolFalse
   vart <- freshVar "t"
@@ -41,7 +41,7 @@ registerIf f = do
       ty = f ^. funDefTypeSig
       freeTVars = HashSet.fromList [vart]
       u = ExpressionUniverse (Universe {_universeLevel = Nothing, _universeLoc = error "Universe with no location"})
-  unless (((u <>--> bool --> vart --> vart --> vart) ==% ty) freeTVars) (error "Bool if has the wrong type signature")
+  unless (((u <>--> bool_ --> vart --> vart --> vart) ==% ty) freeTVars) (error "Bool if has the wrong type signature")
   registerBuiltin BuiltinBoolIf if_
   vare <- freshVar "e"
   hole <- freshHole

--- a/src/Juvix/Compiler/Builtins/Nat.hs
+++ b/src/Juvix/Compiler/Builtins/Nat.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Builtins.Natural where
+module Juvix.Compiler.Builtins.Nat where
 
 import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Abstract.Extra
@@ -7,47 +7,47 @@ import Juvix.Compiler.Builtins.Effect
 import Juvix.Data.Effect.NameIdGen
 import Juvix.Prelude
 
-registerNaturalDef :: Member Builtins r => InductiveDef -> Sem r ()
-registerNaturalDef d = do
-  unless (null (d ^. inductiveParameters)) (error "Naturals should have no type parameters")
-  unless (isSmallUniverse' (d ^. inductiveType)) (error "Naturals should be in the small universe")
-  registerBuiltin BuiltinNatural (d ^. inductiveName)
+registerNatDef :: Member Builtins r => InductiveDef -> Sem r ()
+registerNatDef d = do
+  unless (null (d ^. inductiveParameters)) (error "Nats should have no type parameters")
+  unless (isSmallUniverse' (d ^. inductiveType)) (error "Nats should be in the small universe")
+  registerBuiltin BuiltinNat (d ^. inductiveName)
   case d ^. inductiveConstructors of
     [c1, c2] -> registerZero c1 >> registerSuc c2
-    _ -> error "Natural numbers should have exactly two constructors"
+    _ -> error "Nat numbers should have exactly two constructors"
 
 registerZero :: Member Builtins r => InductiveConstructorDef -> Sem r ()
 registerZero d@InductiveConstructorDef {..} = do
   let zero = _constructorName
       ty = _constructorType
-  nat <- getBuiltinName (getLoc d) BuiltinNatural
+  nat <- getBuiltinName (getLoc d) BuiltinNat
   unless (ty === nat) (error $ "zero has the wrong type " <> ppTrace ty <> " | " <> ppTrace nat)
-  registerBuiltin BuiltinNaturalZero zero
+  registerBuiltin BuiltinNatZero zero
 
 registerSuc :: Member Builtins r => InductiveConstructorDef -> Sem r ()
 registerSuc d@InductiveConstructorDef {..} = do
   let suc = _constructorName
       ty = _constructorType
-  nat <- getBuiltinName (getLoc d) BuiltinNatural
+  nat <- getBuiltinName (getLoc d) BuiltinNat
   unless (ty === (nat --> nat)) (error "suc has the wrong type")
-  registerBuiltin BuiltinNaturalSuc suc
+  registerBuiltin BuiltinNatSuc suc
 
-registerNaturalPrint :: Members '[Builtins] r => AxiomDef -> Sem r ()
-registerNaturalPrint f = do
-  nat <- getBuiltinName (getLoc f) BuiltinNatural
+registerNatPrint :: Members '[Builtins] r => AxiomDef -> Sem r ()
+registerNatPrint f = do
+  nat <- getBuiltinName (getLoc f) BuiltinNat
   io <- getBuiltinName (getLoc f) BuiltinIO
-  unless (f ^. axiomType === (nat --> io)) (error "Natural print has the wrong type signature")
-  registerBuiltin BuiltinNaturalPrint (f ^. axiomName)
+  unless (f ^. axiomType === (nat --> io)) (error "Nat print has the wrong type signature")
+  registerBuiltin BuiltinNatPrint (f ^. axiomName)
 
-registerNaturalPlus :: Members '[Builtins, NameIdGen] r => FunctionDef -> Sem r ()
-registerNaturalPlus f = do
-  nat <- getBuiltinName (getLoc f) BuiltinNatural
-  zero <- toExpression <$> getBuiltinName (getLoc f) BuiltinNaturalZero
-  suc <- toExpression <$> getBuiltinName (getLoc f) BuiltinNaturalSuc
+registerNatPlus :: Members '[Builtins, NameIdGen] r => FunctionDef -> Sem r ()
+registerNatPlus f = do
+  nat <- getBuiltinName (getLoc f) BuiltinNat
+  zero <- toExpression <$> getBuiltinName (getLoc f) BuiltinNatZero
+  suc <- toExpression <$> getBuiltinName (getLoc f) BuiltinNatSuc
   let plus = f ^. funDefName
       ty = f ^. funDefTypeSig
-  unless (ty === (nat --> nat --> nat)) (error "Natural plus has the wrong type signature")
-  registerBuiltin BuiltinNaturalPlus plus
+  unless (ty === (nat --> nat --> nat)) (error "Nat plus has the wrong type signature")
+  registerBuiltin BuiltinNatPlus plus
   varn <- freshVar "n"
   varm <- freshVar "m"
   let n = toExpression varn
@@ -67,7 +67,7 @@ registerNaturalPlus f = do
           | c <- toList (f ^. funDefClauses)
         ]
   case zipExactMay exClauses clauses of
-    Nothing -> error "Natural plus has the wrong number of clauses"
+    Nothing -> error "Nat plus has the wrong number of clauses"
     Just z -> forM_ z $ \((exLhs, exBody), (lhs, body)) -> do
       unless (exLhs =% lhs) (error "clause lhs does not match")
       unless (exBody =% body) (error $ "clause body does not match " <> ppTrace exBody <> " | " <> ppTrace body)

--- a/src/Juvix/Compiler/Concrete/Data/Builtins.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Builtins.hs
@@ -38,11 +38,11 @@ instance Pretty BuiltinPrim where
 builtinConstructors :: BuiltinInductive -> [BuiltinConstructor]
 builtinConstructors = \case
   BuiltinNat -> [BuiltinNatZero, BuiltinNatSuc]
-  BuiltinBoolean -> [BuiltinBooleanTrue, BuiltinBooleanFalse]
+  BuiltinBool -> [BuiltinBoolTrue, BuiltinBoolFalse]
 
 data BuiltinInductive
   = BuiltinNat
-  | BuiltinBoolean
+  | BuiltinBool
   deriving stock (Show, Eq, Ord, Enum, Bounded, Generic)
 
 instance Hashable BuiltinInductive
@@ -50,20 +50,20 @@ instance Hashable BuiltinInductive
 instance Pretty BuiltinInductive where
   pretty = \case
     BuiltinNat -> Str.nat
-    BuiltinBoolean -> Str.boolean_
+    BuiltinBool -> Str.bool_
 
 data BuiltinConstructor
   = BuiltinNatZero
   | BuiltinNatSuc
-  | BuiltinBooleanTrue
-  | BuiltinBooleanFalse
+  | BuiltinBoolTrue
+  | BuiltinBoolFalse
   deriving stock (Show, Eq, Ord, Generic)
 
 instance Hashable BuiltinConstructor
 
 data BuiltinFunction
   = BuiltinNatPlus
-  | BuiltinBooleanIf
+  | BuiltinBoolIf
   deriving stock (Show, Eq, Ord, Enum, Bounded, Generic)
 
 instance Hashable BuiltinFunction
@@ -71,7 +71,7 @@ instance Hashable BuiltinFunction
 instance Pretty BuiltinFunction where
   pretty = \case
     BuiltinNatPlus -> Str.natPlus
-    BuiltinBooleanIf -> Str.booleanIf
+    BuiltinBoolIf -> Str.boolIf
 
 data BuiltinAxiom
   = BuiltinNatPrint

--- a/src/Juvix/Compiler/Concrete/Data/Builtins.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Builtins.hs
@@ -37,11 +37,11 @@ instance Pretty BuiltinPrim where
 
 builtinConstructors :: BuiltinInductive -> [BuiltinConstructor]
 builtinConstructors = \case
-  BuiltinNatural -> [BuiltinNaturalZero, BuiltinNaturalSuc]
+  BuiltinNat -> [BuiltinNatZero, BuiltinNatSuc]
   BuiltinBoolean -> [BuiltinBooleanTrue, BuiltinBooleanFalse]
 
 data BuiltinInductive
-  = BuiltinNatural
+  = BuiltinNat
   | BuiltinBoolean
   deriving stock (Show, Eq, Ord, Enum, Bounded, Generic)
 
@@ -49,12 +49,12 @@ instance Hashable BuiltinInductive
 
 instance Pretty BuiltinInductive where
   pretty = \case
-    BuiltinNatural -> Str.natural
+    BuiltinNat -> Str.nat
     BuiltinBoolean -> Str.boolean_
 
 data BuiltinConstructor
-  = BuiltinNaturalZero
-  | BuiltinNaturalSuc
+  = BuiltinNatZero
+  | BuiltinNatSuc
   | BuiltinBooleanTrue
   | BuiltinBooleanFalse
   deriving stock (Show, Eq, Ord, Generic)
@@ -62,7 +62,7 @@ data BuiltinConstructor
 instance Hashable BuiltinConstructor
 
 data BuiltinFunction
-  = BuiltinNaturalPlus
+  = BuiltinNatPlus
   | BuiltinBooleanIf
   deriving stock (Show, Eq, Ord, Enum, Bounded, Generic)
 
@@ -70,11 +70,11 @@ instance Hashable BuiltinFunction
 
 instance Pretty BuiltinFunction where
   pretty = \case
-    BuiltinNaturalPlus -> Str.naturalPlus
+    BuiltinNatPlus -> Str.natPlus
     BuiltinBooleanIf -> Str.booleanIf
 
 data BuiltinAxiom
-  = BuiltinNaturalPrint
+  = BuiltinNatPrint
   | BuiltinIO
   | BuiltinIOSequence
   deriving stock (Show, Eq, Ord, Enum, Bounded, Generic)
@@ -83,6 +83,6 @@ instance Hashable BuiltinAxiom
 
 instance Pretty BuiltinAxiom where
   pretty = \case
-    BuiltinNaturalPrint -> Str.naturalPrint
+    BuiltinNatPrint -> Str.natPrint
     BuiltinIO -> Str.io
     BuiltinIOSequence -> Str.ioSequence

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -470,7 +470,7 @@ freshHole l = do
 literalType :: Members '[NameIdGen, Builtins] r => LiteralLoc -> Sem r TypedExpression
 literalType lit@(WithLoc i l) = case l of
   LitInteger {} -> do
-    nat <- getBuiltinName i BuiltinNatural
+    nat <- getBuiltinName i BuiltinNat
     return
       TypedExpression
         { _typedExpression = ExpressionLiteral lit,

--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -115,8 +115,8 @@ kwEnd = keyword Str.end
 kwBuiltin :: Doc Ann
 kwBuiltin = keyword Str.builtin
 
-kwNatural :: Doc Ann
-kwNatural = keyword Str.natural
+kwNat :: Doc Ann
+kwNat = keyword Str.nat
 
 kwInductive :: Doc Ann
 kwInductive = keyword Str.inductive

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -92,8 +92,8 @@ string = "string"
 nat :: IsString s => s
 nat = "nat"
 
-boolean_ :: IsString s => s
-boolean_ = "boolean"
+bool_ :: IsString s => s
+bool_ = "bool"
 
 io :: IsString s => s
 io = "IO"
@@ -107,8 +107,8 @@ natPrint = "nat-print"
 natPlus :: IsString s => s
 natPlus = "nat-plus"
 
-booleanIf :: IsString s => s
-booleanIf = "boolean-if"
+boolIf :: IsString s => s
+boolIf = "bool-if"
 
 builtin :: IsString s => s
 builtin = "builtin"

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -89,8 +89,8 @@ error = "error"
 string :: IsString s => s
 string = "string"
 
-natural :: IsString s => s
-natural = "natural"
+nat :: IsString s => s
+nat = "nat"
 
 boolean_ :: IsString s => s
 boolean_ = "boolean"
@@ -101,11 +101,11 @@ io = "IO"
 ioSequence :: IsString s => s
 ioSequence = "IO-sequence"
 
-naturalPrint :: IsString s => s
-naturalPrint = "natural-print"
+natPrint :: IsString s => s
+natPrint = "nat-print"
 
-naturalPlus :: IsString s => s
-naturalPlus = "natural-plus"
+natPlus :: IsString s => s
+natPlus = "nat-plus"
 
 booleanIf :: IsString s => s
 booleanIf = "boolean-if"

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -205,7 +205,7 @@ tests =
       StdlibInclude
       "Symbols.juvix",
     PosTest
-      "Builtin boolean"
+      "Builtin bool"
       "."
       StdlibExclude
       "BuiltinsBool.juvix"

--- a/tests/positive/BuiltinsBool.juvix
+++ b/tests/positive/BuiltinsBool.juvix
@@ -1,12 +1,12 @@
 module BuiltinsBool;
 
-builtin boolean
+builtin bool
 inductive Bool {
   true : Bool;
   false : Bool;
 };
 
-builtin boolean-if
+builtin bool-if
 if : {A : Type} → Bool → A → A → A;
 if true t _ := t;
 if false _ e := e;

--- a/tests/positive/BuiltinsMultiImport/Nat.juvix
+++ b/tests/positive/BuiltinsMultiImport/Nat.juvix
@@ -1,6 +1,6 @@
 module Nat;
 
-builtin natural
+builtin nat
 inductive Nat {
   zero : Nat;
   suc : Nat → Nat;

--- a/tests/positive/BuiltinsMultiOpenImport/Nat.juvix
+++ b/tests/positive/BuiltinsMultiOpenImport/Nat.juvix
@@ -1,6 +1,6 @@
 module Nat;
 
-builtin natural
+builtin nat
 inductive Nat {
   zero : Nat;
   suc : Nat → Nat;

--- a/tests/positive/MiniC/Builtins/Input.juvix
+++ b/tests/positive/MiniC/Builtins/Input.juvix
@@ -1,12 +1,12 @@
 module Input;
 
-builtin boolean
+builtin bool
 inductive Bool {
   true : Bool;
   false : Bool;
 };
 
-builtin boolean-if
+builtin bool-if
 if : {A : Type} → Bool → A → A → A;
 if true t _ := t;
 if false _ e := e;

--- a/tests/positive/MiniC/Builtins/Input.juvix
+++ b/tests/positive/MiniC/Builtins/Input.juvix
@@ -11,7 +11,7 @@ if : {A : Type} → Bool → A → A → A;
 if true t _ := t;
 if false _ e := e;
 
-builtin natural
+builtin nat
 inductive ℕ {
  zero : ℕ;
  suc : ℕ → ℕ;
@@ -22,7 +22,7 @@ boolToNat false := zero;
 boolToNat true := suc zero;
 
 infixl 4 +;
-builtin natural-plus
+builtin nat-plus
 + : ℕ → ℕ → ℕ;
 + zero x := x;
 + (suc a) b := suc (a + b);
@@ -47,7 +47,7 @@ builtin IO axiom IO : Type;
 
 infixl 1 >>;
 builtin IO-sequence axiom >> : IO → IO → IO;
-builtin natural-print axiom printNat : ℕ → IO;
+builtin nat-print axiom printNat : ℕ → IO;
 
 main : IO;
 main := printNat (boolToNat true)


### PR DESCRIPTION
The builtin labels for natural and boolean are renamed to nat and bool.

This PR also updates the reference to the stdlib containing updates to the stdlib Nat and Bool definitions.

```
builtin nat
inductive Nat  {
  zero : Nat;
  suc : Nat → Nat;
};
```

```
builtin bool
inductive Bool {
  true : Bool;
  false : Bool;
};
```

Now that `Bool` is builtin, we do not need the `BackendBool` type and bridge from the Juvix Bool inductive type and the `bool` C type.

### Updating stdlib submodule

After merging this PR - the juvix-stdlib PR https://github.com/anoma/juvix-stdlib/pull/18 can be merged, then the juvix-stdlib submodule should be updated to point to juvix-stdlib main.