### PR TITLE
Remove module parameters

### DIFF
--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -69,17 +69,15 @@ goModule m = case sing :: SModuleIsTop t of
   SModuleLocal -> goModule' m
   where
     goModule' :: Module 'Scoped t -> Sem r Abstract.Module
-    goModule' Module {..}
-      | null _moduleParameters = do
-          body' <- goModuleBody _moduleBody
-          examples' <- goExamples _moduleDoc
-          return
-            Abstract.Module
-              { _moduleName = name',
-                _moduleBody = body',
-                _moduleExamples = examples'
-              }
-      | otherwise = unsupported "Module parameters"
+    goModule' Module {..} = do
+      body' <- goModuleBody _moduleBody
+      examples' <- goExamples _moduleDoc
+      return
+        Abstract.Module
+          { _moduleName = name',
+            _moduleBody = body',
+            _moduleExamples = examples'
+          }
       where
         name' :: Abstract.Name
         name' = case sing :: SModuleIsTop t of

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -398,7 +398,6 @@ type LocalModuleName s = SymbolType s
 data Module (s :: Stage) (t :: ModuleIsTop) = Module
   { _moduleKw :: KeywordRef,
     _modulePath :: ModulePathType s t,
-    _moduleParameters :: [InductiveParameters s],
     _moduleDoc :: Maybe (Judoc s),
     _moduleBody :: [Statement s]
   }
@@ -511,7 +510,6 @@ data OpenModule (s :: Stage) = OpenModule
   { _openModuleKw :: KeywordRef,
     _openModuleName :: ModuleRefType s,
     _openModuleImportKw :: Maybe KeywordRef,
-    _openParameters :: [ExpressionType s],
     _openUsingHiding :: Maybe UsingHiding,
     _openPublic :: PublicAnn
   }

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -208,19 +208,17 @@ instance (SingI s, SingI t) => PrettyCode (Module s t) where
   ppCode Module {..} = do
     moduleBody' <- indent' <$> ppCode _moduleBody
     modulePath' <- ppModulePathType _modulePath
-    moduleParameters' <- ppInductiveParameters _moduleParameters
     moduleDoc' <- mapM ppCode _moduleDoc
     return $
       moduleDoc'
         ?<> kwModule
         <+> modulePath'
-        <+?> moduleParameters'
-        <> kwSemicolon
-        <> line
-        <> moduleBody'
-        <> line
-        <> kwEnd
-        <>? lastSemicolon
+          <> kwSemicolon
+          <> line
+          <> moduleBody'
+          <> line
+          <> kwEnd
+          <>? lastSemicolon
     where
       lastSemicolon = case sing :: SModuleIsTop t of
         SModuleLocal -> Nothing
@@ -368,18 +366,10 @@ instance (SingI s) => PrettyCode (OpenModule s) where
       SParsed -> ppCode _openModuleName
       SScoped -> ppCode _openModuleName
     openUsingHiding' <- mapM ppUsingHiding _openUsingHiding
-    openParameters' <- ppOpenParams
     importkw' <- mapM ppCode _openModuleImportKw
     let openPublic' = ppPublic
-    return $ kwOpen <+?> importkw' <+> openModuleName' <+?> openParameters' <+?> openUsingHiding' <+?> openPublic'
+    return $ kwOpen <+?> importkw' <+> openModuleName' <+?> openUsingHiding' <+?> openPublic'
     where
-      ppAtom' = case sing :: SStage s of
-        SParsed -> ppCodeAtom
-        SScoped -> ppCodeAtom
-      ppOpenParams :: Sem r (Maybe (Doc Ann))
-      ppOpenParams = case _openParameters of
-        [] -> return Nothing
-        _ -> Just . hsep <$> mapM ppAtom' _openParameters
       ppUsingHiding :: UsingHiding -> Sem r (Doc Ann)
       ppUsingHiding uh = do
         bracedList <-

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -252,7 +252,6 @@ instance PrettyPrint (OpenModule 'Scoped) where
   ppCode OpenModule {..} = do
     let name' = ppCode _openModuleName
         usingHiding' = ppCode <$> _openUsingHiding
-        openParameters' = hsep . fmap ppAtom <$> nonEmpty _openParameters
         importkw' = ppCode <$> _openModuleImportKw
         public' = case _openPublic of
           Public -> Just (noLoc P.kwPublic)
@@ -260,7 +259,6 @@ instance PrettyPrint (OpenModule 'Scoped) where
     ppCode _openModuleKw
       <+?> importkw'
       <+> name'
-      <+?> openParameters'
       <+?> usingHiding'
       <+?> public'
 


### PR DESCRIPTION
This pr removes module parameters from the syntax. Before this pr, module parameters were supported until scoping (included). Since we don't plan to support them in the near future, at least until we discuss the module system (#1792), it is better to remove them from the codebase.