### PR TITLE
Fix termination with as-patterns

### DIFF
--- a/src/Juvix/Compiler/Abstract/Data/Name.hs
+++ b/src/Juvix/Compiler/Abstract/Data/Name.hs
@@ -51,10 +51,7 @@ instance HasNameKind Name where
   getNameKind = (^. nameKind)
 
 instance Pretty Name where
-  pretty n =
-    pretty (n ^. namePretty)
-      <> "@"
-      <> pretty (n ^. nameId)
+  pretty n = pretty (n ^. namePretty)
 
 addNameIdTag :: Bool -> NameId -> Doc a -> Doc a
 addNameIdTag showNameId nid

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract/Analysis/Termination/Error/Types.hs
@@ -24,7 +24,7 @@ instance ToGenericError NoLexOrder where
       i = getLoc name
 
       msg :: Doc Ann
-      msg =
+      msg = do
         "The function"
           <+> code (pretty name)
           <+> "fails the termination checker."

--- a/test/Termination/Positive.hs
+++ b/test/Termination/Positive.hs
@@ -50,8 +50,6 @@ testDescrFlag N.NegTest {..} =
             (void . runIO' iniState entryPoint) upToInternal
         }
 
---------------------------------------------------------------------------------
-
 tests :: [PosTest]
 tests =
   [ PosTest
@@ -65,7 +63,11 @@ tests =
     PosTest
       "Recursive functions on Lists"
       $(mkRelDir ".")
-      $(mkRelFile "Data/List.juvix")
+      $(mkRelFile "Data/List.juvix"),
+    PosTest
+      "Recursive function on a tree"
+      $(mkRelDir ".")
+      $(mkRelFile "TreeGen.juvix")
   ]
 
 testsWithKeyword :: [PosTest]
@@ -82,8 +84,6 @@ testsWithKeyword =
 
 negTests :: [N.NegTest]
 negTests = N.tests
-
---------------------------------------------------------------------------------
 
 allTests :: TestTree
 allTests =

--- a/tests/positive/Termination/TreeGen.juvix
+++ b/tests/positive/Termination/TreeGen.juvix
@@ -1,0 +1,17 @@
+module TreeGen;
+  open import Stdlib.Prelude;
+
+  type Tree :=
+    | leaf : Tree
+    | node : Tree → Tree → Tree;
+
+  gen : Nat → Tree;
+  gen zero := leaf;
+  gen (suc zero) := node leaf leaf;
+  gen (suc (suc n')) := node (gen n') (gen (suc n'));
+
+  gen2 : Nat → Tree;
+  gen2 zero := leaf;
+  gen2 (suc zero) := node leaf leaf;
+  gen2 (suc n@(suc n')) := node (gen2 n') (gen2 n);
+end;


### PR DESCRIPTION
- Fixes #1702.
Now, if we have a pattern like `suc @n(suc n')`, then `n` is detected to be a proper subpattern