### PR TITLE
Install wasmer binary from Github releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,11 +228,11 @@ jobs:
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
       - name: Install the latest Wasmer version
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        uses: jonaprieto/action-install-gh-release
         with:
           repo: wasmerio/wasmer
           tag: latest
-          rename-to: wasmer
+          binaries-location: bin
           cache: true
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,9 +232,6 @@ jobs:
         with:
           repo: wasmerio/wasmer
           tag: v3.1.0
-          cache: enable
-          rename-to: wasmer
-          chmod: 0755
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,9 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
           repo: wasmerio/wasmer
-          tag: v3.1.0
+          tag: latest
+          rename-to: wasmer
+          cache: true
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
       - name: Install the latest Wasmer version
-        uses: jonaprieto/action-install-gh-release
+        uses: jonaprieto/action-install-gh-release@1
         with:
           repo: wasmerio/wasmer
           tag: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,14 @@ jobs:
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v2
+      - name: Install the latest Wasmer version
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        with:
+          repo: wasmerio/wasmer
+          tag: v3.1.0
+          cache: enable
+          rename-to: wasmer
+          chmod: 0755
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
The current Github action responsible for installing Wasmer fails from time to time, and it also is outdated, not following the new NodeJS 16 requirement by Github.

We could use https://github.com/jaxxstorm/action-install-gh-release instead, but unfortunately, it does not have the proper support to expose the binaries contained in an inner folder, as in the case with the Wasmer release. In the meantime, let's use my [fork](https://github.com/jonaprieto/action-install-gh-release) while I open PR to the main repository. 

