### PR TITLE
Fix `juvix init`

### DIFF
--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -39,16 +39,17 @@ checkNotInProject =
       say "You are already in a Juvix project"
       embed exitFailure
 
-getPackage :: forall r. (Members '[Embed IO] r) => Sem r Package
+getPackage :: forall r. Members '[Embed IO] r => Sem r Package
 getPackage = do
   tproj <- getProjName
-  say "Tell me the version of your project [leave empty for 0.0.0]"
+  say "Write the version of your project [leave empty for 0.0.0]"
+  root <- getCurrentDir
+  let pkg = defaultPackage root (rootBuildDir root)
   tversion :: SemVer <- getVersion
   return
-    Package
+    pkg
       { _packageName = tproj,
-        _packageVersion = Ideal tversion,
-        _packageDependencies = mempty
+        _packageVersion = Ideal tversion
       }
 
 getProjName :: forall r. (Members '[Embed IO] r) => Sem r Text
@@ -59,7 +60,7 @@ getProjName = do
         Nothing -> mempty
         Just d' -> " [leave empty for '" <> d' <> "']"
   say
-    ( "Tell me the name of your project"
+    ( "Write the name of your project"
         <> defMsg
         <> " (lower case letters, numbers and dashes are allowed): "
     )

--- a/src/Juvix/Compiler/Pipeline/Package/Dependency.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Dependency.hs
@@ -38,6 +38,7 @@ deriving stock instance Show RawDependency
 deriving stock instance Show Dependency
 
 instance ToJSON RawDependency where
+  toJSON (Dependency p) = toJSON (fromSomeDir p)
   toEncoding (Dependency p) = toEncoding (fromSomeDir p)
 
 instance FromJSON RawDependency where

--- a/tests/smoke/Commands/init.smoke.yaml
+++ b/tests/smoke/Commands/init.smoke.yaml
@@ -1,0 +1,19 @@
+working-directory: ./../../../tests/
+
+tests:
+  - name: init
+    command:
+      shell:
+        - bash
+      script: |
+        mkdir tmp
+        cd tmp
+        juvix init
+        cat juvix.yaml
+        cd ..
+        rm -rf tmp
+    stdout:
+      contains:
+        "name: tmp"
+    stdin: "\n\n"
+    exit-status: 0


### PR DESCRIPTION
- Closes #1831 

My guess is that the behaviour of `aeson` changed at some point.
Before, providing `toEncoding` was working as expected. Now I needed to implement `toJSON` as well.