### PR TITLE
Improve error message for confusing ':=' with '='

### DIFF
--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -592,7 +592,10 @@ ppPattern = case sing :: SStage s of
 ppPatternAtom :: forall s r. (SingI s, Members '[Reader Options] r) => PatternType s -> Sem r (Doc Ann)
 ppPatternAtom = case sing :: SStage s of
   SParsed -> ppCodeAtom
-  SScoped -> ppCodeAtom
+  SScoped -> \pat ->
+    case pat ^. patternArgPattern of
+      PatternVariable s | s ^. S.nameVerbatim == "=" -> parens <$> ppCodeAtom pat
+      _ -> ppCodeAtom pat
 
 instance PrettyCode Text where
   ppCode = return . pretty

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -564,11 +564,11 @@ parsePatternAtoms = do
 
 functionClause :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Symbol -> ParsecS r (FunctionClause 'Parsed)
 functionClause _clauseOwnerFunction = do
-  _clausePatterns <-functionClausePatterns
+  _clausePatterns <- functionClausePatterns
   _clauseBody <- parseExpressionAtoms
   return FunctionClause {..}
 
-functionClausePatterns :: forall r . Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r [PatternAtom 'Parsed]
+functionClausePatterns :: forall r. Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r [PatternAtom 'Parsed]
 functionClausePatterns =
   P.manyTill patternAtom (kw kwAssign <|> wrongEq)
   where

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -574,7 +574,9 @@ functionClausePatterns =
   where
     wrongEq :: ParsecS r ()
     wrongEq = do
-      P.chunk "="
+      P.try $ do
+        w <- morpheme
+        unless (w == "=") (P.failure Nothing mempty)
       off <- P.getOffset
       parseFailure off "expected \":=\" instead of \"=\""
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -537,25 +537,40 @@ wildcard = Wildcard . snd <$> interval (kw kwWildcard)
 patternAtomAnon :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
 patternAtomAnon =
   PatternAtomWildcard <$> wildcard
-    <|> PatternAtomParens <$> parens parsePatternAtoms
-    <|> PatternAtomBraces <$> braces parsePatternAtoms
+    <|> PatternAtomParens <$> parens parsePatternAtomsNested
+    <|> PatternAtomBraces <$> braces parsePatternAtomsNested
 
 patternAtomAt :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => SymbolType 'Parsed -> ParsecS r (PatternAtom 'Parsed)
 patternAtomAt s = kw kwAt >> PatternAtomAt . PatternBinding s <$> patternAtom
 
-patternAtomNamed :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
-patternAtomNamed = do
+patternAtomNamed :: forall r. Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Bool -> ParsecS r (PatternAtom 'Parsed)
+patternAtomNamed nested = do
+  off <- P.getOffset
   n <- name
   case n of
     NameQualified _ -> return (PatternAtomIden n)
-    NameUnqualified s -> patternAtomAt s <|> return (PatternAtomIden n)
+    NameUnqualified s -> do
+      checkWrongEq off s
+      patternAtomAt s <|> return (PatternAtomIden n)
+  where
+    checkWrongEq :: Int -> WithLoc Text -> ParsecS r ()
+    checkWrongEq off t =
+      when
+        (not nested && t ^. withLocParam == "=")
+        (parseFailure off "expected \":=\" instead of \"=\"")
+
+patternAtomNested :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
+patternAtomNested = patternAtom' True
 
 patternAtom :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
-patternAtom = P.label "<pattern>" $ patternAtomNamed <|> patternAtomAnon
+patternAtom = patternAtom' False
 
-parsePatternAtoms :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtoms 'Parsed)
-parsePatternAtoms = do
-  (_patternAtoms, _patternAtomsLoc) <- interval (P.some patternAtom)
+patternAtom' :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Bool -> ParsecS r (PatternAtom 'Parsed)
+patternAtom' nested = P.label "<pattern>" $ patternAtomNamed nested <|> patternAtomAnon
+
+parsePatternAtomsNested :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtoms 'Parsed)
+parsePatternAtomsNested = do
+  (_patternAtoms, _patternAtomsLoc) <- interval (P.some patternAtomNested)
   return PatternAtoms {..}
 
 --------------------------------------------------------------------------------
@@ -564,21 +579,10 @@ parsePatternAtoms = do
 
 functionClause :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Symbol -> ParsecS r (FunctionClause 'Parsed)
 functionClause _clauseOwnerFunction = do
-  _clausePatterns <- functionClausePatterns
+  _clausePatterns <- P.many patternAtom
+  kw kwAssign
   _clauseBody <- parseExpressionAtoms
   return FunctionClause {..}
-
-functionClausePatterns :: forall r. Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r [PatternAtom 'Parsed]
-functionClausePatterns =
-  P.manyTill patternAtom (kw kwAssign <|> wrongEq)
-  where
-    wrongEq :: ParsecS r ()
-    wrongEq = do
-      P.try $ do
-        w <- morpheme
-        unless (w == "=") (P.failure Nothing mempty)
-      off <- P.getOffset
-      parseFailure off "expected \":=\" instead of \"=\""
 
 --------------------------------------------------------------------------------
 -- Module declaration

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -564,10 +564,19 @@ parsePatternAtoms = do
 
 functionClause :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Symbol -> ParsecS r (FunctionClause 'Parsed)
 functionClause _clauseOwnerFunction = do
-  _clausePatterns <- P.many patternAtom
-  kw kwAssign
+  _clausePatterns <-functionClausePatterns
   _clauseBody <- parseExpressionAtoms
   return FunctionClause {..}
+
+functionClausePatterns :: forall r . Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r [PatternAtom 'Parsed]
+functionClausePatterns =
+  P.manyTill patternAtom (kw kwAssign <|> wrongEq)
+  where
+    wrongEq :: ParsecS r ()
+    wrongEq = do
+      P.chunk "="
+      off <- P.getOffset
+      parseFailure off "expected \":=\" instead of \"=\""
 
 --------------------------------------------------------------------------------
 -- Module declaration

--- a/tests/positive/Symbols.juvix
+++ b/tests/positive/Symbols.juvix
@@ -28,4 +28,11 @@ module Symbols;
 
   主功能 : Nat;
   主功能 := （0）;
+
+  axiom = : Type;
+
+  K : Nat → Nat → Nat;
+  K =a@zero (=) :=(=a · =);
+  K =a@(suc =) == := = · ==;
+
 end;

--- a/tests/positive/Symbols.juvix
+++ b/tests/positive/Symbols.juvix
@@ -1,13 +1,12 @@
 module Symbols;
-
   open import Stdlib.Data.Nat;
 
   ╘⑽╛ : Nat;
   ╘⑽╛ := suc nine;
 
-   -- no - function!?
-   - : Nat -> Nat -> Nat;
-   - := (+);
+  -- no - function!?
+  - : Nat -> Nat -> Nat;
+  - := (+);
 
   （-） : Nat -> Nat -> Nat;
   （-） := (-);
@@ -32,7 +31,6 @@ module Symbols;
   axiom = : Type;
 
   K : Nat → Nat → Nat;
-  K =a@zero (=) :=(=a · =);
+  K =a@zero (=) := =a · =;
   K =a@(suc =) == := = · ==;
-
 end;


### PR DESCRIPTION
Closes #1483 

The error now points to the offending `=`, works correctly with multi-line clauses, and explains exactly what's wrong. E.g. for
```agda
f : Nat → Nat → Nat;
f zero x = x;
```
we get
```
  |
6 | f zero x = x;
  |           ^
expected ":=" instead of "="
```
A minor disadvantage of the proposed solution is that now it's impossible to use `=` without parentheses as a top variable name in a pattern, e.g.
```
f zero = := =;
```
gives an error.

However, if one really wants to name a variable `=`, it is enough just to enclose it in parentheses:
```agda
f : Nat → Nat → Nat;
f zero (=) := =;
f (suc n) (=) := f n =;
```

I believe this slight non-uniformity is well worth the increased usability due to a better error message. Confusing `:=` with `=` is very common. Using `=` as a variable name in a top pattern is rare.
