### PR TITLE
Translate Nat builtins to the correct Core Ops

### DIFF
--- a/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
+++ b/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
@@ -104,17 +104,17 @@ convertNode tab = convert [] 0
               where
                 boolSymbol =
                   fromJust (HashMap.lookup (BuiltinTag TagTrue) (tab ^. infoConstructors)) ^. constructorInductive
-            Just BuiltinNatMul -> f (\info x y -> mkBuiltinApp info OpIntAdd [x, y])
+            Just BuiltinNatMul -> f (\info x y -> mkBuiltinApp info OpIntMul [x, y])
             Just BuiltinNatUDiv ->
               f
                 ( \info x y ->
                     mkBuiltinApp info OpIntDiv [mkBuiltinApp' OpIntAdd [x, mkBuiltinApp' OpIntSub [y, mkConstant' (ConstInteger 1)]], y]
                 )
-            Just BuiltinNatDiv -> f (\info x y -> mkBuiltinApp info OpIntAdd [x, y])
-            Just BuiltinNatMod -> f (\info x y -> mkBuiltinApp info OpIntAdd [x, y])
-            Just BuiltinNatLe -> f (\info x y -> mkBuiltinApp info OpIntAdd [x, y])
-            Just BuiltinNatLt -> f (\info x y -> mkBuiltinApp info OpIntAdd [x, y])
-            Just BuiltinNatEq -> f (\info x y -> mkBuiltinApp info OpIntAdd [x, y])
+            Just BuiltinNatDiv -> f (\info x y -> mkBuiltinApp info OpIntDiv [x, y])
+            Just BuiltinNatMod -> f (\info x y -> mkBuiltinApp info OpIntMod [x, y])
+            Just BuiltinNatLe -> f (\info x y -> mkBuiltinApp info OpIntLe [x, y])
+            Just BuiltinNatLt -> f (\info x y -> mkBuiltinApp info OpIntLt [x, y])
+            Just BuiltinNatEq -> f (\info x y -> mkBuiltinApp info OpEq [x, y])
             _ -> node
 
 natToInt :: InfoTable -> InfoTable


### PR DESCRIPTION
Test.juvix
```
module Test;

open import Stdlib.Prelude;
t : Nat -> Nat -> Nat;
t x y := x + (2 * y);

main : IO;
main := printNatLn (t 1 3);

end;
```

Before this fix:

```
juvix dev internal core-eval -t nat-to-int Test.juvix
```

prints `6` instead of `7` as the `*` is translated to `OpIntAdd` instead of `OpIntMul`.

We can properly test this once the new pipeline is complete.