### PR TITLE
Run the new Juvix formatter for all the Juvix examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,8 @@ format: clang-format
 clang-format:
 	@cd runtime && ${MAKE} format
 
-TOFORMATFILES = ./examples
-TOFORMAT = $(shell find ${TOFORMATFILES} -name "*.juvix" -print)
+TOFORMATJUVIXFILES = ./examples
+TOFORMAT = $(shell find ${TOFORMATJUVIXFILES} -name "*.juvix" -print)
 
 .PHONY: $(TOFORMAT)
 juvix-format: $(TOFORMAT)

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,18 @@ format: clang-format
 clang-format:
 	@cd runtime && ${MAKE} format
 
+TOFORMATFILES = ./examples
+TOFORMAT = $(shell find ${TOFORMATFILES} -name "*.juvix" -print)
+
+.PHONY: $(TOFORMAT)
+juvix-format: $(TOFORMAT)
+$(TOFORMAT): %:
+	@echo "Formatting $@"
+	@juvix dev scope $@ --with-comments > $@.tmp
+	@mv $@.tmp $@
+	@echo "Typechecking formatted $@"
+	@juvix typecheck $@ --only-errors
+
 .PHONY: check-ormolu
 check-ormolu: export ORMOLUMODE = check
 check-ormolu:
@@ -193,6 +205,7 @@ check: clean
 	@${MAKE} install
 	@${MAKE} test
 	@${MAKE} smoke
+	@${MAKE} juvix-format
 	@${MAKE} format
 	@${MAKE} pre-commit
 

--- a/examples/demo/Demo.juvix
+++ b/examples/demo/Demo.juvix
@@ -1,56 +1,60 @@
 module Demo;
+  -- standard library prelude
+  open import Stdlib.Prelude;
+  -- for comparisons on natural numbers
+  open import Stdlib.Data.Nat.Ord;
+  -- for Ordering
+  open import Stdlib.Data.Ord;
 
--- standard library prelude
-open import Stdlib.Prelude;
--- for comparisons on natural numbers
-open import Stdlib.Data.Nat.Ord;
--- for Ordering
-open import Stdlib.Data.Ord;
+  even : Nat → Bool;
+  even zero := true;
+  even (suc zero) := false;
+  even (suc (suc n)) := even n;
 
-even : Nat → Bool;
-even zero := true;
-even (suc zero) := false;
-even (suc (suc n)) := even n;
+  even' : Nat → Bool;
+  even' n := mod n 2 == 0;
 
-even' : Nat → Bool;
-even' n := mod n 2 == 0;
+  -- base 2 logarithm rounded down
+  terminating
+  log2 : Nat → Nat;
+  log2 n := if (n <= 1) 0 (suc (log2 (div n 2)));
 
--- base 2 logarithm rounded down
-terminating
-log2 : Nat → Nat;
-log2 n := if (n <= 1) 0 (suc (log2 (div n 2)));
+  type Tree (A : Type) :=
+    | leaf : A → Tree A
+    | node : A → Tree A → Tree A → Tree A;
 
-type Tree (A : Type) :=
-| leaf : A → Tree A
-| node : A → Tree A → Tree A → Tree A;
+  mirror : {A : Type} → Tree A → Tree A;
+  mirror t@(leaf _) := t;
+  mirror (node x l r) := node x (mirror r) (mirror l);
 
-mirror : {A : Type} → Tree A → Tree A;
-mirror t@(leaf _) := t;
-mirror (node x l r) := node x (mirror r) (mirror l);
+  tree : Tree Nat;
+  tree := node 2 (node 3 (leaf 0) (leaf 1)) (leaf 7);
 
-tree : Tree Nat;
-tree := node 2 (node 3 (leaf 0) (leaf 1)) (leaf 7);
+  preorder : {A : Type} → Tree A → List A;
+  preorder (leaf x) := x :: nil;
+  preorder (node x l r) := x
+    :: nil
+    ++ preorder l
+    ++ preorder r;
 
-preorder : {A : Type} → Tree A → List A;
-preorder (leaf x) := x :: nil;
-preorder (node x l r) := x :: nil ++ preorder l ++ preorder r;
+  terminating
+  sort : {A : Type} → (A → A → Ordering) → List A → List A;
+  sort _ nil := nil;
+  sort _ xs@(_ :: nil) := xs;
+  sort cmp xs := uncurry
+    (merge cmp)
+    (both (sort cmp) (splitAt (div (length xs) 2) xs));
 
-terminating
-sort : {A : Type} → (A → A → Ordering) → List A → List A;
-sort _ nil := nil;
-sort _ xs@(_ :: nil) := xs;
-sort cmp xs := uncurry (merge cmp) (both (sort cmp) (splitAt (div (length xs) 2) xs));
+  printNatListLn : List Nat → IO;
+  printNatListLn nil := printStringLn "nil";
+  printNatListLn (x :: xs) := printNat x
+    >> printString " :: "
+    >> printNatListLn xs;
 
-printNatListLn : List Nat → IO;
-printNatListLn nil := printStringLn "nil";
-printNatListLn (x :: xs) := printNat x >> printString " :: " >> printNatListLn xs;
-
-main : IO;
-main :=
-  printStringLn "Hello!" >>
-  printNatListLn (preorder (mirror tree)) >>
-  printNatListLn (sort compare (preorder (mirror tree))) >>
-  printNatLn (log2 3) >>
-  printNatLn (log2 130);
-
+  main : IO;
+  main := printStringLn "Hello!"
+    >> printNatListLn (preorder (mirror tree))
+    >> printNatListLn (sort compare (preorder (mirror tree)))
+    >> printNatLn (log2 3)
+    >> printNatLn (log2 130);
 end;

--- a/examples/milestone/Collatz/Collatz.juvix
+++ b/examples/milestone/Collatz/Collatz.juvix
@@ -1,54 +1,54 @@
 module Collatz;
+  open import Stdlib.Prelude;
 
-open import Stdlib.Prelude;
+  mapMaybe : {A : Type} → {B : Type} → (A → B) → Maybe
+    A → Maybe B;
+  mapMaybe _ nothing := nothing;
+  mapMaybe f (just x) := just (f x);
 
-mapMaybe : {A : Type} → {B : Type} → (A → B) → Maybe A → Maybe B;
-mapMaybe _ nothing := nothing;
-mapMaybe f (just x) := just (f x);
+  div2 : Nat → Maybe Nat;
+  div2 zero := just zero;
+  div2 (suc (suc n)) := mapMaybe suc (div2 n);
+  div2 _ := nothing;
 
-div2 : Nat → Maybe Nat;
-div2 zero := just zero;
-div2 (suc (suc n)) := mapMaybe suc (div2 n);
-div2 _ := nothing;
+  collatzNext : Nat → Nat;
+  collatzNext n := fromMaybe (suc (3 * n)) (div2 n);
 
-collatzNext : Nat → Nat;
-collatzNext n := fromMaybe (suc (3 * n)) (div2 n);
+  collatz : Nat → Nat;
+  collatz zero := zero;
+  collatz (suc zero) := suc zero;
+  collatz (suc (suc n)) := collatzNext (suc (suc n));
 
-collatz : Nat → Nat;
-collatz zero := zero;
-collatz (suc zero) := suc zero;
-collatz (suc (suc n)) := collatzNext (suc (suc n));
+  --- -----------------------------------------------------------------------------
 
---------------------------------------------------------------------------------
--- IO
---------------------------------------------------------------------------------
+  -- IO
+  --- -----------------------------------------------------------------------------
+  axiom readline : String;
 
-axiom readline : String;
-compile readline {
-  c ↦ "readline()";
-};
+  compile readline {
+    c ↦ "readline()";
+  };
 
-axiom parsePositiveInt : String → Nat;
+  axiom parsePositiveInt : String → Nat;
 
-compile parsePositiveInt {
-  c ↦ "parsePositiveInt";
-};
+  compile parsePositiveInt {
+    c ↦ "parsePositiveInt";
+  };
 
-getInitial : Nat;
-getInitial := parsePositiveInt (readline);
+  getInitial : Nat;
+  getInitial := parsePositiveInt (readline);
 
-output : Nat → Nat × IO;
-output n := (n, printNatLn n);
+  output : Nat → Nat × IO;
+  output n := n , printNatLn n;
 
