### PR TITLE
Add default empty value for the transformations options `-t`

### DIFF
--- a/app/CommonOptions.hs
+++ b/app/CommonOptions.hs
@@ -240,6 +240,7 @@ optTransformationIds =
     (eitherReader parseTransf)
     ( long "transforms"
         <> short 't'
+        <> value []
         <> metavar "[Transform]"
         <> completer (mkCompleter (return . completionsString))
         <> help "hint: use autocomplete"


### PR DESCRIPTION
The pr #1868 was missing a default value.