### PR TITLE
Allow type signatures to have a body

### DIFF
--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -186,6 +186,7 @@ data TypeSignature (s :: Stage) = TypeSignature
     _sigType :: ExpressionType s,
     _sigDoc :: Maybe (Judoc s),
     _sigBuiltin :: Maybe (WithLoc BuiltinFunction),
+    _sigBody :: Maybe (ExpressionType s),
     _sigTerminating :: Maybe KeywordRef
   }
 
@@ -1078,6 +1079,7 @@ instance SingI s => HasLoc (TypeSignature s) where
     (_sigDoc >>= getJudocLoc)
       ?<> (getLoc <$> _sigBuiltin)
       ?<> (getLoc <$> _sigTerminating)
+      ?<> (getLocExpressionType <$> _sigBody)
       ?<> getLocExpressionType _sigType
 
 instance HasLoc (Example s) where

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -439,7 +439,8 @@ instance (SingI s) => PrettyCode (TypeSignature s) where
     sigType' <- ppExpression _sigType
     builtin' <- traverse ppCode _sigBuiltin
     doc' <- mapM ppCode _sigDoc
-    return $ doc' ?<> builtin' <?+> sigTerminating' <> hang' (sigName' <+> kwColon <+> sigType')
+    body' :: Maybe (Doc Ann) <- fmap (kwAssign <+>) <$> mapM ppExpression _sigBody
+    return $ doc' ?<> builtin' <?+> sigTerminating' <> hang' (sigName' <+> kwColon <+> sigType' <+?> body')
 
 instance (SingI s) => PrettyCode (Function s) where
   ppCode :: forall r. (Members '[Reader Options] r) => Function s -> Sem r (Doc Ann)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -187,6 +187,9 @@ instance PrettyPrint (TypeSignature 'Scoped) where
         builtin' :: Maybe (Sem r ()) = ppCode <$> _sigBuiltin
         type' = ppCode _sigType
         name' = region (P.annDef _sigName) (ppCode _sigName)
+        body' = case _sigBody of
+          Nothing -> Nothing
+          Just body -> Just (noLoc P.kwAssign <+> ppCode body)
     doc'
       ?<> builtin'
       <?+> termin'
@@ -194,6 +197,7 @@ instance PrettyPrint (TypeSignature 'Scoped) where
           ( name'
               <+> noLoc P.kwColon
               <+> type'
+              <+?> body'
           )
 
 instance PrettyPrint Pattern where

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -17,6 +17,7 @@ data ScoperError
   | ErrMultipleDeclarations MultipleDeclarations
   | ErrLacksTypeSig LacksTypeSig
   | ErrLacksFunctionClause LacksFunctionClause
+  | ErrDuplicateFunctionClause DuplicateFunctionClause
   | ErrImportCycle ImportCycle
   | ErrSymNotInScope NotInScope
   | ErrQualSymNotInScope QualSymNotInScope
@@ -41,6 +42,7 @@ data ScoperError
 
 instance ToGenericError ScoperError where
   genericError = \case
+    ErrDuplicateFunctionClause e -> genericError e
     ErrInfixParser e -> genericError e
     ErrAppLeftImplicit e -> genericError e
     ErrInfixPattern e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -447,6 +447,7 @@ typeSignature _sigTerminating _sigName _sigBuiltin = do
   kw kwColon
   _sigType <- parseExpressionAtoms
   _sigDoc <- getJudoc
+  _sigBody <- optional (kw kwAssign >> parseExpressionAtoms)
   return TypeSignature {..}
 
 -- | Used to minimize the amount of required @P.try@s.

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -254,5 +254,12 @@ scoperErrorTests =
       $(mkRelFile "DuplicateInductiveParameterName.juvix")
       $ \case
         ErrDuplicateInductiveParameterName {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "A function has a duplicate clause"
+      $(mkRelDir ".")
+      $(mkRelFile "DuplicateClause.juvix")
+      $ \case
+        ErrDuplicateFunctionClause {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -216,5 +216,9 @@ tests =
     PosTest
       "Builtin bool"
       $(mkRelDir ".")
-      $(mkRelFile "BuiltinsBool.juvix")
+      $(mkRelFile "BuiltinsBool.juvix"),
+    PosTest
+      "Type signature with body"
+      $(mkRelDir ".")
+      $(mkRelFile "SignatureWithBody.juvix")
   ]

--- a/tests/negative/DuplicateClause.juvix
+++ b/tests/negative/DuplicateClause.juvix
@@ -1,0 +1,10 @@
+module DuplicateClause;
+
+axiom T : Type;
+
+id : T → T := λ {
+  t := t
+};
+id t := t;
+
+end;

--- a/tests/positive/SignatureWithBody.juvix
+++ b/tests/positive/SignatureWithBody.juvix
@@ -1,0 +1,15 @@
+module SignatureWithBody;
+  open import Stdlib.Prelude;
+
+  isNull : {A : Type} → List A → Bool := λ {
+      | nil := true
+      | _ := false
+    };
+
+  isNull' : {A : Type} → List A → Bool := let {
+      aux : {A : Type} → List A → Bool := λ {
+          | nil := true
+          | _ := false
+        };
+    } in aux;
+end;


### PR DESCRIPTION
- Closes #1637.

A function type signature is now allowed to have a body. This is valid for both top level and let definitions.
```
not : Bool -> Bool := λ {
 | true := false
 | false := true
};
```