-terminating
-run : (Nat → Nat) → Nat → IO;
-run _ (suc zero) := printStringLn "Finished!";
-run f n := run f (fst (output (f n)));
+  terminating
+  run : (Nat → Nat) → Nat → IO;
+  run _ (suc zero) := printStringLn "Finished!";
+  run f n := run f (fst (output (f n)));
 
-welcome : String;
-welcome := "Collatz calculator\n------------------\n\nType a number then ENTER";
+  welcome : String;
+  welcome := "Collatz calculator\n------------------\n\nType a number then ENTER";
 
-main : IO;
-main := printStringLn welcome >> run collatz getInitial;
-
+  main : IO;
+  main := printStringLn welcome >> run collatz getInitial;
 end;

--- a/examples/milestone/Fibonacci/Fibonacci.juvix
+++ b/examples/milestone/Fibonacci/Fibonacci.juvix
@@ -1,15 +1,13 @@
 module Fibonacci;
+  open import Stdlib.Prelude;
 
-open import Stdlib.Prelude;
+  fib : Nat → Nat → Nat → Nat;
+  fib zero x1 _ := x1;
+  fib (suc n) x1 x2 := fib n x2 (x1 + x2);
 
-fib : Nat → Nat → Nat → Nat;
-fib zero x1 _ := x1;
-fib (suc n) x1 x2 := fib n x2 (x1 + x2);
+  fibonacci : Nat → Nat;
+  fibonacci n := fib n 0 1;
 
-fibonacci : Nat → Nat;
-fibonacci n := fib n 0 1;
-
-main : IO;
-main := printNatLn (fibonacci 25);
-
+  main : IO;
+  main := printNatLn (fibonacci 25);
 end;

--- a/examples/milestone/Hanoi/Hanoi.juvix
+++ b/examples/milestone/Hanoi/Hanoi.juvix
@@ -1,71 +1,78 @@
 --- Towers of Hanoi is a puzzle with three rods and n disks of decresing size.
----
 --- The disks are stacked ontop of each other through the first rod.
+
 --- The aim of the game is to move the stack of disks to another rod while
+
 --- following these rules:
----
 --- 1. Only one disk can be moved at a time
+
 --- 2. You may only move a disk from the top of one of the stacks to the top of another stack
+
 --- 3. No disk may be moved on top of a smaller disk
----
 --- The function ;hanoi; computes the sequence of moves to solve puzzle.
-
 module Hanoi;
+  open import Stdlib.Prelude;
 
-open import Stdlib.Prelude;
+  infixr 5 ++str;
+  --- Concatenation of ;String;s
+  axiom ++str : String → String → String;
 
---- Concatenation of ;String;s
-infixr 5 ++str;
-axiom ++str : String → String → String;
-compile ++str {
-  c ↦ "concat";
-};
+  compile ++str {
+    c ↦ "concat";
+  };
 
---- Concatenates a list of strings
----
---- ;concat (("a" :: nil) :: ("b" :: nil)); evaluates to ;"a" :: "b" :: nil;
-concat : List String → String;
-concat := foldl (++str) "";
+  --- Concatenates a list of strings
+  --- ;concat (("a" :: nil) :: "b" :: nil); evaluates to ;"a"
+  :: "b"
+  :: nil;
+  concat : List String → String;
+  concat := foldl (++str) "";
 
-intercalate : String → List String → String;
-intercalate sep xs := concat (intersperse sep xs);
+  intercalate : String → List String → String;
+  intercalate sep xs := concat (intersperse sep xs);
 
---- Joins a list of strings with the newline character
-unlines : List String → String;
-unlines := intercalate "\n";
+  --- Joins a list of strings with the newline character
+  unlines : List String → String;
+  unlines := intercalate "\n";
 
---- Produce a singleton List
-singleton : {A : Type} → A → List A;
-singleton a := a :: nil;
+  --- Produce a singleton List
+  singleton : {A : Type} → A → List A;
+  singleton a := a :: nil;
 
---- Produce a ;String; representation of a ;List Nat;
-showList : List Nat → String;
-showList xs := "[" ++str intercalate "," (map natToStr xs) ++str "]";
+  --- Produce a ;String; representation of a ;List Nat;
+  showList : List Nat → String;
+  showList xs := "["
+    ++str intercalate "," (map natToStr xs)
+    ++str "]";
 
---- A Peg represents a peg in the towers of Hanoi game
-type Peg :=
-    left : Peg
-  | middle : Peg
-  | right : Peg;
+  --- A Peg represents a peg in the towers of Hanoi game
+  type Peg :=
+    | left : Peg
+    | middle : Peg
+    | right : Peg;
 
-showPeg : Peg → String;
-showPeg left := "left";
-showPeg middle := "middle";
-showPeg right := "right";
+  showPeg : Peg → String;
+  showPeg left := "left";
+  showPeg middle := "middle";
+  showPeg right := "right";
 
+  --- A Move represents a move between pegs
+  type Move :=
+    | move : Peg → Peg → Move;
 
---- A Move represents a move between pegs
-type Move := move : Peg → Peg → Move;
+  showMove : Move → String;
+  showMove (move from to) := showPeg from
+    ++str " -> "
+    ++str showPeg to;
 
-showMove : Move → String;
-showMove (move from to) := showPeg from ++str " -> " ++str showPeg to;
+  --- Produce a list of ;Move;s that solves the towers of Hanoi game
+  hanoi : Nat → Peg → Peg → Peg → List Move;
+  hanoi zero _ _ _ := nil;
+  hanoi (suc n) p1 p2 p3 := hanoi n p1 p3 p2
+    ++ singleton (move p1 p2)
+    ++ hanoi n p3 p2 p1;
 
---- Produce a list of ;Move;s that solves the towers of Hanoi game
-hanoi : Nat → Peg → Peg → Peg → List Move;
-hanoi zero _ _ _ := nil;
-hanoi (suc n) p1 p2 p3 := hanoi n p1 p3 p2 ++ singleton (move p1 p2) ++ hanoi n p3 p2 p1;
-
-main : IO;
-main := printStringLn (unlines (map showMove (hanoi 5 left middle right)));
-
+  main : IO;
+  main := printStringLn
+    (unlines (map showMove (hanoi 5 left middle right)));
 end;

--- a/examples/milestone/Hanoi/Hanoi.juvix
+++ b/examples/milestone/Hanoi/Hanoi.juvix
@@ -1,14 +1,17 @@
 --- Towers of Hanoi is a puzzle with three rods and n disks of decresing size.
+
 --- The disks are stacked ontop of each other through the first rod.
 
 --- The aim of the game is to move the stack of disks to another rod while
 
 --- following these rules:
+
 --- 1. Only one disk can be moved at a time
 
 --- 2. You may only move a disk from the top of one of the stacks to the top of another stack
 
 --- 3. No disk may be moved on top of a smaller disk
+
 --- The function ;hanoi; computes the sequence of moves to solve puzzle.
 module Hanoi;
   open import Stdlib.Prelude;
@@ -22,6 +25,7 @@ module Hanoi;
   };
 
   --- Concatenates a list of strings
+
   --- ;concat (("a" :: nil) :: "b" :: nil); evaluates to ;"a"
   :: "b"
   :: nil;

--- a/examples/milestone/HelloWorld/HelloWorld.juvix
+++ b/examples/milestone/HelloWorld/HelloWorld.juvix
@@ -1,9 +1,7 @@
 -- HelloWorld.juvix
 module HelloWorld;
+  open import Stdlib.Prelude;
 
-open import Stdlib.Prelude;
-
-main : IO;
-main := printStringLn "hello world!";
-
+  main : IO;
+  main := printStringLn "hello world!";
 end;

--- a/examples/milestone/PascalsTriangle/PascalsTriangle.juvix
+++ b/examples/milestone/PascalsTriangle/PascalsTriangle.juvix
@@ -1,60 +1,64 @@
 --- Pascal's triangle is the arrangement of binomial coefficients in a triangular array.
----
 --- The rows of the triangle are staggered so that each number can be computed as the
+
 --- sum of the numbers to the left and right in the previous row.
----
 --- The function ;pascal; produces the triangle to a given depth.
-
 module PascalsTriangle;
+  open import Stdlib.Prelude;
 
