### PR TITLE
Fix discrepancy between Juvix and WASM pages

### DIFF
--- a/runtime/src/juvix/mem/pages.c
+++ b/runtime/src/juvix/mem/pages.c
@@ -88,7 +88,7 @@ void *palloc(size_t n) {
             if (__builtin_wasm_memory_grow(0, delta) == (size_t)-1) {
                 error_exit_msg("error: out of memory");
             }
-            heap_size += delta;
+            heap_size += delta << WASM_PAGE_SIZE_LOG2;
             ASSERT((uintptr_t)heap_end <= heap_size);
         }
         heap_pages_num =

--- a/runtime/src/juvix/mem/pages.c
+++ b/runtime/src/juvix/mem/pages.c
@@ -32,6 +32,8 @@ void pfree(void *ptr, size_t n) {
 
 #define WASM_PAGE_SIZE_LOG2 16U
 
+STATIC_ASSERT(PAGE_SIZE_LOG2 >= WASM_PAGE_SIZE_LOG2);
+
 typedef struct Page {
     struct Page *next;
     size_t size;  // the number of WASM pages
@@ -45,6 +47,7 @@ static page_t *free_page = NULL;
 void *palloc(size_t n) {
     ASSERT(n > 0);
     n = n << (PAGE_SIZE_LOG2 - WASM_PAGE_SIZE_LOG2);
+    // now `n` is the number of WASM pages to allocate
     page_t *prev = NULL;
     page_t *page = free_page;
     while (page && page->size < n) {
@@ -54,7 +57,7 @@ void *palloc(size_t n) {
     if (page) {
         page_t *next;
         if (page->size > n) {
-            next = (page_t *)((char *)page + (n << PAGE_SIZE_LOG2));
+            next = (page_t *)((char *)page + (n << WASM_PAGE_SIZE_LOG2));
             next->size = page->size - n;
             next->next = page->next;
         } else {
@@ -74,13 +77,14 @@ void *palloc(size_t n) {
     }
 
     // Allocate `n` pages from WebAssembly
-    uintptr_t heap_size = __builtin_wasm_memory_size(0) << PAGE_SIZE_LOG2;
+    uintptr_t heap_size = __builtin_wasm_memory_size(0) << WASM_PAGE_SIZE_LOG2;
     if (heap_end == NULL) {
         // first-time allocation
         heap_end = palign(&__heap_base, PAGE_SIZE);
-        heap_pages_num = (heap_size - (uintptr_t)heap_end) >> PAGE_SIZE_LOG2;
+        heap_pages_num =
+            (heap_size - (uintptr_t)heap_end) >> WASM_PAGE_SIZE_LOG2;
     }
-    if (heap_size - (uintptr_t)heap_end < (n << PAGE_SIZE_LOG2)) {
+    if (heap_size - (uintptr_t)heap_end < (n << WASM_PAGE_SIZE_LOG2)) {
         size_t delta = max(opt_heap_grow_pages, max(n, heap_pages_num / 2));
         ASSERT(delta != 0);
         if (__builtin_wasm_memory_grow(0, delta) == (size_t)-1) {
@@ -89,9 +93,9 @@ void *palloc(size_t n) {
         heap_pages_num += delta;
     }
     void *ptr = heap_end;
-    heap_end = (char *)heap_end + (n << PAGE_SIZE_LOG2);
+    heap_end = (char *)heap_end + (n << WASM_PAGE_SIZE_LOG2);
     ASSERT_ALIGNED(ptr, PAGE_SIZE);
-    juvix_allocated_pages_num += n;
+    juvix_allocated_pages_num += n >> (PAGE_SIZE_LOG2 - WASM_PAGE_SIZE_LOG2);
     if (juvix_allocated_pages_num > juvix_max_allocated_pages_num) {
         juvix_max_allocated_pages_num = juvix_allocated_pages_num;
     }
@@ -104,7 +108,7 @@ void pfree(void *ptr, size_t n) {
     page->size = n;
     page->next = free_page;
     free_page = page;
-    juvix_allocated_pages_num -= n;
+    juvix_allocated_pages_num -= n >> (PAGE_SIZE_LOG2 - WASM_PAGE_SIZE_LOG2);
 }
 
 #else


### PR DESCRIPTION
The Juvix runtime page size can be a multiple of the WebAssembly page size, but this was handled incorrectly in the page allocator.
