### PR TITLE
Remove shelltest threading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ SHELLTEST := $(shell command -v shelltest 2> /dev/null)
 .PHONY : test-shell
 test-shell : install
 	@$(if $(SHELLTEST),, stack install shelltestrunner)
-	shelltest --color --diff -a -j8 tests
+	shelltest --color --diff -a tests
 
 # -- Release
 


### PR DESCRIPTION
`juvix` CLI invocations read/write/delete the standard library in the project's `.juvix-build/stdlib` directory.

When shelltest runs in threaded mode, two tests may run conflicting IO operations on the same `.juvix-build/stdlib` directory.

These errors are more likely to happen when the `.juvix-build/stdlib` directory doesn't exist - which is the case when running on CI.

This will fix shell test failures e.g https://github.com/anoma/juvix/actions/runs/3412901383/jobs/5679016888