### PR TITLE
Run shelltests on macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,13 +258,23 @@ jobs:
           cd main
           make test
 
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name : Shell tests (Linux)
-        id: shell-tests
+        id: shell-tests-linux
         if: runner.os == 'Linux'
         run : |
           cd main
-          echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
           make test-shell
+
+      - name : Shell tests (macOS)
+        id: shell-tests-macos
+        if: runner.os == 'macOS'
+        run : |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL test-shell
 
   docs:
     needs: build


### PR DESCRIPTION
This PR re-enables the shell tests on the macOS build.

I can't remember why we disabled the shell tests on Mac. It may have been because the PATH was not setup correctly (1. Adding `$GITHUB_WORKSPACE/.local/bin` instead of `$HOME/.local/bin` to the PATH and 2. Adding to the PATH in the same step as using it). The setup issue is now fixed.
