### PR TITLE
Improve formatter

### DIFF
--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -530,7 +530,7 @@ instance (SingI s) => PrettyCode (FunctionClause s) where
       clauseOwnerFunction'
         <+?> clausePatterns'
         <+> kwAssign
-        <+> nest 2 clauseBody'
+        <+> PP.group (flatAlt (line <> indent' clauseBody') clauseBody')
 
 instance (SingI s) => PrettyCode (AxiomDef s) where
   ppCode AxiomDef {..} = do
@@ -636,7 +636,7 @@ instance PrettyCode Application where
       let (f, args) = unfoldApplication a
       f' <- ppCode f
       args' <- mapM ppCodeAtom args
-      return $ PP.group (f' <+> nest 2 (vsep args'))
+      return $ PP.group (f' <+> nest' (vsep args'))
 
 apeHelper :: (IsApe a Expression, Members '[Reader Options] r) => a -> Sem r (Doc CodeAnn) -> Sem r (Doc CodeAnn)
 apeHelper a alt = do

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -530,7 +530,7 @@ instance (SingI s) => PrettyCode (FunctionClause s) where
       clauseOwnerFunction'
         <+?> clausePatterns'
         <+> kwAssign
-        <+> PP.group (flatAlt (line <> indent' clauseBody') clauseBody')
+        <+> oneLineOrNext clauseBody'
 
 instance (SingI s) => PrettyCode (AxiomDef s) where
   ppCode AxiomDef {..} = do

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -274,7 +274,7 @@ instance PrettyPrint (FunctionClause 'Scoped) where
     clauseFun'
       <+?> clausePatterns'
       <+> noLoc P.kwAssign
-      <+> nest clauseBody'
+      <+> oneLineOrNext clauseBody'
 
 ppPatternAtom :: forall r. (Members '[Reader Options, ExactPrint] r) => PatternArg -> Sem r ()
 ppPatternAtom pat =

--- a/src/Juvix/Data/Ape/Base.hs
+++ b/src/Juvix/Data/Ape/Base.hs
@@ -5,16 +5,12 @@ import Juvix.Prelude
 class IsApe a e where
   toApe :: a -> Ape e
 
--- TODO add ApeParens
-
 -- | Abstract pretty expression
 data Ape a
   = ApeLeaf (Leaf a)
   | ApeInfix (Infix a)
   | ApeApp (App a)
   | ApePostfix (Postfix a)
-
--- TODO add CapeParens
 
 -- | Abstract pretty expressions with chains
 data Cape a

--- a/src/Juvix/Data/Effect/ExactPrint.hs
+++ b/src/Juvix/Data/Effect/ExactPrint.hs
@@ -105,3 +105,6 @@ enclose l r p = l >> p >> r
 
 encloseSep :: (Monad m, Foldable f) => m () -> m () -> m () -> f (m ()) -> m ()
 encloseSep l r sep f = l >> sequenceWith sep f >> r
+
+oneLineOrNext :: Members '[ExactPrint] r => Sem r () -> Sem r ()
+oneLineOrNext = region P.oneLineOrNext

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -112,6 +112,9 @@ hsepMaybe l
   | null l = Nothing
   | otherwise = Just (hsep l)
 
+nest' :: Doc ann -> Doc ann
+nest' = nest 2
+
 indent' :: Doc ann -> Doc ann
 indent' = indent 2
 

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -121,6 +121,9 @@ indent' = indent 2
 hang' :: Doc ann -> Doc ann
 hang' = hang 2
 
+oneLineOrNext :: Doc ann -> Doc ann
+oneLineOrNext x = PP.group (flatAlt (line <> indent' x) x)
+
 ordinal :: Int -> Doc a
 ordinal = \case
   1 -> "first"

--- a/tests/positive/Ape.juvix
+++ b/tests/positive/Ape.juvix
@@ -1,5 +1,5 @@
 module Ape;
-  axiom String : Type;
+  builtin string axiom String : Type;
 
   infixl 7 *;
   axiom * : String → String → String;


### PR DESCRIPTION
- Closes #1793.

Now, if the body of a function clause does not fit in a line, the body will start indented in the next line.

The example presented in the linked issue is now formatted thus:
```
  go n s :=
    if
      (s < n)
      (go (sub n 1) s)
      (go n (sub s n) + go (sub n 1) s);
```