### PR TITLE
Workaround ghcup issue on CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
           path: main/.stack-work
           key: ${{ runner.os }}-stack-work-
 
+      - name: Workaround runner image issue
+        # https://github.com/actions/runner-images/issues/7061
+        run: sudo chown -R $USER /usr/local/.ghcup
+
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:


### PR DESCRIPTION
ghcup is currently broken after a CI runner update. See https://github.com/actions/runner-images/issues/7061

This workaround is temporary while the underlying issue is fixed upstream.