### PR TITLE
Use the same stack version in all CI jobs and remove `stack setup` step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,6 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}-${{ hashFiles('main/**/*.hs') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.ghc }}-stack-work-
-      - name: Setup Stack GHC
-        run : |
-          cd main
-          stack setup
       - name: Cache LLVM and Clang
         id: cache-llvm
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,12 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}-${{ hashFiles('main/**/*.hs') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.ghc }}-stack-work-
+      - uses: haskell/actions/setup@v1
+        name: Setup Haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          enable-stack: true
+          stack-version: 'latest'
       - name: Cache LLVM and Clang
         id: cache-llvm
         uses: actions/cache@v3
@@ -253,10 +259,12 @@ jobs:
         with:
           mdbook-version: 'latest'
 
-      - name: Setup Stack GHC
-        run : |
-          cd main
-          stack setup
+      - uses: haskell/actions/setup@v1
+        name: Setup Haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          enable-stack: true
+          stack-version: 'latest'
 
       - name: Cache LLVM and Clang
         id: cache-llvm


### PR DESCRIPTION
This PR fixes failing PR builds.

Builds were failing because of a failure in the `stack setup` stage. See https://github.com/anoma/juvix/actions/runs/3566213502/jobs/5992776908 for example.

This stage was only needed for macOS builds because the GHC installer depends on GCC and the Juvix build depends on Clang, so we needed to make sure that GHC was installed first. This stage can safely be removed from the ubuntu build.

This PR also adds the Haskell setup action to the test and docs jobs. The build, test and docs jobs share the same `~/.stack` directory via the github actions cache mechanism so it's important that they all use the same version of stack.