-open import Stdlib.Prelude;
+  zipWith : {A : Type} → {B : Type} → {C : Type} → (A → B → C) → List
+    A → List B → List C;
+  zipWith f nil _ := nil;
+  zipWith f _ nil := nil;
+  zipWith f (x :: xs) (y :: ys) := f x y :: zipWith f xs ys;
 
-zipWith : {A : Type} → {B : Type} → {C : Type} → (A → B → C) -> List A → List B → List C;
-zipWith f nil _ := nil;
-zipWith f _ nil := nil;
-zipWith f (x :: xs) (y :: ys) := f x y :: zipWith f xs ys;
+  --- Return a list of repeated applications of a given function
+  iterate : {A : Type} → Nat → (A → A) → A → List A;
+  iterate zero _ _ := nil;
+  iterate (suc n) f a := a :: iterate n f (f a);
 
---- Return a list of repeated applications of a given function
-iterate : {A : Type} → Nat → (A → A) → A → List A;
-iterate zero _ _ := nil;
-iterate (suc n) f a := a :: iterate n f (f a);
+  --- Produce a singleton List
+  singleton : {A : Type} → A → List A;
+  singleton a := a :: nil;
 
---- Produce a singleton List
-singleton : {A : Type} → A → List A;
-singleton a := a :: nil;
+  infixr 5 ++str;
+  --- Concatenation of ;String;s
+  axiom ++str : String → String → String;
 
---- Concatenation of ;String;s
-infixr 5 ++str;
-axiom ++str : String → String → String;
-compile ++str {
-  c ↦ "concat";
-};
+  compile ++str {
+    c ↦ "concat";
+  };
 
---- Concatenates a list of strings
----
---- ;concat (("a" :: nil) :: ("b" :: nil)); evaluates to ;"a" :: "b" :: nil;
-concat : List String → String;
-concat := foldl (++str) "";
+  --- Concatenates a list of strings
+  --- ;concat (("a" :: nil) :: "b" :: nil); evaluates to ;"a"
+  :: "b"
+  :: nil;
+  concat : List String → String;
+  concat := foldl (++str) "";
 
-intercalate : String → List String → String;
-intercalate sep xs := concat (intersperse sep xs);
+  intercalate : String → List String → String;
+  intercalate sep xs := concat (intersperse sep xs);
 
---- Joins a list of strings with the newline character
-unlines : List String → String;
-unlines := intercalate "\n";
+  --- Joins a list of strings with the newline character
+  unlines : List String → String;
+  unlines := intercalate "\n";
 
-showList : List Nat → String;
-showList xs := "[" ++str intercalate "," (map natToStr xs) ++str "]";
+  showList : List Nat → String;
+  showList xs := "["
+    ++str intercalate "," (map natToStr xs)
+    ++str "]";
 
---- Compute the next row of Pascal's triangle
-pascalNextRow : List Nat → List Nat;
-pascalNextRow row := zipWith (+) (singleton zero ++ row) (row ++ singleton zero);
+  --- Compute the next row of Pascal's triangle
+  pascalNextRow : List Nat → List Nat;
+  pascalNextRow row := zipWith
+    (+)
+    (singleton zero ++ row)
+    (row ++ singleton zero);
 
---- Produce Pascal's triangle to a given depth
-pascal : Nat → List (List Nat);
-pascal rows := iterate rows pascalNextRow (singleton 1);
+  --- Produce Pascal's triangle to a given depth
+  pascal : Nat → List (List Nat);
+  pascal rows := iterate rows pascalNextRow (singleton 1);
 
-main : IO;
-main := printStringLn (unlines (map showList (pascal 10)));
-
+  main : IO;
+  main := printStringLn (unlines (map showList (pascal 10)));
 end;

--- a/examples/milestone/PascalsTriangle/PascalsTriangle.juvix
+++ b/examples/milestone/PascalsTriangle/PascalsTriangle.juvix
@@ -1,7 +1,9 @@
 --- Pascal's triangle is the arrangement of binomial coefficients in a triangular array.
+
 --- The rows of the triangle are staggered so that each number can be computed as the
 
 --- sum of the numbers to the left and right in the previous row.
+
 --- The function ;pascal; produces the triangle to a given depth.
 module PascalsTriangle;
   open import Stdlib.Prelude;
@@ -30,6 +32,7 @@ module PascalsTriangle;
   };
 
   --- Concatenates a list of strings
+
   --- ;concat (("a" :: nil) :: "b" :: nil); evaluates to ;"a"
   :: "b"
   :: nil;

--- a/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
@@ -1,9 +1,11 @@
 --- Tic-tac-toe is a paper-and-pencil game for two players who take turns marking the spaces
 
 --- in a three-by-three grid with X or O.
+
 --- The player who succeeds in placing three of their marks in a horizontal, vertical, or
 
 --- diagonal row is the winner. It is a solved game, with a forced draw assuming best play from both players.
+
 --- The module Logic.Game contains the game logic.
 module CLI.TicTacToe;
   open import Stdlib.Data.Nat.Ord;
@@ -22,22 +24,22 @@ module CLI.TicTacToe;
     c ↦ "parsePositiveInt";
   };
 
-  -- | Reads a ;Nat; from stdin
-    getMove : Maybe Nat;
+  --- Reads a ;Nat; from stdin
+  getMove : Maybe Nat;
   getMove := validMove (parsePositiveInt (readline));
 
   do : IO × GameState → GameState;
   do (_ , s) := playMove getMove s;
 
-  -- | A ;String; that prompts the user for their input
-    prompt : GameState → String;
+  --- A ;String; that prompts the user for their input
+  prompt : GameState → String;
   prompt x := "\n"
     ++str showGameState x
     ++str "\nPlayer "
     ++str showSymbol (player x)
     ++str ": ";
 
-  -- | Main loop
+  --- Main loop
   terminating
   run : (IO × GameState → GameState) → GameState → IO;
   run _ (state b p (terminate msg)) := printStringLn

--- a/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
@@ -1,50 +1,62 @@
 --- Tic-tac-toe is a paper-and-pencil game for two players who take turns marking the spaces
+
 --- in a three-by-three grid with X or O.
----
 --- The player who succeeds in placing three of their marks in a horizontal, vertical, or
+
 --- diagonal row is the winner. It is a solved game, with a forced draw assuming best play from both players.
----
 --- The module Logic.Game contains the game logic.
 module CLI.TicTacToe;
+  open import Stdlib.Data.Nat.Ord;
+  open import Stdlib.Prelude;
+  open import Logic.Game;
 
-open import Stdlib.Data.Nat.Ord;
-open import Stdlib.Prelude;
-open import Logic.Game;
+  axiom readline : String;
 
-axiom readline : String;
-compile readline {
-  c ↦ "readline()";
-};
+  compile readline {
+    c ↦ "readline()";
+  };
 
-axiom parsePositiveInt : String → Nat;
+  axiom parsePositiveInt : String → Nat;
 
-compile parsePositiveInt {
-  c ↦ "parsePositiveInt";
-};
+  compile parsePositiveInt {
+    c ↦ "parsePositiveInt";
+  };
 
--- | Reads a ;Nat; from stdin
-getMove : Maybe Nat;
-getMove := validMove (parsePositiveInt (readline));
+  -- | Reads a ;Nat; from stdin
+    getMove : Maybe Nat;
+  getMove := validMove (parsePositiveInt (readline));
 
-do : IO × GameState -> GameState;
-do (_, s) := playMove getMove s;
+  do : IO × GameState → GameState;
+  do (_ , s) := playMove getMove s;
 
--- | A ;String; that prompts the user for their input
-prompt : GameState → String;
-prompt x := "\n" ++str (showGameState x) ++str "\nPlayer " ++str showSymbol (player x) ++str ": ";
+  -- | A ;String; that prompts the user for their input
+    prompt : GameState → String;
+  prompt x := "\n"
+    ++str showGameState x
+    ++str "\nPlayer "
+    ++str showSymbol (player x)
+    ++str ": ";
 
--- | Main loop
-terminating
-run : (IO × GameState → GameState) → GameState → IO;
-run _ (state b p (terminate msg)) := printStringLn ("\n" ++str (showGameState (state b p noError)) ++str "\n" ++str msg);
-run f (state b p (continue msg)) := run f (f (printString (msg ++str prompt (state b p noError)), state b p noError));
-run f x := run f (f (printString (prompt x), x));
+  -- | Main loop
+  terminating
+  run : (IO × GameState → GameState) → GameState → IO;
+  run _ (state b p (terminate msg)) := printStringLn
+    ("\n"
+    ++str showGameState (state b p noError)
+    ++str "\n"
+    ++str msg);
+  run f (state b p (continue msg)) := run
+    f
+    (f
+      (printString (msg ++str prompt (state b p noError))
+      , state b p noError));
+  run f x := run f (f (printString (prompt x) , x));
 
