### PR TITLE
Respect the `juvix dev highlight --format` flag when outputting errors

### DIFF
--- a/app/Commands/Dev/Highlight.hs
+++ b/app/Commands/Dev/Highlight.hs
@@ -7,13 +7,13 @@ import Juvix.Compiler.Concrete.Data.InfoTable qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
 
-runCommand :: (Members '[Embed IO, App] r) => HighlightOptions -> Sem r ()
+runCommand :: Members '[Embed IO, App] r => HighlightOptions -> Sem r ()
 runCommand HighlightOptions {..} = do
   res <- runPipelineEither _highlightInputFile upToScoping
   case res of
     Left err -> do
       genOpts <- askGenericOptions
-      say (Highlight.goError (run $ runReader genOpts $ errorIntervals err))
+      sayRaw (Highlight.goErrors _highlightBackend (run $ runReader genOpts $ errorIntervals err))
     Right r -> do
       inputFile <- someBaseToAbs' (_highlightInputFile ^. pathPath)
       let tbl = r ^. _2 . Scoper.resultParserResult . Parser.resultTable

--- a/tests/smoke/Commands/dev/highlight.smoke.yaml
+++ b/tests/smoke/Commands/dev/highlight.smoke.yaml
@@ -1,0 +1,32 @@
+working-directory: ./../../../../tests
+
+tests:
+  - name: highlight-emacs
+    command:
+      - juvix
+      - dev
+      - highlight
+    args:
+      - positive/Internal/LiteralInt.juvix
+
+    stdout:
+      contains: |
+          add-text-properties
+    exit-status: 0
+
+tests:
+  - name: highlight-vscode
+    command:
+      - juvix
+      - dev
+      - highlight
+      - --format
+      - json
+    args:
+      - positive/Internal/LiteralInt.juvix
+
+    stdout:
+      matches:
+        regex: |
+          what magic regex should I use?
+    exit-status: 0

--- a/tests/smoke/Commands/dev/highlight.smoke.yaml
+++ b/tests/smoke/Commands/dev/highlight.smoke.yaml
@@ -26,7 +26,6 @@ tests:
       - positive/Internal/LiteralInt.juvix
 
     stdout:
-      matches:
-        regex: |
-          what magic regex should I use?
+      matches: |-
+          ^\{\"face\".*$
     exit-status: 0

--- a/tests/smoke/Commands/dev/highlight.smoke.yaml
+++ b/tests/smoke/Commands/dev/highlight.smoke.yaml
@@ -14,7 +14,6 @@ tests:
           add-text-properties
     exit-status: 0
 
-tests:
   - name: highlight-vscode
     command:
       - juvix


### PR DESCRIPTION
Currently errors were always being highlighted using the emacs backend. Now they properly depend on the `--format` flag.