### PR TITLE
Improvements to Juvix REPL

### DIFF
--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -16,7 +16,7 @@ import Juvix.Compiler.Core.Info qualified as Info
 import Juvix.Compiler.Core.Info.NoDisplayInfo qualified as Info
 import Juvix.Compiler.Core.Language qualified as Core
 import Juvix.Compiler.Core.Pretty qualified as Core
-import Juvix.Compiler.Core.Translation.FromInternal.Data as Core
+import Juvix.Compiler.Core.Translation.FromInternal.Data qualified as Core
 import Juvix.Compiler.Internal.Language qualified as Internal
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Data.Error.GenericError qualified as Error
@@ -208,7 +208,11 @@ runCommand opts = do
       banner :: MultiLine -> Repl String
       banner = \case
         MultiLine -> return "... "
-        SingleLine -> return "juvix> "
+        SingleLine -> do
+          mctx <- State.gets (fmap (^. replContextExpContext) . (^. replStateContext))
+          case mctx of
+            Just ctx -> return [i|#{unpack (P.prettyText (mainModuleTopPath ctx))}> |]
+            Nothing -> return "juvix> "
 
       prefix :: Maybe Char
       prefix = Just ':'

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -53,23 +53,16 @@ helpTxt =
   liftIO
     ( putStrLn
         [__i|
-  Type any expression to evaluate it in the context of the currently loaded module or use one of the following commands:
-  :help
-         Print help text and describe options
-  :load FILE
-         Load a file into the REPL
-  :reload
-         Reload the currently loaded file
-  :type EXPRESSION
-         Infer the type of an expression
-  :core EXPRESSION
-         Translate the expression to JuvixCore
-  :multiline
-         Start a multi-line input. Submit with <Ctrl-D>
-  :root
-         Print the current project root
-  :quit
-         Exit the REPL
+  EXPRESSION                Evaluate an expression in the context of the currently loaded module
+  :help                     Print help text and describe options
+  :load       FILE          Load a file into the REPL
+  :reload                   Reload the currently loaded file
+  :type       EXPRESSION    Infer the type of an expression
+  :core       EXPRESSION    Translate the expression to JuvixCore
+  :multiline                Start a multi-line input. Submit with <Ctrl-D>
+  :root                     Print the current project root
+  :version                  Display the Juvix version
+  :quit                     Exit the REPL
   |]
     )
 
@@ -128,6 +121,9 @@ runCommand opts = do
       printRoot _ = do
         r <- State.gets (^. replStateRoot)
         liftIO $ putStrLn (pack r)
+
+      displayVersion :: String -> Repl ()
+      displayVersion _ = liftIO (putStrLn versionTag)
 
       command :: String -> Repl ()
       command input = Repline.dontCrash $ do
@@ -197,6 +193,7 @@ runCommand opts = do
           ("reload", Repline.dontCrash . reloadFile),
           ("root", printRoot),
           ("type", inferType),
+          ("version", displayVersion),
           ("core", core)
         ]
 

--- a/app/Commands/Repl/Options.hs
+++ b/app/Commands/Repl/Options.hs
@@ -2,8 +2,10 @@ module Commands.Repl.Options where
 
 import CommonOptions
 
-newtype ReplOptions = ReplOptions
-  {_replInputFile :: Maybe Path}
+data ReplOptions = ReplOptions
+  { _replInputFile :: Maybe Path,
+    _replNoPrelude :: Bool
+  }
   deriving stock (Data)
 
 makeLenses ''ReplOptions
@@ -11,4 +13,9 @@ makeLenses ''ReplOptions
 parseRepl :: Parser ReplOptions
 parseRepl = do
   _replInputFile <- optional parseInputJuvixFile
+  _replNoPrelude <-
+    switch
+      ( long "no-prelude"
+          <> help "Do not load the Prelude module on launch"
+      )
   pure ReplOptions {..}

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -5,6 +5,7 @@ module Juvix.Compiler.Pipeline.EntryPoint
 where
 
 import Juvix.Compiler.Pipeline.Package
+import Juvix.Extra.Paths (juvixStdlibDir)
 import Juvix.Prelude
 
 -- | The head of _entryModulePaths is assumed to be the Main module
@@ -20,6 +21,9 @@ data EntryPoint = EntryPoint
     _entryPointModulePaths :: NonEmpty FilePath
   }
   deriving stock (Eq, Show)
+
+defaultStdlibPath :: FilePath -> FilePath
+defaultStdlibPath root = root </> juvixStdlibDir
 
 defaultEntryPoint :: FilePath -> EntryPoint
 defaultEntryPoint mainFile =

--- a/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
+++ b/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
@@ -49,7 +49,7 @@ moduleScope :: ExpressionContext -> C.TopModulePath -> Maybe S.Scope
 moduleScope e p = e ^. contextScoperResult ^?! Scoper.resultScope . at p
 
 mainModuleScope :: ExpressionContext -> S.Scope
-mainModuleScope e = fromJust (moduleScope e mainModulePath)
-  where
-    mainModulePath :: C.TopModulePath
-    mainModulePath = e ^. contextScoperResult . Scoper.mainModule . C.modulePath . S.nameConcrete
+mainModuleScope e = fromJust (moduleScope e (mainModuleTopPath e))
+
+mainModuleTopPath :: ExpressionContext -> C.TopModulePath
+mainModuleTopPath =  (^. contextScoperResult . Scoper.mainModule . C.modulePath . S.nameConcrete)

--- a/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
+++ b/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
@@ -52,4 +52,4 @@ mainModuleScope :: ExpressionContext -> S.Scope
 mainModuleScope e = fromJust (moduleScope e (mainModuleTopPath e))
 
 mainModuleTopPath :: ExpressionContext -> C.TopModulePath
-mainModuleTopPath =  (^. contextScoperResult . Scoper.mainModule . C.modulePath . S.nameConcrete)
+mainModuleTopPath = (^. contextScoperResult . Scoper.mainModule . C.modulePath . S.nameConcrete)

--- a/src/Juvix/Compiler/Pipeline/Setup.hs
+++ b/src/Juvix/Compiler/Pipeline/Setup.hs
@@ -1,7 +1,6 @@
 module Juvix.Compiler.Pipeline.Setup where
 
 import Juvix.Compiler.Pipeline.EntryPoint
-import Juvix.Extra.Paths
 import Juvix.Prelude
 
 entrySetup ::
@@ -19,7 +18,7 @@ setupStdlib = do
   e <- ask
   stdlibRootPath <- case e ^. entryPointStdlibPath of
     Nothing -> do
-      let d = (e ^. entryPointRoot) </> juvixStdlibDir
+      let d = defaultStdlibPath (e ^. entryPointRoot)
       updateStdlib d
       return d
     Just p -> return p


### PR DESCRIPTION
* Adds the following new commands to the REPL:

`:reload` - reload the current module
`:version` - display the current Juvix version
`:prelude` - load the Prelude module from the stdlib

* The name of the currently loaded module is now shown in the banner.

* The Prelude module is now loaded when the REPL is launched (unless `--no-prelude` REPL option or `--no-stdlib` global option is set).
