### PR TITLE
Add internal core-eval option to evaluate named function identifier

### DIFF
--- a/app/Commands/Dev/Internal/CoreEval.hs
+++ b/app/Commands/Dev/Internal/CoreEval.hs
@@ -2,14 +2,31 @@ module Commands.Dev.Internal.CoreEval where
 
 import Commands.Base
 import Commands.Dev.Internal.CoreEval.Options
+import Data.HashMap.Internal.Strict (elems)
 import Data.HashMap.Strict qualified as HashMap
 import Evaluator
 import Juvix.Compiler.Core.Data.InfoTable
+import Juvix.Compiler.Core.Language.Base
 import Juvix.Compiler.Core.Transformation qualified as Core
 import Juvix.Compiler.Core.Translation
+import Safe (headMay)
+
+getSymbol :: forall r. Member App r => InfoTable -> Text -> Sem r Symbol
+getSymbol tab name = maybe failAction (return . (^. identifierSymbol)) mIdent
+  where
+    identifiers :: [IdentifierInfo]
+    identifiers = elems (tab ^. infoIdentifiers)
+
+    mIdent :: Maybe IdentifierInfo
+    mIdent = headMay (filter ((== name) . (^. identifierName)) identifiers)
+
+    failAction :: Sem r a
+    failAction = exitMsg (ExitFailure 1) (name <> " is not a function identifier")
 
 runCommand :: (Members '[Embed IO, App] r) => InternalCoreEvalOptions -> Sem r ()
 runCommand localOpts = do
   tab <- (^. coreResultTable) <$> runPipeline (localOpts ^. internalCoreEvalInputFile) upToCore
   let tab' = Core.applyTransformations (project localOpts ^. internalCoreEvalTransformations) tab
-  forM_ ((tab' ^. infoMain) >>= ((tab' ^. identContext) HashMap.!?)) (evalAndPrint localOpts tab')
+  ms <- mapM (getSymbol tab') (localOpts ^. internalCoreEvalSymbolName)
+  let symbol = ms <|> (tab' ^. infoMain)
+  forM_ (symbol >>= ((tab' ^. identContext) HashMap.!?)) (evalAndPrint localOpts tab')

--- a/app/Commands/Dev/Internal/CoreEval/Options.hs
+++ b/app/Commands/Dev/Internal/CoreEval/Options.hs
@@ -9,7 +9,8 @@ data InternalCoreEvalOptions = InternalCoreEvalOptions
   { _internalCoreEvalTransformations :: [TransformationId],
     _internalCoreEvalShowDeBruijn :: Bool,
     _internalCoreEvalNoIO :: Bool,
-    _internalCoreEvalInputFile :: AppPath File
+    _internalCoreEvalInputFile :: AppPath File,
+    _internalCoreEvalSymbolName :: Maybe Text
   }
   deriving stock (Data)
 
@@ -42,4 +43,12 @@ parseInternalCoreEval = do
           <> help "Don't interpret the IO effects"
       )
   _internalCoreEvalInputFile <- parseInputJuvixFile
+  _internalCoreEvalSymbolName <-
+    optional $
+      strOption
+        ( long "symbol-name"
+            <> short 's'
+            <> help "Evaluate a function identifier (default: main)"
+            <> metavar "NAME"
+        )
   pure InternalCoreEvalOptions {..}

--- a/tests/positive/Internal/LiteralInt.juvix
+++ b/tests/positive/Internal/LiteralInt.juvix
@@ -5,4 +5,7 @@ module LiteralInt;
 
   f : Nat;
   f := 1;
+
+  main : IO;
+  main := printNatLn 2;
 end;

--- a/tests/smoke/Commands/dev/internal.smoke.yaml
+++ b/tests/smoke/Commands/dev/internal.smoke.yaml
@@ -50,3 +50,43 @@ tests:
       matches: |-
         (.+)\/([^\/]+)\.juvix\:[0-9]*\:[0-9]*\-[0-9]*\: error
     exit-status: 1
+
+  - name: internal-core-eval
+    command:
+      - juvix
+      - dev
+      - internal
+      - core-eval
+    args:
+      - positive/Internal/LiteralInt.juvix
+    stdout: |
+      suc (suc zero)
+    exit-status: 0
+
+  - name: internal-core-eval-transform
+    command:
+      - juvix
+      - dev
+      - internal
+      - core-eval
+      - --transforms
+      - nat-to-int
+    args:
+      - positive/Internal/LiteralInt.juvix
+    stdout: |
+      2
+    exit-status: 0
+
+  - name: internal-core-eval-symbol-name
+    command:
+      - juvix
+      - dev
+      - internal
+      - core-eval
+      - --symbol-name
+      - f
+    args:
+      - positive/Internal/LiteralInt.juvix
+    stdout: |
+      suc zero
+    exit-status: 0


### PR DESCRIPTION
By default the main function identifier is evaluated by `juvix dev internal core-eval`. When debugging it's often useful to evaluate some other function in a module.

```
module Symbol;

open import Stdlib.Prelude;

f : Nat;
f := 1;

main : IO;
main := printNatLn f;

end;
```

With core-eval you can now evaluate `f`:

For example:
```
$ juvix dev internal core-eval Symbol.juvix -s f
suc zero
```