---- The welcome message
-welcome : String;
-welcome := "MiniTicTacToe\n-------------\n\nType a number then ENTER to make a move";
+  --- The welcome message
+  welcome : String;
+  welcome := "MiniTicTacToe\n-------------\n\nType a number then ENTER to make a move";
 
---- The entry point of the program
-main : IO;
-main := printStringLn welcome >> run do beginState;
+  --- The entry point of the program
+  main : IO;
+  main := printStringLn welcome >> run do beginState;
 end;

--- a/examples/milestone/TicTacToe/Logic/Board.juvix
+++ b/examples/milestone/TicTacToe/Logic/Board.juvix
@@ -1,38 +1,42 @@
 module Logic.Board;
+  open import Stdlib.Prelude;
+  open import Logic.Square public;
+  open import Logic.Symbol public;
+  open import Logic.Extra;
 
-open import Stdlib.Prelude;
-open import Logic.Square public;
-open import Logic.Symbol public;
-open import Logic.Extra;
+  --- A 3x3 grid of ;Square;s
+  type Board :=
+    | board : List (List Square) → Board;
 
---- A 3x3 grid of ;Square;s
-type Board :=
-  board : List (List Square) → Board;
+  --- Returns the list of numbers corresponding to the empty ;Square;s
+  possibleMoves : List Square → List Nat;
+  possibleMoves nil := nil;
+  possibleMoves (empty n :: xs) := n :: possibleMoves xs;
+  possibleMoves (_ :: xs) := possibleMoves xs;
 
---- Returns the list of numbers corresponding to the empty ;Square;s
-possibleMoves : List Square → List Nat;
-possibleMoves nil := nil;
-possibleMoves ((empty n) :: xs) := n :: possibleMoves xs;
-possibleMoves (_ :: xs) := possibleMoves xs;
+  --- ;true; if all the ;Square;s in the list are equal
+  full : List Square → Bool;
+  full (a :: b :: c :: nil) := ==Square a b && ==Square b c;
 
---- ;true; if all the ;Square;s in the list are equal
-full : List Square → Bool;
-full (a :: b :: c :: nil) := (==Square a b) && (==Square b c);
+  diagonals : List (List Square) → List (List Square);
+  diagonals ((a1 :: _ :: b1 :: nil) :: (_ :: c :: _ :: nil) :: (b2 :: _ :: a2 :: nil) :: nil) := (a1
+      :: c
+      :: a2
+      :: nil)
+    :: (b1 :: c :: b2 :: nil)
+    :: nil;
 
-diagonals : List (List Square) → List (List Square);
-diagonals ((a1 :: _ :: b1 :: nil) :: (_ :: c :: _ :: nil) :: (b2 :: _ :: a2 :: nil) :: nil) := (a1 :: c :: a2 :: nil) :: (b1 :: c :: b2 :: nil) :: nil;
+  columns : List (List Square) → List (List Square);
+  columns := transpose;
 
-columns : List (List Square) → List (List Square);
-columns := transpose;
+  rows : List (List Square) → List (List Square);
+  rows := id;
 
-rows : List (List Square) → List (List Square);
-rows := id;
+  --- Textual representation of a ;List Square;
+  showRow : List Square → String;
+  showRow xs := concat (surround "|" (map showSquare xs));
 
---- Textual representation of a ;List Square;
-showRow : List Square → String;
-showRow xs := concat (surround "|" (map showSquare xs));
-
-showBoard : Board → String;
-showBoard (board squares) := unlines (surround "+---+---+---+" (map showRow squares));
-
+  showBoard : Board → String;
+  showBoard (board squares) := unlines
+    (surround "+---+---+---+" (map showRow squares));
 end;

--- a/examples/milestone/TicTacToe/Logic/Extra.juvix
+++ b/examples/milestone/TicTacToe/Logic/Extra.juvix
@@ -12,6 +12,7 @@ module Logic.Extra;
   };
 
   --- Concatenates a list of strings
+
   --- ;concat (("a" :: nil) :: "b" :: nil); evaluates to ;"a"
   :: "b"
   :: nil;

--- a/examples/milestone/TicTacToe/Logic/Extra.juvix
+++ b/examples/milestone/TicTacToe/Logic/Extra.juvix
@@ -1,32 +1,32 @@
 --- Some generic helper definitions.
 module Logic.Extra;
+  open import Stdlib.Data.Nat.Ord;
+  open import Stdlib.Prelude;
 
-open import Stdlib.Data.Nat.Ord;
-open import Stdlib.Prelude;
+  infixr 5 ++str;
+  --- Primitive concatenation of ;String;s
+  axiom ++str : String → String → String;
 
-infixr 5 ++str;
---- Primitive concatenation of ;String;s
-axiom ++str : String → String → String;
-compile ++str {
-  c ↦ "concat";
-};
+  compile ++str {
+    c ↦ "concat";
+  };
 
---- Concatenates a list of strings
----
---- ;concat (("a" :: nil) :: ("b" :: nil)); evaluates to ;"a" :: "b" :: nil;
-concat : List String → String;
-concat := foldl (++str) "";
+  --- Concatenates a list of strings
+  --- ;concat (("a" :: nil) :: "b" :: nil); evaluates to ;"a"
+  :: "b"
+  :: nil;
+  concat : List String → String;
+  concat := foldl (++str) "";
 
---- It inserts the first ;String; at the beginning, in between, and at the end of the second list
-surround : String → List String → List String;
-surround x xs := (x :: intersperse x xs) ++ (x :: nil);
+  --- It inserts the first ;String; at the beginning, in between, and at the end of the second list
+  surround : String → List String → List String;
+  surround x xs := (x :: intersperse x xs) ++ x :: nil;
 
---- It inserts the first ;String; in between the ;String;s in the second list and concatenates the result
-intercalate : String → List String → String;
-intercalate sep xs := concat (intersperse sep xs);
+  --- It inserts the first ;String; in between the ;String;s in the second list and concatenates the result
+  intercalate : String → List String → String;
+  intercalate sep xs := concat (intersperse sep xs);
 
---- Joins a list of strings with the newline character
-unlines : List String → String;
-unlines := intercalate "\n";
-
+  --- Joins a list of strings with the newline character
+  unlines : List String → String;
+  unlines := intercalate "\n";
 end;

--- a/examples/milestone/TicTacToe/Logic/Game.juvix
+++ b/examples/milestone/TicTacToe/Logic/Game.juvix
@@ -1,6 +1,7 @@
 --- Tic-tac-toe is a paper-and-pencil game for two players who take turns marking the spaces
 
 --- in a three-by-three grid with X or O.
+
 --- The player who succeeds in placing three of their marks in a horizontal, vertical, or
 
 --- diagonal row is the winner. It is a solved game, with a forced draw assuming best play from both players.

--- a/examples/milestone/TicTacToe/Logic/Game.juvix
+++ b/examples/milestone/TicTacToe/Logic/Game.juvix
@@ -1,39 +1,49 @@
 --- Tic-tac-toe is a paper-and-pencil game for two players who take turns marking the spaces
+
 --- in a three-by-three grid with X or O.
----
 --- The player who succeeds in placing three of their marks in a horizontal, vertical, or
+
 --- diagonal row is the winner. It is a solved game, with a forced draw assuming best play from both players.
----
 module Logic.Game;
+  open import Stdlib.Data.Nat.Ord;
+  open import Stdlib.Prelude;
+  open import Logic.Extra public;
+  open import Logic.Board public;
+  open import Logic.GameState public;
 
-open import Stdlib.Data.Nat.Ord;
-open import Stdlib.Prelude;
-open import Logic.Extra public;
-open import Logic.Board public;
-open import Logic.GameState public;
+  --- Checks if we reached the end of the game.
+  checkState : GameState → GameState;
+  checkState (state b p e) := if
+    (won (state b p e))
+    (state
+      b
+      p
+      (terminate
+        ("Player " ++str showSymbol (switch p) ++str " wins!")))
+    (if
+      (draw (state b p e))
+      (state b p (terminate "It's a draw!"))
+      (state b p e));
 
