### PR TITLE
Use restore/save github action to speed up the CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
       - name: Install the latest Wasmer version
-        uses: jonaprieto/action-install-gh-release@1
+        uses: jonaprieto/action-install-gh-release@2
         with:
           repo: wasmerio/wasmer
           tag: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.run_id }}'
   cancel-in-progress: true
 env:
-  STACKFLAGS: '--pedantic'
-  STACK_ROOT: ${{ github.workspace }}/.stack
+  STACKFLAGS: '--pedantic --stack-root ${{ github.workspace }}/.stack'
 
 jobs:
 
@@ -139,6 +138,7 @@ jobs:
       - name: Build Project
         run: |
           cd main
+          stack path --stack-root
           make build
 
       - name: Test suite
@@ -305,6 +305,7 @@ jobs:
       - name: Build Project (macOS)
         run: |
           cd main
+          stack path --stack-root
           make CC=$CC LIBTOOL=$LIBTOOL build
 
       - name: Download and extract wasi-sysroot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,12 @@ jobs:
       - uses: actions/cache/save@v3
         if: always()
         with:
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
           path: |
             ~/.stack
       - uses: actions/cache/save@v3
         with:
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
           path: |
             main/.stack-work
   test-linux:
@@ -141,8 +141,7 @@ jobs:
           path: |
             ~/.stack
             main/.stack-work
-          key: >-
-            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
             hashFiles('main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
@@ -209,12 +208,12 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
 
 
   docs-linux:
@@ -284,7 +283,7 @@ jobs:
           path: |
             ~/.stack
             main/.stack-work
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
       - name: Deploy HTML to github pages
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -337,12 +336,12 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
   test-macos:
     needs: build-macos
     runs-on: macos-12
@@ -425,9 +424,9 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
-          key: '${{ steps.cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.cache-primary-key }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,6 @@ jobs:
           path: main
           submodules: true
 
-      - uses: actions/cache@v3
-
       - uses: actions/cache/restore@v3
         id: cache
         name: Stack cache
@@ -187,7 +185,6 @@ jobs:
           path: main
           submodules: recursive
 
-      - uses: actions/checkout@v3
       - uses: actions/cache/restore@v3
         id: cache
         with:
@@ -339,7 +336,6 @@ jobs:
           path: main
           submodules: recursive
 
-      - uses: actions/checkout@v3
       - uses: actions/cache/restore@v3
         id: cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,7 @@ jobs:
           path: |
             ~/.stack
           key: >-
-            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml') }}-${{
-            hashFiles('main/package.yaml') }}
+            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-stack-
 
@@ -95,8 +94,7 @@ jobs:
             ~/.stack
             main/.stack-work
           key: >-
-            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{
-            hashFiles('main/package.yaml') }}
+            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-stack-work-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
       - name: Install the latest Wasmer version
-        uses: jonaprieto/action-install-gh-release@1
+        uses: jonaprieto/action-install-gh-release@2
         with:
           repo: wasmerio/wasmer
           tag: latest
@@ -367,9 +367,7 @@ jobs:
         run: |
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL test
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Download Smoke binary
         uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
@@ -379,12 +377,18 @@ jobs:
           extension-matching: disable
           rename-to: smoke
           chmod: 0755
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Smoke testing (macOS)
         id: smoke-macos
         if: ${{ success() }}
         run: |
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL smoke
+
       - name: Save stack cache
         uses: actions/cache/save@v3
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
           enable_jekyll: false
           cname: docs.juvix.org
 
-  build-macos:
+  build-and-test-macos:
     runs-on: macos-12
     steps:
       - name: Checkout our repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,13 @@ jobs:
       # - name: Install libicu for testing
       #   run: sudo apt install -y libicu66
 
-      # - name: Build Project
-      #   run: |
-      #     cd main
-      #     make build
+      - name: Build Project
+        run: |
+          mkdir -p ~/.stack
+          touch ~/.stack/config.yaml
+          cd main
+          mkdir -p .stack-work
+          touch .stack-work/stack.yaml
 
       # - name: Test suite
       #   id: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,51 +23,51 @@ concurrency:
 env:
   STACKFLAGS: '--pedantic'
 jobs:
-  ormolu:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mrkkrp/ormolu-action@v9
-        with:
-          extra-args: >-
-            --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
-            --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
-            --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
-  clang-format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: jidicula/clang-format-action@v4.10.1
-        with:
-          clang-format-version: '15'
-          check-path: runtime/src
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: trailing-whitespace --all-files
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: end-of-file-fixer --all-files
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: check-yaml --all-files
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: check-added-large-files --all-files
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: check-case-conflict --all-files
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: mixed-line-ending --all-files
+  # ormolu:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: mrkkrp/ormolu-action@v9
+  #       with:
+  #         extra-args: >-
+  #           --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
+  #           --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
+  #           --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
+  # clang-format:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: jidicula/clang-format-action@v4.10.1
+  #       with:
+  #         clang-format-version: '15'
+  #         check-path: runtime/src
+  # pre-commit:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.9'
+  #     - uses: pre-commit/action@v3.0.0
+  #       with:
+  #         extra_args: trailing-whitespace --all-files
+  #     - uses: pre-commit/action@v3.0.0
+  #       with:
+  #         extra_args: end-of-file-fixer --all-files
+  #     - uses: pre-commit/action@v3.0.0
+  #       with:
+  #         extra_args: check-yaml --all-files
+  #     - uses: pre-commit/action@v3.0.0
+  #       with:
+  #         extra_args: check-added-large-files --all-files
+  #     - uses: pre-commit/action@v3.0.0
+  #       with:
+  #         extra_args: check-case-conflict --all-files
+  #     - uses: pre-commit/action@v3.0.0
+  #       with:
+  #         extra_args: mixed-line-ending --all-files
 
-  build-linux:
+  build-and-test-linux:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout our repository
@@ -76,144 +76,118 @@ jobs:
           path: main
           submodules: true
       - uses: actions/cache/restore@v3
-        id: cache
+        id: stack-cache
         name: Stack cache
         with:
           path: |
             ~/.stack
