### PR TITLE
Add REPL option to apply Core transformations

### DIFF
--- a/app/Commands/Repl/Options.hs
+++ b/app/Commands/Repl/Options.hs
@@ -2,11 +2,13 @@ module Commands.Repl.Options where
 
 import CommonOptions
 import Juvix.Compiler.Core.Pretty.Options qualified as Core
+import Juvix.Compiler.Core.Transformation
 
 data ReplOptions = ReplOptions
   { _replInputFile :: Maybe (AppPath File),
     _replShowDeBruijn :: Bool,
-    _replNoPrelude :: Bool
+    _replNoPrelude :: Bool,
+    _replTransformations :: [TransformationId]
   }
   deriving stock (Data)
 
@@ -20,6 +22,7 @@ instance CanonicalProjection ReplOptions Core.Options where
 
 parseRepl :: Parser ReplOptions
 parseRepl = do
+  _replTransformations <- optTransformationIds
   _replInputFile <- optional parseInputJuvixFile
   _replShowDeBruijn <-
     switch

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -244,3 +244,14 @@ tests:
       contains: |
         evaluation error: failure: Enough
     exit-status: 0
+
+  - name: repl-nat-to-int-transform
+    command:
+      - juvix
+      - repl
+      - -t nat-to-int
+    stdin: "1 + 2"
+    stdout:
+      contains: |
+        3
+    exit-status: 0


### PR DESCRIPTION
Core transformations apply to the whole InfoTable, the REPL needs to apply Core transformations to the single node that it compiles from the user input string.

The solution in this commit is to:

1. Compile the input string as before to obtain a Core Node.
2. Add this Node to a copy of the Core InfoTable for the loaded file.
3. Apply the (CLI specified) Core transformations to this InfoTable.
4. Extract the (now transformed) Node from the InfoTable.

We can think of a way to improve this, maybe when we tackle allowing the user to make new definitions in the REPL.

As soon as compilation of pattern matching is complete we should enable some (all?) Core transformations by default.

Example:

At the moment we get the following result in the REPL:

```
juvix repl
...
Stdlib.Prelude> 1 + 1
suc (suc zero)
```

After this commit we can turn on `nat-to-int` transformation:

```
juvix repl -t nat-to-int
Stdlib.Prelude> 1 + 1
2
```

* Part of https://github.com/anoma/juvix/issues/1531