---- Checks if we reached the end of the game.
-checkState : GameState → GameState;
-checkState (state b p e) :=
-  if (won (state b p e))
-     (state b p (terminate ("Player " ++str (showSymbol (switch p)) ++str " wins!")))
-     (if (draw (state b p e))
-         (state b p (terminate "It's a draw!"))
-         (state b p e));
+  --- Given a player attempted move, updates the state accordingly.
+  playMove : Maybe Nat → GameState → GameState;
+  playMove nothing (state b p _) := state
+    b
+    p
+    (continue "\nInvalid number, try again\n");
+  playMove (just k) (state (board s) player e) := if
+    (not (elem (==) k (possibleMoves (flatten s))))
+    (state
+      (board s)
+      player
+      (continue "\nThe square is already occupied, try again\n"))
+    (checkState
+      (state
+        (board (map (map (replace player k)) s))
+        (switch player)
+        noError));
 
---- Given a player attempted move, updates the state accordingly.
-playMove : Maybe Nat → GameState → GameState;
-playMove nothing (state b p _) :=
-    state b p (continue "\nInvalid number, try again\n");
-playMove (just k) (state (board s) player e) :=
-    if (not (elem (==) k (possibleMoves (flatten s))))
-        (state (board s) player (continue "\nThe square is already occupied, try again\n"))
-        (checkState (state (board (map (map (replace player k)) s))
-                           (switch player)
-                           noError));
-
---- Returns ;just; if the given ;Nat; is in range of 1..9
-validMove : Nat → Maybe Nat;
-validMove n := if ((n <= 9) && (n >= 1)) (just n) nothing;
-
+  --- Returns ;just; if the given ;Nat; is in range of 1..9
+  validMove : Nat → Maybe Nat;
+  validMove n := if (n <= 9 && n >= 1) (just n) nothing;
 end;

--- a/examples/milestone/TicTacToe/Logic/GameState.juvix
+++ b/examples/milestone/TicTacToe/Logic/GameState.juvix
@@ -1,41 +1,48 @@
 module Logic.GameState;
+  open import Stdlib.Prelude;
+  open import Logic.Extra;
+  open import Logic.Board;
 
-open import Stdlib.Prelude;
-open import Logic.Extra;
-open import Logic.Board;
+  type Error :=
+    | --- no error occurred
+    noError : Error
+    | --- a non-fatal error occurred
+    continue : String → Error
+    | --- a fatal occurred
+    terminate : String → Error;
 
-type Error :=
---- no error occurred
-  noError : Error |
---- a non-fatal error occurred
-continue : String → Error |
---- a fatal occurred
-terminate : String → Error;
+  type GameState :=
+    | state : Board → Symbol → Error → GameState;
 
-type GameState :=
-  state : Board → Symbol → Error → GameState;
+  --- Textual representation of a ;GameState;
+  showGameState : GameState → String;
+  showGameState (state b _ _) := showBoard b;
 
---- Textual representation of a ;GameState;
-showGameState : GameState → String;
-showGameState (state b _ _) := showBoard b;
+  --- Projects the player
+  player : GameState → Symbol;
+  player (state _ p _) := p;
 
---- Projects the player
-player : GameState → Symbol;
-player (state _ p _) := p;
+  --- initial ;GameState;
+  beginState : GameState;
+  beginState := state
+    (board
+      (map
+        (map empty)
+        ((1 :: 2 :: 3 :: nil)
+        :: (4 :: 5 :: 6 :: nil)
+        :: (7 :: 8 :: 9 :: nil)
+        :: nil)))
+    X
+    noError;
 
---- initial ;GameState;
-beginState : GameState;
-beginState := state
-     (board (map (map empty) ((1 :: 2 :: 3 :: nil) :: (4 :: 5 :: 6 :: nil) :: (7 :: 8 :: 9 :: nil) :: nil)))
-     X
-     noError;
+  --- ;true; if some player has won the game
+  won : GameState → Bool;
+  won (state (board squares) _ _) := any
+    full
+    (diagonals squares ++ rows squares ++ columns squares);
 
---- ;true; if some player has won the game
-won : GameState → Bool;
-won (state (board squares) _ _) := any full (diagonals squares ++ rows squares ++ columns squares);
-
---- ;true; if there is a draw
-draw : GameState → Bool;
-draw (state (board squares) _ _) := null (possibleMoves (flatten squares));
-
+  --- ;true; if there is a draw
+  draw : GameState → Bool;
+  draw (state (board squares) _ _) := null
+    (possibleMoves (flatten squares));
 end;

--- a/examples/milestone/TicTacToe/Logic/Square.juvix
+++ b/examples/milestone/TicTacToe/Logic/Square.juvix
@@ -1,32 +1,32 @@
 module Logic.Square;
+  open import Stdlib.Prelude;
+  open import Logic.Symbol;
+  open import Stdlib.Data.Nat.Ord;
+  open import Logic.Extra;
 
-open import Stdlib.Prelude;
-open import Logic.Symbol;
-open import Stdlib.Data.Nat.Ord;
-open import Logic.Extra;
+  --- A square is each of the holes in a board
+  type Square :=
+    | --- An empty square has a ;Nat; that uniquely identifies it
+    empty : Nat → Square
+    | -- TODO: Check the line below using Judoc
+        -- - An occupied square has a ;Symbol; in it
+        occupied : Symbol → Square;
 
---- A square is each of the holes in a board
-type Square :=
-  --- An empty square has a ;Nat; that uniquely identifies it
-  empty : Nat → Square
-  -- TODO: Check the line below using Judoc
-  -- - An occupied square has a ;Symbol; in it
-  | occupied : Symbol → Square;
+  --- Equality for ;Square;s
+  ==Square : Square → Square → Bool;
+  ==Square (empty m) (empty n) := m == n;
+  ==Square (occupied s) (occupied t) := ==Symbol s t;
+  ==Square _ _ := false;
 
---- Equality for ;Square;s
-==Square : Square → Square → Bool;
-==Square (empty m) (empty n) := m == n;
-==Square (occupied s) (occupied t) := ==Symbol s t;
-==Square _ _ := false;
+  --- Textual representation of a ;Square;
+  showSquare : Square → String;
+  showSquare (empty n) := " " ++str natToStr n ++str " ";
+  showSquare (occupied s) := " " ++str showSymbol s ++str " ";
 
---- Textual representation of a ;Square;
-showSquare : Square → String;
-showSquare (empty n) := " " ++str natToStr n ++str " ";
-showSquare (occupied s) := " " ++str showSymbol s ++str " ";
-
-replace : Symbol → Nat → Square → Square;
-replace player k (empty n) := if (n Stdlib.Data.Nat.Ord.== k) (occupied player) (empty n);
-replace _ _ s := s;
-
-
+  replace : Symbol → Nat → Square → Square;
+  replace player k (empty n) := if
+    (n Stdlib.Data.Nat.Ord.== k)
+    (occupied player)
+    (empty n);
+  replace _ _ s := s;
 end;

--- a/examples/milestone/TicTacToe/Logic/Symbol.juvix
+++ b/examples/milestone/TicTacToe/Logic/Symbol.juvix
@@ -1,29 +1,27 @@
 --- This module defines the ;Symbol; type and some helper functions.
 module Logic.Symbol;
+  open import Stdlib.Prelude;
 
-open import Stdlib.Prelude;
+  --- A symbol represents a token that can be placed in a square
+  type Symbol :=
+    | --- The circle token
+    O : Symbol
+    | --- The cross token
+    X : Symbol;
 
---- A symbol represents a token that can be placed in a square
-type Symbol :=
---- The circle token
-  O : Symbol |
---- The cross token
-  X : Symbol;
+  --- Equality for ;Symbol;s
+  ==Symbol : Symbol → Symbol → Bool;
+  ==Symbol O O := true;
+  ==Symbol X X := true;
+  ==Symbol _ _ := false;
 
---- Equality for ;Symbol;s
-==Symbol : Symbol → Symbol → Bool;
-==Symbol O O := true;
-==Symbol X X := true;
-==Symbol _ _ := false;
+  --- Turns ;O; into ;X; and ;X; into ;O;
+  switch : Symbol → Symbol;
+  switch O := X;
+  switch X := O;
 
