### PR TITLE
Add an emacs function to restart the REPL

### DIFF
--- a/juvix-mode/juvix-repl.el
+++ b/juvix-mode/juvix-repl.el
@@ -47,4 +47,16 @@
     (when proc-alive
       (comint-simple-send juvix-repl-buffer-name (concat ":load " filename)))))
 
+(defun juvix-repl-restart ()
+  "Restart the juvix REPL."
+  (interactive)
+  (let* ((buffer (get-buffer juvix-repl-buffer-name))
+         (proc-alive (comint-check-proc buffer))
+         (process (get-buffer-process buffer)))
+    (if proc-alive
+        (progn
+          (set-process-sentinel process (lambda (p e) (run-juvix-repl)))
+          (kill-process process))
+      (error "No juvix repl process is runnning. Use run-juvix-repl"))))
+
 (provide 'juvix-repl)


### PR DESCRIPTION
Without using set-process-sentinel `run-juvix-repl` may try to start a new REPL before the old REPL process has exited.