### PR TITLE
Move `substEnv` to its own module

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/SubstEnv.hs
+++ b/src/Juvix/Compiler/Core/Extra/SubstEnv.hs
@@ -1,0 +1,18 @@
+-- | This module contains `substEnv`. This function is used in the pretty
+-- printer. So it is convenient to have it isolated so that when debugging other
+-- functions in Core.Utils we can use `ppTrace`
+module Juvix.Compiler.Core.Extra.SubstEnv where
+
+import Juvix.Compiler.Core.Extra.Recursors
+import Juvix.Compiler.Core.Language
+
+-- | substitution of all free variables for values in an environment
+substEnv :: Env -> Node -> Node
+substEnv env
+  | null env = id
+  | otherwise = umapN go
+  where
+    go k n = case n of
+      NVar (Var _ idx)
+        | idx >= k -> env !! (idx - k)
+      _ -> n

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -6,6 +6,7 @@ module Juvix.Compiler.Core.Extra.Utils
     module Juvix.Compiler.Core.Extra.Equality,
     module Juvix.Compiler.Core.Extra.Recursors.Fold.Named,
     module Juvix.Compiler.Core.Extra.Recursors.Map.Named,
+    module Juvix.Compiler.Core.Extra.SubstEnv,
   )
 where
 
@@ -20,6 +21,7 @@ import Juvix.Compiler.Core.Extra.Info
 import Juvix.Compiler.Core.Extra.Recursors
 import Juvix.Compiler.Core.Extra.Recursors.Fold.Named
 import Juvix.Compiler.Core.Extra.Recursors.Map.Named
+import Juvix.Compiler.Core.Extra.SubstEnv
 import Juvix.Compiler.Core.Info.TypeInfo
 import Juvix.Compiler.Core.Language
 
@@ -168,17 +170,6 @@ developBeta = umap go
 etaExpand :: Int -> Node -> Node
 etaExpand 0 n = n
 etaExpand k n = mkLambdas' k (mkApps' (shift k n) (map mkVar' (reverse [0 .. k - 1])))
-
--- | substitution of all free variables for values in an environment
-substEnv :: Env -> Node -> Node
-substEnv env
-  | null env = id
-  | otherwise = umapN go
-  where
-    go k n = case n of
-      NVar (Var _ idx)
-        | idx >= k -> env !! (idx - k)
-      _ -> n
 
 convertClosures :: Node -> Node
 convertClosures = umap go

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -11,7 +11,8 @@ import Juvix.Compiler.Abstract.Data.Name
 import Juvix.Compiler.Core.Data.BinderList as BL
 import Juvix.Compiler.Core.Data.InfoTable
 import Juvix.Compiler.Core.Data.Stripped.InfoTable qualified as Stripped
-import Juvix.Compiler.Core.Extra
+import Juvix.Compiler.Core.Extra.Base
+import Juvix.Compiler.Core.Extra.SubstEnv
 import Juvix.Compiler.Core.Info.NameInfo
 import Juvix.Compiler.Core.Language
 import Juvix.Compiler.Core.Language.Stripped qualified as Stripped


### PR DESCRIPTION
The pretty printer for `Core` depends on `substEnv`, so it is convenient to have it isolated so that it is possible to use ``ppTrace`` when debugging functions in `Core.Utils` (or anything depending on it).