---- Turns ;O; into ;X; and ;X; into ;O;
-switch : Symbol → Symbol;
-switch O := X;
-switch X := O;
-
---- Textual representation of a ;Symbol;
-showSymbol : Symbol → String;
-showSymbol O := "O";
-showSymbol X := "X";
-
+  --- Textual representation of a ;Symbol;
+  showSymbol : Symbol → String;
+  showSymbol O := "O";
+  showSymbol X := "X";
 end;

--- a/examples/milestone/TicTacToe/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/TicTacToe.juvix
@@ -1,6 +1,4 @@
 module TicTacToe;
-
-import CLI.TicTacToe;
-import Web.TicTacToe;
-
+  import CLI.TicTacToe;
+  import Web.TicTacToe;
 end;

--- a/examples/milestone/TicTacToe/Web/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/Web/TicTacToe.juvix
@@ -1,146 +1,172 @@
 --- Tic-tac-toe is a paper-and-pencil game for two players who take turns marking the spaces
+
 --- in a three-by-three grid with X or O.
----
 --- The player who succeeds in placing three of their marks in a horizontal, vertical, or
+
 --- diagonal row is the winner. It is a solved game, with a forced draw assuming best play from both players.
----
 --- The module Logic.Game contains the game logic.
 module Web.TicTacToe;
+  open import Stdlib.Data.Nat.Ord;
+  open import Stdlib.Prelude;
+  open import Logic.Game;
 
-open import Stdlib.Data.Nat.Ord;
-open import Stdlib.Prelude;
-open import Logic.Game;
+  -- Functions provided by the host
+  axiom hostLog : String → IO;
+  -- XCoord → YCoord → Width → Height → Color → IO
+  axiom hostFillRect : Nat → Nat → Nat → Nat → String → IO;
+  -- XCoord → YCoord → Text → Size → Color → Align → IO
+  axiom hostFillText : Nat → Nat → String → Nat → String → Nat → IO;
 
--- Functions provided by the host
+  -- IO extensions
+    IOUnit : IO;
+  IOUnit := printString "";
 
-axiom hostLog : String → IO;
+  sequenceIO : List IO → IO;
+  sequenceIO := foldr (>>) IOUnit;
 
--- XCoord → YCoord → Width → Height → Color → IO
-axiom hostFillRect : Nat → Nat → Nat → Nat → String → IO;
+  mapIO : {A : Type} → (A → IO) → List A → IO;
+  mapIO f xs := sequenceIO (map f xs);
 
--- XCoord → YCoord → Text → Size → Color → Align → IO
-axiom hostFillText : Nat → Nat → String → Nat → String → Nat → IO;
+  -- List extensions
+    zip : {A : Type} → {B : Type} → List A → List B → List
+    (A × B);
+  zip (a :: as) (b :: bs) := (a , b) :: zip as bs;
+  zip _ _ := nil;
 
--- IO extensions
+  rangeAux : Nat → Nat → List Nat;
+  rangeAux _ zero := nil;
+  rangeAux m (suc n) := m :: rangeAux (suc m) n;
 
-IOUnit : IO;
-IOUnit := printString "";
+  range : Nat → List Nat;
+  range n := rangeAux zero n;
 
-sequenceIO : List IO → IO;
-sequenceIO := foldr (>>) IOUnit;
+  enumerate : {A : Type} → List A → List (Nat × A);
+  enumerate l := zip (range (length l)) l;
 
-mapIO : {A : Type} → (A → IO) → List A → IO;
-mapIO f xs := sequenceIO (map f xs);
+  -- Formatting constants
+    squareWidth : Nat;
+  squareWidth := 100;
 
--- List extensions
+  textSize : Nat;
+  textSize := 30;
 
-zip : {A : Type} → {B : Type} → List A → List B → List (A × B);
-zip (a :: as) (b :: bs) := (a, b) :: zip as bs;
-zip _ _ := nil;
+  xTextOffset : Nat;
+  xTextOffset := 50;
 
-rangeAux : Nat → Nat → List Nat;
-rangeAux _ zero := nil;
-rangeAux m (suc n) := m :: rangeAux (suc m) n;
+  yTextOffset : Nat;
+  yTextOffset := 60;
 
-range : Nat → List Nat;
-range n := rangeAux zero n;
+  canvasPadding : Nat;
+  canvasPadding := 8;
 
-enumerate : {A : Type} → List A → List (Nat × A);
-enumerate l := zip (range (length l)) l;
+  textColor : String;
+  textColor := "#000000";
 
--- Formatting constants
+  backgroundColor : String;
+  backgroundColor := "#c4434e";
 
-squareWidth : Nat;
-squareWidth := 100;
+  lightBackgroundColor : String;
+  lightBackgroundColor := "#c7737a";
 
-textSize : Nat;
-textSize := 30;
+  -- Rendering
+  type Align :=
+    | left : Align
+    | right : Align
+    | center : Align;
 
-xTextOffset : Nat;
-xTextOffset := 50;
+  alignNum : Align → Nat;
+  alignNum left := 0;
+  alignNum right := 1;
+  alignNum center := 2;
 
-yTextOffset : Nat;
-yTextOffset := 60;
+  renderText : String → Nat → Nat → Align → IO;
+  renderText t row col a := hostFillText
+    (squareWidth * row + xTextOffset)
+    (squareWidth * col + yTextOffset)
+    t
+    textSize
+    textColor
+    (alignNum a);
 
-canvasPadding : Nat;
-canvasPadding := 8;
+  renderSymbol : Symbol → Nat → Nat → IO;
+  renderSymbol s row col := renderText
+    (showSymbol s)
+    row
+    col
+    center;
 
-textColor : String;
-textColor := "#000000";
+  renderNumber : Nat → Nat → Nat → IO;
+  renderNumber n row col := renderText
+    (natToStr n)
+    row
+    col
+    center;
 
-backgroundColor : String;
-backgroundColor := "#c4434e";
-
-lightBackgroundColor : String;
-lightBackgroundColor := "#c7737a";
-
--- Rendering
-
-type Align :=
-    left : Align
-  | right : Align
-  | center : Align;
-
-alignNum : Align → Nat;
-alignNum left := 0;
-alignNum right := 1;
-alignNum center := 2;
-
-renderText : String → Nat → Nat → Align → IO;
-renderText t row col a := hostFillText ((squareWidth * row) + xTextOffset) ((squareWidth * col) + yTextOffset) t textSize textColor (alignNum a);
-
-renderSymbol : Symbol → Nat → Nat → IO;
-renderSymbol s row col := renderText (showSymbol s) row col center;
-
-renderNumber : Nat → Nat → Nat → IO;
-renderNumber n row col := renderText (natToStr n) row col center;
-
-renderSquare : Nat → Nat → Square → IO;
-renderSquare row col (occupied s) :=
-    hostFillRect (squareWidth * row) (squareWidth * col) squareWidth squareWidth backgroundColor
+  renderSquare : Nat → Nat → Square → IO;
+  renderSquare row col (occupied s) := hostFillRect
+      (squareWidth * row)
+      (squareWidth * col)
+      squareWidth
+      squareWidth
+      backgroundColor
     >> renderSymbol s row col;
-renderSquare row col (empty n) :=
-    hostFillRect (squareWidth * row) (squareWidth * col) squareWidth squareWidth lightBackgroundColor
+  renderSquare row col (empty n) := hostFillRect
+      (squareWidth * row)
+      (squareWidth * col)
+      squareWidth
+      squareWidth
+      lightBackgroundColor
     >> renderNumber n row col;
 
-renderRowAux : Nat → (Nat × Square) → IO;
-renderRowAux col (row, s) := renderSquare row col s;
+  renderRowAux : Nat → Nat × Square → IO;
+  renderRowAux col (row , s) := renderSquare row col s;
 
-renderRow : Nat × (List Square) → IO;
-renderRow (n, xs) := mapIO (renderRowAux n) (enumerate xs);
+  renderRow : Nat × List Square → IO;
+  renderRow (n , xs) := mapIO (renderRowAux n) (enumerate xs);
 
-renderBoard : Board → IO;
-renderBoard (board squares) := mapIO renderRow (enumerate squares);
+  renderBoard : Board → IO;
+  renderBoard (board squares) := mapIO
+    renderRow
+    (enumerate squares);
 
-renderFooterText : String → IO;
-renderFooterText msg := renderText msg 0 3 left;
+  renderFooterText : String → IO;
+  renderFooterText msg := renderText msg 0 3 left;
 
