### PR TITLE
Parse JuvixCore with absolute paths

### DIFF
--- a/app/Commands/Dev/Core/Asm.hs
+++ b/app/Commands/Dev/Core/Asm.hs
@@ -13,7 +13,7 @@ runCommand :: forall r a. (Members '[Embed IO, App] r, CanonicalProjection a Cor
 runCommand opts = do
   inputFile :: Path Abs File <- someBaseToAbs' sinputFile
   s' <- embed (readFile $ toFilePath inputFile)
-  tab <- getRight (mapLeft JuvixError (Core.runParserMain (toFilePath inputFile) Core.emptyInfoTable s'))
+  tab <- getRight (mapLeft JuvixError (Core.runParserMain inputFile Core.emptyInfoTable s'))
   let tab' = Asm.fromCore $ Stripped.fromCore (Core.toStripped tab)
   if
       | project opts ^. coreAsmPrint ->

--- a/app/Commands/Dev/Core/Compile.hs
+++ b/app/Commands/Dev/Core/Compile.hs
@@ -14,7 +14,7 @@ runCommand :: forall r. (Members '[Embed IO, App] r) => CoreCompileOptions -> Se
 runCommand opts = do
   file <- getFile
   s <- embed (readFile (toFilePath file))
-  tab <- getRight (mapLeft JuvixError (Core.runParserMain (toFilePath file) Core.emptyInfoTable s))
+  tab <- getRight (mapLeft JuvixError (Core.runParserMain file Core.emptyInfoTable s))
   C.MiniCResult {..} <- getRight (run (runError (coreToMiniC asmOpts tab :: Sem '[Error JuvixError] C.MiniCResult)))
   buildDir <- askBuildDir
   ensureDir buildDir

--- a/app/Commands/Dev/Core/Eval.hs
+++ b/app/Commands/Dev/Core/Eval.hs
@@ -10,7 +10,7 @@ runCommand :: forall r. (Members '[Embed IO, App] r) => CoreEvalOptions -> Sem r
 runCommand opts = do
   f :: Path Abs File <- someBaseToAbs' b
   s <- embed (readFile (toFilePath f))
-  case Core.runParser (toFilePath f) Core.emptyInfoTable s of
+  case Core.runParser f Core.emptyInfoTable s of
     Left err -> exitJuvixError (JuvixError err)
     Right (tab, Just node) -> do evalAndPrint opts tab node
     Right (_, Nothing) -> return ()

--- a/app/Commands/Dev/Core/Read.hs
+++ b/app/Commands/Dev/Core/Read.hs
@@ -12,7 +12,7 @@ runCommand :: forall r a. (Members '[Embed IO, App] r, CanonicalProjection a Eva
 runCommand opts = do
   inputFile :: Path Abs File <- someBaseToAbs' sinputFile
   s' <- embed . readFile . toFilePath $ inputFile
-  tab <- getRight (mapLeft JuvixError (Core.runParserMain (toFilePath inputFile) Core.emptyInfoTable s'))
+  tab <- getRight (mapLeft JuvixError (Core.runParserMain inputFile Core.emptyInfoTable s'))
   let tab' = Core.applyTransformations (project opts ^. coreReadTransformations) tab
   embed (Scoper.scopeTrace tab')
   unless (project opts ^. coreReadNoPrint) $ do

--- a/app/Commands/Dev/Core/Strip.hs
+++ b/app/Commands/Dev/Core/Strip.hs
@@ -11,7 +11,7 @@ runCommand :: forall r a. (Members '[Embed IO, App] r, CanonicalProjection a Cor
 runCommand opts = do
   inputFile :: Path Abs File <- someBaseToAbs' sinputFile
   s' <- embed (readFile $ toFilePath inputFile)
-  (tab, _) <- getRight (mapLeft JuvixError (Core.runParser (toFilePath inputFile) Core.emptyInfoTable s'))
+  (tab, _) <- getRight (mapLeft JuvixError (Core.runParser inputFile Core.emptyInfoTable s'))
   let tab' = Stripped.fromCore (Core.toStripped tab)
   unless (project opts ^. coreStripNoPrint) $ do
     renderStdOut (Core.ppOut opts tab')

--- a/app/Commands/Extra/Paths.hs
+++ b/app/Commands/Extra/Paths.hs
@@ -1,0 +1,7 @@
+module Commands.Extra.Paths where
+
+import Juvix.Prelude
+
+-- | imaginary file path for error messages in the repl.
+replPath :: Path Abs File
+replPath = $(mkAbsFile "/<repl>")

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -3,6 +3,7 @@
 module Commands.Repl where
 
 import Commands.Base hiding (command)
+import Commands.Extra.Paths
 import Commands.Repl.Options
 import Control.Exception (throwIO)
 import Control.Monad.State.Strict qualified as State
@@ -26,7 +27,6 @@ import System.Console.ANSI qualified as Ansi
 import System.Console.Haskeline
 import System.Console.Repline
 import System.Console.Repline qualified as Repline
-import Text.Megaparsec qualified as M
 
 type ReplS = State.StateT ReplState IO
 
@@ -167,7 +167,7 @@ runCommand opts = do
           Nothing -> noFileLoadedMsg
         where
           defaultLoc :: Interval
-          defaultLoc = singletonInterval (mkLoc 0 (M.initialPos ""))
+          defaultLoc = singletonInterval (mkInitialLoc replPath)
 
           compileThenEval :: ReplContext -> String -> Repl (Either JuvixError Core.Node)
           compileThenEval ctx s = bindEither compileString eval
@@ -316,10 +316,6 @@ replMakeAbsolute = \case
   Rel r -> do
     invokeDir <- State.gets (^. replStateInvokeDir)
     return (invokeDir <//> r)
-
--- | imaginary file path for error messages in the repl.
-replPath :: Path Abs File
-replPath = $(mkAbsFile "/<repl>")
 
 inferExpressionIO' :: ReplContext -> Text -> IO (Either JuvixError Internal.Expression)
 inferExpressionIO' ctx = inferExpressionIO replPath (ctx ^. replContextExpContext) (ctx ^. replContextBuiltins)

--- a/src/Juvix/Compiler/Asm/Error.hs
+++ b/src/Juvix/Compiler/Asm/Error.hs
@@ -2,7 +2,6 @@ module Juvix.Compiler.Asm.Error where
 
 import Juvix.Compiler.Asm.Language
 import Juvix.Data.PPOutput
-import Text.Megaparsec.Pos qualified as M
 import Text.Show
 
 data AsmError = AsmError
@@ -37,4 +36,8 @@ instance Show AsmError where
 instance HasLoc AsmError where
   getLoc (AsmError {..}) = fromMaybe defaultLoc _asmErrorLoc
     where
-      defaultLoc = singletonInterval (mkLoc 0 (M.initialPos ""))
+      defaultLoc :: Interval
+      defaultLoc = singletonInterval (mkInitialLoc sourcePath)
+
+      sourcePath :: Path Abs File
+      sourcePath = $(mkAbsFile "/<asm>")

--- a/src/Juvix/Compiler/Core/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource.hs
@@ -21,20 +21,17 @@ import Juvix.Compiler.Core.Translation.FromSource.Lexer
 import Juvix.Parser.Error
 import Text.Megaparsec qualified as P
 
-parseText :: InfoTable -> Text -> Either ParserError (InfoTable, Maybe Node)
-parseText = runParser ""
-
 -- | Note: only new symbols and tags that are not in the InfoTable already will be
 -- generated during parsing
-runParser :: FilePath -> InfoTable -> Text -> Either ParserError (InfoTable, Maybe Node)
+runParser :: Path Abs File -> InfoTable -> Text -> Either ParserError (InfoTable, Maybe Node)
 runParser fileName tab input =
   case run $
     runInfoTableBuilder tab $
-      P.runParserT parseToplevel fileName input of
+      P.runParserT parseToplevel (fromAbsFile fileName) input of
     (_, Left err) -> Left (ParserError err)
     (tbl, Right r) -> Right (tbl, r)
 
-runParserMain :: FilePath -> InfoTable -> Text -> Either ParserError InfoTable
+runParserMain :: Path Abs File -> InfoTable -> Text -> Either ParserError InfoTable
 runParserMain fileName tab input =
   case runParser fileName tab input of
     Left err -> Left err

--- a/test/Core/Eval/Base.hs
+++ b/test/Core/Eval/Base.hs
@@ -78,7 +78,7 @@ parseFile :: Path Abs File -> IO (Either ParserError (InfoTable, Maybe Node))
 parseFile f = do
   let f' = toFilePath f
   s <- readFile f'
-  return $ runParser f' emptyInfoTable s
+  return $ runParser f emptyInfoTable s
 
 doEval ::
   Path Abs File ->


### PR DESCRIPTION
Filepaths within a Loc must now be absolute or an error is thrown when mkLoc is called. This Loc is used when displaying errors.

This commit uses imaginary absolute file paths in the Core repl and Asm commands in the cases (parsing a single expression for example).

Before this fix, the `core {repl, read, eval}` and `asm` commands would crash if it encountered an error when invoked with a relative path, or in the case of a repl when parsing a single expression.