### PR TITLE
Precompute maximum heap allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ TAGS
 # other
 .DS_Store
 
-/runtime/include
+/runtime/include/
 _build/
 _build.*/
 *.agdai

--- a/app/Commands/Dev/Asm/Run.hs
+++ b/app/Commands/Dev/Asm/Run.hs
@@ -7,6 +7,7 @@ import Juvix.Compiler.Asm.Error qualified as Asm
 import Juvix.Compiler.Asm.Extra qualified as Asm
 import Juvix.Compiler.Asm.Interpreter qualified as Asm
 import Juvix.Compiler.Asm.Pretty qualified as Asm
+import Juvix.Compiler.Asm.Transformation.Validate qualified as Asm
 import Juvix.Compiler.Asm.Translation.FromSource qualified as Asm
 
 runCommand :: forall r. Members '[Embed IO, App] r => AsmRunOptions -> Sem r ()
@@ -15,7 +16,7 @@ runCommand opts = do
   case Asm.runParser file s of
     Left err -> exitJuvixError (JuvixError err)
     Right tab ->
-      let v = if opts ^. asmRunNoValidate then Nothing else Asm.validate tab
+      let v = if opts ^. asmRunNoValidate then Nothing else Asm.validate' tab
        in case v of
             Just err ->
               exitJuvixError (JuvixError err)

--- a/app/Commands/Dev/Asm/Validate.hs
+++ b/app/Commands/Dev/Asm/Validate.hs
@@ -2,7 +2,7 @@ module Commands.Dev.Asm.Validate where
 
 import Commands.Base
 import Commands.Dev.Asm.Validate.Options
-import Juvix.Compiler.Asm.Extra qualified as Asm
+import Juvix.Compiler.Asm.Transformation.Validate qualified as Asm
 import Juvix.Compiler.Asm.Translation.FromSource qualified as Asm
 
 runCommand :: forall r. Members '[Embed IO, App] r => AsmValidateOptions -> Sem r ()
@@ -11,7 +11,7 @@ runCommand opts = do
   case Asm.runParser file s of
     Left err -> exitJuvixError (JuvixError err)
     Right tab -> do
-      case Asm.validate tab of
+      case Asm.validate' tab of
         Just err ->
           exitJuvixError (JuvixError err)
         Nothing ->

--- a/runtime/src/juvix/limits.h
+++ b/runtime/src/juvix/limits.h
@@ -30,16 +30,12 @@
 #define MAX_FIELDS 255U
 
 #define MAX_CONSTR_ARGS MAX_FIELDS
-// Max number of fields minus the extra field in a closure.
-#define MAX_FUNCTION_ARGS (MAX_FIELDS - 1)
+// Max number of fields minus the extra fields in a closure.
+#define MAX_FUNCTION_ARGS (MAX_FIELDS - 2)
 
 #define MAX_CSTRING_LENGTH (MAX_FIELDS * sizeof(word_t) - 1)
 
 #define MAX_LOCAL_VARS (PAGE_SIZE / 2 / sizeof(word_t))
-
-// The maximum number of words that can be allocated on the heap by an
-// invocation of the dispatch loop (CallClosures)
-#define MAX_DISPATCH_ALLOC (MAX_FUNCTION_ARGS + CLOSURE_SKIP + 1)
 
 /*****************************************/
 /* Static asserts */

--- a/src/Juvix/Compiler/Asm/Extra.hs
+++ b/src/Juvix/Compiler/Asm/Extra.hs
@@ -1,78 +1,12 @@
 module Juvix.Compiler.Asm.Extra
