### PR TITLE
make = rule work for every non-nested pattern

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -537,25 +537,40 @@ wildcard = Wildcard . snd <$> interval (kw kwWildcard)
 patternAtomAnon :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
 patternAtomAnon =
   PatternAtomWildcard <$> wildcard
-    <|> PatternAtomParens <$> parens parsePatternAtoms
-    <|> PatternAtomBraces <$> braces parsePatternAtoms
+    <|> PatternAtomParens <$> parens parsePatternAtomsNested
+    <|> PatternAtomBraces <$> braces parsePatternAtomsNested
 
 patternAtomAt :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => SymbolType 'Parsed -> ParsecS r (PatternAtom 'Parsed)
 patternAtomAt s = kw kwAt >> PatternAtomAt . PatternBinding s <$> patternAtom
 
-patternAtomNamed :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
-patternAtomNamed = do
+patternAtomNamed :: forall r. Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Bool -> ParsecS r (PatternAtom 'Parsed)
+patternAtomNamed nested = do
+  off <- P.getOffset
   n <- name
   case n of
     NameQualified _ -> return (PatternAtomIden n)
-    NameUnqualified s -> patternAtomAt s <|> return (PatternAtomIden n)
+    NameUnqualified s -> do
+      checkWrongEq off s
+      patternAtomAt s <|> return (PatternAtomIden n)
+  where
+    checkWrongEq :: Int -> WithLoc Text -> ParsecS r ()
+    checkWrongEq off t =
+      when
+        (not nested && t ^. withLocParam == "=")
+        (parseFailure off "expected \":=\" instead of \"=\"")
+
+patternAtomNested :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
+patternAtomNested = patternAtom' True
 
 patternAtom :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtom 'Parsed)
-patternAtom = P.label "<pattern>" $ patternAtomNamed <|> patternAtomAnon
+patternAtom = patternAtom' False
 
-parsePatternAtoms :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtoms 'Parsed)
-parsePatternAtoms = do
-  (_patternAtoms, _patternAtomsLoc) <- interval (P.some patternAtom)
+patternAtom' :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Bool -> ParsecS r (PatternAtom 'Parsed)
+patternAtom' nested = P.label "<pattern>" $ patternAtomNamed nested <|> patternAtomAnon
+
+parsePatternAtomsNested :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r (PatternAtoms 'Parsed)
+parsePatternAtomsNested = do
+  (_patternAtoms, _patternAtomsLoc) <- interval (P.some patternAtomNested)
   return PatternAtoms {..}
 
 --------------------------------------------------------------------------------
@@ -564,21 +579,10 @@ parsePatternAtoms = do
 
 functionClause :: Members '[InfoTableBuilder, JudocStash, NameIdGen] r => Symbol -> ParsecS r (FunctionClause 'Parsed)
 functionClause _clauseOwnerFunction = do
-  _clausePatterns <- functionClausePatterns
+  _clausePatterns <- P.many patternAtom
+  kw kwAssign
   _clauseBody <- parseExpressionAtoms
   return FunctionClause {..}
-
-functionClausePatterns :: forall r. Members '[InfoTableBuilder, JudocStash, NameIdGen] r => ParsecS r [PatternAtom 'Parsed]
-functionClausePatterns =
-  P.manyTill patternAtom (kw kwAssign <|> wrongEq)
-  where
-    wrongEq :: ParsecS r ()
-    wrongEq = do
-      P.try $ do
-        w <- morpheme
-        unless (w == "=") (P.failure Nothing mempty)
-      off <- P.getOffset
-      parseFailure off "expected \":=\" instead of \"=\""
 
 --------------------------------------------------------------------------------
 -- Module declaration

--- a/tests/positive/Symbols.juvix
+++ b/tests/positive/Symbols.juvix
@@ -28,4 +28,11 @@ module Symbols;
 
   主功能 : Nat;
   主功能 := （0）;
+
+  axiom = : Type;
+
+  K : Nat → Nat → Nat;
+  K =a@zero (=) := =a · =;
+  K =a@(suc =) (==) := = · ==;
+
 end;


### PR DESCRIPTION
In the original pr the rules only works for function clauses. I think it is better to modify how patterns are parsed so it works for lambda functions as well.
I also add a test.