### PR TITLE
Remove wildcard patterns from Internal

### DIFF
--- a/src/Juvix/Compiler/Abstract/Data/Name.hs
+++ b/src/Juvix/Compiler/Abstract/Data/Name.hs
@@ -23,6 +23,15 @@ data Name = Name
 
 makeLenses ''Name
 
+varFromWildcard :: Members '[NameIdGen] r => Wildcard -> Sem r VarName
+varFromWildcard w = do
+  _nameId <- freshNameId
+  let _nameText :: Text = "ω" <> prettyText _nameId
+      _nameKind = KNameLocal
+      _namePretty = _nameText
+      _nameLoc = getLoc w
+  return Name {..}
+
 instance HasAtomicity Name where
   atomicity = const Atom
 

--- a/src/Juvix/Compiler/Abstract/Data/Name.hs
+++ b/src/Juvix/Compiler/Abstract/Data/Name.hs
@@ -26,7 +26,7 @@ makeLenses ''Name
 varFromWildcard :: Members '[NameIdGen] r => Wildcard -> Sem r VarName
 varFromWildcard w = do
   _nameId <- freshNameId
-  let _nameText :: Text = "ω" <> prettyText _nameId
+  let _nameText :: Text = "_ω" <> prettyText _nameId
       _nameKind = KNameLocal
       _namePretty = _nameText
       _nameLoc = getLoc w

--- a/src/Juvix/Compiler/Backend/C/Data/Base.hs
+++ b/src/Juvix/Compiler/Backend/C/Data/Base.hs
@@ -219,7 +219,6 @@ buildPatternInfoTable argTyps c =
           [(v ^. Internal.nameText, BindingInfo {_bindingInfoExpr = exp, _bindingInfoType = typ})]
       Internal.PatternConstructorApp Internal.ConstructorApp {..} ->
         goConstructorApp exp _constrAppConstructor _constrAppParameters
-      Internal.PatternWildcard {} -> return []
 
     goConstructorApp :: Expression -> Internal.Name -> [Internal.PatternArg] -> Sem r [(Text, BindingInfo)]
     goConstructorApp exp constructorName ps = do

--- a/src/Juvix/Compiler/Backend/C/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Backend/C/Translation/FromInternal.hs
@@ -342,7 +342,6 @@ goFunctionClause funSig argTyps clause = do
                 )
         fmap (isCtor :) subConditions
       Micro.PatternVariable {} -> return []
-      Micro.PatternWildcard {} -> return []
 
     clauseCondition :: Sem r (Maybe Expression)
     clauseCondition = fmap (foldr1 f) . nonEmpty <$> conditions

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -397,7 +397,6 @@ fromPattern ::
   Internal.Pattern ->
   Sem r Pattern
 fromPattern = \case
-  Internal.PatternWildcard {} -> return wildcard
   Internal.PatternVariable n -> return $ PatBinder (PatternBinder (Binder (n ^. nameText) (Just (n ^. nameLoc)) mkDynamic') wildcard)
   Internal.PatternConstructorApp c -> do
     let n = c ^. Internal.constrAppConstructor
@@ -424,7 +423,6 @@ fromPattern = \case
 
 getPatternVars :: Internal.Pattern -> [Name]
 getPatternVars = \case
-  Internal.PatternWildcard {} -> []
   Internal.PatternVariable n -> [n]
   Internal.PatternConstructorApp c ->
     concatMap getPatternVars explicitPatterns

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -330,7 +330,6 @@ patternVariables :: Traversal' Pattern VarName
 patternVariables f p = case p of
   PatternVariable v -> PatternVariable <$> f v
   PatternConstructorApp a -> PatternConstructorApp <$> goApp f a
-  PatternWildcard {} -> pure p
   where
     goApp :: Traversal' ConstructorApp VarName
     goApp g = traverseOf constrAppParameters (traverse (patternArgVariables g))

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -167,7 +167,6 @@ instance Hashable PatternArg
 data Pattern
   = PatternVariable VarName
   | PatternConstructorApp ConstructorApp
-  | PatternWildcard Wildcard
   deriving stock (Eq, Generic)
 
 instance Hashable Pattern
@@ -269,7 +268,6 @@ instance HasAtomicity Pattern where
   atomicity p = case p of
     PatternConstructorApp a -> atomicity a
     PatternVariable {} -> Atom
-    PatternWildcard {} -> Atom
 
 instance HasLoc InductiveParameter where
   getLoc (InductiveParameter n) = getLoc n
@@ -319,7 +317,6 @@ instance HasLoc Pattern where
   getLoc = \case
     PatternVariable v -> getLoc v
     PatternConstructorApp a -> getLoc a
-    PatternWildcard i -> getLoc i
 
 instance HasLoc PatternArg where
   getLoc a = fmap getLoc (a ^. patternArgName) ?<> getLoc (a ^. patternArgPattern)

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -149,7 +149,6 @@ instance PrettyCode Pattern where
   ppCode p = case p of
     PatternVariable v -> ppCode v
     PatternConstructorApp a -> ppCode a
-    PatternWildcard {} -> return kwWildcard
 
 instance PrettyCode FunctionDef where
   ppCode f = do

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -360,7 +360,6 @@ checkPattern = go
           name = patArg ^. patternArgName
       whenJust name (\n -> addVar n ty argTy)
       case pat of
-        PatternWildcard {} -> return ()
         PatternVariable v -> addVar v ty argTy
         PatternConstructorApp a -> do
           s <- checkSaturatedInductive ty

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Inference.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Inference.hs
@@ -363,11 +363,8 @@ matchPatterns (PatternArg impl1 name1 pat1) (PatternArg impl2 name2 pat2) =
     goName _ _ = err
     goPattern :: Pattern -> Pattern -> Sem r Bool
     goPattern p1 p2 = case (p1, p2) of
-      (PatternWildcard {}, PatternWildcard {}) -> ok
       (PatternVariable v1, PatternVariable v2) -> modify (HashMap.insert v1 v2) $> True
       (PatternConstructorApp c1, PatternConstructorApp c2) -> goConstructor c1 c2
-      (PatternWildcard {}, _) -> err
-      (_, PatternWildcard {}) -> err
       (PatternVariable {}, _) -> err
       (_, PatternVariable {}) -> err
     goConstructor :: ConstructorApp -> ConstructorApp -> Sem r Bool


### PR DESCRIPTION
This pr removes wildcard patterns from the Internal language.
Wildcards are translated to variables with generated names.
This should resolve the issue of having unbound names after inference