### PR TITLE
Translate as-pattern binders to Core PatternBinders

### DIFF
--- a/test/Internal/Eval/Positive.hs
+++ b/test/Internal/Eval/Positive.hs
@@ -178,5 +178,10 @@ tests =
       "Type Aliases"
       $(mkRelDir ".")
       $(mkRelFile "Church.juvix")
-      $(mkRelFile "out/Church.out")
+      $(mkRelFile "out/Church.out"),
+    PosTest
+      "Nested as patterns"
+      $(mkRelDir ".")
+      $(mkRelFile "AsPatterns.juvix")
+      $(mkRelFile "out/AsPatterns.out")
   ]

--- a/tests/Internal/positive/AsPatterns.juvix
+++ b/tests/Internal/positive/AsPatterns.juvix
@@ -1,0 +1,39 @@
+module AsPatterns;
+
+open import Stdlib.Prelude;
+
+printListNatLn : List Nat → IO;
+printListNatLn nil := printStringLn "nil";
+printListNatLn (x :: xs) := printNat x >> printString " :: " >> printListNatLn xs;
+
+f1 : List Nat -> List Nat;
+f1 a@(x :: (x' :: xs)) := a;
+f1 _ := nil;
+
+f2 : List Nat -> List Nat;
+f2  (x :: a@(x' :: xs)) := a;
+f2 _ := nil;
+
+f3 : Nat -> List Nat -> List Nat;
+f3 _ a@(x :: (x' :: xs)) := a;
+
+f4 : Nat -> List Nat -> Nat;
+f4 y (x :: a@(x' :: xs)) := y;
+
+f5 : List Nat -> List Nat -> List Nat;
+f5 (x :: a@(x' :: xs)) (y :: b@(y' :: ys)) := b;
+
+l1 : List Nat;
+l1 := zero :: suc zero :: nil;
+
+l2 : List Nat;
+l2 := zero :: suc zero :: suc (suc zero) :: suc (suc (suc zero)) :: nil;
+
+main : IO;
+main := printListNatLn (f1 l1)
+     >> printListNatLn (f2 l1)
+     >> printListNatLn (f3 zero l1)
+     >> printNatLn (f4 zero l1)
+     >> printListNatLn (f5 l1 l2);
+
+end;

--- a/tests/Internal/positive/out/AsPatterns.out
+++ b/tests/Internal/positive/out/AsPatterns.out
@@ -1,0 +1,5 @@
+zero :: suc zero :: nil
+suc zero :: nil
+zero :: suc zero :: nil
+zero
+suc zero :: suc (suc zero) :: suc (suc (suc zero)) :: nil


### PR DESCRIPTION
Before this change, nested as-patterns (i.e as-patterns binding arguments to constructors) were not translated to Core pattern binders.

This meant that the following function would crash the compiler:

```
f : List Nat -> List Nat;
f  (x :: a@(x' :: xs)) := a;
f _ := nil;
```

i.e the nested as-pattern `a` was ignored in the internal to core translation.

This commit translates each as-pattern to a Core `PatternBinder`.

* Fixes https://github.com/anoma/juvix/issues/1788
* Fixes https://github.com/anoma/juvix/issues/1738