### PR TITLE
Fix de Brujin indexing of lambda arguments

### DIFF
--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -298,18 +298,12 @@ goLambda l = do
     local
       (over indexTableVarsNum (+ nPatterns))
       (mapM goLambdaClause (l ^. Internal.lambdaClauses))
-  values' <- values
-  let match = mkMatch' (fromList values') (toList ms)
-  return $ foldr (\_ n -> mkLambda' n) match values'
+  let values = take nPatterns (mkVar' <$> [0 ..])
+      match = mkMatch' (fromList values) (toList ms)
+  return $ foldr (\_ n -> mkLambda' n) match values
   where
     nPatterns :: Int
     nPatterns = length (l ^. Internal.lambdaClauses . _head1 . Internal.lambdaPatterns)
-
-    values :: Sem r [Node]
-    values = do
-      varsNum <- asks (^. indexTableVarsNum)
-      let vs = take nPatterns [varsNum ..]
-      return (mkVar' <$> vs)
 
 goAxiomInductive ::
   forall r.

--- a/test/Internal/Eval/Positive.hs
+++ b/test/Internal/Eval/Positive.hs
@@ -163,5 +163,10 @@ tests =
       "Builtin Inductive type"
       $(mkRelDir ".")
       $(mkRelFile "BuiltinInductive.juvix")
-      $(mkRelFile "out/BuiltinInductive.out")
+      $(mkRelFile "out/BuiltinInductive.out"),
+    PosTest
+      "Higher Order Lambda"
+      $(mkRelDir ".")
+      $(mkRelFile "HigherOrderLambda.juvix")
+      $(mkRelFile "out/HigherOrderLambda.out")
   ]

--- a/tests/Internal/positive/HigherOrderLambda.juvix
+++ b/tests/Internal/positive/HigherOrderLambda.juvix
@@ -1,0 +1,14 @@
+module HigherOrderLambda;
+
+open import Stdlib.Prelude;
+
+map' : {A : Type} → {B : Type} → (A → B) → List A → List B;
+map' f := \{ nil := nil; (h :: t) := f h :: map' f t};
+
+lst : List Nat;
+lst := zero :: one :: nil;
+
+main : IO;
+main := printNatLn (foldr (+) zero (map' ((+) one) lst));
+
+end;

--- a/tests/Internal/positive/out/HigherOrderLambda.out
+++ b/tests/Internal/positive/out/HigherOrderLambda.out
@@ -1,0 +1,1 @@
+suc (suc (suc zero))


### PR DESCRIPTION
A lambda:

```
\ { v0 := b0 ; v1 := b1 ; ... ; vn := bn }
```

should be translated to:

```
λ? (λ? ... (λ? (match ?$0, ?$1, ... , ?$n with ...)))
```

i.e the de Brujin index of the values in the match always start from 0.

Fixes: https://github.com/anoma/juvix/issues/1695