### PR TITLE
Compute JuvixAsm stack usage info

### DIFF
--- a/src/Juvix/Compiler/Asm/Extra.hs
+++ b/src/Juvix/Compiler/Asm/Extra.hs
@@ -71,8 +71,8 @@ computeFunctionStackUsage tab fi = do
 
 computeStackUsage :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
 computeStackUsage tab = do
-  lst <- mapM (secondM (computeFunctionStackUsage tab)) (HashMap.toList (tab ^. infoFunctions))
-  return tab {_infoFunctions = HashMap.fromList lst}
+  fns <- mapM (computeFunctionStackUsage tab) (tab ^. infoFunctions)
+  return tab {_infoFunctions = fns}
 
 computeStackUsage' :: InfoTable -> Either AsmError InfoTable
 computeStackUsage' tab = run $ runError $ computeStackUsage tab

--- a/src/Juvix/Compiler/Asm/Extra.hs
+++ b/src/Juvix/Compiler/Asm/Extra.hs
@@ -18,7 +18,7 @@ import Juvix.Compiler.Asm.Language
 validateCode :: forall r. Member (Error AsmError) r => InfoTable -> Arguments -> Code -> Sem r ()
 validateCode tab args = void . recurse sig args
   where
-    sig :: RecursorSig r ()
+    sig :: RecursorSig Memory r ()
     sig =
       RecursorSig
         { _recursorInfoTable = tab,
@@ -30,11 +30,49 @@ validateCode tab args = void . recurse sig args
 validateFunction :: Member (Error AsmError) r => InfoTable -> FunctionInfo -> Sem r ()
 validateFunction tab fi = validateCode tab (argumentsFromFunctionInfo fi) (fi ^. functionCode)
 
-validateInfoTable :: Member (Error AsmError) r => InfoTable -> Sem r ()
-validateInfoTable tab = mapM_ (validateFunction tab) (HashMap.elems (tab ^. infoFunctions))
+validateInfoTable :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
+validateInfoTable tab = do
+  mapM_ (validateFunction tab) (HashMap.elems (tab ^. infoFunctions))
+  return tab
 
 validate :: InfoTable -> Maybe AsmError
 validate tab =
   case run $ runError $ validateInfoTable tab of
     Left err -> Just err
     _ -> Nothing
+
+computeFunctionStackUsage :: Member (Error AsmError) r => InfoTable -> FunctionInfo -> Sem r FunctionInfo
+computeFunctionStackUsage tab fi = do
+  ps <- snd <$> recurseS sig initialStackInfo (fi ^. functionCode)
+  let maxValueStack = maximum (map fst ps)
+      maxTempStack = maximum (map snd ps)
+  return
+    fi
+      { _functionMaxValueStackHeight = maxValueStack,
+        _functionMaxTempStackHeight = maxTempStack
+      }
+  where
+    sig :: RecursorSig StackInfo r (Int, Int)
+    sig =
+      RecursorSig
+        { _recursorInfoTable = tab,
+          _recurseInstr = \si _ -> return (si ^. stackInfoValueStackHeight, si ^. stackInfoTempStackHeight),
+          _recurseBranch = \si _ l r ->
+            return
+              ( max (si ^. stackInfoValueStackHeight) (max (maximum (map fst l)) (maximum (map fst r))),
+                max (si ^. stackInfoTempStackHeight) (max (maximum (map snd l)) (maximum (map snd r)))
+              ),
+          _recurseCase = \si _ cs md ->
+            return
+              ( max (si ^. stackInfoValueStackHeight) (max (maximum (map (maximum . map fst) cs)) (maybe 0 (maximum . map fst) md)),
+                max (si ^. stackInfoTempStackHeight) (max (maximum (map (maximum . map snd) cs)) (maybe 0 (maximum . map snd) md))
+              )
+        }
+
+computeStackUsage :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
+computeStackUsage tab = do
+  lst <- mapM (secondM (computeFunctionStackUsage tab)) (HashMap.toList (tab ^. infoFunctions))
+  return tab {_infoFunctions = HashMap.fromList lst}
+
+computeStackUsage' :: InfoTable -> Either AsmError InfoTable
+computeStackUsage' tab = run $ runError $ computeStackUsage tab

--- a/src/Juvix/Compiler/Asm/Pipeline.hs
+++ b/src/Juvix/Compiler/Asm/Pipeline.hs
@@ -1,0 +1,10 @@
+module Juvix.Compiler.Asm.Pipeline where
+
+import Juvix.Compiler.Asm.Data.InfoTable
+import Juvix.Compiler.Asm.Extra
+import Juvix.Compiler.Asm.Language
+
+-- | Perform transformations on JuvixAsm necessary before the translation to
+-- JuvixReg
+toReg :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
+toReg = validateInfoTable >=> computeStackUsage

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -59,7 +59,7 @@ fromAsmFun tab fi =
     Left err -> error (show err)
     Right code -> code
   where
-    sig :: Asm.RecursorSig (Error Asm.AsmError ': r) Instruction
+    sig :: Asm.RecursorSig Asm.Memory (Error Asm.AsmError ': r) Instruction
     sig =
       Asm.RecursorSig
         { _recursorInfoTable = tab,


### PR DESCRIPTION
# Description

* Introduce a simplified version of the recursor `recurseS` which only computes stack information without doing extensive input validation. We will need this simpler recursor in a few more passes.
* Using `recurseS`, compute the maximum value stack height and the maximum temporary stack height in each JuvixAsm function. This is necessary for the translation to JuvixReg.

Closes #1553, #1555