-            main/.stack-work
-          cache-primary-key: >-
-            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+          key: >-
+            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml') }}-${{
             hashFiles('main/package.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-
+            ${{ runner.os }}-stack-
 
-      - uses: haskell/actions/setup@v2
-        name: Setup Haskell
-        with:
-          ghc-version: 9.2.5
-          enable-stack: true
-          stack-version: latest
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@v3
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: '${{ runner.os }}-llvm-13'
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: '13.0'
-          cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
-
-      - name: Install libicu for testing
-        run: sudo apt install -y libicu66
-      - name: Build Project
-        run: |
-          cd main
-          make build
-      - uses: actions/cache/save@v3
-        if: always()
-        with:
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
-          path: |
-            ~/.stack
-      - uses: actions/cache/save@v3
-        with:
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
-          path: |
-            main/.stack-work
-  test-linux:
-    needs: build-linux
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout the main repository
-        uses: actions/checkout@v3
-        with:
-          path: main
-          submodules: recursive
       - uses: actions/cache/restore@v3
-        id: cache
+        id: stack-work-cache
+        name: Stack Work cache
         with:
-          fail-on-cache-miss: true
           path: |
             ~/.stack
             main/.stack-work
-          cache-primary-key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+          key: >-
+            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{
             hashFiles('main/package.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-
-      - uses: haskell/actions/setup@v2
-        name: Setup Haskell
-        with:
-          ghc-version: 9.2.5
-          enable-stack: true
-          stack-version: latest
-      - name: Cache LLVM and Clang (Linux)
-        id: cache-llvm
-        uses: actions/cache@v3
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: '${{ runner.os }}-llvm-13'
-      - name: Install LLVM and Clang (Linux)
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: '13.0'
-          cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
-      - name: Download and extract wasi-sysroot
-        run: >
-          curl
-          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-          -OL
+            ${{ runner.os }}-stack-work-
 
-          tar xfv wasi-sysroot-15.0.tar.gz
-      - name: Set WASI_SYSROOT_PATH
-        run: |
-          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-      - name: Install the latest Wasmer version
-        uses: jonaprieto/action-install-gh-release@1
-        with:
-          repo: wasmerio/wasmer
-          tag: latest
-          binaries-location: bin
-          cache: true
-      - name: Test suite
-        id: test
-        run: |
-          cd main
-          make test
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3
-        with:
-          repository: jonaprieto/smoke
-          path: smoke
-      - name: Install Smoke
-        run: |
-          cd smoke
-          stack install
-        shell: bash
-      - name: Smoke testing
-        id: smoke-linux
-        run: |
-          cd main
-          make smoke
+      # - uses: haskell/actions/setup@v2
+      #   name: Setup Haskell
+      #   with:
+      #     ghc-version: 9.2.5
+      #     enable-stack: true
+      #     stack-version: latest
+
+      # - name: Cache LLVM and Clang
+      #   id: cache-llvm
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       C:/Program Files/LLVM
+      #       ./llvm
+      #     key: '${{ runner.os }}-llvm-13'
+
+      # - name: Install LLVM and Clang
+      #   uses: KyleMayes/install-llvm-action@v1
+      #   with:
+      #     version: '13.0'
+      #     cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
+
+      # - name: Download and extract wasi-sysroot
+      #   run: >
+      #     curl
+      #     https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+      #     -OL
+
+      #     tar xfv wasi-sysroot-15.0.tar.gz
+      # - name: Set WASI_SYSROOT_PATH
+      #   run: |
+      #     echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+
+      # - name: Install the latest Wasmer version
+      #   uses: jonaprieto/action-install-gh-release@1
+      #   with:
+      #     repo: wasmerio/wasmer
+      #     tag: latest
+      #     binaries-location: bin
+      #     cache: true
+
+      # - name: Install libicu for testing
+      #   run: sudo apt install -y libicu66
+
+      # - name: Build Project
+      #   run: |
+      #     cd main
+      #     make build
+
+      # - name: Test suite
+      #   id: test
+      #   run: |
+      #     cd main
+      #     make test
+
+      # - name: Add ~/.local/bin to PATH
+      #   run: |
+      #     echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: jonaprieto/smoke
+      #     path: smoke
+
+      # - name: Install Smoke
+      #   run: |
+      #     cd smoke
+      #     stack install
+      #   shell: bash
+
+      # - name: Smoke testing
+      #   id: smoke-linux
+      #   run: |
+      #     cd main
+      #     make smoke
+
       - uses: actions/cache/save@v3
         if: always()
         with:
           path: |
             ~/.stack
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
+          key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
+
       - uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
+          key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'
 
 
   docs-linux:
@@ -228,31 +202,48 @@ jobs:
         with:
           path: main
           submodules: recursive
+
       - uses: actions/cache/restore@v3
-        id: cache
+        id: stack-cache
         with:
           fail-on-cache-miss: true
           path: |
             ~/.stack
             main/.stack-work
           key: >-
-            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml') }}-${{
             hashFiles('main/package.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-
+            ${{ runner.os }}-stack-
+
+      - uses: actions/cache/restore@v3
+        id: stack-work-cache
+        with:
+          fail-on-cache-miss: true
+          path: |
+            main/.stack-work
+          key: >-
+            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{
+            hashFiles('main/package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-work-     
+
       - uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: 2.19.2
+
       - name: MDBook setup
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 0.4.22
+
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
-          ghc-version: '${{ matrix.ghc }}'
+          ghc-version: 9.2.5
           enable-stack: true
           stack-version: latest
+
       - name: Cache LLVM and Clang
         id: cache-llvm
         uses: actions/cache@v3
@@ -261,15 +252,18 @@ jobs:
             C:/Program Files/LLVM
             ./llvm
           key: '${{ runner.os }}-llvm-13'
+
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: '13.0'
           cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
+
       - name: Generate Markdown files for each Org file
         run: |
           cd main
           make markdown-docs
+
       - name: Generate HTML and Web App files from milestone examples
         run: |
           cd main
@@ -278,12 +272,7 @@ jobs:
           make html-examples
           make webapp-examples
           make demo-example
-      - uses: actions/cache/save@v3
-        with:
-          path: |
-            ~/.stack
-            main/.stack-work
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
+
       - name: Deploy HTML to github pages
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -292,141 +281,140 @@ jobs:
           enable_jekyll: false
           cname: docs.juvix.org
 
+  # build-macos:
+  #   runs-on: macos-12
+  #   steps:
+  #     - name: Checkout our repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: main
+  #         submodules: true
+  #     - uses: actions/cache/restore@v3
+  #       id: cache
+  #       name: Stack cache
+  #       with:
+  #         path: |
+  #           ~/.stack
+  #           main/.stack-work
+  #         key: >-
+  #           ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+  #           hashFiles('main/package.yaml') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-
+  #     - uses: haskell/actions/setup@v2
+  #       name: Setup Haskell
+  #       with:
+  #         ghc-version: 9.2.5
+  #         enable-stack: true
+  #         stack-version: latest
+  #     - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+  #       run: |
+  #         echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+  #         echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+  #     - name: Install ICU4C
+  #       run: |
+  #         brew install icu4c
+  #         brew link icu4c --force
+  #     - name: Build Project (macOS)
+  #       run: |
+  #         cd main
+  #         make CC=$CC LIBTOOL=$LIBTOOL build
+  #     - uses: actions/cache/save@v3
+  #       if: always()
+  #       with:
+  #         path: |
+  #           ~/.stack
+  #         key: '${{ steps.cache.outputs.cache-primary-key }}'
+  #     - uses: actions/cache/save@v3
+  #       with:
+  #         path: |
+  #           main/.stack-work
+  #         key: '${{ steps.cache.outputs.cache-primary-key }}'
+  # test-macos:
+  #   needs: build-macos
+  #   runs-on: macos-12
+  #   steps:
+  #     - name: Checkout the main repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: main
+  #         submodules: recursive
+  #     - uses: actions/cache/restore@v3
+  #       id: cache
+  #       with:
+  #         fail-on-cache-miss: true
+  #         path: |
+  #           ~/.stack
+  #           main/.stack-work
+  #         key: >-
+  #           ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+  #           hashFiles('main/package.yaml') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-
+  #     - uses: haskell/actions/setup@v2
+  #       name: Setup Haskell
+  #       with:
+  #         ghc-version: 9.2.5
+  #         enable-stack: true
+  #         stack-version: latest
+  #     - name: Download and extract wasi-sysroot
+  #       run: >
+  #         curl
+  #         https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+  #         -OL
 
-  build-macos:
-    runs-on: macos-12
-    steps:
-      - name: Checkout our repository
-        uses: actions/checkout@v3
-        with:
-          path: main
-          submodules: true
-      - uses: actions/cache/restore@v3
-        id: cache
-        name: Stack cache
-        with:
-          path: |
-            ~/.stack
-            main/.stack-work
-          key: >-
-            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
-            hashFiles('main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: haskell/actions/setup@v2
-        name: Setup Haskell
-        with:
-          ghc-version: 9.2.5
-          enable-stack: true
-          stack-version: latest
-      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-        run: |
-          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-      - name: Install ICU4C
-        run: |
-          brew install icu4c
-          brew link icu4c --force
-      - name: Build Project (macOS)
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL build
-      - uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: |
-            ~/.stack
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
-      - uses: actions/cache/save@v3
-        with:
-          path: |
-            main/.stack-work
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
-  test-macos:
-    needs: build-macos
-    runs-on: macos-12
-    steps:
-      - name: Checkout the main repository
-        uses: actions/checkout@v3
-        with:
-          path: main
-          submodules: recursive
-      - uses: actions/cache/restore@v3
-        id: cache
-        with:
-          fail-on-cache-miss: true
-          path: |
-            ~/.stack
-            main/.stack-work
-          key: >-
-            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
-            hashFiles('main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: haskell/actions/setup@v2
-        name: Setup Haskell
-        with:
-          ghc-version: 9.2.5
-          enable-stack: true
-          stack-version: latest
-      - name: Download and extract wasi-sysroot
-        run: >
-          curl
-          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-          -OL
-
-          tar xfv wasi-sysroot-15.0.tar.gz
-      - name: Set WASI_SYSROOT_PATH
-        run: |
-          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-      - name: Install the latest Wasmer version
-        uses: jonaprieto/action-install-gh-release@1
-        with:
-          repo: wasmerio/wasmer
-          tag: latest
-          binaries-location: bin
-          cache: true
-      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-        run: |
-          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-      - name: stack setup (macOS)
-        run: |
-          cd main
-          stack setup
-      - name: Add homebrew clang to the PATH (macOS)
-        run: |
-          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
-      - name: Test suite (macOS)
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL test
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - name: Download Smoke binary
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
-        with:
-          repo: jonaprieto/smoke
-          tag: v2.3.2
-          cache: enable
-          extension-matching: disable
-          rename-to: smoke
-          chmod: 493
-      - name: Smoke testing (macOS)
-        id: smoke-macos
-        if: runner.os == 'macOS'
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL smoke
-      - uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: |
-            ~/.stack
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
-      - uses: actions/cache/save@v3
-        with:
-          path: |
-            main/.stack-work
-          key: '${{ steps.cache.outputs.cache-primary-key }}'
+  #         tar xfv wasi-sysroot-15.0.tar.gz
+  #     - name: Set WASI_SYSROOT_PATH
+  #       run: |
+  #         echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+  #     - name: Install the latest Wasmer version
+  #       uses: jonaprieto/action-install-gh-release@1
+  #       with:
+  #         repo: wasmerio/wasmer
+  #         tag: latest
+  #         binaries-location: bin
+  #         cache: true
+  #     - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+  #       run: |
+  #         echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+  #         echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+  #     - name: stack setup (macOS)
+  #       run: |
+  #         cd main
+  #         stack setup
+  #     - name: Add homebrew clang to the PATH (macOS)
+  #       run: |
+  #         echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+  #     - name: Test suite (macOS)
+  #       run: |
+  #         cd main
+  #         make CC=$CC LIBTOOL=$LIBTOOL test
+  #     - name: Add ~/.local/bin to PATH
+  #       run: |
+  #         echo "$HOME/.local/bin" >> $GITHUB_PATH
+  #     - name: Download Smoke binary
+  #       uses: jaxxstorm/action-install-gh-release@v1.9.0
+  #       with:
+  #         repo: jonaprieto/smoke
+  #         tag: v2.3.2
+  #         cache: enable
+  #         extension-matching: disable
+  #         rename-to: smoke
+  #         chmod: 493
+  #     - name: Smoke testing (macOS)
+  #       id: smoke-macos
+  #       if: runner.os == 'macOS'
+  #       run: |
+  #         cd main
+  #         make CC=$CC LIBTOOL=$LIBTOOL smoke
+  #     - uses: actions/cache/save@v3
+  #       if: always()
+  #       with:
+  #         path: |
+  #           ~/.stack
+  #         key: '${{ steps.cache.outputs.cache-primary-key }}'
+  #     - uses: actions/cache/save@v3
+  #       with:
+  #         path: |
+  #           main/.stack-work
+  #         key: '${{ steps.cache.outputs.cache-primary-key }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,10 +368,26 @@ jobs:
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL test
 
+      - name: Save stack cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.stack
+          key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
+
+      - name: Save stack-work cache
+        uses: actions/cache/save@v3
+        if: ${{ success() }}
+        with:
+          path: |
+            main/.stack-work
+          key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'
+
       - name: Add ~/.local/bin to PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          
+
       - name: Install Smoke
         uses: jonaprieto/action-install-gh-release@2
         with:
@@ -388,17 +404,3 @@ jobs:
         run: |
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL smoke
-
-      - name: Save stack cache
-        uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: |
-            ~/.stack
-          key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
-      - name: Save stack-work cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            main/.stack-work
-          key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           path: |
             ~/.stack
             main/.stack-work
-          key: >-
+          cache-primary-key: >-
             ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
             hashFiles('main/package.yaml') }}
           restore-keys: |
@@ -141,7 +141,7 @@ jobs:
           path: |
             ~/.stack
             main/.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+          cache-primary-key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
             hashFiles('main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
@@ -354,7 +354,7 @@ jobs:
       - uses: actions/cache/restore@v3
         id: cache
         with:
-          fail-on-cache-miss: false
+          fail-on-cache-miss: true
           path: |
             ~/.stack
             main/.stack-work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
           cache: enable
           extension-matching: disable
           rename-to: smoke
-          chmod: 493
+          chmod: 0755
       - name: Smoke testing (macOS)
         id: smoke-macos
         if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: The Juvix compiler CI
-
-on:
+'on':
   workflow_dispatch:
     inputs:
       ref:
-       description: 'the repository ref to build'
-       required: true
-       default: 'main'
+        description: the repository ref to build
+        required: true
+        default: main
   push:
     branches:
       - main
@@ -18,14 +17,11 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: '${{ github.workflow }}-${{ github.head_ref || github.run_id }}'
   cancel-in-progress: true
-
 env:
-  STACKFLAGS: --pedantic
-
+  STACKFLAGS: '--pedantic'
 jobs:
   ormolu:
     runs-on: ubuntu-latest
@@ -34,13 +30,9 @@ jobs:
       - uses: mrkkrp/ormolu-action@v9
         with:
           extra-args: >-
-            --ghc-opt -XDerivingStrategies
-            --ghc-opt -XImportQualifiedPost
-            --ghc-opt -XMultiParamTypeClasses
-            --ghc-opt -XStandaloneDeriving
-            --ghc-opt -XTemplateHaskell
-            --ghc-opt -XUnicodeSyntax
-
+            --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
+            --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
+            --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
   clang-format:
     runs-on: ubuntu-latest
     steps:
@@ -48,109 +40,95 @@ jobs:
       - uses: jidicula/clang-format-action@v4.10.1
         with:
           clang-format-version: '15'
-          check-path: 'runtime/src'
-
+          check-path: runtime/src
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args:
-          trailing-whitespace --all-files
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args:
-          end-of-file-fixer --all-files
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args:
-          check-yaml --all-files
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args:
-          check-added-large-files --all-files
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args:
-          check-case-conflict --all-files
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args:
-          mixed-line-ending --all-files
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: trailing-whitespace --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: end-of-file-fixer --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: check-yaml --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: check-added-large-files --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: check-case-conflict --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: mixed-line-ending --all-files
 
   build-linux:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout our repository
-      uses: actions/checkout@v3
-      with:
-        path: main
-        submodules: true
+      - name: Checkout our repository
+        uses: actions/checkout@v3
+        with:
+          path: main
+          submodules: true
+      - uses: actions/cache/restore@v3
+        id: cache
+        name: Stack cache
+        with:
+          path: |
+            ~/.stack
+            main/.stack-work
+          key: >-
+            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+            hashFiles('main/package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
-    - uses: actions/cache/restore@v3
-      id: cache
-      name: Stack cache
-      with:
-        path: |
-          ~/.stack
-          main/.stack-work
-        key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-
-
-    - uses: haskell/actions/setup@v2
-      name: Setup Haskell
-      with:
-        ghc-version: 9.2.5
-        enable-stack: true
-        stack-version: 'latest'
-
-    - name: Cache LLVM and Clang
-      id: cache-llvm
-      uses: actions/cache@v3
-      with:
-        path: |
-          C:/Program Files/LLVM
-          ./llvm
-        key: ${{ runner.os }}-llvm-13
-
-    - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "13.0"
-        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
-
-    - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-      if: runner.os == 'macOS'
-      run: |
-        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-        echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-
-    - name: Install libicu for testing
-      run: sudo apt install -y libicu66
-
-    - name: Build Project
-      run: |
-        cd main
-        make build
-
-    - uses: actions/cache/save@v3
-      if: always() # Saving Stack cache even if the Juvix build fails
-      with:
-        path: |
-          ~/.stack
-        key: ${{ steps.stack-cache.outputs.key }}
-
-    - uses: actions/cache/save@v3
-      with:
-        path: |
-          main/.stack-work
-        key: ${{ steps.cache.outputs.key }}
-
+      - uses: haskell/actions/setup@v2
+        name: Setup Haskell
+        with:
+          ghc-version: 9.2.5
+          enable-stack: true
+          stack-version: latest
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v3
+        with:
+          path: |
+            C:/Program Files/LLVM
+            ./llvm
+          key: '${{ runner.os }}-llvm-13'
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: '13.0'
+          cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
+      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+      - name: Install libicu for testing
+        run: sudo apt install -y libicu66
+      - name: Build Project
+        run: |
+          cd main
+          make build
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.stack
+          key: '${{ steps.stack-cache.outputs.key }}'
+      - uses: actions/cache/save@v3
+        with:
+          path: |
+            main/.stack-work
+          key: '${{ steps.cache.outputs.key }}'
   test-linux:
     needs: build-linux
     runs-on: ubuntu-20.04
@@ -160,24 +138,23 @@ jobs:
         with:
           path: main
           submodules: recursive
-
       - uses: actions/cache/restore@v3
         id: cache
         with:
           path: |
             ~/.stack
             main/.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          key: >-
+            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+            hashFiles('main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
           ghc-version: 9.2.5
           enable-stack: true
-          stack-version: 'latest'
-
+          stack-version: latest
       - name: Cache LLVM and Clang (Linux)
         id: cache-llvm
         uses: actions/cache@v3
@@ -185,23 +162,22 @@ jobs:
           path: |
             C:/Program Files/LLVM
             ./llvm
-          key: ${{ runner.os }}-llvm-13
-
+          key: '${{ runner.os }}-llvm-13'
       - name: Install LLVM and Clang (Linux)
         uses: KyleMayes/install-llvm-action@v1
         with:
-          version: "13.0"
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
-
+          version: '13.0'
+          cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
       - name: Download and extract wasi-sysroot
-        run: |
-          curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz -OL
-          tar xfv wasi-sysroot-15.0.tar.gz
+        run: >
+          curl
+          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+          -OL
 
+          tar xfv wasi-sysroot-15.0.tar.gz
       - name: Set WASI_SYSROOT_PATH
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-
       - name: Install the latest Wasmer version
         uses: jonaprieto/action-install-gh-release@1
         with:
@@ -209,50 +185,46 @@ jobs:
           tag: latest
           binaries-location: bin
           cache: true
-
       - name: Test suite
         id: test
         run: |
           cd main
           make test
-
       - name: Add ~/.local/bin to PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-
       - uses: actions/checkout@v3
         with:
           repository: jonaprieto/smoke
           path: smoke
-
       - name: Install Smoke
         run: |
           cd smoke
           stack install
         shell: bash
-
-      - name : Smoke testing
+      - name: Smoke testing
         id: smoke-linux
-        run : |
+        run: |
           cd main
           make smoke
-
       - uses: actions/cache/save@v3
-        if: always() # Saving Stack cache even if the Juvix build fails
+        if: always()
         with:
           path: |
             ~/.stack
-          key: ${{ steps.stack-cache.outputs.key }}
-
+          key: '${{ steps.stack-cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
-          key: ${{ steps.cache.outputs.key }}
+          key: '${{ steps.cache.outputs.key }}'
+
 
   docs-linux:
     needs: build-linux
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.ref == 'refs/heads/main' || github.event_name ==
+      'workflow_dispatch'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout our repository
@@ -260,33 +232,30 @@ jobs:
         with:
           path: main
           submodules: recursive
-
       - uses: actions/cache/restore@v3
         id: cache
         with:
           path: |
             ~/.stack
             main/.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          key: >-
+            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+            hashFiles('main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-
       - uses: r-lib/actions/setup-pandoc@v2
         with:
-          pandoc-version: '2.19.2'
-
+          pandoc-version: 2.19.2
       - name: MDBook setup
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.22'
-
+          mdbook-version: 0.4.22
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc-version: '${{ matrix.ghc }}'
           enable-stack: true
-          stack-version: 'latest'
-
+          stack-version: latest
       - name: Cache LLVM and Clang
         id: cache-llvm
         uses: actions/cache@v3
@@ -294,43 +263,37 @@ jobs:
           path: |
             C:/Program Files/LLVM
             ./llvm
-          key: ${{ runner.os }}-llvm-13
-
+          key: '${{ runner.os }}-llvm-13'
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
-          version: "13.0"
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
-
+          version: '13.0'
+          cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
       - name: Generate Markdown files for each Org file
         run: |
           cd main
           make markdown-docs
-
-      - name : Generate HTML and Web App files from milestone examples
-        run : |
+      - name: Generate HTML and Web App files from milestone examples
+        run: |
           cd main
           echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
           make install
           make html-examples
           make webapp-examples
           make demo-example
-
       - uses: actions/cache/save@v3
         with:
           path: |
             ~/.stack
             main/.stack-work
-          key: ${{ steps.cache.outputs.key }}
-
+          key: '${{ steps.cache.outputs.key }}'
       - name: Deploy HTML to github pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
           publish_dir: main/_docs
           enable_jekyll: false
           cname: docs.juvix.org
-
   build-macos:
     runs-on: macos-12
     steps:
@@ -339,7 +302,6 @@ jobs:
         with:
           path: main
           submodules: true
-
       - uses: actions/cache/restore@v3
         id: cache
         name: Stack cache
@@ -347,45 +309,40 @@ jobs:
           path: |
             ~/.stack
             main/.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          key: >-
+            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+            hashFiles('main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
           ghc-version: 9.2.5
           enable-stack: true
-          stack-version: 'latest'
-
+          stack-version: latest
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |
           echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
           echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-
       - name: Install ICU4C
         run: |
           brew install icu4c
           brew link icu4c --force
-
       - name: Build Project (macOS)
         run: |
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL build
-
       - uses: actions/cache/save@v3
-        if: always() # Saving Stack cache even if the Juvix build fails
+        if: always()
         with:
           path: |
             ~/.stack
-          key: ${{ steps.stack-cache.outputs.key }}
-
+          key: '${{ steps.stack-cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
-          key: ${{ steps.cache.outputs.key }}
-
+          key: '${{ steps.cache.outputs.key }}'
   test-macos:
     needs: build-macos
     runs-on: macos-12
@@ -395,33 +352,33 @@ jobs:
         with:
           path: main
           submodules: recursive
-
       - uses: actions/cache/restore@v3
         id: cache
         with:
           path: |
             ~/.stack
             main/.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          key: >-
+            ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
+            hashFiles('main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
           ghc-version: 9.2.5
           enable-stack: true
-          stack-version: 'latest'
-
+          stack-version: latest
       - name: Download and extract wasi-sysroot
-        run: |
-          curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz -OL
-          tar xfv wasi-sysroot-15.0.tar.gz
+        run: >
+          curl
+          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+          -OL
 
+          tar xfv wasi-sysroot-15.0.tar.gz
       - name: Set WASI_SYSROOT_PATH
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-
       - name: Install the latest Wasmer version
         uses: jonaprieto/action-install-gh-release@1
         with:
@@ -429,30 +386,24 @@ jobs:
           tag: latest
           binaries-location: bin
           cache: true
-
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |
           echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
           echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-
       - name: stack setup (macOS)
         run: |
           cd main
           stack setup
-
       - name: Add homebrew clang to the PATH (macOS)
         run: |
           echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
-
       - name: Test suite (macOS)
         run: |
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL test
-
       - name: Add ~/.local/bin to PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-
       - name: Download Smoke binary
         uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
@@ -461,24 +412,21 @@ jobs:
           cache: enable
           extension-matching: disable
           rename-to: smoke
-          chmod: 0755
-
-      - name : Smoke testing (macOS)
+          chmod: 493
+      - name: Smoke testing (macOS)
         id: smoke-macos
         if: runner.os == 'macOS'
-        run : |
+        run: |
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL smoke
-
       - uses: actions/cache/save@v3
-        if: always() # Saving Stack cache even if the Juvix build fails
+        if: always()
         with:
           path: |
             ~/.stack
-          key: ${{ steps.stack-cache.outputs.key }}
-
+          key: '${{ steps.stack-cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
-          key: ${{ steps.cache.outputs.key }}
+          key: '${{ steps.cache.outputs.key }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,19 +368,19 @@ jobs:
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL test
 
-      - name: Download Smoke binary
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          
+      - name: Install Smoke
+        uses: jonaprieto/action-install-gh-release@2
         with:
           repo: jonaprieto/smoke
-          tag: v2.3.2
-          cache: enable
+          tag: latest
           extension-matching: disable
           rename-to: smoke
           chmod: 0755
 
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Smoke testing (macOS)
         id: smoke-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           submodules: true
       - uses: actions/cache/restore@v3
         id: stack-cache
-        name: Stack cache
+        name: Restore .stack cache
         with:
           path: |
             ~/.stack
@@ -88,7 +88,7 @@ jobs:
 
       - uses: actions/cache/restore@v3
         id: stack-work-cache
-        name: Stack Work cache
+        name: Restore main/.stack-work cache
         with:
           path: |
             ~/.stack
@@ -177,14 +177,16 @@ jobs:
       #     cd main
       #     make smoke
 
-      - uses: actions/cache/save@v3
+      - name: Save cache .stack 
+        uses: actions/cache/save@v3
         if: always()
         with:
           path: |
             ~/.stack
           key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
 
-      - uses: actions/cache/save@v3
+      - name: Save cache main/.stack-work if the job was successful
+        uses: actions/cache/save@v3
         with:
           path: |
             main/.stack-work
@@ -205,15 +207,14 @@ jobs:
           submodules: recursive
 
       - uses: actions/cache/restore@v3
+        name: Restore .stack cache
         id: stack-cache
         with:
           fail-on-cache-miss: true
           path: |
             ~/.stack
-            main/.stack-work
           key: >-
-            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml') }}-${{
-            hashFiles('main/package.yaml') }}
+            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-stack-
 
@@ -224,8 +225,7 @@ jobs:
           path: |
             main/.stack-work
           key: >-
-            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{
-            hashFiles('main/package.yaml') }}
+            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-stack-work-     
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ concurrency:
   cancel-in-progress: true
 env:
   STACKFLAGS: '--pedantic'
-  STACK_ROOT: ~/.stack
-  STACK_WORK: .stack-work
+  STACK_ROOT: ${{ github.workspace }}/.stack
 
 jobs:
 
@@ -83,7 +82,7 @@ jobs:
         id: stack-cache
         name: Restore .stack cache
         with:
-          path: ~/.stack
+          path: ${{ github.workspace }}/.stack
           key: ${{ runner.os }}-stack
 
       - uses: actions/cache/restore@v3
@@ -175,7 +174,7 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: ~/.stack
+          path: ${{ github.workspace }}/.stack
           key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
 
       - name: Save cache main/.stack-work if the job was successful
@@ -202,7 +201,7 @@ jobs:
         id: stack-cache
         with:
           fail-on-cache-miss: true
-          path: ~/.stack
+          path: ${{ github.workspace }}/.stack
           key: ${{ runner.os }}-stack
 
       - uses: actions/cache/restore@v3
@@ -279,7 +278,7 @@ jobs:
         id: stack-cache
         name: Restore .stack cache
         with:
-          path: ~/.stack
+          path: ${{ github.workspace }}/.stack
           key: ${{ runner.os }}-stack
 
       - uses: actions/cache/restore@v3
@@ -347,7 +346,7 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: ~/.stack
+          path: ${{ github.workspace }}/.stack
           key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
 
       - name: Save stack-work cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,7 @@ jobs:
         with:
           version: '13.0'
           cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
-      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+
       - name: Install libicu for testing
         run: sudo apt install -y libicu66
       - name: Build Project
@@ -121,14 +117,14 @@ jobs:
       - uses: actions/cache/save@v3
         if: always()
         with:
+          key: '${{ steps.cache.outputs.key }}'
           path: |
             ~/.stack
-          key: '${{ steps.cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
+          key: '${{ steps.cache.outputs.key }}'
           path: |
             main/.stack-work
-          key: '${{ steps.cache.outputs.key }}'
   test-linux:
     needs: build-linux
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           cd main
           make smoke
 
-      - name: Save cache .stack 
+      - name: Save cache .stack
         uses: actions/cache/save@v3
         if: always()
         with:
@@ -193,7 +193,7 @@ jobs:
 
 
   docs-linux:
-    # needs: build-and-test-linux
+    needs: build-and-test-linux
     # if: >-
     #   github.ref == 'refs/heads/main' || github.event_name ==
     #   'workflow_dispatch'
@@ -226,7 +226,7 @@ jobs:
           key: >-
             ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-stack-work-     
+            ${{ runner.os }}-stack-work-
 
       - uses: r-lib/actions/setup-pandoc@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,50 +22,52 @@ concurrency:
   cancel-in-progress: true
 env:
   STACKFLAGS: '--pedantic'
+
 jobs:
-  # ormolu:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: mrkkrp/ormolu-action@v9
-  #       with:
-  #         extra-args: >-
-  #           --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
-  #           --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
-  #           --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
-  # clang-format:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: jidicula/clang-format-action@v4.10.1
-  #       with:
-  #         clang-format-version: '15'
-  #         check-path: runtime/src
-  # pre-commit:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '3.9'
-  #     - uses: pre-commit/action@v3.0.0
-  #       with:
-  #         extra_args: trailing-whitespace --all-files
-  #     - uses: pre-commit/action@v3.0.0
-  #       with:
-  #         extra_args: end-of-file-fixer --all-files
-  #     - uses: pre-commit/action@v3.0.0
-  #       with:
-  #         extra_args: check-yaml --all-files
-  #     - uses: pre-commit/action@v3.0.0
-  #       with:
-  #         extra_args: check-added-large-files --all-files
-  #     - uses: pre-commit/action@v3.0.0
-  #       with:
-  #         extra_args: check-case-conflict --all-files
-  #     - uses: pre-commit/action@v3.0.0
-  #       with:
-  #         extra_args: mixed-line-ending --all-files
+
+  ormolu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mrkkrp/ormolu-action@v9
+        with:
+          extra-args: >-
+            --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
+            --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
+            --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jidicula/clang-format-action@v4.10.1
+        with:
+          clang-format-version: '15'
+          check-path: runtime/src
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: trailing-whitespace --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: end-of-file-fixer --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: check-yaml --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: check-added-large-files --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: check-case-conflict --all-files
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: mixed-line-ending --all-files
 
   build-and-test-linux:
     runs-on: ubuntu-20.04
@@ -98,84 +100,81 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-stack-work-
 
-      # - uses: haskell/actions/setup@v2
-      #   name: Setup Haskell
-      #   with:
-      #     ghc-version: 9.2.5
-      #     enable-stack: true
-      #     stack-version: latest
+      - uses: haskell/actions/setup@v2
+        name: Setup Haskell
+        with:
+          ghc-version: 9.2.5
+          enable-stack: true
+          stack-version: latest
 
-      # - name: Cache LLVM and Clang
-      #   id: cache-llvm
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       C:/Program Files/LLVM
-      #       ./llvm
-      #     key: '${{ runner.os }}-llvm-13'
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v3
+        with:
+          path: |
+            C:/Program Files/LLVM
+            ./llvm
+          key: '${{ runner.os }}-llvm-13'
 
-      # - name: Install LLVM and Clang
-      #   uses: KyleMayes/install-llvm-action@v1
-      #   with:
-      #     version: '13.0'
-      #     cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: '13.0'
+          cached: '${{ steps.cache-llvm.outputs.cache-hit }}'
 
-      # - name: Download and extract wasi-sysroot
-      #   run: >
-      #     curl
-      #     https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-      #     -OL
+      - name: Download and extract wasi-sysroot
+        run: >
+          curl
+          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+          -OL
 
-      #     tar xfv wasi-sysroot-15.0.tar.gz
-      # - name: Set WASI_SYSROOT_PATH
-      #   run: |
-      #     echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+          tar xfv wasi-sysroot-15.0.tar.gz
+      - name: Set WASI_SYSROOT_PATH
+        run: |
+          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      # - name: Install the latest Wasmer version
-      #   uses: jonaprieto/action-install-gh-release@1
-      #   with:
-      #     repo: wasmerio/wasmer
-      #     tag: latest
-      #     binaries-location: bin
-      #     cache: true
+      - name: Install the latest Wasmer version
+        uses: jonaprieto/action-install-gh-release@1
+        with:
+          repo: wasmerio/wasmer
+          tag: latest
+          binaries-location: bin
+          cache: true
 
-      # - name: Install libicu for testing
-      #   run: sudo apt install -y libicu66
+      - name: Install libicu for testing
+        run: sudo apt install -y libicu66
 
       - name: Build Project
         run: |
-          mkdir -p ~/.stack
-          touch ~/.stack/config.yaml
           cd main
-          mkdir -p .stack-work
-          touch stack.yaml
+          make build
 
-      # - name: Test suite
-      #   id: test
-      #   run: |
-      #     cd main
-      #     make test
+      - name: Test suite
+        id: test
+        run: |
+          cd main
+          make test
 
-      # - name: Add ~/.local/bin to PATH
-      #   run: |
-      #     echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: jonaprieto/smoke
-      #     path: smoke
+      - uses: actions/checkout@v3
+        with:
+          repository: jonaprieto/smoke
+          path: smoke
 
-      # - name: Install Smoke
-      #   run: |
-      #     cd smoke
-      #     stack install
-      #   shell: bash
+      - name: Install Smoke
+        run: |
+          cd smoke
+          stack install
+        shell: bash
 
-      # - name: Smoke testing
-      #   id: smoke-linux
-      #   run: |
-      #     cd main
-      #     make smoke
+      - name: Smoke testing
+        id: smoke-linux
+        run: |
+          cd main
+          make smoke
 
       - name: Save cache .stack 
         uses: actions/cache/save@v3
@@ -194,7 +193,7 @@ jobs:
 
 
   docs-linux:
-    needs: build-and-test-linux
+    # needs: build-and-test-linux
     # if: >-
     #   github.ref == 'refs/heads/main' || github.event_name ==
     #   'workflow_dispatch'
@@ -274,13 +273,13 @@ jobs:
           make webapp-examples
           make demo-example
 
-      - name: Deploy HTML to github pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          publish_dir: main/_docs
-          enable_jekyll: false
-          cname: docs.juvix.org
+      # - name: Deploy HTML to github pages
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   with:
+      #     github_token: '${{ secrets.GITHUB_TOKEN }}'
+      #     publish_dir: main/_docs
+      #     enable_jekyll: false
+      #     cname: docs.juvix.org
 
   # build-macos:
   #   runs-on: macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ concurrency:
   cancel-in-progress: true
 env:
   STACKFLAGS: '--pedantic'
+  STACK_ROOT: ${{ github.workspace }}/.stack
+  STACK_WORK: ${{ github.workspace }}/main/.stack-work
 
 jobs:
 
@@ -82,20 +84,14 @@ jobs:
         name: Restore .stack cache
         with:
           path: ~/.stack
-          key: >-
-            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-
+          key: ${{ runner.os }}-stack
 
       - uses: actions/cache/restore@v3
         id: stack-work-cache
         name: Restore main/.stack-work cache
         with:
           path: main/.stack-work
-          key: >-
-            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-work-
+          key: ${{ runner.os }}-stack-work-
 
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
@@ -207,10 +203,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           path: ~/.stack
-          key: >-
-            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-
+          key: ${{ runner.os }}-stack
 
       - uses: actions/cache/restore@v3
         name: Restore main/.stack-work cache
@@ -218,10 +211,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           path: main/.stack-work
-          key: >-
-            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-work-
+          key: ${{ runner.os }}-stack-work
 
       - uses: r-lib/actions/setup-pandoc@v2
         with:
@@ -290,20 +280,14 @@ jobs:
         name: Restore .stack cache
         with:
           path: ~/.stack
-          key: >-
-            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-
+          key: ${{ runner.os }}-stack
 
       - uses: actions/cache/restore@v3
         name: Restore main/.stack-work cache
         id: stack-work-cache
         with:
           path: main/.stack-work
-          key: >-
-            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-stack-work-
+          key: ${{ runner.os }}-stack-work
 
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
@@ -368,7 +352,7 @@ jobs:
 
       - name: Save stack-work cache
         uses: actions/cache/save@v3
-        if: ${{ success() }}
+        if: always()
         with:
           path: main/.stack-work
           key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
         with:
           path: main
           submodules: true
+
       - uses: actions/cache/restore@v3
         id: stack-cache
         name: Restore .stack cache
@@ -302,16 +303,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-stack-
 
-        - uses: actions/cache/restore@v3
-          name: Restore main/.stack-work cache
-          id: stack-work-cache
-          with:
-            path: |
-              main/.stack-work
-            key: >-
-              ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
-            restore-keys: |
-              ${{ runner.os }}-stack-work-
+      - uses: actions/cache/restore@v3
+        name: Restore main/.stack-work cache
+        id: stack-work-cache
+        with:
+          path: |
+            main/.stack-work
+          key: >-
+            ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-work-
 
       - uses: haskell/actions/setup@v2
         name: Setup Haskell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: '${{ steps.stack-cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
@@ -141,6 +141,7 @@ jobs:
       - uses: actions/cache/restore@v3
         id: cache
         with:
+          fail-on-cache-miss: true
           path: |
             ~/.stack
             main/.stack-work
@@ -212,7 +213,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: '${{ steps.stack-cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
@@ -235,6 +236,7 @@ jobs:
       - uses: actions/cache/restore@v3
         id: cache
         with:
+          fail-on-cache-miss: true
           path: |
             ~/.stack
             main/.stack-work
@@ -294,6 +296,8 @@ jobs:
           publish_dir: main/_docs
           enable_jekyll: false
           cname: docs.juvix.org
+
+
   build-macos:
     runs-on: macos-12
     steps:
@@ -337,7 +341,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: '${{ steps.stack-cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
           path: |
@@ -355,6 +359,7 @@ jobs:
       - uses: actions/cache/restore@v3
         id: cache
         with:
+          fail-on-cache-miss: false
           path: |
             ~/.stack
             main/.stack-work
@@ -424,7 +429,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: '${{ steps.stack-cache.outputs.key }}'
+          key: '${{ steps.cache.outputs.key }}'
       - uses: actions/cache/save@v3
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,9 @@ jobs:
 
   docs-linux:
     needs: build-and-test-linux
-    if: >-
-      github.ref == 'refs/heads/main' || github.event_name ==
-      'workflow_dispatch'
+    # if: >-
+    #   github.ref == 'refs/heads/main' || github.event_name ==
+    #   'workflow_dispatch'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout our repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
 
 
   docs-linux:
-    needs: build-linux
+    needs: build-and-test-linux
     if: >-
       github.ref == 'refs/heads/main' || github.event_name ==
       'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           touch ~/.stack/config.yaml
           cd main
           mkdir -p .stack-work
-          touch .stack-work/stack.yaml
+          touch stack.yaml
 
       # - name: Test suite
       #   id: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,9 @@ jobs:
 
   docs-linux:
     needs: build-and-test-linux
-    # if: >-
-    #   github.ref == 'refs/heads/main' || github.event_name ==
-    #   'workflow_dispatch'
+    if: >-
+      github.ref == 'refs/heads/main' || github.event_name ==
+      'workflow_dispatch'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout our repository
@@ -219,6 +219,7 @@ jobs:
             ${{ runner.os }}-stack-
 
       - uses: actions/cache/restore@v3
+        name: Restore main/.stack-work cache
         id: stack-work-cache
         with:
           fail-on-cache-miss: true
@@ -274,148 +275,125 @@ jobs:
           make webapp-examples
           make demo-example
 
-      # - name: Deploy HTML to github pages
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: '${{ secrets.GITHUB_TOKEN }}'
-      #     publish_dir: main/_docs
-      #     enable_jekyll: false
-      #     cname: docs.juvix.org
+      - name: Deploy HTML to github pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          publish_dir: main/_docs
+          enable_jekyll: false
+          cname: docs.juvix.org
 
-  # build-macos:
-  #   runs-on: macos-12
-  #   steps:
-  #     - name: Checkout our repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         path: main
-  #         submodules: true
-  #     - uses: actions/cache/restore@v3
-  #       id: cache
-  #       name: Stack cache
-  #       with:
-  #         path: |
-  #           ~/.stack
-  #           main/.stack-work
-  #         key: >-
-  #           ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
-  #           hashFiles('main/package.yaml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-
-  #     - uses: haskell/actions/setup@v2
-  #       name: Setup Haskell
-  #       with:
-  #         ghc-version: 9.2.5
-  #         enable-stack: true
-  #         stack-version: latest
-  #     - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-  #       run: |
-  #         echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-  #         echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-  #     - name: Install ICU4C
-  #       run: |
-  #         brew install icu4c
-  #         brew link icu4c --force
-  #     - name: Build Project (macOS)
-  #       run: |
-  #         cd main
-  #         make CC=$CC LIBTOOL=$LIBTOOL build
-  #     - uses: actions/cache/save@v3
-  #       if: always()
-  #       with:
-  #         path: |
-  #           ~/.stack
-  #         key: '${{ steps.cache.outputs.cache-primary-key }}'
-  #     - uses: actions/cache/save@v3
-  #       with:
-  #         path: |
-  #           main/.stack-work
-  #         key: '${{ steps.cache.outputs.cache-primary-key }}'
-  # test-macos:
-  #   needs: build-macos
-  #   runs-on: macos-12
-  #   steps:
-  #     - name: Checkout the main repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         path: main
-  #         submodules: recursive
-  #     - uses: actions/cache/restore@v3
-  #       id: cache
-  #       with:
-  #         fail-on-cache-miss: true
-  #         path: |
-  #           ~/.stack
-  #           main/.stack-work
-  #         key: >-
-  #           ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{
-  #           hashFiles('main/package.yaml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-
-  #     - uses: haskell/actions/setup@v2
-  #       name: Setup Haskell
-  #       with:
-  #         ghc-version: 9.2.5
-  #         enable-stack: true
-  #         stack-version: latest
-  #     - name: Download and extract wasi-sysroot
-  #       run: >
-  #         curl
-  #         https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-  #         -OL
+  build-macos:
+    runs-on: macos-12
+    steps:
+      - name: Checkout our repository
+        uses: actions/checkout@v3
+        with:
+          path: main
+          submodules: true
+      - uses: actions/cache/restore@v3
+        id: stack-cache
+        name: Restore .stack cache
+        with:
+          path: |
+            ~/.stack
+          key: >-
+            ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-
 
-  #         tar xfv wasi-sysroot-15.0.tar.gz
-  #     - name: Set WASI_SYSROOT_PATH
-  #       run: |
-  #         echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-  #     - name: Install the latest Wasmer version
-  #       uses: jonaprieto/action-install-gh-release@1
-  #       with:
-  #         repo: wasmerio/wasmer
-  #         tag: latest
-  #         binaries-location: bin
-  #         cache: true
-  #     - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-  #       run: |
-  #         echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-  #         echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-  #     - name: stack setup (macOS)
-  #       run: |
-  #         cd main
-  #         stack setup
-  #     - name: Add homebrew clang to the PATH (macOS)
-  #       run: |
-  #         echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
-  #     - name: Test suite (macOS)
-  #       run: |
-  #         cd main
-  #         make CC=$CC LIBTOOL=$LIBTOOL test
-  #     - name: Add ~/.local/bin to PATH
-  #       run: |
-  #         echo "$HOME/.local/bin" >> $GITHUB_PATH
-  #     - name: Download Smoke binary
-  #       uses: jaxxstorm/action-install-gh-release@v1.9.0
-  #       with:
-  #         repo: jonaprieto/smoke
-  #         tag: v2.3.2
-  #         cache: enable
-  #         extension-matching: disable
-  #         rename-to: smoke
-  #         chmod: 493
-  #     - name: Smoke testing (macOS)
-  #       id: smoke-macos
-  #       if: runner.os == 'macOS'
-  #       run: |
-  #         cd main
-  #         make CC=$CC LIBTOOL=$LIBTOOL smoke
-  #     - uses: actions/cache/save@v3
-  #       if: always()
-  #       with:
-  #         path: |
-  #           ~/.stack
-  #         key: '${{ steps.cache.outputs.cache-primary-key }}'
-  #     - uses: actions/cache/save@v3
-  #       with:
-  #         path: |
-  #           main/.stack-work
-  #         key: '${{ steps.cache.outputs.cache-primary-key }}'
+        - uses: actions/cache/restore@v3
+          name: Restore main/.stack-work cache
+          id: stack-work-cache
+          with:
+            path: |
+              main/.stack-work
+            key: >-
+              ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
+            restore-keys: |
+              ${{ runner.os }}-stack-work-
+
+      - uses: haskell/actions/setup@v2
+        name: Setup Haskell
+        with:
+          ghc-version: 9.2.5
+          enable-stack: true
+          stack-version: latest
+      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+        run: |
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+      - name: Install ICU4C
+        run: |
+          brew install icu4c
+          brew link icu4c --force
+      - name: Build Project (macOS)
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL build
+
+      - name: Download and extract wasi-sysroot
+        run: >
+          curl
+          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+          -OL
+
+          tar xfv wasi-sysroot-15.0.tar.gz
+      - name: Set WASI_SYSROOT_PATH
+        run: |
+          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+      - name: Install the latest Wasmer version
+        uses: jonaprieto/action-install-gh-release@1
+        with:
+          repo: wasmerio/wasmer
+          tag: latest
+          binaries-location: bin
+          cache: true
+
+      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+        run: |
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+      - name: stack setup (macOS)
+        run: |
+          cd main
+          stack setup
+      - name: Add homebrew clang to the PATH (macOS)
+        run: |
+          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+      - name: Test suite (macOS)
+        if: ${{ success() }}
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL test
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Download Smoke binary
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        with:
+          repo: jonaprieto/smoke
+          tag: v2.3.2
+          cache: enable
+          extension-matching: disable
+          rename-to: smoke
+          chmod: 493
+      - name: Smoke testing (macOS)
+        id: smoke-macos
+        if: ${{ success() }}
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL smoke
+      - name: Save stack cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.stack
+          key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
+      - name: Save stack-work cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            main/.stack-work
+          key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-20.04
-    setps:
+    steps:
     - name: Checkout our repository
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
 
       - name: Test suite
         id: test
+        if: ${{ success() }}
         run: |
           cd main
           make test
@@ -172,6 +173,7 @@ jobs:
 
       - name: Smoke testing
         id: smoke-linux
+        if: ${{ success() }}
         run: |
           cd main
           make smoke
@@ -190,7 +192,6 @@ jobs:
           path: |
             main/.stack-work
           key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'
-
 
   docs-linux:
     needs: build-and-test-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,102 +82,78 @@ jobs:
         extra_args:
           mixed-line-ending --all-files
 
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-12 , ubuntu-20.04]
-        ghc: ["9.2.5"]
-    steps:
-      - name: Checkout our repository
-        uses: actions/checkout@v3
-        with:
-          path: main
-          submodules: true
+  build-linux:
+    runs-on: ubuntu-20.04
+    setps:
+    - name: Checkout our repository
+      uses: actions/checkout@v3
+      with:
+        path: main
+        submodules: true
 
-      - uses: actions/cache/restore@v3
-        id: cache
-        name: Stack cache
-        with:
-          path: |
-            ~/.stack
-            main/.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
+    - uses: actions/cache/restore@v3
+      id: cache
+      name: Stack cache
+      with:
+        path: |
+          ~/.stack
+          main/.stack-work
+        key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-
 
-      - uses: haskell/actions/setup@v2
-        name: Setup Haskell
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          enable-stack: true
-          stack-version: 'latest'
+    - uses: haskell/actions/setup@v2
+      name: Setup Haskell
+      with:
+        ghc-version: 9.2.5
+        enable-stack: true
+        stack-version: 'latest'
 
-      - name: Cache LLVM and Clang (Linux)
-        if: runner.os == 'Linux'
-        id: cache-llvm
-        uses: actions/cache@v3
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: ${{ runner.os }}-llvm-13
+    - name: Cache LLVM and Clang
+      id: cache-llvm
+      uses: actions/cache@v3
+      with:
+        path: |
+          C:/Program Files/LLVM
+          ./llvm
+        key: ${{ runner.os }}-llvm-13
 
-      - name: Install LLVM and Clang (Linux)
-        if: runner.os == 'Linux'
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "13.0"
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+    - name: Install LLVM and Clang
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "13.0"
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
-      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+    - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
 
-      - name: Install ICU4C
-        if: startsWith(matrix.os, 'macos-')
-        run: |
-          brew install icu4c
-          brew link icu4c --force
+    - name: Install libicu for testing
+      run: sudo apt install -y libicu66
 
-      - name: Install libicu for testing
-        if: startsWith(matrix.os, 'ubuntu-')
-        run: sudo apt install -y libicu66
+    - name: Build Project
+      run: |
+        cd main
+        make build
 
-      - name: Build Project (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL build
+    - uses: actions/cache/save@v3
+      if: always() # Saving Stack cache even if the Juvix build fails
+      with:
+        path: |
+          ~/.stack
+        key: ${{ steps.stack-cache.outputs.key }}
 
-      - name: Build Project (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          cd main
-          make build
+    - uses: actions/cache/save@v3
+      with:
+        path: |
+          main/.stack-work
+        key: ${{ steps.cache.outputs.key }}
 
-      - uses: actions/cache/save@v3
-        if: always() # Saving Stack cache even if the Juvix build fails
-        with:
-          path: |
-            ~/.stack
-          key: ${{ steps.stack-cache.outputs.key }}
-
-      - uses: actions/cache/save@v3
-        with:
-          path: |
-            main/.stack-work
-          key: ${{ steps.cache.outputs.key }}
-
-  test:
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-12]
-        ghc: ["9.2.5"]
+  test-linux:
+    needs: build-linux
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout the main repository
         uses: actions/checkout@v3
@@ -198,12 +174,11 @@ jobs:
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc-version: 9.2.5
           enable-stack: true
           stack-version: 'latest'
 
       - name: Cache LLVM and Clang (Linux)
-        if: runner.os == 'Linux'
         id: cache-llvm
         uses: actions/cache@v3
         with:
@@ -213,7 +188,6 @@ jobs:
           key: ${{ runner.os }}-llvm-13
 
       - name: Install LLVM and Clang (Linux)
-        if: runner.os == 'Linux'
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "13.0"
@@ -236,32 +210,8 @@ jobs:
           binaries-location: bin
           cache: true
 
-      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
-
-      - name: stack setup (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          cd main
-          stack setup
-
-      - name: Add homebrew clang to the PATH (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
-
-      - name: Test suite (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL test
-
-      - name: Test suite (linux)
+      - name: Test suite
         id: test
-        if: runner.os == 'Linux'
         run: |
           cd main
           make test
@@ -270,40 +220,19 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Download Smoke binary
-        uses: jaxxstorm/action-install-gh-release@v1.9.0
-        if: runner.os == 'macOS'
-        with:
-          repo: jonaprieto/smoke
-          tag: v2.3.2
-          cache: enable
-          extension-matching: disable
-          rename-to: smoke
-          chmod: 0755
-
-      - name : Smoke testing (macOS)
-        id: smoke-macos
-        if: runner.os == 'macOS'
-        run : |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL smoke
-
       - uses: actions/checkout@v3
-        if: runner.os == 'Linux'
         with:
           repository: jonaprieto/smoke
           path: smoke
 
       - name: Install Smoke
-        if: runner.os == 'Linux'
         run: |
           cd smoke
           stack install
         shell: bash
 
-      - name : Smoke testing (linux)
+      - name : Smoke testing
         id: smoke-linux
-        if: runner.os == 'Linux'
         run : |
           cd main
           make smoke
@@ -321,14 +250,10 @@ jobs:
             main/.stack-work
           key: ${{ steps.cache.outputs.key }}
 
-  docs:
-    needs: build
+  docs-linux:
+    needs: build-linux
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        ghc: ["9.2.5"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout our repository
         uses: actions/checkout@v3
@@ -405,3 +330,155 @@ jobs:
           publish_dir: main/_docs
           enable_jekyll: false
           cname: docs.juvix.org
+
+  build-macos:
+    runs-on: macos-12
+    steps:
+      - name: Checkout our repository
+        uses: actions/checkout@v3
+        with:
+          path: main
+          submodules: true
+
+      - uses: actions/cache/restore@v3
+        id: cache
+        name: Stack cache
+        with:
+          path: |
+            ~/.stack
+            main/.stack-work
+          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - uses: haskell/actions/setup@v2
+        name: Setup Haskell
+        with:
+          ghc-version: 9.2.5
+          enable-stack: true
+          stack-version: 'latest'
+
+      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+        run: |
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+
+      - name: Install ICU4C
+        run: |
+          brew install icu4c
+          brew link icu4c --force
+
+      - name: Build Project (macOS)
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL build
+
+      - uses: actions/cache/save@v3
+        if: always() # Saving Stack cache even if the Juvix build fails
+        with:
+          path: |
+            ~/.stack
+          key: ${{ steps.stack-cache.outputs.key }}
+
+      - uses: actions/cache/save@v3
+        with:
+          path: |
+            main/.stack-work
+          key: ${{ steps.cache.outputs.key }}
+
+  test-macos:
+    needs: build-macos
+    runs-on: macos-12
+    steps:
+      - name: Checkout the main repository
+        uses: actions/checkout@v3
+        with:
+          path: main
+          submodules: recursive
+
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: |
+            ~/.stack
+            main/.stack-work
+          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - uses: haskell/actions/setup@v2
+        name: Setup Haskell
+        with:
+          ghc-version: 9.2.5
+          enable-stack: true
+          stack-version: 'latest'
+
+      - name: Download and extract wasi-sysroot
+        run: |
+          curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz -OL
+          tar xfv wasi-sysroot-15.0.tar.gz
+
+      - name: Set WASI_SYSROOT_PATH
+        run: |
+          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+
+      - name: Install the latest Wasmer version
+        uses: jonaprieto/action-install-gh-release@1
+        with:
+          repo: wasmerio/wasmer
+          tag: latest
+          binaries-location: bin
+          cache: true
+
+      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+        run: |
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm)/bin/llvm-ar" >> $GITHUB_ENV
+
+      - name: stack setup (macOS)
+        run: |
+          cd main
+          stack setup
+
+      - name: Add homebrew clang to the PATH (macOS)
+        run: |
+          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+
+      - name: Test suite (macOS)
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL test
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Download Smoke binary
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        with:
+          repo: jonaprieto/smoke
+          tag: v2.3.2
+          cache: enable
+          extension-matching: disable
+          rename-to: smoke
+          chmod: 0755
+
+      - name : Smoke testing (macOS)
+        id: smoke-macos
+        if: runner.os == 'macOS'
+        run : |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL smoke
+
+      - uses: actions/cache/save@v3
+        if: always() # Saving Stack cache even if the Juvix build fails
+        with:
+          path: |
+            ~/.stack
+          key: ${{ steps.stack-cache.outputs.key }}
+
+      - uses: actions/cache/save@v3
+        with:
+          path: |
+            main/.stack-work
+          key: ${{ steps.cache.outputs.key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ concurrency:
   cancel-in-progress: true
 env:
   STACKFLAGS: '--pedantic'
-  STACK_ROOT: ${{ github.workspace }}/.stack
-  STACK_WORK: ${{ github.workspace }}/main/.stack-work
+  STACK_ROOT: ~/.stack
+  STACK_WORK: .stack-work
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install Smoke
         run: |
           cd smoke
-          stack install
+          stack install --stack-root ${{ github.workspace }}/.stack
         shell: bash
 
       - name: Smoke testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,7 @@ jobs:
         id: stack-cache
         name: Restore .stack cache
         with:
-          path: |
-            ~/.stack
+          path: ~/.stack
           key: >-
             ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
@@ -92,9 +91,7 @@ jobs:
         id: stack-work-cache
         name: Restore main/.stack-work cache
         with:
-          path: |
-            ~/.stack
-            main/.stack-work
+          path: main/.stack-work
           key: >-
             ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
@@ -182,15 +179,13 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: |
-            ~/.stack
+          path: ~/.stack
           key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
 
       - name: Save cache main/.stack-work if the job was successful
         uses: actions/cache/save@v3
         with:
-          path: |
-            main/.stack-work
+          path: main/.stack-work
           key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'
 
   docs-linux:
@@ -211,8 +206,7 @@ jobs:
         id: stack-cache
         with:
           fail-on-cache-miss: true
-          path: |
-            ~/.stack
+          path: ~/.stack
           key: >-
             ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
@@ -223,8 +217,7 @@ jobs:
         id: stack-work-cache
         with:
           fail-on-cache-miss: true
-          path: |
-            main/.stack-work
+          path: main/.stack-work
           key: >-
             ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
@@ -296,8 +289,7 @@ jobs:
         id: stack-cache
         name: Restore .stack cache
         with:
-          path: |
-            ~/.stack
+          path: ~/.stack
           key: >-
             ${{ runner.os }}-stack-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
@@ -307,8 +299,7 @@ jobs:
         name: Restore main/.stack-work cache
         id: stack-work-cache
         with:
-          path: |
-            main/.stack-work
+          path: main/.stack-work
           key: >-
             ${{ runner.os }}-stack-work-${{ hashFiles('main/stack.yaml','main/package.yaml') }}
           restore-keys: |
@@ -372,16 +363,14 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: |
-            ~/.stack
+          path: ~/.stack
           key: '${{ steps.stack-cache.outputs.cache-primary-key }}'
 
       - name: Save stack-work cache
         uses: actions/cache/save@v3
         if: ${{ success() }}
         with:
-          path: |
-            main/.stack-work
+          path: main/.stack-work
           key: '${{ steps.stack-work-cache.outputs.cache-primary-key }}'
 
       - name: Add ~/.local/bin to PATH
@@ -396,7 +385,6 @@ jobs:
           extension-matching: disable
           rename-to: smoke
           chmod: 0755
-
 
       - name: Smoke testing (macOS)
         id: smoke-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,20 +96,17 @@ jobs:
           submodules: true
 
       - uses: actions/cache@v3
-        name: Cache ~/.stack
-        with:
-          path: ~/.stack
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack-global-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-stack-global-
 
-      - uses: actions/cache@v3
-        name: Cache .stack-work
+      - uses: actions/cache/restore@v3
+        id: cache
+        name: Stack cache
         with:
-          path: main/.stack-work
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}-${{ hashFiles('main/**/*.hs') }}
+          path: |
+            ~/.stack
+            main/.stack-work
+          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-stack-work-
+            ${{ runner.os }}-
 
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
@@ -163,6 +160,19 @@ jobs:
           cd main
           make build
 
+      - uses: actions/cache/save@v3
+        if: always() # Saving Stack cache even if the Juvix build fails
+        with:
+          path: |
+            ~/.stack
+          key: ${{ steps.stack-cache.outputs.key }}
+
+      - uses: actions/cache/save@v3
+        with:
+          path: |
+            main/.stack-work
+          key: ${{ steps.cache.outputs.key }}
+
   test:
     needs: build
     runs-on: ${{ matrix.os }}
@@ -177,21 +187,16 @@ jobs:
           path: main
           submodules: recursive
 
-      - uses: actions/cache@v3
-        name: Cache ~/.stack
+      - uses: actions/checkout@v3
+      - uses: actions/cache/restore@v3
+        id: cache
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack-global-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          path: |
+            ~/.stack
+            main/.stack-work
+          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-stack-global-
-
-      - uses: actions/cache@v3
-        name: Cache .stack-work
-        with:
-          path: main/.stack-work
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}-${{ hashFiles('main/**/*.hs') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-stack-work-
+            ${{ runner.os }}-
 
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
@@ -306,6 +311,19 @@ jobs:
           cd main
           make smoke
 
+      - uses: actions/cache/save@v3
+        if: always() # Saving Stack cache even if the Juvix build fails
+        with:
+          path: |
+            ~/.stack
+          key: ${{ steps.stack-cache.outputs.key }}
+
+      - uses: actions/cache/save@v3
+        with:
+          path: |
+            main/.stack-work
+          key: ${{ steps.cache.outputs.key }}
+
   docs:
     needs: build
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
@@ -321,21 +339,16 @@ jobs:
           path: main
           submodules: recursive
 
-      - uses: actions/cache@v3
-        name: Cache ~/.stack
+      - uses: actions/checkout@v3
+      - uses: actions/cache/restore@v3
+        id: cache
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack-global-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
+          path: |
+            ~/.stack
+            main/.stack-work
+          key: ${{ runner.os }}-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-stack-global-
-
-      - uses: actions/cache@v3
-        name: Cache .stack-work
-        with:
-          path: main/.stack-work
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack-work-${{ hashFiles('main/stack.yaml') }}-${{ hashFiles('main/package.yaml') }}-${{ hashFiles('main/**/*.hs') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-stack-work-
+            ${{ runner.os }}-
 
       - uses: r-lib/actions/setup-pandoc@v2
         with:
@@ -381,6 +394,13 @@ jobs:
           make html-examples
           make webapp-examples
           make demo-example
+
+      - uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.stack
+            main/.stack-work
+          key: ${{ steps.cache.outputs.key }}
 
       - name: Deploy HTML to github pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         name: Restore .stack cache
         with:
           path: ${{ github.workspace }}/.stack
-          key: ${{ runner.os }}-stack
+          key: ${{ runner.os }}-stack-
 
       - uses: actions/cache/restore@v3
         id: stack-work-cache
@@ -202,7 +202,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           path: ${{ github.workspace }}/.stack
-          key: ${{ runner.os }}-stack
+          key: ${{ runner.os }}-stack-
 
       - uses: actions/cache/restore@v3
         name: Restore main/.stack-work cache
@@ -210,7 +210,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           path: main/.stack-work
-          key: ${{ runner.os }}-stack-work
+          key: ${{ runner.os }}-stack-work-
 
       - uses: r-lib/actions/setup-pandoc@v2
         with:
@@ -279,14 +279,14 @@ jobs:
         name: Restore .stack cache
         with:
           path: ${{ github.workspace }}/.stack
-          key: ${{ runner.os }}-stack
+          key: ${{ runner.os }}-stack-
 
       - uses: actions/cache/restore@v3
         name: Restore main/.stack-work cache
         id: stack-work-cache
         with:
           path: main/.stack-work
-          key: ${{ runner.os }}-stack-work
+          key: ${{ runner.os }}-stack-work-
 
       - uses: haskell/actions/setup@v2
         name: Setup Haskell


### PR DESCRIPTION
This PR addresses a caching issue in our CI by streamlining each operating system's build and test processes, reducing CI time. 🤞  Also, our caching strategy has been updated with the new restore/save actions. For example, we aim to cache the .stack folder, and if the stack build is successful, the .stack-build. The building documentation job continues depending on the Linux build. Upon merging this PR, we get back to the point where the CI maintain a cache for each OS to be shared among all PRs, significantly reducing CI testing time. The expected scenario is as follows. The CI can take, on average, 35' in Linux to build and test everything. Using caching, that time is reduced to less than 10'. macOS is a different story. It can easily take one hour, and even more, the first time to build and test the project. After that, it might take an average of 20'.

- Caching strategies [descriptions](https://github.com/actions/cache/blob/main/caching-strategies.md#saving-cache-even-if-the-build-fails)
- Closes #1776