### PR TITLE
Use absolute path in Core Evaluator to generate source file location

### DIFF
--- a/src/Juvix/Data/Loc.hs
+++ b/src/Juvix/Data/Loc.hs
@@ -54,6 +54,10 @@ mkLoc offset M.SourcePos {..} =
         err :: a
         err = error ("The path \"" <> pack fp <> "\" is not absolute. Remember to pass an absolute path to Megaparsec when running a parser")
 
+-- | Make a `Loc` that points to the beginning of a file.
+mkInitialLoc :: Path Abs File -> Loc
+mkInitialLoc = mkLoc 0 . M.initialPos . fromAbsFile
+
 fromPos :: M.Pos -> Pos
 fromPos = Pos . fromIntegral . M.unPos
 

--- a/test/Core/Eval/Base.hs
+++ b/test/Core/Eval/Base.hs
@@ -12,7 +12,6 @@ import Juvix.Compiler.Core.Language
 import Juvix.Compiler.Core.Pretty
 import Juvix.Compiler.Core.Transformation
 import Juvix.Compiler.Core.Translation.FromSource
-import Text.Megaparsec.Pos qualified as M
 
 coreEvalAssertion ::
   Path Abs File ->
@@ -90,4 +89,4 @@ doEval ::
 doEval f hout tab node =
   catchEvalErrorIO defaultLoc (hEvalIO stdin hout (tab ^. identContext) [] node)
   where
-    defaultLoc = singletonInterval (mkLoc 0 (M.initialPos (toFilePath f)))
+    defaultLoc = singletonInterval (mkInitialLoc f)


### PR DESCRIPTION
Filepaths within a `Loc` must now be absolute or an error is thrown when `mkLoc` is called. This `Loc` is used when displaying errors.

This commit converts the Core evaluator filepath to an absolute path before calling `mkLoc`.

Before this fix, the Core evaluator would crash if it encountered an error instead of displaying the error if called on a relative path.