### PR TITLE
Apply CI ghcup workaround to docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,10 @@ jobs:
         with:
           mdbook-version: 0.4.22
 
+      - name: Workaround runner image issue
+        # https://github.com/actions/runner-images/issues/7061
+        run: sudo chown -R $USER /usr/local/.ghcup
+
       - uses: haskell/actions/setup@v2
         name: Setup Haskell
         with:


### PR DESCRIPTION
We also need to apply the workaround from https://github.com/anoma/juvix/pull/1821 to the linux docs build