### PR TITLE
Improve arity inference for repl expressions

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -42,7 +42,7 @@ arityCheckExpression ::
   Sem r Expression
 arityCheckExpression InternalResult {..} exp =
   mapError (JuvixError @ArityChecking.ArityCheckerError) $
-    runReader table (ArityChecking.withEmptyLocalVars (ArityChecking.checkExpression ArityChecking.ArityUnknown exp))
+    runReader table (ArityChecking.inferReplExpression exp)
   where
     table :: InfoTable
     table = buildTable _resultModules

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -137,6 +137,11 @@ withEmptyLocalVars = runReader emptyLocalVars
 arityLet :: (Members '[Reader InfoTable] r) => Let -> Sem r Arity
 arityLet l = guessArity (l ^. letExpression)
 
+inferReplExpression :: Members '[Reader InfoTable, NameIdGen, Error ArityCheckerError] r => Expression -> Sem r Expression
+inferReplExpression e = do
+  ari <- guessArity e
+  withEmptyLocalVars (checkExpression ari e)
+
 guessArity ::
   forall r.
   (Members '[Reader InfoTable] r) =>

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -42,6 +42,15 @@ tests:
           Stdlib.Prelude> \1
     exit-status: 0
     
+  - name: check-type-null
+    command:
+      - juvix
+      - repl
+    stdout:
+      contains: "{A : Type} → List A → Bool"
+    stdin: ":type null"
+    exit-status: 0
+
   - name: check-type-suc
     command:
       - juvix
@@ -180,4 +189,3 @@ tests:
       contains: |
         suc (suc (suc zero))
     exit-status: 0
-    


### PR DESCRIPTION
Closes #1721.

Now the arity checker does not add an unnecessary hole and so the repl displays the type properly:
![image](https://user-images.githubusercontent.com/5511599/214322656-706d6bd7-5fbe-42dd-adf7-cc9170d001b0.png)