-nextPlayerText : Symbol → String;
-nextPlayerText s := "Next player: " ++str (showSymbol s);
+  nextPlayerText : Symbol → String;
+  nextPlayerText s := "Next player: " ++str showSymbol s;
 
-renderError : Error → IO;
-renderError noError := IOUnit;
-renderError (continue msg) := renderText msg 0 3 left;
-renderError (terminate msg) := renderText msg 0 3 left;
+  renderError : Error → IO;
+  renderError noError := IOUnit;
+  renderError (continue msg) := renderText msg 0 3 left;
+  renderError (terminate msg) := renderText msg 0 3 left;
 
-renderGameState : GameState → IO;
-renderGameState (state b _ (terminate msg)) := renderBoard b >> renderFooterText msg;
-renderGameState (state b p (continue msg)) := renderBoard b >> renderFooterText (nextPlayerText p) >> renderText (msg) 0 4 left;
-renderGameState (state b p _) := renderBoard b >> renderFooterText (nextPlayerText p);
+  renderGameState : GameState → IO;
+  renderGameState (state b _ (terminate msg)) := renderBoard b
+    >> renderFooterText msg;
+  renderGameState (state b p (continue msg)) := renderBoard b
+    >> renderFooterText (nextPlayerText p)
+    >> renderText (msg) 0 4 left;
+  renderGameState (state b p _) := renderBoard b
+    >> renderFooterText (nextPlayerText p);
 
-renderAndReturn : GameState → GameState;
-renderAndReturn s := const s (renderGameState s);
+  renderAndReturn : GameState → GameState;
+  renderAndReturn s := const s (renderGameState s);
 
-selectedSquare : Nat → Nat → Nat;
-selectedSquare row col := 3 * (div col squareWidth) + (div row squareWidth) + 1;
+  selectedSquare : Nat → Nat → Nat;
+  selectedSquare row col := 3 * div col squareWidth
+    + div row squareWidth
+    + 1;
 
--- API
+  -- API
+    initGame : GameState;
+  initGame := const
+    beginState
+    (renderGameState beginState
+    >> renderText "Click on a square to make a move" 0 4 left);
 
-initGame : GameState;
-initGame := const beginState (renderGameState beginState >> renderText "Click on a square to make a move" 0 4 left);
-
-move : GameState → Nat → Nat → GameState;
-move (state b p (terminate e)) x y := renderAndReturn (state b p (terminate e));
-move s x y := renderAndReturn (playMove (validMove (selectedSquare x y)) s);
-
+  move : GameState → Nat → Nat → GameState;
+  move (state b p (terminate e)) x y := renderAndReturn
+    (state b p (terminate e));
+  move s x y := renderAndReturn
+    (playMove (validMove (selectedSquare x y)) s);
 end;

--- a/examples/milestone/TicTacToe/Web/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/Web/TicTacToe.juvix
@@ -1,9 +1,11 @@
 --- Tic-tac-toe is a paper-and-pencil game for two players who take turns marking the spaces
 
 --- in a three-by-three grid with X or O.
+
 --- The player who succeeds in placing three of their marks in a horizontal, vertical, or
 
 --- diagonal row is the winner. It is a solved game, with a forced draw assuming best play from both players.
+
 --- The module Logic.Game contains the game logic.
 module Web.TicTacToe;
   open import Stdlib.Data.Nat.Ord;

--- a/examples/milestone/Tutorial/Tutorial.juvix
+++ b/examples/milestone/Tutorial/Tutorial.juvix
@@ -1,14 +1,14 @@
 --- This is an advanced tutorial for the Juvix programming language. You should read
+
 --- the "Quick start" and the "Learn Juvix in minutes" pages in the documentation
+
 --- first.
 module Tutorial;
+  -- import the standard library prelude and bring it into scope
+  open import Stdlib.Prelude;
+  -- bring comparison operators on Nat into scope
+  open import Stdlib.Data.Nat.Ord;
 
--- import the standard library prelude and bring it into scope
-open import Stdlib.Prelude;
--- bring comparison operators on Nat into scope
-open import Stdlib.Data.Nat.Ord;
-
-main : IO;
-main := printStringLn "Hello world!";
-
+  main : IO;
+  main := printStringLn "Hello world!";
 end;

--- a/examples/milestone/ValidityPredicates/Anoma/Base.juvix
+++ b/examples/milestone/ValidityPredicates/Anoma/Base.juvix
@@ -1,10 +1,9 @@
 module Anoma.Base;
-
-foreign ghc {
+  foreign ghc {
   import Anoma.Base
-};
+  };
 
