### PR TITLE
Track builtins in the Core InfoTable

### DIFF
--- a/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
@@ -63,14 +63,29 @@ runInfoTableBuilder tab =
         modify' (over infoNextTag (+ 1))
         return (UserTag (s ^. infoNextTag))
       RegisterIdent idt ii -> do
-        modify' (over infoIdentifiers (HashMap.insert (ii ^. identifierSymbol) ii))
-        modify' (over identMap (HashMap.insert idt (IdentFun (ii ^. identifierSymbol))))
+        let sym = ii ^. identifierSymbol
+        let identKind = IdentFun (ii ^. identifierSymbol)
+        whenJust
+          (ii ^. identifierBuiltin)
+          (\b -> modify' (over infoBuiltins (HashMap.insert (BuiltinsFunction b) identKind)))
+        modify' (over infoIdentifiers (HashMap.insert sym ii))
+        modify' (over identMap (HashMap.insert idt identKind))
       RegisterConstructor idt ci -> do
-        modify' (over infoConstructors (HashMap.insert (ci ^. constructorTag) ci))
-        modify' (over identMap (HashMap.insert idt (IdentConstr (ci ^. constructorTag))))
+        let tag = ci ^. constructorTag
+        let identKind = IdentConstr tag
+        whenJust
+          (ci ^. constructorBuiltin)
+          (\b -> modify' (over infoBuiltins (HashMap.insert (BuiltinsConstructor b) identKind)))
+        modify' (over infoConstructors (HashMap.insert tag ci))
+        modify' (over identMap (HashMap.insert idt identKind))
       RegisterInductive idt ii -> do
-        modify' (over infoInductives (HashMap.insert (ii ^. inductiveSymbol) ii))
-        modify' (over identMap (HashMap.insert idt (IdentInd (ii ^. inductiveSymbol))))
+        let sym = ii ^. inductiveSymbol
+        let identKind = IdentInd sym
+        whenJust
+          (ii ^. inductiveBuiltin)
+          (\b -> modify' (over infoBuiltins (HashMap.insert (BuiltinsInductive b) identKind)))
+        modify' (over infoInductives (HashMap.insert sym ii))
+        modify' (over identMap (HashMap.insert idt identKind))
       RegisterIdentNode sym node ->
         modify' (over identContext (HashMap.insert sym node))
       RegisterMain sym -> do

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -62,9 +62,9 @@ setupIntToNat sym tab =
               (mkConstr (setInfoName "suc" mempty) tagSuc [mkApp' (mkIdent' sym) (mkBuiltinApp' OpIntSub [mkVar' 0, mkConstant' (ConstInteger 1)])])
         _ ->
           mkLambda' $ mkVar' 0
-    tagZeroM = fmap ((^. constructorTag) . fst) $ uncons $ filter (\ci -> ci ^. constructorBuiltin == Just BuiltinNatZero) $ HashMap.elems (tab ^. infoConstructors)
-    tagSucM = fmap ((^. constructorTag) . fst) $ uncons $ filter (\ci -> ci ^. constructorBuiltin == Just BuiltinNatSuc) $ HashMap.elems (tab ^. infoConstructors)
-    boolSymM = fmap ((^. inductiveSymbol) . fst) $ uncons $ filter (\ind -> ind ^. inductiveBuiltin == Just BuiltinBool) $ HashMap.elems (tab ^. infoInductives)
+    tagZeroM = (^. constructorTag) <$> lookupBuiltinConstructor tab BuiltinNatZero
+    tagSucM = (^. constructorTag) <$> lookupBuiltinConstructor tab BuiltinNatSuc
+    boolSymM = (^. inductiveSymbol) <$> lookupBuiltinInductive tab BuiltinBool
 
 fromInternal :: Internal.InternalTypedResult -> Sem k CoreResult
 fromInternal i = do


### PR DESCRIPTION
This PR adds a new field `infoBuiltins : HashMap BuiltinPrim IdentKind` to the Core InfoTable. This is used to register builtin inductive, constructors and functions against their corresponding Core symbols/tags.

The point of doing this is to make it easier to lookup the Infos for builtins during the internal to core translation: https://github.com/anoma/juvix/blob/d91241a685fae5e31cd5594653545664c23b768c/src/Juvix/Compiler/Core/Translation/FromInternal.hs#L65

This is one proposed approach, I think Jan mentioned using the Builtins effect for this but it doesn't seem appropriate to expose the registration function from the Builtins effect at this part of the code. Perhaps I misunderstood, if so I'm happy to revisit this refactor.