### PR TITLE
Compute new entrypoint root when loading a file in the REPL

### DIFF
--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -20,6 +20,7 @@ import Juvix.Compiler.Core.Translation.FromInternal.Data qualified as Core
 import Juvix.Compiler.Internal.Language qualified as Internal
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Data.Error.GenericError qualified as Error
+import Juvix.Extra.Paths
 import Juvix.Extra.Version
 import Juvix.Prelude.Pretty qualified as P
 import Root
@@ -74,9 +75,6 @@ noFileLoadedMsg = liftIO (putStrLn "No file loaded. Load a file using the `:load
 welcomeMsg :: MonadIO m => m ()
 welcomeMsg = liftIO (putStrLn [i|Juvix REPL version #{versionTag}: https://juvix.org. Run :help for help|])
 
-preludePath :: FilePath
-preludePath = "Stdlib" </> "Prelude.juvix"
-
 runCommand :: Members '[Embed IO, App] r => ReplOptions -> Sem r ()
 runCommand opts = do
   let printHelpTxt :: String -> Repl ()
@@ -126,8 +124,8 @@ runCommand opts = do
         mStdlibPath <- State.gets (^. replStateGlobalOptions . globalStdlibPath)
         case mStdlibPath of
           Nothing -> loadDefaultPrelude
-          Just stdlibDir -> do
-            absStdlibDir <- liftIO (makeAbsolute stdlibDir)
+          Just stdlibDir' -> do
+            absStdlibDir <- liftIO (makeAbsolute stdlibDir')
             loadFile (absStdlibDir </> preludePath)
 
       loadDefaultPrelude :: Repl ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,11 +2,8 @@ module Main (main) where
 
 import App
 import CommonOptions
-import Control.Exception qualified as IO
-import Data.ByteString qualified as ByteString
-import Data.Yaml
 import Juvix.Compiler.Pipeline
-import Juvix.Extra.Paths qualified as Paths
+import Root
 import TopCommand
 import TopCommand.Options
 
@@ -14,38 +11,8 @@ main :: IO ()
 main = do
   let p = prefs showHelpOnEmpty
   (global, cli) <- customExecParser p descr >>= secondM makeAbsPaths
-  (root, pkg) <- findRoot cli
+  (root, pkg) <- findRoot' cli
   runM (runAppIO global root pkg (runTopCommand cli))
-
-findRoot :: TopCommand -> IO (FilePath, Package)
-findRoot cli = do
-  let dir :: Maybe FilePath
-      dir = takeDirectory <$> topCommandInputFile cli
-  whenJust dir setCurrentDirectory
-  r <- IO.try go
-  case r of
-    Left (err :: IO.SomeException) -> do
-      putStrLn "Something went wrong when figuring out the root of the project."
-      putStrLn (pack (IO.displayException err))
-      exitFailure
-    Right root -> return root
   where
-    possiblePaths :: FilePath -> [FilePath]
-    possiblePaths start = takeWhile (/= "/") (aux start)
-      where
-        aux f = f : aux (takeDirectory f)
-
-    go :: IO (FilePath, Package)
-    go = do
-      c <- getCurrentDirectory
-      l <- findFile (possiblePaths c) Paths.juvixYamlFile
-      case l of
-        Nothing -> return (c, emptyPackage)
-        Just yaml -> do
-          bs <- ByteString.readFile yaml
-          let isEmpty = ByteString.null bs
-          pkg <-
-            if
-                | isEmpty -> return emptyPackage
-                | otherwise -> decodeThrow bs
-          return (takeDirectory yaml, pkg)
+    findRoot' :: TopCommand -> IO (FilePath, Package)
+    findRoot' cli = findRoot (topCommandInputFile cli)

--- a/app/Root.hs
+++ b/app/Root.hs
@@ -1,0 +1,39 @@
+module Root where
+
+import Control.Exception qualified as IO
+import Data.ByteString qualified as ByteString
+import Data.Yaml
+import Juvix.Compiler.Pipeline
+import Juvix.Extra.Paths qualified as Paths
+import Juvix.Prelude
+
+findRoot :: Maybe FilePath -> IO (FilePath, Package)
+findRoot minputFile = do
+  whenJust (takeDirectory <$> minputFile) setCurrentDirectory
+  r <- IO.try go
+  case r of
+    Left (err :: IO.SomeException) -> do
+      putStrLn "Something went wrong when figuring out the root of the project."
+      putStrLn (pack (IO.displayException err))
+      exitFailure
+    Right root -> return root
+  where
+    possiblePaths :: FilePath -> [FilePath]
+    possiblePaths start = takeWhile (/= "/") (aux start)
+      where
+        aux f = f : aux (takeDirectory f)
+
+    go :: IO (FilePath, Package)
+    go = do
+      c <- getCurrentDirectory
+      l <- findFile (possiblePaths c) Paths.juvixYamlFile
+      case l of
+        Nothing -> return (c, emptyPackage)
+        Just yaml -> do
+          bs <- ByteString.readFile yaml
+          let isEmpty = ByteString.null bs
+          pkg <-
+            if
+                | isEmpty -> return emptyPackage
+                | otherwise -> decodeThrow bs
+          return (takeDirectory yaml, pkg)

--- a/src/Juvix/Extra/Paths.hs
+++ b/src/Juvix/Extra/Paths.hs
@@ -18,3 +18,6 @@ juvixBuildDir = ".juvix-build"
 
 juvixStdlibDir :: FilePath
 juvixStdlibDir = juvixBuildDir </> "stdlib"
+
+preludePath :: FilePath
+preludePath = "Stdlib" </> "Prelude.juvix"

--- a/tests/CLI/Commands/ReplTest.juvix
+++ b/tests/CLI/Commands/ReplTest.juvix
@@ -1,8 +1,0 @@
-module ReplTest;
-
-open import Stdlib.Prelude;
-
-main : Bool;
-main := true;
-
-end;

--- a/tests/CLI/Commands/ReplTest.juvix
+++ b/tests/CLI/Commands/ReplTest.juvix
@@ -1,0 +1,8 @@
+module ReplTest;
+
+open import Stdlib.Prelude;
+
+main : Bool;
+main := true;
+
+end;

--- a/tests/CLI/Commands/repl.test
+++ b/tests/CLI/Commands/repl.test
@@ -1,0 +1,80 @@
+$ juvix repl
+> /Stdlib.Prelude> /
+>= 0
+
+<
+:quit
+$ juvix repl
+> /Stdlib.Prelude> /
+>= 0
+
+<
+:type suc
+$ juvix repl
+> /Nat → Nat/
+>= 0
+
+<
+:t suc
+$ juvix repl
+> /Nat → Nat/
+>= 0
+
+<
+:t   suc
+$ juvix repl
+> /Nat → Nat/
+>= 0
+
+<
+true && false
+$ juvix repl
+> /false/
+>= 0
+
+<
+   true    &&    false
+$ juvix repl
+> /false/
+>= 0
+
+<
+suc true
+$ juvix repl
+> /Stdlib.Prelude> /
+>2 /The expression true has type:
+  Bool
+but is expected to have type:
+  Nat/
+>= 0
+
+<
+:version
+$ juvix repl
+> /[0-9]+\.[0-9]+\.[0-9]\-[a-z0-9]+/
+>= 0
+
+<
+:load ReplTest.juvix
+$ juvix repl
+> /ReplTest> /
+>= 0
+
+<
+:load    ReplTest.juvix
+$ juvix repl
+> /ReplTest> /
+>= 0
+
+<
+:l ReplTest.juvix
+main
+$ juvix repl
+> /true/
+>= 0
+
+<
+:root
+$ juvix repl
+> /\//
+>= 0

--- a/tests/CLI/Commands/repl.test
+++ b/tests/CLI/Commands/repl.test
@@ -27,6 +27,12 @@ $ juvix repl
 >= 0
 
 <
+:t suc
+$ juvix --stdlib-path juvix-stdlib repl
+> /Nat → Nat/
+>= 0
+
+<
 true && false
 $ juvix repl
 > /false/
@@ -55,21 +61,27 @@ $ juvix repl
 >= 0
 
 <
-:load ReplTest.juvix
+:load tests/Internal/positive/BuiltinBool.juvix
 $ juvix repl
-> /ReplTest> /
+> /BuiltinBool> /
 >= 0
 
 <
-:load    ReplTest.juvix
+:load    tests/Internal/positive/BuiltinBool.juvix
 $ juvix repl
-> /ReplTest> /
+> /BuiltinBool> /
 >= 0
 
 <
-:l ReplTest.juvix
+:l tests/Internal/positive/BuiltinBool.juvix
 main
 $ juvix repl
+> /true/
+>= 0
+
+<
+main
+$ juvix repl tests/Internal/positive/BuiltinBool.juvix
 > /true/
 >= 0
 


### PR DESCRIPTION
Previously the REPL would use the `App` effect root (which could be the current directory or the project root of the initially loaded file). Thus files in a different Juvix project could not be loaded. The entrypoint root must be computed each time a new file is `:load`ed.

This PR also adds shelltests for the REPL commands.