### PR TITLE
Fix macOS CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,8 @@ jobs:
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         if: runner.os == 'macOS'
         run: |
-          echo "CC=$(brew --prefix llvm@14)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm@14)/bin/llvm-ar" >> $GITHUB_ENV
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
 
       - name: Build Project (macOS)
         if: runner.os == 'macOS'
@@ -236,8 +236,8 @@ jobs:
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         if: runner.os == 'macOS'
         run: |
-          echo "CC=$(brew --prefix llvm@14)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm@14)/bin/llvm-ar" >> $GITHUB_ENV
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
 
       - name: stack setup (macOS)
         if: runner.os == 'macOS'
@@ -248,7 +248,7 @@ jobs:
       - name: Add homebrew clang to the PATH (macOS)
         if: runner.os == 'macOS'
         run: |
-          echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
 
       - name: Test suite (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
We need to use the homebrew Clang/LLVM installation to build the Juvix runtime because macOS ships with a version of Clang/LLVM that does not support the wasi target.

The GitHub action runner agent has the homebrew packaged Clang/LLVM installed but it is not on the shell PATH.

We were using `brew --prefix llvm@14` to point to the homebrew Clang/LLVM installation. However this breaks when the runner image is updated to a new version of llvm.

So we switch to using `brew --prefix llvm` which will resolve to the latest (and in this case only) version of homebrew Clang/LLVM. This will be stable when Clang/LLVM is updated to a new version.