### PR TITLE
Pin mdbook to version 0.4.22 in docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
 
   docs:
     needs: build
-    # if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -352,7 +352,6 @@ jobs:
           make webapp-examples
 
       - name: Deploy HTML to github pages
-        if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
       - name: MDBook setup
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.4.22'
 
       - uses: haskell/actions/setup@v1
         name: Setup Haskell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
 
   docs:
     needs: build
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    # if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -352,6 +352,7 @@ jobs:
           make webapp-examples
 
       - name: Deploy HTML to github pages
+        if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
mdbook homebrew version (used by the github action to install mdbook) was bumped to 0.4.23
https://github.com/Homebrew/homebrew-core/commit/eb69fcddbab62862737bb76c5d4aff0b241083ce which seems to be incompatible with Ubuntu 20.04 glibc

The mdbook program works with this change, see this successful job: https://github.com/anoma/juvix/actions/runs/3703796868/jobs/6275684983