-  ( module Juvix.Compiler.Asm.Extra,
-    module Juvix.Compiler.Asm.Extra.Base,
+  ( module Juvix.Compiler.Asm.Extra.Base,
     module Juvix.Compiler.Asm.Extra.Type,
     module Juvix.Compiler.Asm.Extra.Recursors,
     module Juvix.Compiler.Asm.Error,
   )
 where
 
-import Data.HashMap.Strict qualified as HashMap
-import Juvix.Compiler.Asm.Data.InfoTable
 import Juvix.Compiler.Asm.Error
 import Juvix.Compiler.Asm.Extra.Base
 import Juvix.Compiler.Asm.Extra.Recursors
 import Juvix.Compiler.Asm.Extra.Type
-import Juvix.Compiler.Asm.Language
-
-validateCode :: forall r. Member (Error AsmError) r => InfoTable -> Arguments -> Code -> Sem r ()
-validateCode tab args = void . recurse sig args
-  where
-    sig :: RecursorSig Memory r ()
-    sig =
-      RecursorSig
-        { _recursorInfoTable = tab,
-          _recurseInstr = \_ _ -> return (),
-          _recurseBranch = \_ _ _ _ -> return (),
-          _recurseCase = \_ _ _ _ -> return ()
-        }
-
-validateFunction :: Member (Error AsmError) r => InfoTable -> FunctionInfo -> Sem r ()
-validateFunction tab fi = validateCode tab (argumentsFromFunctionInfo fi) (fi ^. functionCode)
-
-validateInfoTable :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
-validateInfoTable tab = do
-  mapM_ (validateFunction tab) (HashMap.elems (tab ^. infoFunctions))
-  return tab
-
-validate :: InfoTable -> Maybe AsmError
-validate tab =
-  case run $ runError $ validateInfoTable tab of
-    Left err -> Just err
-    _ -> Nothing
-
-computeFunctionStackUsage :: Member (Error AsmError) r => InfoTable -> FunctionInfo -> Sem r FunctionInfo
-computeFunctionStackUsage tab fi = do
-  ps <- snd <$> recurseS sig initialStackInfo (fi ^. functionCode)
-  let maxValueStack = maximum (map fst ps)
-      maxTempStack = maximum (map snd ps)
-  return
-    fi
-      { _functionMaxValueStackHeight = maxValueStack,
-        _functionMaxTempStackHeight = maxTempStack
-      }
-  where
-    sig :: RecursorSig StackInfo r (Int, Int)
-    sig =
-      RecursorSig
-        { _recursorInfoTable = tab,
-          _recurseInstr = \si _ -> return (si ^. stackInfoValueStackHeight, si ^. stackInfoTempStackHeight),
-          _recurseBranch = \si _ l r ->
-            return
-              ( max (si ^. stackInfoValueStackHeight) (max (maximum (map fst l)) (maximum (map fst r))),
-                max (si ^. stackInfoTempStackHeight) (max (maximum (map snd l)) (maximum (map snd r)))
-              ),
-          _recurseCase = \si _ cs md ->
-            return
-              ( max (si ^. stackInfoValueStackHeight) (max (maximum (map (maximum . map fst) cs)) (maybe 0 (maximum . map fst) md)),
-                max (si ^. stackInfoTempStackHeight) (max (maximum (map (maximum . map snd) cs)) (maybe 0 (maximum . map snd) md))
-              )
-        }
-
-computeStackUsage :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
-computeStackUsage tab = do
-  fns <- mapM (computeFunctionStackUsage tab) (tab ^. infoFunctions)
-  return tab {_infoFunctions = fns}
-
-computeStackUsage' :: InfoTable -> Either AsmError InfoTable
-computeStackUsage' tab = run $ runError $ computeStackUsage tab

--- a/src/Juvix/Compiler/Asm/Extra/Base.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Base.hs
@@ -32,3 +32,11 @@ isFinalInstr = \case
   TailCallClosures {} -> True
   Failure -> True
   _ -> False
+
+getConstrSize :: MemRep -> Int -> Int
+getConstrSize rep argsNum = case rep of
+  MemRepConstr -> 1 + argsNum
+  MemRepTag -> 0
+  MemRepTuple -> argsNum
+  MemRepUnit -> 0
+  MemRepUnpacked {} -> 0

--- a/src/Juvix/Compiler/Asm/Extra/Recursors.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Recursors.hs
@@ -370,17 +370,17 @@ recurseS' sig = go
                 stackInfoPopValueStack (_allocClosureArgsNum - 1) si
             ExtendClosure InstrExtendClosure {..} ->
               return $
-                stackInfoPopValueStack (_extendClosureArgsNum - 1) si
+                stackInfoPopValueStack _extendClosureArgsNum si
             Call x ->
               fixStackCall si x
             TailCall x ->
-              fixStackCall si x
+              fixStackCall (dropTempStack si) x
             CallClosures x ->
               fixStackCallClosures si x
             TailCallClosures x ->
-              fixStackCallClosures si x
+              fixStackCallClosures (dropTempStack si) x
             Return ->
-              return si
+              return (dropTempStack si)
 
         fixStackBinOp :: StackInfo -> Sem r StackInfo
         fixStackBinOp si = return $ stackInfoPopValueStack 1 si
@@ -439,6 +439,9 @@ recurseS' sig = go
 
     stackInfoPopTempStack :: Int -> StackInfo -> StackInfo
     stackInfoPopTempStack n si = si {_stackInfoTempStackHeight = si ^. stackInfoTempStackHeight - n}
+
+    dropTempStack :: StackInfo -> StackInfo
+    dropTempStack si = si {_stackInfoTempStackHeight = 0}
 
 -- | Fold signature. Contains read-only fold parameters.
 data FoldSig m r a = FoldSig

--- a/src/Juvix/Compiler/Asm/Extra/Recursors.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Recursors.hs
@@ -113,6 +113,8 @@ recurse' sig = go True
               return mem
             Failure ->
               return mem
+            Prealloc {} ->
+              return mem
             AllocConstr tag -> do
               let ci = getConstrInfo (sig ^. recursorInfoTable) tag
                   n = ci ^. constructorArgsNum
@@ -294,8 +296,11 @@ initialStackInfo = StackInfo {_stackInfoValueStackHeight = 0, _stackInfoTempStac
 -- program code which need only stack height information. Also, the code using
 -- the simplified recursor can itself be simpler if it doesn't need the extra
 -- info provided by the full recursor.
-recurseS :: forall r a. Member (Error AsmError) r => RecursorSig StackInfo r a -> StackInfo -> Code -> Sem r (StackInfo, [a])
-recurseS sig = go
+recurseS :: forall r a. Member (Error AsmError) r => RecursorSig StackInfo r a -> Code -> Sem r [a]
+recurseS sig code = snd <$> recurseS' sig initialStackInfo code
+
+recurseS' :: forall r a. Member (Error AsmError) r => RecursorSig StackInfo r a -> StackInfo -> Code -> Sem r (StackInfo, [a])
+recurseS' sig = go
   where
     go :: StackInfo -> Code -> Sem r (StackInfo, [a])
     go si = \case
@@ -352,6 +357,8 @@ recurseS sig = go
             Dump ->
               return si
             Failure ->
+              return si
+            Prealloc {} ->
               return si
             AllocConstr tag -> do
               let ci = getConstrInfo (sig ^. recursorInfoTable) tag
@@ -432,3 +439,51 @@ recurseS sig = go
 
     stackInfoPopTempStack :: Int -> StackInfo -> StackInfo
     stackInfoPopTempStack n si = si {_stackInfoTempStackHeight = si ^. stackInfoTempStackHeight - n}
+
+-- | Fold signature. Contains read-only fold parameters.
+data FoldSig m r a = FoldSig
+  { _foldInfoTable :: InfoTable,
+    _foldAdjust :: a -> a,
+    _foldInstr :: m -> CmdInstr -> a -> Sem r a,
+    _foldBranch :: m -> CmdBranch -> a -> a -> a -> Sem r a,
+    _foldCase :: m -> CmdCase -> [a] -> Maybe a -> a -> Sem r a
+  }
+
+makeLenses ''FoldSig
+
+foldS :: forall r a. Member (Error AsmError) r => FoldSig StackInfo r a -> Code -> a -> Sem r a
+foldS sig code a = snd <$> foldS' sig initialStackInfo code a
+
+foldS' :: forall r a. Member (Error AsmError) r => FoldSig StackInfo r a -> StackInfo -> Code -> a -> Sem r (StackInfo, a)
+foldS' sig si code acc = do
+  (si', fs) <- recurseS' sig' si code
+  a' <- compose fs acc
+  return (si', a')
+  where
+    sig' :: RecursorSig StackInfo r (a -> Sem r a)
+    sig' =
+      RecursorSig
+        { _recursorInfoTable = sig ^. foldInfoTable,
+          _recurseInstr = \s cmd -> return ((sig ^. foldInstr) s cmd),
+          _recurseBranch = \s cmd br1 br2 ->
+            return
+              ( \a -> do
+                  let a' = (sig ^. foldAdjust) a
+                  a1 <- compose br1 a'
+                  a2 <- compose br2 a'
+                  (sig ^. foldBranch) s cmd a1 a2 a
+              ),
+          _recurseCase = \s cmd brs md ->
+            return
+              ( \a -> do
+                  let a' = (sig ^. foldAdjust) a
+                  as <- mapM (`compose` a') brs
+                  ad <- case md of
+                    Just d -> Just <$> compose d a'
+                    Nothing -> return Nothing
+                  (sig ^. foldCase) s cmd as ad a
+              )
+        }
+
+    compose :: [a -> Sem r a] -> a -> Sem r a
+    compose lst x = foldr (=<<) (return x) lst

--- a/src/Juvix/Compiler/Asm/Interpreter.hs
+++ b/src/Juvix/Compiler/Asm/Interpreter.hs
@@ -113,6 +113,8 @@ runCodeR infoTable funInfo = goCode (funInfo ^. functionCode) >> popLastValueSta
       Failure -> do
         v <- topValueStack
         runtimeError $ mappend "failure: " (printVal v)
+      Prealloc {} ->
+        goCode cont
       AllocConstr tag -> do
         let ci = getConstrInfo infoTable tag
         args <- replicateM (ci ^. constructorArgsNum) popValueStack

--- a/src/Juvix/Compiler/Asm/Language.hs
+++ b/src/Juvix/Compiler/Asm/Language.hs
@@ -35,7 +35,7 @@ data Value
 data MemValue
   = -- | A direct memory reference.
     DRef DirectRef
-  | -- | ConstrRef references is an indirect reference to a field (argument) of
+  | -- | ConstrRef is an indirect reference to a field (argument) of
     --  a constructor: field k holds the (k+1)th argument.
     ConstrRef Field
 
@@ -87,6 +87,9 @@ data Instruction
   | -- | Interrupt execution with a runtime error printing the value on top of
     -- the stack. JVA opcode: 'fail'.
     Failure
+  | -- | Preallocate memory. This instruction is inserted automatically before
+    -- translation to JuvixReg. It does not occur in JVA files.
+    Prealloc InstrPrealloc
   | -- | Allocate constructor data with a given tag. The n arguments (the number n
     -- determined by the constant tag) are popped from the stack and stored at
     -- increasing offsets (stack[0]: field 0, stack[1]: field 1, ...,
@@ -167,6 +170,11 @@ data Opcode
   | -- | Compare the two top stack cells with structural equality, pop the stack
     -- by two, and push the result. JVA opcode: 'eq'.
     ValEq
+
+newtype InstrPrealloc = InstrPrealloc
+  { -- | How many words to preallocate?
+    _preallocWordsNum :: Int
+  }
 
 data InstrAllocClosure = InstrAllocClosure
   { _allocClosureFunSymbol :: Symbol,

--- a/src/Juvix/Compiler/Asm/Options.hs
+++ b/src/Juvix/Compiler/Asm/Options.hs
@@ -1,0 +1,18 @@
+module Juvix.Compiler.Asm.Options
+  ( module Juvix.Compiler.Asm.Options,
+    module Juvix.Compiler.Backend,
+  )
+where
+
+import Juvix.Compiler.Backend
+import Juvix.Prelude
+
+data Options = Options
+  { _optDebug :: Bool,
+    _optLimits :: Limits
+  }
+
+makeLenses ''Options
+
+getClosureSize :: Options -> Int -> Int
+getClosureSize opts argsNum = opts ^. optLimits . limitsClosureHeadSize + argsNum

--- a/src/Juvix/Compiler/Asm/Pipeline.hs
+++ b/src/Juvix/Compiler/Asm/Pipeline.hs
@@ -3,8 +3,10 @@ module Juvix.Compiler.Asm.Pipeline where
 import Juvix.Compiler.Asm.Data.InfoTable
 import Juvix.Compiler.Asm.Extra
 import Juvix.Compiler.Asm.Language
+import Juvix.Compiler.Asm.Options
+import Juvix.Compiler.Asm.Transformation
 
 -- | Perform transformations on JuvixAsm necessary before the translation to
 -- JuvixReg
-toReg :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
-toReg = validateInfoTable >=> computeStackUsage
+toReg :: Members '[Error AsmError, Reader Options] r => InfoTable -> Sem r InfoTable
+toReg = validate >=> computeStackUsage >=> computePrealloc

--- a/src/Juvix/Compiler/Asm/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Asm/Pretty/Base.hs
@@ -194,6 +194,7 @@ instance PrettyCode Instruction where
     Trace -> return $ pretty ("trace" :: String)
     Dump -> return $ pretty ("dump" :: String)
     Failure -> return $ pretty ("fail" :: String)
+    Prealloc {} -> return $ pretty ("prealloc" :: String)
     AllocConstr {} -> return $ pretty ("alloc" :: String)
     AllocClosure {} -> return $ pretty ("calloc" :: String)
     ExtendClosure {} -> return $ pretty ("cextend" :: String)

--- a/src/Juvix/Compiler/Asm/Transformation.hs
+++ b/src/Juvix/Compiler/Asm/Transformation.hs
@@ -1,0 +1,10 @@
+module Juvix.Compiler.Asm.Transformation
+  ( module Juvix.Compiler.Asm.Transformation.StackUsage,
+    module Juvix.Compiler.Asm.Transformation.Prealloc,
+    module Juvix.Compiler.Asm.Transformation.Validate,
+  )
+where
+
+import Juvix.Compiler.Asm.Transformation.Prealloc
+import Juvix.Compiler.Asm.Transformation.StackUsage
+import Juvix.Compiler.Asm.Transformation.Validate

--- a/src/Juvix/Compiler/Asm/Transformation/Base.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/Base.hs
@@ -19,3 +19,9 @@ liftFunctionTransformation :: Monad m => (FunctionInfo -> m FunctionInfo) -> Inf
 liftFunctionTransformation f tab = do
   fns <- mapM f (tab ^. infoFunctions)
   return tab {_infoFunctions = fns}
+
+runTransformation :: (InfoTable -> Sem '[Error AsmError] InfoTable) -> InfoTable -> Either AsmError InfoTable
+runTransformation trans tab =
+  case run $ runError $ trans tab of
+    Left err -> Left err
+    Right tab' -> Right tab'

--- a/src/Juvix/Compiler/Asm/Transformation/Base.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/Base.hs
@@ -1,0 +1,22 @@
+module Juvix.Compiler.Asm.Transformation.Base
+  ( module Juvix.Compiler.Asm.Transformation.Base,
+    module Juvix.Compiler.Asm.Data.InfoTable,
+    module Juvix.Compiler.Asm.Extra,
+    module Juvix.Compiler.Asm.Language,
+  )
+where
+
+import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Asm.Data.InfoTable
+import Juvix.Compiler.Asm.Extra
+import Juvix.Compiler.Asm.Language
+
+liftCodeTransformation :: Monad m => (Code -> m Code) -> FunctionInfo -> m FunctionInfo
+liftCodeTransformation f fi = do
+  code <- f (fi ^. functionCode)
+  return fi {_functionCode = code}
+
+liftFunctionTransformation :: Monad m => (FunctionInfo -> m FunctionInfo) -> InfoTable -> m InfoTable
+liftFunctionTransformation f tab = do
+  lst <- mapM (secondM f) (HashMap.toList (tab ^. infoFunctions))
+  return tab {_infoFunctions = HashMap.fromList lst}

--- a/src/Juvix/Compiler/Asm/Transformation/Base.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/Base.hs
@@ -6,7 +6,6 @@ module Juvix.Compiler.Asm.Transformation.Base
   )
 where
 
-import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Asm.Data.InfoTable
 import Juvix.Compiler.Asm.Extra
 import Juvix.Compiler.Asm.Language
@@ -18,5 +17,5 @@ liftCodeTransformation f fi = do
 
 liftFunctionTransformation :: Monad m => (FunctionInfo -> m FunctionInfo) -> InfoTable -> m InfoTable
 liftFunctionTransformation f tab = do
-  lst <- mapM (secondM f) (HashMap.toList (tab ^. infoFunctions))
-  return tab {_infoFunctions = HashMap.fromList lst}
+  fns <- mapM f (tab ^. infoFunctions)
+  return tab {_infoFunctions = fns}

--- a/src/Juvix/Compiler/Asm/Transformation/Prealloc.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/Prealloc.hs
@@ -1,0 +1,76 @@
+module Juvix.Compiler.Asm.Transformation.Prealloc where
+
+import Juvix.Compiler.Asm.Options
+import Juvix.Compiler.Asm.Transformation.Base
+
+computeCodePrealloc :: forall r. Members '[Error AsmError, Reader Options] r => InfoTable -> Code -> Sem r Code
+computeCodePrealloc tab code = prealloc <$> foldS sig code (0, [])
+  where
+    -- returns the maximum memory use and the mapping result (Code with the
+    -- Prealloc instructions inserted)
+    sig :: FoldSig StackInfo r (Int, Code)
+    sig =
+      FoldSig
+        { _foldInfoTable = tab,
+          _foldAdjust = second (const []),
+          _foldInstr = const goInstr,
+          _foldBranch = const goBranch,
+          _foldCase = const goCase
+        }
+
+    goInstr :: CmdInstr -> (Int, Code) -> Sem r (Int, Code)
+    goInstr instr@CmdInstr {..} acc@(k, c) = case _cmdInstrInstruction of
+      AllocConstr tag ->
+        return (k + size, cmd : c)
+        where
+          ci = getConstrInfo tab tag
+          size = getConstrSize (ci ^. constructorRepresentation) (ci ^. constructorArgsNum)
+      AllocClosure InstrAllocClosure {..} -> do
+        opts <- ask
+        let size = getClosureSize opts _allocClosureArgsNum
+        return (k + size, cmd : c)
+      ExtendClosure {} -> do
+        opts <- ask
+        let size = opts ^. optLimits . limitsMaxClosureSize
+        return (k + size, cmd : c)
+      Call {} -> return (0, cmd : prealloc acc)
+      TailCall {} -> return (0, cmd : prealloc acc)
+      CallClosures {} -> return (0, cmd : prealloc acc)
+      TailCallClosures {} -> return (0, cmd : prealloc acc)
+      _ -> return (k, cmd : c)
+      where
+        cmd = Instr instr
+
+    goBranch :: CmdBranch -> (Int, Code) -> (Int, Code) -> (Int, Code) -> Sem r (Int, Code)
+    goBranch cmd br1 br2 acc = return (0, cmd' : prealloc acc)
+      where
+        cmd' =
+          Branch
+            cmd
+              { _cmdBranchTrue = prealloc br1,
+                _cmdBranchFalse = prealloc br2
+              }
+
+    goCase :: CmdCase -> [(Int, Code)] -> Maybe (Int, Code) -> (Int, Code) -> Sem r (Int, Code)
+    goCase cmd brs md acc = return (0, cmd' : prealloc acc)
+      where
+        cmd' =
+          Case
+            cmd
+              { _cmdCaseBranches =
+                  zipWith
+                    CaseBranch
+                    (map (^. caseBranchTag) (cmd ^. cmdCaseBranches))
+                    (map prealloc brs),
+                _cmdCaseDefault = fmap prealloc md
+              }
+
+    prealloc :: (Int, Code) -> Code
+    prealloc (0, c) = c
+    prealloc (n, c) = mkInstr (Prealloc (InstrPrealloc n)) : c
+
+computeFunctionPrealloc :: Members '[Error AsmError, Reader Options] r => InfoTable -> FunctionInfo -> Sem r FunctionInfo
+computeFunctionPrealloc tab = liftCodeTransformation (computeCodePrealloc tab)
+
+computePrealloc :: Members '[Error AsmError, Reader Options] r => InfoTable -> Sem r InfoTable
+computePrealloc tab = liftFunctionTransformation (computeFunctionPrealloc tab) tab

--- a/src/Juvix/Compiler/Asm/Transformation/StackUsage.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/StackUsage.hs
@@ -1,0 +1,34 @@
+module Juvix.Compiler.Asm.Transformation.StackUsage where
+
+import Juvix.Compiler.Asm.Transformation.Base
+
+computeFunctionStackUsage :: Member (Error AsmError) r => InfoTable -> FunctionInfo -> Sem r FunctionInfo
+computeFunctionStackUsage tab fi = do
+  ps <- recurseS sig (fi ^. functionCode)
+  let maxValueStack = maximum (map fst ps)
+      maxTempStack = maximum (map snd ps)
+  return
+    fi
+      { _functionMaxValueStackHeight = maxValueStack,
+        _functionMaxTempStackHeight = maxTempStack
+      }
+  where
+    sig :: RecursorSig StackInfo r (Int, Int)
+    sig =
+      RecursorSig
+        { _recursorInfoTable = tab,
+          _recurseInstr = \si _ -> return (si ^. stackInfoValueStackHeight, si ^. stackInfoTempStackHeight),
+          _recurseBranch = \si _ l r ->
+            return
+              ( max (si ^. stackInfoValueStackHeight) (max (maximum (map fst l)) (maximum (map fst r))),
+                max (si ^. stackInfoTempStackHeight) (max (maximum (map snd l)) (maximum (map snd r)))
+              ),
+          _recurseCase = \si _ cs md ->
+            return
+              ( max (si ^. stackInfoValueStackHeight) (max (maximum (map (maximum . map fst) cs)) (maybe 0 (maximum . map fst) md)),
+                max (si ^. stackInfoTempStackHeight) (max (maximum (map (maximum . map snd) cs)) (maybe 0 (maximum . map snd) md))
+              )
+        }
+
+computeStackUsage :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
+computeStackUsage tab = liftFunctionTransformation (computeFunctionStackUsage tab) tab

--- a/src/Juvix/Compiler/Asm/Transformation/Validate.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/Validate.hs
@@ -1,0 +1,29 @@
+module Juvix.Compiler.Asm.Transformation.Validate where
+
+import Juvix.Compiler.Asm.Transformation.Base
+
+validateCode :: forall r. Member (Error AsmError) r => InfoTable -> FunctionInfo -> Code -> Sem r Code
+validateCode tab fi code = do
+  recurse sig (argumentsFromFunctionInfo fi) code
+  return code
+  where
+    sig :: RecursorSig Memory r ()
+    sig =
+      RecursorSig
+        { _recursorInfoTable = tab,
+          _recurseInstr = \_ _ -> return (),
+          _recurseBranch = \_ _ _ _ -> return (),
+          _recurseCase = \_ _ _ _ -> return ()
+        }
+
+validateFunction :: Member (Error AsmError) r => InfoTable -> FunctionInfo -> Sem r FunctionInfo
+validateFunction tab fi = liftCodeTransformation (validateCode tab fi) fi
+
+validate :: Member (Error AsmError) r => InfoTable -> Sem r InfoTable
+validate tab = liftFunctionTransformation (validateFunction tab) tab
+
+validate' :: InfoTable -> Maybe AsmError
+validate' tab =
+  case run $ runError $ validate tab of
+    Left err -> Just err
+    _ -> Nothing

--- a/src/Juvix/Compiler/Backend.hs
+++ b/src/Juvix/Compiler/Backend.hs
@@ -1,0 +1,45 @@
+module Juvix.Compiler.Backend where
+
+import Juvix.Prelude
+
+data Target = TargetCWasm32Wasi | TargetCNative64
+
+data Limits = Limits
+  { _limitsMaxConstrs :: Int,
+    _limitsMaxConstrArgs :: Int,
+    _limitsMaxFunctionArgs :: Int,
+    _limitsMaxLocalVars :: Int,
+    _limitsMaxClosureSize :: Int,
+    _limitsClosureHeadSize :: Int,
+    _limitsMaxStackDelta :: Int,
+    _limitsMaxFunctionAlloc :: Int
+  }
+
+makeLenses ''Limits
+
+-- Make sure the following limits correspond to the limits in the runtime for
+-- each backend target
+getLimits :: Target -> Bool -> Limits
+getLimits tgt debug = case tgt of
+  TargetCWasm32Wasi ->
+    Limits
+      { _limitsMaxConstrs = 1048576,
+        _limitsMaxConstrArgs = 255,
+        _limitsMaxFunctionArgs = 253,
+        _limitsMaxLocalVars = 2048,
+        _limitsMaxClosureSize = 253 + 3,
+        _limitsClosureHeadSize = if debug then 3 else 2,
+        _limitsMaxStackDelta = 16368,
+        _limitsMaxFunctionAlloc = 16368
+      }
+  TargetCNative64 ->
+    Limits
+      { _limitsMaxConstrs = 1048576,
+        _limitsMaxConstrArgs = 255,
+        _limitsMaxFunctionArgs = 253,
+        _limitsMaxLocalVars = 1024,
+        _limitsMaxClosureSize = 253 + 3,
+        _limitsClosureHeadSize = if debug then 3 else 2,
+        _limitsMaxStackDelta = 8184,
+        _limitsMaxFunctionAlloc = 8184
+      }

--- a/src/Juvix/Compiler/Reg/Language.hs
+++ b/src/Juvix/Compiler/Reg/Language.hs
@@ -42,6 +42,7 @@ data Instruction
   | Trace InstrTrace
   | Dump
   | Failure InstrFailure
+  | Prealloc InstrPrealloc
   | Alloc InstrAlloc
   | AllocClosure InstrAllocClosure
   | ExtendClosure InstrExtendClosure
@@ -83,27 +84,29 @@ newtype InstrFailure = InstrFailure
   { _instrFailure :: Value
   }
 
+data InstrPrealloc = InstrPrealloc
+  { _instrPreallocWordsNum :: Int,
+    _instrPreallocLiveVars :: [VarRef]
+  }
+
 data InstrAlloc = InstrAlloc
   { _instrAllocResult :: VarRef,
     _instrAllocTag :: Tag,
     _instrAllocMemRep :: MemRep,
-    _instrAllocArgs :: [Value],
-    _instrAllocLiveVars :: [VarRef]
+    _instrAllocArgs :: [Value]
   }
 
 data InstrAllocClosure = InstrAllocClosure
   { _instrAllocClosureResult :: VarRef,
     _instrAllocClosureSymbol :: Symbol,
     _instrAllocClosureExpectedArgsNum :: Int,
-    _instrAllocClosureArgs :: [Value],
-    _instrAllocClosureLiveVars :: [VarRef]
+    _instrAllocClosureArgs :: [Value]
   }
 
 data InstrExtendClosure = InstrExtendClosure
   { _instrExtendClosureResult :: VarRef,
     _instrExtendClosureValue :: VarRef,
-    _instrExtendClosureArgs :: [Value],
-    _instrExtendClosureLiveVars :: [VarRef]
+    _instrExtendClosureArgs :: [Value]
   }
 
 data CallType = CallFun Symbol | CallClosure VarRef

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -55,7 +55,7 @@ fromAsmFun ::
   Asm.FunctionInfo ->
   Code
 fromAsmFun tab fi =
-  case run $ runError $ snd <$> Asm.recurseS sig Asm.initialStackInfo (fi ^. Asm.functionCode) of
+  case run $ runError $ Asm.recurseS sig (fi ^. Asm.functionCode) of
     Left err -> error (show err)
     Right code -> code
   where

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -88,6 +88,7 @@ fromAsmInstr funInfo tab si Asm.CmdInstr {..} =
     Asm.Trace -> return $ Trace $ InstrTrace (VRef $ VarRef VarGroupStack n)
     Asm.Dump -> return Dump
     Asm.Failure -> return $ Failure $ InstrFailure (VRef $ VarRef VarGroupStack n)
+    Asm.Prealloc x -> return $ mkPrealloc x
     Asm.AllocConstr tag -> return $ mkAlloc tag
     Asm.AllocClosure x -> return $ mkAllocClosure x
     Asm.ExtendClosure x -> return $ mkExtendClosure x
@@ -102,8 +103,9 @@ fromAsmInstr funInfo tab si Asm.CmdInstr {..} =
     n :: Int
     n = si ^. Asm.stackInfoValueStackHeight - 1
 
-    -- Live variables *after* executing the instruction. TODO: proper liveness
-    -- analysis in JuvixAsm.
+    -- Live variables *after* executing the instruction. `k` is the number of
+    -- value stack cells that will be popped by the instruction. TODO: proper
+    -- liveness analysis in JuvixAsm.
     liveVars :: Int -> [VarRef]
     liveVars k =
       map (VarRef VarGroupStack) [0 .. n - k]
@@ -164,6 +166,14 @@ fromAsmInstr funInfo tab si Asm.CmdInstr {..} =
       Asm.ArgRef idx -> VarRef VarGroupArgs idx
       Asm.TempRef idx -> VarRef VarGroupTemp idx
 
+    mkPrealloc :: Asm.InstrPrealloc -> Instruction
+    mkPrealloc Asm.InstrPrealloc {..} =
+      Prealloc $
+        InstrPrealloc
+          { _instrPreallocWordsNum = _preallocWordsNum,
+            _instrPreallocLiveVars = liveVars 0
+          }
+
     mkAlloc :: Tag -> Instruction
     mkAlloc tag =
       Alloc $
@@ -171,8 +181,7 @@ fromAsmInstr funInfo tab si Asm.CmdInstr {..} =
           { _instrAllocTag = tag,
             _instrAllocResult = VarRef VarGroupStack n,
             _instrAllocArgs = getArgs 0 (ci ^. Asm.constructorArgsNum),
-            _instrAllocMemRep = ci ^. Asm.constructorRepresentation,
-            _instrAllocLiveVars = liveVars (ci ^. Asm.constructorArgsNum)
+            _instrAllocMemRep = ci ^. Asm.constructorRepresentation
           }
       where
         ci = fromJust impossible $ HashMap.lookup tag (tab ^. Asm.infoConstrs)
@@ -184,8 +193,7 @@ fromAsmInstr funInfo tab si Asm.CmdInstr {..} =
           { _instrAllocClosureSymbol = fi ^. Asm.functionSymbol,
             _instrAllocClosureResult = VarRef VarGroupStack n,
             _instrAllocClosureExpectedArgsNum = fi ^. Asm.functionArgsNum,
-            _instrAllocClosureArgs = getArgs 0 _allocClosureArgsNum,
-            _instrAllocClosureLiveVars = liveVars _allocClosureArgsNum
+            _instrAllocClosureArgs = getArgs 0 _allocClosureArgsNum
           }
       where
         fi = fromJust impossible $ HashMap.lookup _allocClosureFunSymbol (tab ^. Asm.infoFunctions)
@@ -196,8 +204,7 @@ fromAsmInstr funInfo tab si Asm.CmdInstr {..} =
         InstrExtendClosure
           { _instrExtendClosureResult = VarRef VarGroupStack n,
             _instrExtendClosureValue = VarRef VarGroupStack n,
-            _instrExtendClosureArgs = getArgs 1 _extendClosureArgsNum,
-            _instrExtendClosureLiveVars = liveVars (_extendClosureArgsNum + 1)
+            _instrExtendClosureArgs = getArgs 1 _extendClosureArgsNum
           }
 
     mkCall :: Bool -> Asm.InstrCall -> Instruction

--- a/test/Asm.hs
+++ b/test/Asm.hs
@@ -1,8 +1,9 @@
 module Asm where
 
 import Asm.Run qualified as Run
+import Asm.Transformation qualified as Transformation
 import Asm.Validate qualified as Validate
 import Base
 
 allTests :: TestTree
-allTests = testGroup "JuvixAsm tests" [Validate.allTests, Run.allTests]
+allTests = testGroup "JuvixAsm tests" [Validate.allTests, Run.allTests, Transformation.allTests]

--- a/test/Asm/Run/Base.hs
+++ b/test/Asm/Run/Base.hs
@@ -7,6 +7,7 @@ import Juvix.Compiler.Asm.Error
 import Juvix.Compiler.Asm.Extra
 import Juvix.Compiler.Asm.Interpreter
 import Juvix.Compiler.Asm.Pretty
+import Juvix.Compiler.Asm.Transformation.Validate
 import Juvix.Compiler.Asm.Translation.FromSource
 import Juvix.Data.PPOutput
 import System.IO.Extra (withTempDir)
@@ -19,7 +20,7 @@ asmRunAssertion mainFile expectedFile step = do
     Left err -> assertFailure (show (pretty err))
     Right tab -> do
       step "Validate"
-      case validate tab of
+      case validate' tab of
         Just err -> assertFailure (show (pretty err))
         Nothing ->
           case tab ^. infoMainFunction of
@@ -54,7 +55,7 @@ asmRunErrorAssertion mainFile step = do
     Left _ -> assertBool "" True
     Right tab -> do
       step "Validate"
-      case validate tab of
+      case validate' tab of
         Just _ -> assertBool "" True
         Nothing ->
           case tab ^. infoMainFunction of

--- a/test/Asm/Run/Positive.hs
+++ b/test/Asm/Run/Positive.hs
@@ -19,7 +19,7 @@ testDescr PosTest {..} =
    in TestDescr
         { _testName = _name,
           _testRoot = tRoot,
-          _testAssertion = Steps $ asmRunAssertion _file _expectedFile
+          _testAssertion = Steps $ asmRunAssertion _file _expectedFile return (const (return ()))
         }
 
 allTests :: TestTree

--- a/test/Asm/Transformation.hs
+++ b/test/Asm/Transformation.hs
@@ -1,0 +1,7 @@
+module Asm.Transformation where
+
+import Asm.Transformation.Prealloc qualified as Prealloc
+import Base
+
+allTests :: TestTree
+allTests = testGroup "JuvixAsm transformations" [Prealloc.allTests]

--- a/test/Asm/Transformation/Base.hs
+++ b/test/Asm/Transformation/Base.hs
@@ -1,0 +1,29 @@
+module Asm.Transformation.Base where
+
+import Asm.Run.Base
+import Asm.Run.Positive qualified as Run
+import Base
+import Juvix.Compiler.Asm.Data.InfoTable
+import Juvix.Compiler.Asm.Error
+
+data Test = Test
+  { _testTransformation :: InfoTable -> Either AsmError InfoTable,
+    _testAssertion :: InfoTable -> Assertion,
+    _testEval :: Run.PosTest
+  }
+
+fromTest :: Test -> TestTree
+fromTest = mkTest . toTestDescr
+
+troot :: FilePath
+troot = "tests/Asm/positive/"
+
+toTestDescr :: Test -> TestDescr
+toTestDescr Test {..} =
+  let Run.PosTest {..} = _testEval
+      tRoot = troot </> _relDir
+   in TestDescr
+        { _testName = _name,
+          _testRoot = tRoot,
+          _testAssertion = Steps $ asmRunAssertion _file _expectedFile _testTransformation _testAssertion
+        }

--- a/test/Asm/Transformation/Prealloc.hs
+++ b/test/Asm/Transformation/Prealloc.hs
@@ -1,0 +1,26 @@
+module Asm.Transformation.Prealloc (allTests) where
+
+import Asm.Run.Positive qualified as Run
+import Asm.Transformation.Base
+import Base
+import Juvix.Compiler.Asm.Options
+import Juvix.Compiler.Asm.Transformation
+import Juvix.Compiler.Asm.Transformation.Base
+
+allTests :: TestTree
+allTests = testGroup "Prealloc" (map liftTest Run.tests)
+
+liftTest :: Run.PosTest -> TestTree
+liftTest _testEval =
+  fromTest
+    Test
+      { _testTransformation = runTransformation (runReader opts . computePrealloc),
+        _testAssertion = \tab -> unless (checkPrealloc opts tab) (error "check prealloc"),
+        _testEval
+      }
+  where
+    opts =
+      Options
+        { _optDebug = True,
+          _optLimits = getLimits TargetCWasm32Wasi False
+        }

--- a/test/Asm/Transformation/Prealloc.hs
+++ b/test/Asm/Transformation/Prealloc.hs
@@ -22,5 +22,5 @@ liftTest _testEval =
     opts =
       Options
         { _optDebug = True,
-          _optLimits = getLimits TargetCWasm32Wasi False
+          _optLimits = getLimits TargetCWasm32Wasi True
         }

--- a/test/Asm/Validate/Base.hs
+++ b/test/Asm/Validate/Base.hs
@@ -2,7 +2,7 @@ module Asm.Validate.Base where
 
 import Base
 import Juvix.Compiler.Asm.Data.InfoTable
-import Juvix.Compiler.Asm.Extra
+import Juvix.Compiler.Asm.Transformation.Validate
 import Juvix.Compiler.Asm.Translation.FromSource
 
 asmValidateErrorAssertion :: FilePath -> (String -> IO ()) -> Assertion
@@ -13,7 +13,7 @@ asmValidateErrorAssertion mainFile step = do
     Left _ -> assertBool "" True
     Right tab -> do
       step "Validate"
-      case validate tab of
+      case validate' tab of
         Just _ -> assertBool "" True
         Nothing -> assertFailure "no error"
 


### PR DESCRIPTION
# Description

* Add a new `Prealloc` instruction which corresponds to the `PREALLOC` macro in the Juvix runtime.
* Implement `foldS` using `recurseS`.
* Using `foldS`, compute maximum memory allocation for each [basic block](https://en.wikipedia.org/wiki/Basic_block), inserting `Prealloc` instructions at basic block boundaries.
* Add a JuvixAsm transformation framework and tests.
* Add Juvix.Compiler.Backend module which contains implementation-specific limit values for each backend runtime configuration (e.g. max number of constructors, closure head size).

Closes #1586
