### PR TITLE
Keep regular comments in html output

### DIFF
--- a/app/Commands/Dev/Core/Repl.hs
+++ b/app/Commands/Dev/Core/Repl.hs
@@ -17,7 +17,7 @@ runCommand opts = do
   showReplWelcome
   runRepl opts Core.emptyInfoTable
 
-parseText :: Core.InfoTable -> Text -> Either Core.ParserError (Core.InfoTable, Maybe Core.Node)
+parseText :: Core.InfoTable -> Text -> Either Core.MegaparsecError (Core.InfoTable, Maybe Core.Node)
 parseText = Core.runParser replPath
 
 runRepl :: forall r. (Members '[Embed IO, App] r) => CoreReplOptions -> Core.InfoTable -> Sem r ()

--- a/app/Commands/Dev/Highlight.hs
+++ b/app/Commands/Dev/Highlight.hs
@@ -16,7 +16,7 @@ runCommand HighlightOptions {..} = do
       say (Highlight.goError (run $ runReader genOpts $ errorIntervals err))
     Right r -> do
       inputFile <- someBaseToAbs' (_highlightInputFile ^. pathPath)
-      let tbl = r ^. _2 . Scoper.resultParserTable
+      let tbl = r ^. _2 . Scoper.resultParserResult . Parser.resultTable
           items = tbl ^. Parser.infoParsedItems
           names = r ^. _2 . (Scoper.resultScoperTable . Scoper.infoNames)
           hinput =

--- a/app/Commands/Dev/Scope.hs
+++ b/app/Commands/Dev/Scope.hs
@@ -20,9 +20,7 @@ runCommand opts = do
         | otherwise ->
             renderStdOut (Scoper.ppOut (globalOpts, opts) s)
   when (opts ^. scopeListComments) $ do
-    let mainFile :: Path Abs File = getLoc (res ^. Scoper.mainModule) ^. intervalFile
     newline
     newline
     say "Comments:"
-    forM_ (fileComments mainFile (res ^. Scoper.comments) ^. fileCommentsSorted) $ \c ->
-      say (prettyText (c ^. commentInterval) <> " " <> prettyText c)
+    say (prettyText (res ^. Scoper.comments))

--- a/app/Commands/Dev/Scope.hs
+++ b/app/Commands/Dev/Scope.hs
@@ -6,7 +6,6 @@ import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Pretty qualified as Scoper
 import Juvix.Compiler.Concrete.Print qualified as Print
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
-import Juvix.Data.Comment
 import Juvix.Prelude.Pretty
 
 runCommand :: (Members '[Embed IO, App] r) => ScopeOptions -> Sem r ()

--- a/app/Commands/Html.hs
+++ b/app/Commands/Html.hs
@@ -9,6 +9,7 @@ import Juvix.Compiler.Backend.Html.Translation.FromTyped.Source
   )
 import Juvix.Compiler.Concrete.Pretty qualified as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context
 import Juvix.Extra.Process
 import System.Process qualified as Process
 
@@ -25,7 +26,8 @@ runGenOnlySourceHtml HtmlOptions {..} = do
           _genSourceHtmlArgsParamBase = "",
           _genSourceHtmlArgsUrlPrefix = _htmlUrlPrefix,
           _genSourceHtmlArgsConcreteOpts = Concrete.defaultOptions,
-          _genSourceHtmlArgsEntryPoint = m,
+          _genSourceHtmlArgsModule = m,
+          _genSourceHtmlArgsComments = res ^. comments,
           _genSourceHtmlArgsOutputDir = outputDir,
           _genSourceHtmlArgsNoFooter = _htmlNoFooter,
           _genSourceHtmlArgsNonRecursive = _htmlNonRecursive,

--- a/src/Juvix/Compiler/Asm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource.hs
@@ -15,16 +15,16 @@ import Juvix.Compiler.Asm.Translation.FromSource.Lexer
 import Juvix.Parser.Error
 import Text.Megaparsec qualified as P
 
-parseText :: Text -> Either ParserError InfoTable
+parseText :: Text -> Either MegaparsecError InfoTable
 parseText = runParser ""
 
-runParser :: FilePath -> Text -> Either ParserError InfoTable
+runParser :: FilePath -> Text -> Either MegaparsecError InfoTable
 runParser fileName input =
   case run $
     runInfoTableBuilder $
       runNameIdGen $
         P.runParserT parseToplevel fileName input of
-    (_, Left err) -> Left (ParserError err)
+    (_, Left err) -> Left (MegaparsecError err)
     (tbl, Right ()) -> Right tbl
 
 createBuiltinConstr ::

--- a/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
@@ -32,6 +32,7 @@ data CompileInfo = CompileInfo
 
 data InfoTable = InfoTable
   { _infoConstructors :: HashMap ConstructorRef ConstructorInfo,
+    _infoModules :: HashMap S.TopModulePath (Module 'Scoped 'ModuleTop),
     _infoAxioms :: HashMap AxiomRef AxiomInfo,
     _infoInductives :: HashMap InductiveRef InductiveInfo,
     _infoFunctions :: HashMap FunctionRef FunctionInfo,
@@ -45,6 +46,7 @@ emptyInfoTable =
   InfoTable
     { _infoConstructors = mempty,
       _infoAxioms = mempty,
+      _infoModules = mempty,
       _infoInductives = mempty,
       _infoFunctions = mempty,
       _infoFunctionClauses = mempty,

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -14,6 +14,7 @@ data InfoTableBuilder m a where
   RegisterFunctionClause :: FunctionClause 'Scoped -> InfoTableBuilder m ()
   RegisterName :: (HasLoc c) => S.Name' c -> InfoTableBuilder m ()
   RegisterCompile :: Compile 'Scoped -> InfoTableBuilder m ()
+  RegisterModule :: Module 'Scoped 'ModuleTop -> InfoTableBuilder m ()
 
 makeSem ''InfoTableBuilder
 
@@ -90,6 +91,7 @@ toState = reinterpret $ \case
         value = c
      in modify (over infoFunctionClauses (HashMap.insert key value))
   RegisterName n -> modify (over infoNames (cons (S.AName n)))
+  RegisterModule m -> modify (over infoModules (HashMap.insert (m ^. modulePath) m))
 
 runInfoTableBuilder :: InfoTable -> Sem (InfoTableBuilder ': r) a -> Sem r (InfoTable, a)
 runInfoTableBuilder tab = runState tab . toState

--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -88,4 +88,9 @@ topModulePathToDottedPath :: IsString s => TopModulePath -> s
 topModulePathToDottedPath (TopModulePath l r) =
   fromText $ mconcat $ intersperse "." $ map (^. symbolText) $ l ++ [r]
 
+moduleNameToTopModulePath :: Name -> TopModulePath
+moduleNameToTopModulePath = \case
+  NameUnqualified s -> TopModulePath [] s
+  NameQualified (QualifiedName (SymbolPath p) s) -> TopModulePath (toList p) s
+
 instance Hashable TopModulePath

--- a/src/Juvix/Compiler/Concrete/Data/ParsedInfoTable.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedInfoTable.hs
@@ -1,7 +1,6 @@
 module Juvix.Compiler.Concrete.Data.ParsedInfoTable where
 
 import Juvix.Compiler.Concrete.Data.ParsedItem
-import Juvix.Data.Comment
 import Juvix.Prelude
 
 data InfoTable = InfoTable

--- a/src/Juvix/Compiler/Concrete/Data/ParsedInfoTable.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedInfoTable.hs
@@ -1,11 +1,13 @@
 module Juvix.Compiler.Concrete.Data.ParsedInfoTable where
 
 import Juvix.Compiler.Concrete.Data.ParsedItem
+import Juvix.Compiler.Concrete.Language
 import Juvix.Prelude
 
 data InfoTable = InfoTable
   { _infoParsedItems :: [ParsedItem],
-    _infoParsedComments :: Comments
+    _infoParsedComments :: Comments,
+    _infoParsedModules :: HashMap TopModulePath (Module 'Parsed 'ModuleTop)
   }
   deriving stock (Eq, Show)
 

--- a/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
@@ -14,7 +14,6 @@ where
 import Juvix.Compiler.Concrete.Data.Literal
 import Juvix.Compiler.Concrete.Data.ParsedInfoTable
 import Juvix.Compiler.Concrete.Data.ParsedItem
-import Juvix.Data.Comment
 import Juvix.Data.Keyword
 import Juvix.Prelude
 

--- a/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
@@ -4,23 +4,29 @@ module Juvix.Compiler.Concrete.Data.ParsedInfoTableBuilder
     registerKeyword,
     registerJudocText,
     registerComment,
-    mergeTable,
-    runInfoTableBuilder,
-    ignoreInfoTableBuilder,
+    registerModule,
+    moduleVisited,
+    visitModule,
+    runParserInfoTableBuilder,
     module Juvix.Compiler.Concrete.Data.ParsedInfoTable,
   )
 where
 
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Concrete.Data.Literal
 import Juvix.Compiler.Concrete.Data.ParsedInfoTable
 import Juvix.Compiler.Concrete.Data.ParsedItem
+import Juvix.Compiler.Concrete.Language
 import Juvix.Data.Keyword
 import Juvix.Prelude
 
 data InfoTableBuilder m a where
   RegisterItem :: ParsedItem -> InfoTableBuilder m ()
   RegisterComment :: Comment -> InfoTableBuilder m ()
-  MergeTable :: InfoTable -> InfoTableBuilder m ()
+  RegisterModule :: Module 'Parsed 'ModuleTop -> InfoTableBuilder m ()
+  VisitModule :: TopModulePath -> InfoTableBuilder m ()
+  ModuleVisited :: TopModulePath -> InfoTableBuilder m Bool
 
 makeSem ''InfoTableBuilder
 
@@ -57,7 +63,9 @@ registerLiteral l =
 
 data BuilderState = BuilderState
   { _stateItems :: [ParsedItem],
-    _stateComments :: [Comment]
+    _stateComments :: [Comment],
+    _stateVisited :: HashSet TopModulePath,
+    _stateModules :: HashMap TopModulePath (Module 'Parsed 'ModuleTop)
   }
   deriving stock (Show)
 
@@ -67,30 +75,34 @@ iniState :: BuilderState
 iniState =
   BuilderState
     { _stateItems = [],
-      _stateComments = []
+      _stateComments = [],
+      _stateVisited = mempty,
+      _stateModules = mempty
     }
 
 build :: BuilderState -> InfoTable
 build st =
   InfoTable
     { _infoParsedItems = nubHashable (st ^. stateItems),
-      _infoParsedComments = mkComments (st ^. stateComments)
+      _infoParsedComments = mkComments (st ^. stateComments),
+      _infoParsedModules = st ^. stateModules
     }
 
 registerItem' :: Members '[State BuilderState] r => ParsedItem -> Sem r ()
 registerItem' i = modify' (over stateItems (i :))
 
-runInfoTableBuilder :: Sem (InfoTableBuilder ': r) a -> Sem r (InfoTable, a)
-runInfoTableBuilder =
+runParserInfoTableBuilder :: Sem (InfoTableBuilder ': r) a -> Sem r (InfoTable, a)
+runParserInfoTableBuilder =
   fmap (first build)
     . runState iniState
     . reinterpret
       ( \case
+          ModuleVisited i -> HashSet.member i <$> gets (^. stateVisited)
+          VisitModule i -> modify' (over stateVisited (HashSet.insert i))
+          RegisterModule m ->
+            modify' (over stateModules (HashMap.insert (m ^. modulePath) m))
           RegisterItem i ->
             modify' (over stateItems (i :))
-          MergeTable tbl -> do
-            modify' (over stateItems ((tbl ^. infoParsedItems) <>))
-            modify' (over stateComments (allComments (tbl ^. infoParsedComments) <>))
           RegisterComment c -> do
             modify' (over stateComments (c :))
             registerItem'
@@ -99,6 +111,3 @@ runInfoTableBuilder =
                   _parsedTag = ParsedTagComment
                 }
       )
-
-ignoreInfoTableBuilder :: Sem (InfoTableBuilder ': r) a -> Sem r a
-ignoreInfoTableBuilder = fmap snd . runInfoTableBuilder

--- a/src/Juvix/Compiler/Concrete/Data/Scope.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope.hs
@@ -52,9 +52,10 @@ newtype ModulesCache = ModulesCache
 
 makeLenses ''ModulesCache
 
-newtype ScopeParameters = ScopeParameters
+data ScopeParameters = ScopeParameters
   { -- | Used for import cycle detection.
-    _scopeTopParents :: [Import 'Parsed]
+    _scopeTopParents :: [Import 'Parsed],
+    _scopeParsedModules :: HashMap TopModulePath (Module 'Parsed 'ModuleTop)
   }
 
 makeLenses ''ScopeParameters

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -48,8 +48,8 @@ getAllModules' m = recordModule m
       SModuleLocal -> Nothing
       SModuleTop -> Just _moduleRefModule
 
-getModuleFilePath :: Module 'Scoped 'ModuleTop -> Path Abs File
-getModuleFilePath m = getLoc (m ^. modulePath) ^. intervalFile
+getModuleFilePath :: Module s 'ModuleTop -> Path Abs File
+getModuleFilePath m = getLoc (m ^. moduleKw) ^. intervalFile
 
 unfoldApplication :: Application -> (Expression, [Expression])
 unfoldApplication (Application l r) = go [r] l

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1063,6 +1063,21 @@ instance (SingI s, SingI t) => HasLoc (Module s t) where
       SModuleLocal -> getLoc (m ^. modulePath)
       SModuleTop -> getLoc (m ^. modulePath)
 
+getLocExpressionType :: forall s. SingI s => ExpressionType s -> Interval
+getLocExpressionType = case sing :: SStage s of
+  SParsed -> getLoc
+  SScoped -> getLoc
+
+getJudocLoc :: Judoc s -> Maybe Interval
+getJudocLoc = fmap getLocSpan . nonEmpty . (^. block)
+
+instance SingI s => HasLoc (TypeSignature s) where
+  getLoc TypeSignature {..} =
+    (_sigDoc >>= getJudocLoc)
+      ?<> (getLoc <$> _sigBuiltin)
+      ?<> (getLoc <$> _sigTerminating)
+      ?<> getLocExpressionType _sigType
+
 instance HasLoc (Example s) where
   getLoc e = e ^. exampleLoc
 

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -1,4 +1,9 @@
-module Juvix.Compiler.Concrete.Print.Base where
+module Juvix.Compiler.Concrete.Print.Base
+  ( module Juvix.Compiler.Concrete.Print.Base,
+    module Juvix.Data.CodeAnn,
+    module Juvix.Compiler.Concrete.Pretty.Options,
+  )
+where
 
 import Data.List.NonEmpty.Extra qualified as NonEmpty
 import Data.Text qualified as Text
@@ -22,13 +27,19 @@ instance PrettyPrint Keyword where
 instance PrettyPrint KeywordRef where
   ppCode = ppMorpheme
 
-doc :: (PrettyPrint c, HasLoc c) => Options -> Comments -> c -> Doc Ann
-doc opts cs x =
+docNoComments :: PrettyPrint c => Options -> c -> Doc Ann
+docNoComments = docHelper Nothing
+
+docHelper :: PrettyPrint c => Maybe FileComments -> Options -> c -> Doc Ann
+docHelper cs opts x =
   run
-    . execExactPrint (fileComments file cs)
+    . execExactPrint cs
     . runReader opts
     . ppCode
     $ x
+
+doc :: (PrettyPrint c, HasLoc c) => Options -> Comments -> c -> Doc Ann
+doc opts cs x = docHelper (Just (fileComments file cs)) opts x
   where
     file :: Path Abs File
     file = getLoc x ^. intervalFile
@@ -283,23 +294,26 @@ instance PrettyPrint (InductiveConstructorDef 'Scoped) where
         doc' = ppCode <$> _constructorDoc
     doc' ?<> hang (constructorName' <+> noLoc P.kwColon <+> constructorType')
 
+ppInductiveSignature :: forall r. Members '[ExactPrint, Reader Options] r => InductiveDef 'Scoped -> Sem r ()
+ppInductiveSignature InductiveDef {..} = do
+  let builtin' = ppCode <$> _inductiveBuiltin
+      name' = region (P.annDef _inductiveName) (ppCode _inductiveName)
+      params' = ppCode <$> nonEmpty _inductiveParameters
+      ty' = case _inductiveType of
+        Nothing -> Nothing
+        Just e -> Just (noLoc P.kwColon <+> ppCode e)
+  builtin'
+    <?+> ppCode _inductiveKw
+    <+> name'
+    <+?> params'
+    <+?> ty'
+
 instance PrettyPrint (InductiveDef 'Scoped) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => InductiveDef 'Scoped -> Sem r ()
-  ppCode InductiveDef {..} = do
+  ppCode d@InductiveDef {..} = do
     let doc' = ppCode <$> _inductiveDoc
         constrs' = ppConstructorBlock _inductiveConstructors
-        sig' = do
-          let builtin' = ppCode <$> _inductiveBuiltin
-              name' = region (P.annDef _inductiveName) (ppCode _inductiveName)
-              params' = ppCode <$> nonEmpty _inductiveParameters
-              ty' = case _inductiveType of
-                Nothing -> Nothing
-                Just e -> Just (noLoc P.kwColon <+> ppCode e)
-          builtin'
-            <?+> ppCode _inductiveKw
-            <+> name'
-            <+?> params'
-            <+?> ty'
+        sig' = ppInductiveSignature d
     doc'
       ?<> sig'
       <+> noLoc P.kwAssign

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -57,7 +57,7 @@ ppModulePathType x = case sing :: SStage s of
     SModuleLocal -> P.ppCode x >>= morpheme (getLoc x) . P.annSDef x
     SModuleTop -> P.ppCode x >>= morpheme (getLoc x) . P.annSDef x
 
-instance (SingI t) => PrettyPrint (Module 'Scoped t) where
+instance SingI t => PrettyPrint (Module 'Scoped t) where
   ppCode :: forall r. (Members '[ExactPrint, Reader Options] r) => Module 'Scoped t -> Sem r ()
   ppCode Module {..} = do
     let moduleBody' = indent (ppCode _moduleBody)
@@ -76,7 +76,7 @@ instance (SingI t) => PrettyPrint (Module 'Scoped t) where
       lastSemicolon :: Sem r ()
       lastSemicolon = case sing :: SModuleIsTop t of
         SModuleLocal -> return ()
-        SModuleTop -> semicolon
+        SModuleTop -> semicolon >> end
 
 instance PrettyPrint [Statement 'Scoped] where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => [Statement 'Scoped] -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed.hs
@@ -5,7 +5,6 @@ module Juvix.Compiler.Concrete.Translation.FromParsed
   )
 where
 
-import Juvix.Compiler.Concrete.Data.InfoTable
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping
@@ -21,4 +20,4 @@ fromParsed ::
   Sem r ScoperResult
 fromParsed pr = mapError (JuvixError @ScoperError) $ do
   let modules = pr ^. Parser.resultModules
-  scopeCheck pr emptyInfoTable modules
+  scopeCheck pr modules

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
@@ -1,4 +1,8 @@
-module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context where
+module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context
+  ( module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context,
+    module Juvix.Compiler.Concrete.Data.InfoTable,
+  )
+where
 
 import Juvix.Compiler.Concrete.Data.InfoTable
 import Juvix.Compiler.Concrete.Data.ParsedInfoTable qualified as Parsed
@@ -9,7 +13,6 @@ import Juvix.Prelude
 
 data ScoperResult = ScoperResult
   { _resultParserResult :: Parsed.ParserResult,
-    _resultParserTable :: Parsed.InfoTable,
     _resultScoperTable :: InfoTable,
     _resultModules :: NonEmpty (Module 'Scoped 'ModuleTop),
     _resultExports :: HashSet NameId,

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
@@ -5,7 +5,6 @@ import Juvix.Compiler.Concrete.Data.ParsedInfoTable qualified as Parsed
 import Juvix.Compiler.Concrete.Data.Scope
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromSource.Data.Context qualified as Parsed
-import Juvix.Data.Comment
 import Juvix.Prelude
 
 data ScoperResult = ScoperResult

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -11,8 +11,7 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error.Typ
 import Juvix.Prelude
 
 data ScoperError
-  = ErrParser MegaParsecError
-  | ErrInfixParser InfixError
+  = ErrInfixParser InfixError
   | ErrAppLeftImplicit AppLeftImplicit
   | ErrInfixPattern InfixErrorP
   | ErrMultipleDeclarations MultipleDeclarations
@@ -28,7 +27,6 @@ data ScoperError
   | ErrAmbiguousSym AmbiguousSym
   | ErrAmbiguousModuleSym AmbiguousModuleSym
   | ErrUnusedOperatorDef UnusedOperatorDef
-  | ErrWrongTopModuleName WrongTopModuleName
   | ErrWrongLocationCompileBlock WrongLocationCompileBlock
   | ErrMultipleCompileBlockSameName MultipleCompileBlockSameName
   | ErrMultipleCompileRuleSameBackend MultipleCompileRuleSameBackend
@@ -39,12 +37,10 @@ data ScoperError
   | ErrAliasBinderPattern AliasBinderPattern
   | ErrImplicitPatternLeftApplication ImplicitPatternLeftApplication
   | ErrConstructorExpectedLeftApplication ConstructorExpectedLeftApplication
-  | ErrTopModulePath TopModulePathError
   deriving stock (Show)
 
 instance ToGenericError ScoperError where
   genericError = \case
-    ErrParser e -> genericError e
     ErrInfixParser e -> genericError e
     ErrAppLeftImplicit e -> genericError e
     ErrInfixPattern e -> genericError e
@@ -58,7 +54,6 @@ instance ToGenericError ScoperError where
     ErrDuplicateFixity e -> genericError e
     ErrMultipleExport e -> genericError e
     ErrAmbiguousSym e -> genericError e
-    ErrWrongTopModuleName e -> genericError e
     ErrAmbiguousModuleSym e -> genericError e
     ErrUnusedOperatorDef e -> genericError e
     ErrLacksFunctionClause e -> genericError e
@@ -72,4 +67,3 @@ instance ToGenericError ScoperError where
     ErrAliasBinderPattern e -> genericError e
     ErrImplicitPatternLeftApplication e -> genericError e
     ErrConstructorExpectedLeftApplication e -> genericError e
-    ErrTopModulePath e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Data/Context.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Data/Context.hs
@@ -1,4 +1,8 @@
-module Juvix.Compiler.Concrete.Translation.FromSource.Data.Context where
+module Juvix.Compiler.Concrete.Translation.FromSource.Data.Context
+  ( module Juvix.Compiler.Concrete.Translation.FromSource.Data.Context,
+    module Juvix.Compiler.Concrete.Data.ParsedInfoTable,
+  )
+where
 
 import Juvix.Compiler.Concrete.Data.ParsedInfoTable
 import Juvix.Compiler.Concrete.Language

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -83,9 +83,6 @@ judocEmptyLine = lexeme (void (P.try (judocStart >> P.newline)))
 kw :: Member InfoTableBuilder r => Keyword -> ParsecS r KeywordRef
 kw k = lexeme $ kw' k >>= P.lift . registerKeyword
 
--- kwOld :: Member InfoTableBuilder r => Keyword -> ParsecS r ()
--- kwOld k = lexeme $ kw' k >>= P.lift . registerKeyword
-
 -- | Same as @identifier@ but does not consume space after it.
 bareIdentifier :: ParsecS r (Text, Interval)
 bareIdentifier = interval (rawIdentifier allKeywordStrings)

--- a/src/Juvix/Compiler/Core/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource.hs
@@ -23,15 +23,15 @@ import Text.Megaparsec qualified as P
 
 -- | Note: only new symbols and tags that are not in the InfoTable already will be
 -- generated during parsing
-runParser :: Path Abs File -> InfoTable -> Text -> Either ParserError (InfoTable, Maybe Node)
+runParser :: Path Abs File -> InfoTable -> Text -> Either MegaparsecError (InfoTable, Maybe Node)
 runParser fileName tab input =
   case run $
     runInfoTableBuilder tab $
       P.runParserT parseToplevel (fromAbsFile fileName) input of
-    (_, Left err) -> Left (ParserError err)
+    (_, Left err) -> Left (MegaparsecError err)
     (tbl, Right r) -> Right (tbl, r)
 
-runParserMain :: Path Abs File -> InfoTable -> Text -> Either ParserError InfoTable
+runParserMain :: Path Abs File -> InfoTable -> Text -> Either MegaparsecError InfoTable
 runParserMain fileName tab input =
   case runParser fileName tab input of
     Left err -> Left err

--- a/src/Juvix/Data.hs
+++ b/src/Juvix/Data.hs
@@ -8,6 +8,7 @@ module Juvix.Data
     module Juvix.Data.IsImplicit,
     module Juvix.Data.Loc,
     module Juvix.Data.NameId,
+    module Juvix.Data.Comment,
     module Juvix.Data.Processed,
     module Juvix.Data.Uid,
     module Juvix.Data.Universe,
@@ -19,6 +20,7 @@ module Juvix.Data
 where
 
 import Juvix.Data.Backends
+import Juvix.Data.Comment
 import Juvix.Data.DependencyInfo
 import Juvix.Data.Effect
 import Juvix.Data.Error

--- a/src/Juvix/Data/Comment.hs
+++ b/src/Juvix/Data/Comment.hs
@@ -80,4 +80,6 @@ instance Pretty FileComments where
       <> vsep [pretty c | c <- toList (fc ^. fileCommentsSorted)]
 
 instance Pretty Comments where
-  pretty c = vsep [pretty fc | fc <- toList (c ^. commentsByFile)]
+  pretty c
+    | null (c ^. commentsByFile) = "<empty comments>"
+    | otherwise = vsep [pretty fc | fc <- toList (c ^. commentsByFile)]

--- a/src/Juvix/Data/Effect/ExactPrint/Base.hs
+++ b/src/Juvix/Data/Effect/ExactPrint/Base.hs
@@ -27,18 +27,18 @@ data Builder = Builder
 
 makeLenses ''Builder
 
-runExactPrint :: FileComments -> Sem (ExactPrint ': r) x -> Sem r (Doc Ann, x)
+runExactPrint :: Maybe FileComments -> Sem (ExactPrint ': r) x -> Sem r (Doc Ann, x)
 runExactPrint cs = fmap (first (^. builderDoc)) . runState ini . re
   where
     ini :: Builder
     ini =
       Builder
-        { _builderComments = cs ^. fileCommentsSorted,
+        { _builderComments = fromMaybe [] (cs ^? _Just . fileCommentsSorted),
           _builderDoc = mempty,
           _builderEnd = FileLoc 0 0 0
         }
 
-execExactPrint :: FileComments -> Sem (ExactPrint ': r) x -> Sem r (Doc Ann)
+execExactPrint :: Maybe FileComments -> Sem (ExactPrint ': r) x -> Sem r (Doc Ann)
 execExactPrint cs = fmap fst . runExactPrint cs
 
 re :: forall r a. Sem (ExactPrint ': r) a -> Sem (State Builder ': r) a

--- a/src/Juvix/Parser/Error.hs
+++ b/src/Juvix/Parser/Error.hs
@@ -1,16 +1,45 @@
 module Juvix.Parser.Error where
 
+import Juvix.Compiler.Concrete.Language
+import Juvix.Compiler.Concrete.Pretty.Options (fromGenericOptions)
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error.Pretty
 import Juvix.Prelude
-import Juvix.Prelude.Pretty
 import Text.Megaparsec qualified as M
 import Text.Megaparsec.Error (errorOffset)
 
-newtype ParserError = ParserError
-  { _parseError :: M.ParseErrorBundle Text Void
-  }
+data ParserError
+  = ErrMegaparsec MegaparsecError
+  | ErrTopModulePath TopModulePathError
+  | ErrWrongTopModuleName WrongTopModuleName
   deriving stock (Show)
 
 instance ToGenericError ParserError where
+  genericError = \case
+    ErrMegaparsec e -> genericError e
+    ErrTopModulePath e -> genericError e
+    ErrWrongTopModuleName e -> genericError e
+
+instance Pretty MegaparsecError where
+  pretty (MegaparsecError b) = pretty (M.errorBundlePretty b)
+
+instance HasLoc MegaparsecError where
+  getLoc (MegaparsecError b) = singletonInterval (mkLoc offset sourcePos)
+    where
+      state :: M.PosState Text
+      state = M.bundlePosState b
+      offset = errorOffset (head (M.bundleErrors b))
+      sourcePos :: M.SourcePos
+      sourcePos =
+        (snd . head . fst)
+          (M.attachSourcePos errorOffset (M.bundleErrors b) state)
+
+newtype MegaparsecError = MegaparsecError
+  { _megaParsecError :: M.ParseErrorBundle Text Void
+  }
+  deriving stock (Show)
+
+instance ToGenericError MegaparsecError where
   genericError e =
     return
       GenericError
@@ -21,16 +50,52 @@ instance ToGenericError ParserError where
     where
       i = getLoc e
 
-instance Pretty ParserError where
-  pretty (ParserError b) = pretty (M.errorBundlePretty b)
+data TopModulePathError = TopModulePathError
+  { _topModulePathErrorPath :: TopModulePath,
+    _topModulePathError :: PathResolverError
+  }
+  deriving stock (Show)
 
-instance HasLoc ParserError where
-  getLoc (ParserError b) = singletonInterval (mkLoc offset sourcePos)
+instance ToGenericError TopModulePathError where
+  genericError TopModulePathError {..} = do
+    let msg = ppCodeAnn _topModulePathError
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = AnsiText msg,
+          _genericErrorIntervals = [i]
+        }
     where
-      state :: M.PosState Text
-      state = M.bundlePosState b
-      offset = errorOffset (head (M.bundleErrors b))
-      sourcePos :: M.SourcePos
-      sourcePos =
-        (snd . head . fst)
-          (M.attachSourcePos errorOffset (M.bundleErrors b) state)
+      i :: Interval
+      i = getLoc _topModulePathErrorPath
+
+data WrongTopModuleName = WrongTopModuleName
+  { _wrongTopModuleNameExpectedPath :: Path Abs File,
+    _wrongTopModuleNameActualPath :: Path Abs File,
+    _wrongTopModuleNameActualName :: TopModulePath
+  }
+  deriving stock (Show)
+
+instance ToGenericError WrongTopModuleName where
+  genericError WrongTopModuleName {..} = ask >>= generr
+    where
+      generr opts =
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
+        where
+          opts' = fromGenericOptions opts
+          i = getLoc _wrongTopModuleNameActualName
+          msg =
+            "The top module"
+              <+> ppCode opts' _wrongTopModuleNameActualName
+              <+> "is defined in the file:"
+                <> line
+                <> pretty _wrongTopModuleNameActualPath
+                <> line
+                <> "But it should be in the file:"
+                <> line
+                <> pretty _wrongTopModuleNameExpectedPath

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -6,7 +6,6 @@ import Data.HashSet qualified as HashSet
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import GHC.Unicode
-import Juvix.Data.Comment
 import Juvix.Data.Keyword
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude

--- a/test/Asm/Run/Base.hs
+++ b/test/Asm/Run/Base.hs
@@ -80,7 +80,7 @@ asmRunErrorAssertion mainFile step = do
                 )
             Nothing -> assertBool "" True
 
-parseFile :: Path Abs File -> IO (Either ParserError InfoTable)
+parseFile :: Path Abs File -> IO (Either MegaparsecError InfoTable)
 parseFile f = do
   let f' = toFilePath f
   s <- readFile f'

--- a/test/Asm/Validate/Base.hs
+++ b/test/Asm/Validate/Base.hs
@@ -17,7 +17,7 @@ asmValidateErrorAssertion mainFile step = do
         Just _ -> assertBool "" True
         Nothing -> assertFailure "no error"
 
-parseFile :: Path Abs File -> IO (Either ParserError InfoTable)
+parseFile :: Path Abs File -> IO (Either MegaparsecError InfoTable)
 parseFile f = do
   s <- readFile (toFilePath f)
   return $ runParser (toFilePath f) s

--- a/test/Core/Eval/Base.hs
+++ b/test/Core/Eval/Base.hs
@@ -74,7 +74,7 @@ coreEvalErrorAssertion mainFile step = do
               Right _ -> assertFailure "no error"
         )
 
-parseFile :: Path Abs File -> IO (Either ParserError (InfoTable, Maybe Node))
+parseFile :: Path Abs File -> IO (Either MegaparsecError (InfoTable, Maybe Node))
 parseFile f = do
   let f' = toFilePath f
   s <- readFile f'

--- a/test/Parsing/Negative.hs
+++ b/test/Parsing/Negative.hs
@@ -2,45 +2,83 @@ module Parsing.Negative where
 
 import Base
 import Juvix.Compiler.Builtins (iniState)
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error
 import Juvix.Compiler.Pipeline
 import Juvix.Parser.Error
 
 root :: Path Abs Dir
 root = relToProject $(mkRelDir "tests/negative")
 
+type FailMsg = String
+
 data NegTest = NegTest
   { _name :: String,
-    _relDir :: Path Rel Dir,
-    _file :: Path Rel File
+    _dir :: Path Abs Dir,
+    _file :: Path Abs File,
+    _checkErr :: ParserError -> Maybe FailMsg
   }
 
 testDescr :: NegTest -> TestDescr
 testDescr NegTest {..} =
-  let tRoot = root <//> _relDir
-      file' = tRoot <//> _file
+  let tRoot = _dir
    in TestDescr
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            let entryPoint = defaultEntryPoint tRoot file'
+            let entryPoint = defaultEntryPoint tRoot _file
             res <- runIOEither iniState entryPoint upToParsing
             case mapLeft fromJuvixError res of
-              Left (Just (_ :: ParserError)) -> return ()
-              Left Nothing -> assertFailure "The parser did not find an error."
-              Right _ -> assertFailure "An error ocurred but it was not in the parser."
+              Left (Just parErr) -> whenJust (_checkErr parErr) assertFailure
+              Left Nothing -> assertFailure "An error ocurred but it was not in the parser."
+              Right _ -> assertFailure "The parser did not find an error."
         }
 
 allTests :: TestTree
 allTests =
   testGroup
     "Parsing negative tests"
-    ( map (mkTest . testDescr) scoperErrorTests
+    ( map (mkTest . testDescr) (parserErrorTests <> filesErrorTests)
     )
 
-scoperErrorTests :: [NegTest]
-scoperErrorTests =
-  [ NegTest
+wrongError :: Maybe FailMsg
+wrongError = Just "Incorrect error"
+
+negTest :: String -> Path Rel Dir -> Path Rel File -> (ParserError -> Maybe FailMsg) -> NegTest
+negTest _name d f _checkErr =
+  let _dir = root <//> d
+   in NegTest
+        { _file = _dir <//> f,
+          _dir,
+          _name,
+          _checkErr
+        }
+
+parserErrorTests :: [NegTest]
+parserErrorTests =
+  [ negTest
       "Tab character"
       $(mkRelDir ".")
       $(mkRelFile "Tab.juvix")
+      $ \case
+        ErrMegaparsec {} -> Nothing
+        _ -> wrongError
+  ]
+
+filesErrorTests :: [NegTest]
+filesErrorTests =
+  [ negTest
+      "Importing a module that conflicts with a module in the stdlib"
+      $(mkRelDir "StdlibConflict")
+      $(mkRelFile "Input.juvix")
+      $ \case
+        ErrTopModulePath
+          TopModulePathError {_topModulePathError = ErrDependencyConflict {}} -> Nothing
+        _ -> wrongError,
+    negTest
+      "Incorrect top module path"
+      $(mkRelDir ".")
+      $(mkRelFile "WrongModuleName.juvix")
+      $ \case
+        ErrWrongTopModuleName {} -> Nothing
+        _ -> wrongError
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -2,7 +2,6 @@ module Scope.Negative (allTests) where
 
 import Base
 import Juvix.Compiler.Builtins (iniState)
-import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error
 import Juvix.Compiler.Pipeline
 
@@ -39,7 +38,6 @@ allTests =
   testGroup
     "Scope negative tests"
     ( map (mkTest . testDescr) scoperErrorTests
-        <> map (mkTest . testDescr) filesErrorTests
     )
 
 wrongError :: Maybe FailMsg
@@ -153,13 +151,6 @@ scoperErrorTests =
         ErrLacksFunctionClause {} -> Nothing
         _ -> wrongError,
     NegTest
-      "Incorrect top module path"
-      $(mkRelDir ".")
-      $(mkRelFile "WrongModuleName.juvix")
-      $ \case
-        ErrWrongTopModuleName {} -> Nothing
-        _ -> wrongError,
-    NegTest
       "Ambiguous export"
       $(mkRelDir ".")
       $(mkRelFile "AmbiguousExport.juvix")
@@ -263,25 +254,5 @@ scoperErrorTests =
       $(mkRelFile "DuplicateInductiveParameterName.juvix")
       $ \case
         ErrDuplicateInductiveParameterName {} -> Nothing
-        _ -> wrongError
-  ]
-
-filesErrorTests :: [NegTest ScoperError]
-filesErrorTests =
-  [ NegTest
-      "A module that conflicts with a module in the stdlib"
-      $(mkRelDir "StdlibConflict")
-      $(mkRelFile "Input.juvix")
-      $ \case
-        ErrTopModulePath
-          TopModulePathError {_topModulePathError = ErrDependencyConflict {}} -> Nothing
-        _ -> wrongError,
-    NegTest
-      "Importing a module that conflicts with a module in the stdlib"
-      $(mkRelDir "StdlibConflict")
-      $(mkRelFile "Input.juvix")
-      $ \case
-        ErrTopModulePath
-          TopModulePathError {_topModulePathError = ErrDependencyConflict {}} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -13,7 +13,6 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
 import Juvix.Compiler.Pipeline
 import Juvix.Compiler.Pipeline.Setup
-import Juvix.Data.Comment
 import Juvix.Prelude.Aeson
 import Juvix.Prelude.Pretty
 

--- a/tests/positive/Imports/A.juvix
+++ b/tests/positive/Imports/A.juvix
@@ -5,10 +5,10 @@ module A;
    type T :=
     t : T;
   end ;
-  infix 2 +;
+  infixr 2 +;
   axiom + : Type → Type → Type;
   end;
   import M;
   f : M.N.T;
-  f (_ M.N.t _) := Type M.+ Type;
+  f (_ M.N.t _) := Type M.+ Type M.+ M.MType;
 end;

--- a/tests/positive/Imports/M.juvix
+++ b/tests/positive/Imports/M.juvix
@@ -1,3 +1,3 @@
 module M;
-  axiom T : Type;
+  axiom MType : Type;
 end;


### PR DESCRIPTION
- Fixes #1723 
- It refactors parsing/scoping so that the scoper does not need to read files or parse any module. Instead, the parser takes care of parsing all the imported modules transitively.