### PR TITLE
Add transformation group synonyms in `core read -t`

### DIFF
--- a/app/CommonOptions.hs
+++ b/app/CommonOptions.hs
@@ -8,7 +8,6 @@ where
 
 import Control.Exception qualified as GHC
 import Juvix.Compiler.Core.Data.TransformationId.Parser
-import Juvix.Compiler.Core.Pipeline qualified as Core
 import Juvix.Prelude
 import Options.Applicative
 import System.Process
@@ -241,7 +240,6 @@ optTransformationIds =
     (eitherReader parseTransf)
     ( long "transforms"
         <> short 't'
-        <> value Core.toEvalTransformations
         <> metavar "[Transform]"
         <> completer (mkCompleter (return . completionsString))
         <> help "hint: use autocomplete"

--- a/src/Juvix/Compiler/Core/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId.hs
@@ -15,4 +15,44 @@ data TransformationId
   | ComputeTypeInfo
   | MatchToCase
   | EtaExpandApps
+  deriving stock (Data, Bounded, Enum)
+
+data PipelineId
+  = PipelineEval
+  | PipelineGeb
+  | PipelineStripped
+  deriving stock (Data, Bounded, Enum)
+
+data TransformationLikeId
+  = TransformationId TransformationId
+  | PipelineId PipelineId
   deriving stock (Data)
+
+allTransformationLikeIds :: [TransformationLikeId]
+allTransformationLikeIds =
+  map TransformationId allElements
+    ++ map PipelineId allElements
+
+fromTransformationLike :: TransformationLikeId -> [TransformationId]
+fromTransformationLike = \case
+  TransformationId i -> [i]
+  PipelineId p -> pipeline p
+
+fromTransformationLikes :: [TransformationLikeId] -> [TransformationId]
+fromTransformationLikes = concatMap fromTransformationLike
+
+toStrippedTransformations :: [TransformationId]
+toStrippedTransformations =
+  toEvalTransformations ++ [LambdaLetRecLifting, TopEtaExpand, MoveApps, RemoveTypeArgs]
+
+toGebTransformations :: [TransformationId]
+toGebTransformations = toEvalTransformations ++ [UnrollRecursion, ComputeTypeInfo]
+
+toEvalTransformations :: [TransformationId]
+toEvalTransformations = [EtaExpandApps, MatchToCase, NatToInt, ConvertBuiltinTypes]
+
+pipeline :: PipelineId -> [TransformationId]
+pipeline = \case
+  PipelineEval -> toEvalTransformations
+  PipelineGeb -> toGebTransformations
+  PipelineStripped -> toStrippedTransformations

--- a/src/Juvix/Compiler/Core/Pipeline.hs
+++ b/src/Juvix/Compiler/Core/Pipeline.hs
@@ -7,24 +7,14 @@ where
 import Juvix.Compiler.Core.Data.InfoTable
 import Juvix.Compiler.Core.Transformation
 
-toEvalTransformations :: [TransformationId]
-toEvalTransformations = [EtaExpandApps, MatchToCase, NatToInt, ConvertBuiltinTypes]
-
 -- | Perform transformations on Core necessary for efficient evaluation
 toEval :: InfoTable -> InfoTable
 toEval = applyTransformations toEvalTransformations
-
-toStrippedTransformations :: [TransformationId]
-toStrippedTransformations =
-  toEvalTransformations ++ [LambdaLetRecLifting, TopEtaExpand, MoveApps, RemoveTypeArgs]
 
 -- | Perform transformations on Core necessary before the translation to
 -- Core.Stripped
 toStripped :: InfoTable -> InfoTable
 toStripped = applyTransformations toStrippedTransformations
-
-toGebTransformations :: [TransformationId]
-toGebTransformations = toEvalTransformations ++ [UnrollRecursion, ComputeTypeInfo]
 
 -- | Perform transformations on Core necessary before the translation to GEB
 toGeb :: InfoTable -> InfoTable


### PR DESCRIPTION
This pr adds the option to pass the arguments `pipeline-eval`, `pipeline-geb`,  `pipeline-stripped` to `core read -t`. These will desugar as expected to the corresponding sequences of transformations.

This pr also removes the default `pipeline-eval` if the user does not provide an explicit transformation. Instead, no transformations will be applied by default. To have the same behavour as now, the option `-t pipeline-eval` will need to be passed