-foreign c {
+  foreign c {
   int readPre(const char *key) {
       if (strcmp("change1-key", key)) {
           return 100;
@@ -28,51 +27,58 @@ foreign c {
   char* isBalanceKey(const char* s1, const char* s2) {
       return "owner-address";
   \}
-};
+  };
 
-open import Stdlib.Prelude;
-open import Data.Int;
-open import Data.Int.Ops;
-import Stdlib.Data.String.Ord;
+  open import Stdlib.Prelude;
+  open import Data.Int;
+  open import Data.Int.Ops;
 
-from-int : Int → Maybe Int;
-from-int i := if (i < Int_0) nothing (just i);
+  import Stdlib.Data.String.Ord;
 
-from-string : String → Maybe String;
-from-string s := if (s Stdlib.Data.String.Ord.== "") nothing (just s);
+  from-int : Int → Maybe Int;
+  from-int i := if (i < Int_0) nothing (just i);
 
---------------------------------------------------------------------------------
--- Anoma
---------------------------------------------------------------------------------
+  from-string : String → Maybe String;
+  from-string s := if
+    (s Stdlib.Data.String.Ord.== "")
+    nothing
+    (just s);
 
-axiom readPre : String → Int;
-compile readPre {
-  c ↦ "readPre";
-  ghc ↦ "readPre";
-};
+  --- -----------------------------------------------------------------------------
 
-axiom readPost : String → Int;
-compile readPost {
-  c ↦ "readPost";
-  ghc ↦ "readPost";
-};
+  -- Anoma
+  --- -----------------------------------------------------------------------------
+  axiom readPre : String → Int;
 
-axiom isBalanceKey : String → String → String;
-compile isBalanceKey {
-  c ↦ "isBalanceKey";
-  ghc ↦ "isBalanceKey";
-};
+  compile readPre {
+    c ↦ "readPre";
+    ghc ↦ "readPre";
+  };
 
-read-pre : String → Maybe Int;
-read-pre s := from-int (readPre s);
+  axiom readPost : String → Int;
 
-read-post : String → Maybe Int;
-read-post s := from-int (readPost s);
+  compile readPost {
+    c ↦ "readPost";
+    ghc ↦ "readPost";
+  };
 
-is-balance-key : String → String → Maybe String;
-is-balance-key token key := from-string (isBalanceKey token key);
+  axiom isBalanceKey : String → String → String;
 
-unwrap-default : Maybe Int → Int;
-unwrap-default := maybe Int_0 id;
+  compile isBalanceKey {
+    c ↦ "isBalanceKey";
+    ghc ↦ "isBalanceKey";
+  };
 
+  read-pre : String → Maybe Int;
+  read-pre s := from-int (readPre s);
+
+  read-post : String → Maybe Int;
+  read-post s := from-int (readPost s);
+
+  is-balance-key : String → String → Maybe String;
+  is-balance-key token key := from-string
+    (isBalanceKey token key);
+
+  unwrap-default : Maybe Int → Int;
+  unwrap-default := maybe Int_0 id;
 end;

--- a/examples/milestone/ValidityPredicates/Data/Int.juvix
+++ b/examples/milestone/ValidityPredicates/Data/Int.juvix
@@ -1,19 +1,19 @@
 module Data.Int;
+  axiom Int : Type;
 
-axiom Int : Type;
+  compile Int {
+    c ↦ "int";
+  };
 
-compile Int {
-  c ↦ "int";
-};
+  axiom Int_0 : Int;
 
-axiom Int_0 : Int;
-compile Int_0 {
-  c ↦ "0";
-};
+  compile Int_0 {
+    c ↦ "0";
+  };
 
-axiom Int_1 : Int;
-compile Int_1 {
-  c ↦ "1";
-};
+  axiom Int_1 : Int;
 
+  compile Int_1 {
+    c ↦ "1";
+  };
 end;

--- a/examples/milestone/ValidityPredicates/Data/Int/Ops.juvix
+++ b/examples/milestone/ValidityPredicates/Data/Int/Ops.juvix
@@ -1,53 +1,56 @@
 module Data.Int.Ops;
+  open import Data.Int;
+  open import Stdlib.Data.Bool;
 
-open import Data.Int;
-open import Stdlib.Data.Bool;
+  foreign c {
+  bool lessThan(int l, int r) {
+    return l < r;
+  \}
 
-foreign c {
-   bool lessThan(int l, int r) {
-     return l < r;
-   \}
+  bool eqInt(int l, int r) {
+    return l == r;
+  \}
 
-   bool eqInt(int l, int r) {
-     return l == r;
-   \}
+  int plus(int l, int r) {
+    return l + r;
+  \}
 
-   int plus(int l, int r) {
-     return l + r;
-   \}
+  int minus(int l, int r) {
+    return l - r;
+  \}
+  };
 
-   int minus(int l, int r) {
-     return l - r;
-   \}
-};
+  infix 4 <;
+  axiom < : Int → Int → Bool;
 
-infix 4 <;
-axiom < : Int → Int → Bool;
-compile < {
-  c ↦ "lessThan";
-};
+  compile < {
+    c ↦ "lessThan";
+  };
 
-axiom eqInt : Int → Int → Bool;
-compile eqInt {
-  c ↦ "eqInt";
-};
+  axiom eqInt : Int → Int → Bool;
 
-infix 4 ==;
-axiom == : Int → Int → Bool;
-compile == {
-  c ↦ "eqInt";
-};
+  compile eqInt {
+    c ↦ "eqInt";
+  };
 
-infixl 6 -;
-axiom - : Int -> Int -> Int;
-compile - {
-  c ↦ "minus";
-};
+  infix 4 ==;
+  axiom == : Int → Int → Bool;
 
-infixl 6 +;
-axiom + : Int -> Int -> Int;
-compile + {
-  c ↦ "plus";
-};
+  compile == {
+    c ↦ "eqInt";
+  };
 
+  infixl 6 -;
+  axiom - : Int → Int → Int;
+
+  compile - {
+    c ↦ "minus";
+  };
+
+  infixl 6 +;
+  axiom + : Int → Int → Int;
+
+  compile + {
+    c ↦ "plus";
+  };
 end;

--- a/examples/milestone/ValidityPredicates/SimpleFungibleToken.juvix
+++ b/examples/milestone/ValidityPredicates/SimpleFungibleToken.juvix
@@ -1,44 +1,49 @@
 module SimpleFungibleToken;
+  open import Anoma.Base;
+  open import Stdlib.Prelude;
 
-open import Anoma.Base;
-open import Stdlib.Prelude;
-import Stdlib.Data.String.Ord;
-open import Data.Int;
-import Data.Int.Ops;
+  import Stdlib.Data.String.Ord;
 
--- Misc
+  open import Data.Int;
 
-pair-from-optionString : (String → Int × Bool) → Maybe String → Int × Bool;
-pair-from-optionString := maybe (Int_0, false);
+  import Data.Int.Ops;
 
--- Validity Predicate
+  -- Misc
+    pair-from-optionString : (String → Int × Bool) → Maybe
+    String → Int × Bool;
+  pair-from-optionString := maybe (Int_0 , false);
 
-change-from-key : String → Int;
-change-from-key key := unwrap-default (read-post key) Data.Int.Ops.- unwrap-default (read-pre key);
+  -- Validity Predicate
+    change-from-key : String → Int;
+  change-from-key key := unwrap-default (read-post key)
+    Data.Int.Ops.- unwrap-default (read-pre key);
 
-check-vp : List String → String → Int → String → Int × Bool;
-check-vp verifiers key change owner :=
-    if
-        (change-from-key key Data.Int.Ops.< Int_0)
-        -- make sure the spender approved the transaction
-        (change Data.Int.Ops.+ (change-from-key key), elem (Stdlib.Data.String.Ord.==) owner verifiers)
-        (change Data.Int.Ops.+ (change-from-key key),  true);
+  check-vp : List String → String → Int → String → Int × Bool;
+  check-vp verifiers key change owner := if
+    (change-from-key key Data.Int.Ops.< Int_0)
+    (change Data.Int.Ops.+ change-from-key key
+    , elem (Stdlib.Data.String.Ord.==) owner verifiers)
+    (change Data.Int.Ops.+ change-from-key key , true);
 
-check-keys : String → List String → Int × Bool → String → Int × Bool;
-check-keys token verifiers (change, is-success) key :=
-    if
-        is-success
-        (pair-from-optionString (check-vp verifiers key change) (is-balance-key token key))
-        (Int_0, false);
+  -- make sure the spender approved the transaction
+    check-keys : String → List String → Int
+    × Bool → String → Int × Bool;
+  check-keys token verifiers (change , is-success) key := if
+    is-success
+    (pair-from-optionString
+      (check-vp verifiers key change)
+      (is-balance-key token key))
+    (Int_0 , false);
 
-check-result : Int × Bool → Bool;
-check-result (change, all-checked) := (change Data.Int.Ops.== Int_0) && all-checked;
+  check-result : Int × Bool → Bool;
+  check-result (change , all-checked) := change
+      Data.Int.Ops.== Int_0
+    && all-checked;
 
-vp : String → List String → List String → Bool;
-vp token keys-changed verifiers :=
-    check-result
-        (foldl
-            (check-keys token verifiers)
-            (Int_0, true)
-            keys-changed);
+  vp : String → List String → List String → Bool;
+  vp token keys-changed verifiers := check-result
+    (foldl
+      (check-keys token verifiers)
+      (Int_0 , true)
+      keys-changed);
 end;

--- a/examples/milestone/ValidityPredicates/Tests.juvix
+++ b/examples/milestone/ValidityPredicates/Tests.juvix
@@ -1,37 +1,35 @@
 module Tests;
+  open import Stdlib.Prelude;
+  open import SimpleFungibleToken;
 
-open import Stdlib.Prelude;
-open import SimpleFungibleToken;
+  --- -----------------------------------------------------------------------------
 
---------------------------------------------------------------------------------
--- Testing VP
---------------------------------------------------------------------------------
+  -- Testing VP
+  --- -----------------------------------------------------------------------------
+  token : String;
+  token := "owner-token";
 
-token : String;
-token := "owner-token";
+  owner-address : String;
+  owner-address := "owner-address";
 
-owner-address : String;
-owner-address := "owner-address";
+  change1-key : String;
+  change1-key := "change1-key";
 
-change1-key : String;
-change1-key := "change1-key";
+  change2-key : String;
+  change2-key := "change2-key";
 
-change2-key : String;
-change2-key := "change2-key";
+  verifiers : List String;
+  verifiers := owner-address :: nil;
 
-verifiers : List String;
-verifiers := owner-address :: nil;
+  keys-changed : List String;
+  keys-changed := change1-key :: change2-key :: nil;
 
-keys-changed : List String;
-keys-changed := change1-key :: change2-key :: nil;
+  show-result : Bool → String;
+  show-result true := "OK";
+  show-result false := "FAIL";
 
-show-result : Bool → String;
-show-result true := "OK";
-show-result false := "FAIL";
-
-main : IO;
-main :=
-    (printString "VP Status: ")
-    >> (printStringLn (show-result (vp token keys-changed verifiers)));
-
+  main : IO;
+  main := printString "VP Status: "
+    >> printStringLn
+      (show-result (vp token keys-changed verifiers));
 end;


### PR DESCRIPTION
Juvix now provides an intial and functional formatting tool by calling the command `juvix dev scope file --with-comments` .

This PR adds a new Makefile target `juvix-format` to format all the Juvix programs we showcase in the documentation as Juvix-projects, i.e., files from the `examples` directory. Note the corresponding target in the Makefile also calls the typechecker to ensure the programs do not have type errors introduced by the formatter, considering also that all the Juvix files in the `examples` directory type-checked before this PR. Thus, we should preserve that state. Finally, I included `juvix-format` as part of the `check` target, so we widen the testing of the compiler.

The formatter is not perfect yet, so we need to fix some formatting issues manually.
For example, the end of the line is modified by the formatting. We can fix this by calling after
`make pre-commit`.

