### PR TITLE
Preserve single wildcards pretty printing function parameters

### DIFF
--- a/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Abstract/Translation/FromConcrete.hs
@@ -466,7 +466,7 @@ goFunctionParameters (FunctionParameters {..}) = do
               Abstract._paramName = goSymbol <$> param
             }
       )
-      _paramNames
+      (fromMaybe (pure Nothing) (nonEmpty _paramNames))
 
 goPatternApplication ::
   (Members '[Error ScoperError, InfoTableBuilder] r) =>

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -16,7 +16,6 @@ module Juvix.Compiler.Concrete.Language
 where
 
 import Data.Kind qualified as GHC
-import Data.List.NonEmpty qualified as NonEmpty
 import Juvix.Compiler.Concrete.Data.Builtins
 import Juvix.Compiler.Concrete.Data.Literal
 import Juvix.Compiler.Concrete.Data.ModuleIsTop
@@ -598,7 +597,7 @@ instance HasAtomicity (Lambda s) where
 --------------------------------------------------------------------------------
 
 data FunctionParameters (s :: Stage) = FunctionParameters
-  { _paramNames :: NonEmpty (Maybe (SymbolType s)),
+  { _paramNames :: [Maybe (SymbolType s)],
     _paramImplicit :: IsImplicit,
     _paramType :: ExpressionType s
   }
@@ -1069,7 +1068,7 @@ instance HasLoc (Lambda 'Scoped) where
   getLoc l = getLoc (l ^. lambdaKw) <> getLocSpan (l ^. lambdaClauses)
 
 instance HasLoc (FunctionParameters 'Scoped) where
-  getLoc p = (getLoc <$> NonEmpty.head (p ^. paramNames)) ?<> getLoc (p ^. paramType)
+  getLoc p = (getLoc <$> join (listToMaybe (p ^. paramNames))) ?<> getLoc (p ^. paramType)
 
 instance HasLoc (Function 'Scoped) where
   getLoc f = getLoc (f ^. funParameters) <> getLoc (f ^. funReturn)

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -449,7 +449,7 @@ instance (SingI s) => PrettyCode (Function s) where
 instance (SingI s) => PrettyCode (FunctionParameters s) where
   ppCode FunctionParameters {..} = do
     case _paramNames of
-      Nothing :| [] -> ppLeftExpression' funFixity _paramType
+      [] -> ppLeftExpression' funFixity _paramType
       _ -> do
         paramNames' <-
           forM

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -954,7 +954,7 @@ checkFunction Function {..} = do
           }
       where
         FunctionParameters {..} = _funParameters
-        checkParamNames :: Sem r (NonEmpty (Maybe S.Symbol))
+        checkParamNames :: Sem r [Maybe S.Symbol]
         checkParamNames =
           forM
             _paramNames
@@ -1389,7 +1389,7 @@ makeExpressionTable2 (ExpressionAtoms atoms _) = [appOpExplicit] : operators ++ 
           where
             param =
               FunctionParameters
-                { _paramNames = NonEmpty.singleton Nothing,
+                { _paramNames = [],
                   _paramImplicit = Explicit,
                   _paramType = a
                 }

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -507,7 +507,7 @@ functionParams :: forall r. (Members '[InfoTableBuilder, JudocStash, NameIdGen] 
 functionParams = do
   (_paramNames, _paramImplicit) <- P.try $ do
     impl <- implicitOpen
-    n <- some1 pName
+    n <- some pName
     kw kwColon
     return (n, impl)
   _paramType <- parseExpressionAtoms

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -77,4 +77,8 @@ module Format;
             +l7 "Hellooooooooo"
         , "hi"
         , "hi";
+
+  -- function with single wildcard parameter
+  g : (_ : Type) -> Nat;
+  g _ := 1;
 end;


### PR DESCRIPTION
Before this change:

```
f : (_ : Type) -> Nat;
```

was pretty printed as

```
f : Type -> Nat;
```

This PR rectifies this issue.