### PR TITLE
Add errors to the Core pipeline and check GEB prerequisites

### DIFF
--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -30,5 +30,8 @@ runCommand opts@CompileOptions {..} = do
 writeCoreFile :: (Members '[Embed IO, App] r) => Compile.PipelineArg -> Sem r ()
 writeCoreFile Compile.PipelineArg {..} = do
   coreFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
-  let tab = Core.toEval _pipelineArgInfoTable
-  embed $ TIO.writeFile (toFilePath coreFile) (show $ Core.ppOutDefault (Core.disambiguateNames tab))
+  r <- runError @JuvixError $ Core.toEval _pipelineArgInfoTable
+  case r of
+    Left e -> exitJuvixError e
+    Right tab ->
+      embed $ TIO.writeFile (toFilePath coreFile) (show $ Core.ppOutDefault (Core.disambiguateNames tab))

--- a/app/Commands/Dev/Core/Asm.hs
+++ b/app/Commands/Dev/Core/Asm.hs
@@ -14,7 +14,8 @@ runCommand opts = do
   inputFile :: Path Abs File <- someBaseToAbs' sinputFile
   s' <- embed (readFile $ toFilePath inputFile)
   tab <- getRight (mapLeft JuvixError (Core.runParserMain inputFile Core.emptyInfoTable s'))
-  let tab' = Asm.fromCore $ Stripped.fromCore (Core.toStripped tab)
+  r <- runError @JuvixError $ Core.toStripped tab
+  tab' <- Asm.fromCore . Stripped.fromCore <$> getRight r
   if
       | project opts ^. coreAsmPrint ->
           renderStdOut (Asm.ppOutDefault tab' tab')

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -73,6 +73,7 @@ runGebPipeline PipelineArg {..} = do
 runAsmPipeline :: (Members '[Embed IO, App] r) => PipelineArg -> Sem r ()
 runAsmPipeline PipelineArg {..} = do
   asmFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
-  let tab' = coreToAsm _pipelineArgInfoTable
-      code = Pretty.ppPrint tab' tab'
+  r <- runError @JuvixError (coreToAsm _pipelineArgInfoTable)
+  tab' <- getRight r
+  let code = Pretty.ppPrint tab' tab'
   embed $ TIO.writeFile (toFilePath asmFile) code

--- a/app/Commands/Dev/Core/Read.hs
+++ b/app/Commands/Dev/Core/Read.hs
@@ -22,8 +22,9 @@ runCommand opts = do
   inputFile :: Path Abs File <- someBaseToAbs' sinputFile
   s' <- embed . readFile . toFilePath $ inputFile
   tab <- getRight (mapLeft JuvixError (Core.runParserMain inputFile Core.emptyInfoTable s'))
-  let tab0 = Core.applyTransformations (project opts ^. coreReadTransformations) tab
-      tab' = if project opts ^. coreReadNoDisambiguate then tab0 else Core.disambiguateNames tab0
+  r <- runError @JuvixError $ Core.applyTransformations (project opts ^. coreReadTransformations) tab
+  tab0 <- getRight $ mapLeft JuvixError r
+  let tab' = if project opts ^. coreReadNoDisambiguate then tab0 else Core.disambiguateNames tab0
   embed (Scoper.scopeTrace tab')
   unless (project opts ^. coreReadNoPrint) $ do
     renderStdOut (Core.ppOut opts tab')

--- a/app/Commands/Dev/Core/Strip.hs
+++ b/app/Commands/Dev/Core/Strip.hs
@@ -11,8 +11,9 @@ runCommand :: forall r a. (Members '[Embed IO, App] r, CanonicalProjection a Cor
 runCommand opts = do
   inputFile :: Path Abs File <- someBaseToAbs' sinputFile
   s' <- embed (readFile $ toFilePath inputFile)
-  tab <- getRight (mapLeft JuvixError (Core.runParserMain inputFile Core.emptyInfoTable s'))
-  let tab' = Stripped.fromCore (Core.toStripped tab)
+  (tab, _) <- getRight (mapLeft JuvixError (Core.runParser inputFile Core.emptyInfoTable s'))
+  r <- runError @JuvixError (Core.toStripped tab)
+  tab' <- getRight $ mapLeft JuvixError $ mapRight Stripped.fromCore r
   unless (project opts ^. coreStripNoPrint) $ do
     renderStdOut (Core.ppOut opts tab')
   where

--- a/app/Commands/Eval.hs
+++ b/app/Commands/Eval.hs
@@ -11,8 +11,9 @@ import Juvix.Compiler.Core.Pipeline qualified as Core
 runCommand :: (Members '[Embed IO, App] r) => EvalOptions -> Sem r ()
 runCommand opts@EvalOptions {..} = do
   Core.CoreResult {..} <- runPipeline _evalInputFile upToCore
-  let tab = Core.toEval _coreResultTable
-      evalNode =
+  r <- runError @JuvixError $ Core.toEval _coreResultTable
+  tab <- getRight r
+  let evalNode =
         if
             | isJust (_evalSymbolName) -> getNode' tab (selInfo tab)
             | otherwise -> getNode' tab (mainInfo tab)

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -187,9 +187,6 @@ runCommand opts = do
               compileString :: Repl (Either JuvixError Core.Node)
               compileString = liftIO $ compileExpressionIO' ctx (strip (pack s))
 
-              bindEither :: (Monad m) => m (Either e a) -> (a -> m (Either e b)) -> m (Either e b)
-              bindEither x f = join <$> (x >>= mapM f)
-
       core :: String -> Repl ()
       core input = Repline.dontCrash $ do
         ctx <- State.gets (^. replStateContext)

--- a/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
@@ -5,6 +5,7 @@ import Data.List qualified as List
 import Juvix.Compiler.Backend.Geb.Extra
 import Juvix.Compiler.Backend.Geb.Language
 import Juvix.Compiler.Core.Data.InfoTable qualified as Core
+import Juvix.Compiler.Core.Data.IdentDependencyInfo qualified as Core
 import Juvix.Compiler.Core.Extra qualified as Core
 import Juvix.Compiler.Core.Info.TypeInfo qualified as Info
 import Juvix.Compiler.Core.Language (Index, Level, Symbol)

--- a/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
@@ -185,72 +185,8 @@ fromCore tab = case tab ^. Core.infoMain of
       Core.OpIntDiv -> convertBinop OpDiv _builtinAppArgs
       Core.OpIntMod -> convertBinop OpMod _builtinAppArgs
       Core.OpIntLt -> convertBinop OpLt _builtinAppArgs
-      Core.OpIntLe -> case _builtinAppArgs of
-        [arg1, arg2] -> do
-          arg1' <- convertNode arg1
-          arg2' <- convertNode arg2
-          let le =
-                MorphismLambda
-                  Lambda
-                    { _lambdaVarType = ObjectInteger,
-                      _lambdaBodyType =
-                        ObjectHom
-                          Hom
-                            { _homDomain = ObjectInteger,
-                              _homCodomain = objectBool
-                            },
-                      _lambdaBody =
-                        MorphismLambda
-                          Lambda
-                            { _lambdaVarType = ObjectInteger,
-                              _lambdaBodyType = objectBool,
-                              _lambdaBody =
-                                mkOr
-                                  ( MorphismBinop
-                                      Binop
-                                        { _binopOpcode = OpLt,
-                                          _binopLeft = MorphismVar Var {_varIndex = 1},
-                                          _binopRight = MorphismVar Var {_varIndex = 0}
-                                        }
-                                  )
-                                  ( MorphismBinop
-                                      Binop
-                                        { _binopOpcode = OpEq,
-                                          _binopLeft = MorphismVar Var {_varIndex = 1},
-                                          _binopRight = MorphismVar Var {_varIndex = 0}
-                                        }
-                                  )
-                            }
-                    }
-           in return $
-                MorphismApplication
-                  Application
-                    { _applicationDomainType = ObjectInteger,
-                      _applicationCodomainType =
-                        ObjectHom
-                          Hom
-                            { _homDomain = ObjectInteger,
-                              _homCodomain = objectBool
-                            },
-                      _applicationLeft =
-                        MorphismApplication
-                          Application
-                            { _applicationDomainType = ObjectInteger,
-                              _applicationCodomainType = objectBool,
-                              _applicationLeft = le,
-                              _applicationRight = arg2'
-                            },
-                      _applicationRight = arg1'
-                    }
-        _ ->
-          error "wrong builtin application argument number"
-      Core.OpEq ->
-        case _builtinAppArgs of
-          arg : _
-            | Info.getNodeType arg == Core.mkTypeInteger' ->
-                convertBinop OpEq _builtinAppArgs
-          _ ->
-            error "unsupported equality argument types"
+      Core.OpIntLe -> convertOpIntLe _builtinAppArgs
+      Core.OpEq -> convertOpEq _builtinAppArgs
       _ ->
         unsupported
 
@@ -268,6 +204,75 @@ fromCore tab = case tab ^. Core.infoMain of
               }
       _ ->
         error "wrong builtin application argument number"
+
+    convertOpIntLe :: [Core.Node] -> Trans Morphism
+    convertOpIntLe = \case
+      [arg1, arg2] -> do
+        arg1' <- convertNode arg1
+        arg2' <- convertNode arg2
+        let le =
+              MorphismLambda
+                Lambda
+                  { _lambdaVarType = ObjectInteger,
+                    _lambdaBodyType =
+                      ObjectHom
+                        Hom
+                          { _homDomain = ObjectInteger,
+                            _homCodomain = objectBool
+                          },
+                    _lambdaBody =
+                      MorphismLambda
+                        Lambda
+                          { _lambdaVarType = ObjectInteger,
+                            _lambdaBodyType = objectBool,
+                            _lambdaBody =
+                              mkOr
+                                ( MorphismBinop
+                                    Binop
+                                      { _binopOpcode = OpLt,
+                                        _binopLeft = MorphismVar Var {_varIndex = 1},
+                                        _binopRight = MorphismVar Var {_varIndex = 0}
+                                      }
+                                )
+                                ( MorphismBinop
+                                    Binop
+                                      { _binopOpcode = OpEq,
+                                        _binopLeft = MorphismVar Var {_varIndex = 1},
+                                        _binopRight = MorphismVar Var {_varIndex = 0}
+                                      }
+                                )
+                          }
+                  }
+         in return $
+              MorphismApplication
+                Application
+                  { _applicationDomainType = ObjectInteger,
+                    _applicationCodomainType =
+                      ObjectHom
+                        Hom
+                          { _homDomain = ObjectInteger,
+                            _homCodomain = objectBool
+                          },
+                    _applicationLeft =
+                      MorphismApplication
+                        Application
+                          { _applicationDomainType = ObjectInteger,
+                            _applicationCodomainType = objectBool,
+                            _applicationLeft = le,
+                            _applicationRight = arg2'
+                          },
+                    _applicationRight = arg1'
+                  }
+      _ ->
+        error "wrong builtin application argument number"
+
+    convertOpEq :: [Core.Node] -> Trans Morphism
+    convertOpEq args = case args of
+      arg : _
+        | Info.getNodeType arg == Core.mkTypeInteger' ->
+            convertBinop OpEq args
+      _ ->
+        error "unsupported equality argument types"
 
     convertConstr :: Core.Constr -> Trans Morphism
     convertConstr Core.Constr {..} = do

--- a/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
@@ -4,8 +4,8 @@ import Data.HashMap.Strict qualified as HashMap
 import Data.List qualified as List
 import Juvix.Compiler.Backend.Geb.Extra
 import Juvix.Compiler.Backend.Geb.Language
-import Juvix.Compiler.Core.Data.InfoTable qualified as Core
 import Juvix.Compiler.Core.Data.IdentDependencyInfo qualified as Core
+import Juvix.Compiler.Core.Data.InfoTable qualified as Core
 import Juvix.Compiler.Core.Extra qualified as Core
 import Juvix.Compiler.Core.Info.TypeInfo qualified as Info
 import Juvix.Compiler.Core.Language (Index, Level, Symbol)

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -156,10 +156,10 @@ genJudocHtml JudocArgs {..} =
     cs =
       _judocArgsCtx
         ^. resultInternalArityResult
-          . InternalArity.resultInternalResult
-          . Internal.resultAbstract
-          . Abstract.resultScoper
-          . Scoped.comments
+        . InternalArity.resultInternalResult
+        . Internal.resultAbstract
+        . Abstract.resultScoper
+        . Scoped.comments
 
     entry :: EntryPoint
     entry = _judocArgsCtx ^. InternalTyped.internalTypedResultEntryPoint
@@ -171,10 +171,10 @@ genJudocHtml JudocArgs {..} =
     mainMod =
       _judocArgsCtx
         ^. InternalTyped.resultInternalArityResult
-          . InternalArity.resultInternalResult
-          . Internal.resultAbstract
-          . Abstract.resultScoper
-          . Scoped.mainModule
+        . InternalArity.resultInternalResult
+        . Internal.resultAbstract
+        . Abstract.resultScoper
+        . Scoped.mainModule
 
     htmlOpts :: HtmlOptions
     htmlOpts =

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -156,10 +156,10 @@ genJudocHtml JudocArgs {..} =
     cs =
       _judocArgsCtx
         ^. resultInternalArityResult
-        . InternalArity.resultInternalResult
-        . Internal.resultAbstract
-        . Abstract.resultScoper
-        . Scoped.comments
+          . InternalArity.resultInternalResult
+          . Internal.resultAbstract
+          . Abstract.resultScoper
+          . Scoped.comments
 
     entry :: EntryPoint
     entry = _judocArgsCtx ^. InternalTyped.internalTypedResultEntryPoint
@@ -171,10 +171,10 @@ genJudocHtml JudocArgs {..} =
     mainMod =
       _judocArgsCtx
         ^. InternalTyped.resultInternalArityResult
-        . InternalArity.resultInternalResult
-        . Internal.resultAbstract
-        . Abstract.resultScoper
-        . Scoped.mainModule
+          . InternalArity.resultInternalResult
+          . Internal.resultAbstract
+          . Abstract.resultScoper
+          . Scoped.mainModule
 
     htmlOpts :: HtmlOptions
     htmlOpts =

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -73,9 +73,9 @@ groupStatements = reverse . map reverse . uncurry cons . foldl' aux ([], [])
         SScoped ->
           i
             ^. importModule
-              . moduleRefModule
-              . modulePath
-              . S.nameId
+            . moduleRefModule
+            . modulePath
+            . S.nameId
             == getModuleRefNameId (o ^. openModuleName)
       (StatementImport _, _) -> False
       (StatementOpenModule {}, StatementOpenModule {}) -> True

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -73,9 +73,9 @@ groupStatements = reverse . map reverse . uncurry cons . foldl' aux ([], [])
         SScoped ->
           i
             ^. importModule
-            . moduleRefModule
-            . modulePath
-            . S.nameId
+              . moduleRefModule
+              . modulePath
+              . S.nameId
             == getModuleRefNameId (o ^. openModuleName)
       (StatementImport _, _) -> False
       (StatementOpenModule {}, StatementOpenModule {}) -> True

--- a/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Core.Extra.IdentDependencyInfo where
+module Juvix.Compiler.Core.Data.IdentDependencyInfo where
 
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet

--- a/src/Juvix/Compiler/Core/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId.hs
@@ -16,6 +16,7 @@ data TransformationId
   | MatchToCase
   | EtaExpandApps
   | DisambiguateNames
+  | CheckGeb
   deriving stock (Data, Bounded, Enum)
 
 data PipelineId

--- a/src/Juvix/Compiler/Core/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId.hs
@@ -48,7 +48,7 @@ toStrippedTransformations =
   toEvalTransformations ++ [LambdaLetRecLifting, TopEtaExpand, MoveApps, RemoveTypeArgs]
 
 toGebTransformations :: [TransformationId]
-toGebTransformations = toEvalTransformations ++ [UnrollRecursion, ComputeTypeInfo]
+toGebTransformations = toEvalTransformations ++ [LetRecLifting, CheckGeb, UnrollRecursion, ComputeTypeInfo]
 
 toEvalTransformations :: [TransformationId]
 toEvalTransformations = [EtaExpandApps, MatchToCase, NatToInt, ConvertBuiltinTypes]

--- a/src/Juvix/Compiler/Core/Data/TransformationId/Parser.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId/Parser.hs
@@ -80,6 +80,7 @@ transformationText = \case
   ComputeTypeInfo -> strComputeTypeInfo
   UnrollRecursion -> strUnrollRecursion
   DisambiguateNames -> strDisambiguateNames
+  CheckGeb -> strCheckGeb
 
 parsePipeline :: MonadParsec e Text m => m PipelineId
 parsePipeline = choice [symbol (pipelineText t) $> t | t <- allElements]
@@ -137,3 +138,6 @@ strUnrollRecursion = "unroll-recursion"
 
 strDisambiguateNames :: Text
 strDisambiguateNames = "disambiguate-names"
+
+strCheckGeb :: Text
+strCheckGeb = "check-geb"

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -262,7 +262,7 @@ catchEvalErrorIO loc ma =
 toCoreError :: Location -> EvalError -> CoreError
 toCoreError loc (EvalError {..}) =
   CoreError
-    { _coreErrorMsg = mappend "evaluation error: " _evalErrorMsg,
+    { _coreErrorMsg = "evaluation error: " <> _evalErrorMsg,
       _coreErrorNode = _evalErrorNode,
       _coreErrorLoc = fromMaybe loc (lookupLocation =<< _evalErrorNode)
     }

--- a/src/Juvix/Compiler/Core/Extra.hs
+++ b/src/Juvix/Compiler/Core/Extra.hs
@@ -1,8 +1,6 @@
 module Juvix.Compiler.Core.Extra
-  ( module Juvix.Compiler.Core.Extra.Utils,
-    module Juvix.Compiler.Core.Extra.IdentDependencyInfo,
+  ( module Juvix.Compiler.Core.Extra.Utils
   )
 where
 
-import Juvix.Compiler.Core.Extra.IdentDependencyInfo
 import Juvix.Compiler.Core.Extra.Utils

--- a/src/Juvix/Compiler/Core/Extra.hs
+++ b/src/Juvix/Compiler/Core/Extra.hs
@@ -1,5 +1,5 @@
 module Juvix.Compiler.Core.Extra
-  ( module Juvix.Compiler.Core.Extra.Utils
+  ( module Juvix.Compiler.Core.Extra.Utils,
   )
 where
 

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -31,6 +31,14 @@ import Juvix.Compiler.Core.Language
 isClosed :: Node -> Bool
 isClosed = not . has freeVars
 
+isTypeConstr :: InfoTable -> Type -> Bool
+isTypeConstr tab ty = case typeTarget ty of
+  NUniv {} ->
+    True
+  NIdt Ident {..} ->
+    isTypeConstr tab (fromJust $ HashMap.lookup _identSymbol (tab ^. identContext))
+  _ -> False
+
 freeVarsSorted :: Node -> Set Var
 freeVarsSorted n = Set.fromList (n ^.. freeVars)
 

--- a/src/Juvix/Compiler/Core/Pipeline.hs
+++ b/src/Juvix/Compiler/Core/Pipeline.hs
@@ -8,14 +8,14 @@ import Juvix.Compiler.Core.Data.InfoTable
 import Juvix.Compiler.Core.Transformation
 
 -- | Perform transformations on Core necessary for efficient evaluation
-toEval :: InfoTable -> InfoTable
+toEval :: Member (Error JuvixError) r => InfoTable -> Sem r InfoTable
 toEval = applyTransformations toEvalTransformations
 
 -- | Perform transformations on Core necessary before the translation to
 -- Core.Stripped
-toStripped :: InfoTable -> InfoTable
+toStripped :: Member (Error JuvixError) r => InfoTable -> Sem r InfoTable
 toStripped = applyTransformations toStrippedTransformations
 
 -- | Perform transformations on Core necessary before the translation to GEB
-toGeb :: InfoTable -> InfoTable
+toGeb :: Member (Error JuvixError) r => InfoTable -> Sem r InfoTable
 toGeb = applyTransformations toGebTransformations

--- a/src/Juvix/Compiler/Core/Transformation.hs
+++ b/src/Juvix/Compiler/Core/Transformation.hs
@@ -26,7 +26,7 @@ import Juvix.Compiler.Core.Transformation.TopEtaExpand
 import Juvix.Compiler.Core.Transformation.UnrollRecursion
 
 applyTransformations :: forall r. Member (Error JuvixError) r => [TransformationId] -> InfoTable -> Sem r InfoTable
-applyTransformations ts tbl = foldr (\tid acc -> acc >>= appTrans tid) (return tbl) ts
+applyTransformations ts tbl = foldl' (\acc tid -> acc >>= appTrans tid) (return tbl) ts
   where
     appTrans :: TransformationId -> InfoTable -> Sem r InfoTable
     appTrans = \case

--- a/src/Juvix/Compiler/Core/Transformation.hs
+++ b/src/Juvix/Compiler/Core/Transformation.hs
@@ -9,7 +9,9 @@ module Juvix.Compiler.Core.Transformation
 where
 
 import Juvix.Compiler.Core.Data.TransformationId
+import Juvix.Compiler.Core.Error
 import Juvix.Compiler.Core.Transformation.Base
+import Juvix.Compiler.Core.Transformation.CheckGeb
 import Juvix.Compiler.Core.Transformation.ComputeTypeInfo
 import Juvix.Compiler.Core.Transformation.ConvertBuiltinTypes
 import Juvix.Compiler.Core.Transformation.DisambiguateNames
@@ -23,21 +25,22 @@ import Juvix.Compiler.Core.Transformation.RemoveTypeArgs
 import Juvix.Compiler.Core.Transformation.TopEtaExpand
 import Juvix.Compiler.Core.Transformation.UnrollRecursion
 
-applyTransformations :: [TransformationId] -> InfoTable -> InfoTable
-applyTransformations ts tbl = foldl' (flip appTrans) tbl ts
+applyTransformations :: forall r. Member (Error JuvixError) r => [TransformationId] -> InfoTable -> Sem r InfoTable
+applyTransformations ts tbl = foldr (\tid acc -> acc >>= appTrans tid) (return tbl) ts
   where
-    appTrans :: TransformationId -> InfoTable -> InfoTable
+    appTrans :: TransformationId -> InfoTable -> Sem r InfoTable
     appTrans = \case
-      LambdaLetRecLifting -> lambdaLetRecLifting
-      LetRecLifting -> letRecLifting
-      Identity -> identity
-      TopEtaExpand -> topEtaExpand
-      RemoveTypeArgs -> removeTypeArgs
-      MoveApps -> moveApps
-      NatToInt -> natToInt
-      ConvertBuiltinTypes -> convertBuiltinTypes
-      ComputeTypeInfo -> computeTypeInfo
-      UnrollRecursion -> unrollRecursion
-      MatchToCase -> matchToCase
-      EtaExpandApps -> etaExpansionApps
-      DisambiguateNames -> disambiguateNames
+      LambdaLetRecLifting -> return . lambdaLetRecLifting
+      LetRecLifting -> return . letRecLifting
+      Identity -> return . identity
+      TopEtaExpand -> return . topEtaExpand
+      RemoveTypeArgs -> return . removeTypeArgs
+      MoveApps -> return . moveApps
+      NatToInt -> return . natToInt
+      ConvertBuiltinTypes -> return . convertBuiltinTypes
+      ComputeTypeInfo -> return . computeTypeInfo
+      UnrollRecursion -> return . unrollRecursion
+      MatchToCase -> return . matchToCase
+      EtaExpandApps -> return . etaExpansionApps
+      DisambiguateNames -> return . disambiguateNames
+      CheckGeb -> mapError (JuvixError @CoreError) . checkGeb

--- a/src/Juvix/Compiler/Core/Transformation/Base.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Base.hs
@@ -10,6 +10,30 @@ import Juvix.Compiler.Core.Data.InfoTable
 import Juvix.Compiler.Core.Data.InfoTableBuilder
 import Juvix.Compiler.Core.Language
 
+mapIdentsM :: Monad m => (IdentifierInfo -> m IdentifierInfo) -> InfoTable -> m InfoTable
+mapIdentsM = overM infoIdentifiers . mapM
+
+mapInductivesM :: Monad m => (InductiveInfo -> m InductiveInfo) -> InfoTable -> m InfoTable
+mapInductivesM = overM infoInductives . mapM
+
+mapConstructorsM :: Monad m => (ConstructorInfo -> m ConstructorInfo) -> InfoTable -> m InfoTable
+mapConstructorsM = overM infoConstructors . mapM
+
+mapAxiomsM :: Monad m => (AxiomInfo -> m AxiomInfo) -> InfoTable -> m InfoTable
+mapAxiomsM = overM infoAxioms . mapM
+
+mapNodesM :: Monad m => (Node -> m Node) -> InfoTable -> m InfoTable
+mapNodesM = overM identContext . mapM
+
+mapAllNodesM :: Monad m => (Node -> m Node) -> InfoTable -> m InfoTable
+mapAllNodesM f tab =
+  mapNodesM f tab >>=
+  mapAxiomsM (overM axiomType f) >>=
+  mapConstructorsM (overM constructorType f) >>=
+  mapInductivesM (overM inductiveKind f) >>=
+  mapInductivesM (overM inductiveConstructors (mapM (overM constructorType f))) >>=
+  mapIdentsM (overM identifierType f)
+
 mapIdents :: (IdentifierInfo -> IdentifierInfo) -> InfoTable -> InfoTable
 mapIdents = over infoIdentifiers . fmap
 

--- a/src/Juvix/Compiler/Core/Transformation/Base.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Base.hs
@@ -27,12 +27,12 @@ mapNodesM = overM identContext . mapM
 
 mapAllNodesM :: Monad m => (Node -> m Node) -> InfoTable -> m InfoTable
 mapAllNodesM f tab =
-  mapNodesM f tab >>=
-  mapAxiomsM (overM axiomType f) >>=
-  mapConstructorsM (overM constructorType f) >>=
-  mapInductivesM (overM inductiveKind f) >>=
-  mapInductivesM (overM inductiveConstructors (mapM (overM constructorType f))) >>=
-  mapIdentsM (overM identifierType f)
+  mapNodesM f tab
+    >>= mapAxiomsM (overM axiomType f)
+    >>= mapConstructorsM (overM constructorType f)
+    >>= mapInductivesM (overM inductiveKind f)
+    >>= mapInductivesM (overM inductiveConstructors (mapM (overM constructorType f)))
+    >>= mapIdentsM (overM identifierType f)
 
 mapIdents :: (IdentifierInfo -> IdentifierInfo) -> InfoTable -> InfoTable
 mapIdents = over infoIdentifiers . fmap

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -1,0 +1,55 @@
+module Juvix.Compiler.Core.Transformation.CheckGeb where
+
+import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Core.Transformation.Base
+import Juvix.Compiler.Core.Error
+import Juvix.Compiler.Core.Data.IdentDependencyInfo
+import Juvix.Compiler.Core.Extra
+import Juvix.Compiler.Core.Info.LocationInfo (getInfoLocation)
+
+checkGeb :: forall r . Member (Error CoreError) r => InfoTable -> Sem r InfoTable
+checkGeb tab = checkNoRecursion >> mapAllNodesM checkTypes tab
+  where
+    checkTypes :: Node -> Sem r Node
+    checkTypes = dmapM go
+      where
+        go :: Node -> Sem r Node
+        go node = case node of
+          NIdt Ident {..} |
+            isDynamic (fromJust (HashMap.lookup _identSymbol (tab ^. infoIdentifiers)) ^. identifierType) ->
+              throw (dynamicTypeError node (getInfoLocation _identInfo))
+          NLam Lambda {..} | isDynamic (_lambdaBinder ^. binderType) ->
+              throw (dynamicTypeError node (_lambdaBinder ^. binderLocation))
+          NPi (Pi {..}) | isTypeConstr (_piBinder ^. binderType) ->
+            throw CoreError {
+              _coreErrorMsg = "polymorphism not supported for the GEB target",
+              _coreErrorNode = Just node,
+              _coreErrorLoc = fromMaybe defaultLoc (getInfoLocation _piInfo)
+            }
+          _ -> return node
+
+        dynamicTypeError :: Node -> Maybe Location -> CoreError
+        dynamicTypeError node loc =
+          CoreError {
+            _coreErrorMsg = "compilation for the GEB target requires full type information",
+            _coreErrorNode = Just node,
+            _coreErrorLoc = fromMaybe defaultLoc loc
+          }
+
+    checkNoRecursion :: Sem r ()
+    checkNoRecursion =
+      if
+        | isCyclic (createIdentDependencyInfo tab) ->
+          throw CoreError {
+            _coreErrorMsg = "recursion not supported for the GEB target",
+            _coreErrorNode = Nothing,
+            _coreErrorLoc = defaultLoc
+          }
+        | otherwise ->
+          return ()
+
+    mockFile :: Path Abs File
+    mockFile = $(mkAbsFile "/core-to-geb")
+
+    defaultLoc :: Interval
+    defaultLoc = singletonInterval (mkInitialLoc mockFile)

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -22,7 +22,7 @@ checkGeb tab = checkNoRecursion >> mapAllNodesM checkTypes tab
             | isDynamic (_lambdaBinder ^. binderType) ->
                 throw (dynamicTypeError node (_lambdaBinder ^. binderLocation))
           NPi (Pi {..})
-            | isTypeConstr (_piBinder ^. binderType) ->
+            | isTypeConstr tab (_piBinder ^. binderType) ->
                 throw
                   CoreError
                     { _coreErrorMsg = "polymorphism not supported for the GEB target",

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -8,7 +8,7 @@ import Juvix.Compiler.Core.Info.LocationInfo (getInfoLocation)
 import Juvix.Compiler.Core.Transformation.Base
 
 checkGeb :: forall r. Member (Error CoreError) r => InfoTable -> Sem r InfoTable
-checkGeb tab = checkNoRecursion >> mapAllNodesM checkTypes tab
+checkGeb tab = checkNoRecursion >> mapAllNodesM checkBuiltins tab >> mapAllNodesM checkTypes tab
   where
     checkTypes :: Node -> Sem r Node
     checkTypes = dmapM go
@@ -35,6 +35,32 @@ checkGeb tab = checkNoRecursion >> mapAllNodesM checkTypes tab
         dynamicTypeError node loc =
           CoreError
             { _coreErrorMsg = "compilation for the GEB target requires full type information",
+              _coreErrorNode = Just node,
+              _coreErrorLoc = fromMaybe defaultLoc loc
+            }
+
+    checkBuiltins :: Node -> Sem r Node
+    checkBuiltins = dmapM go
+      where
+        go :: Node -> Sem r Node
+        go node = case node of
+          NPrim TypePrim {..}
+            | _typePrimPrimitive == PrimString ->
+                throw $ unsupportedError "strings" node (getInfoLocation _typePrimInfo)
+          NBlt BuiltinApp {..} ->
+            case _builtinAppOp of
+              OpShow -> throw $ unsupportedError "strings" node (getInfoLocation _builtinAppInfo)
+              OpStrConcat -> throw $ unsupportedError "strings" node (getInfoLocation _builtinAppInfo)
+              OpStrToInt -> throw $ unsupportedError "strings" node (getInfoLocation _builtinAppInfo)
+              OpTrace -> throw $ unsupportedError "tracing" node (getInfoLocation _builtinAppInfo)
+              OpFail -> throw $ unsupportedError "failing" node (getInfoLocation _builtinAppInfo)
+              _ -> return node
+          _ -> return node
+
+        unsupportedError :: Text -> Node -> Maybe Location -> CoreError
+        unsupportedError what node loc =
+          CoreError
+            { _coreErrorMsg = what <> " not supported for the GEB target",
               _coreErrorNode = Just node,
               _coreErrorLoc = fromMaybe defaultLoc loc
             }

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -25,7 +25,7 @@ checkGeb tab =
           NLam Lambda {..}
             | isDynamic (_lambdaBinder ^. binderType) ->
                 throw (dynamicTypeError node (_lambdaBinder ^. binderLocation))
-          NPi (Pi {..})
+          NPi Pi {..}
             | isTypeConstr tab (_piBinder ^. binderType) ->
                 throw
                   CoreError
@@ -68,17 +68,16 @@ checkGeb tab =
           _ -> return node
 
     checkNoRecursion :: Sem r ()
-    checkNoRecursion =
-      if
-          | isCyclic (createIdentDependencyInfo tab) ->
-              throw
-                CoreError
-                  { _coreErrorMsg = "recursion not supported for the GEB target",
-                    _coreErrorNode = Nothing,
-                    _coreErrorLoc = defaultLoc
-                  }
-          | otherwise ->
-              return ()
+    checkNoRecursion
+      | isCyclic (createIdentDependencyInfo tab) =
+          throw
+            CoreError
+              { _coreErrorMsg = "recursion not supported for the GEB target",
+                _coreErrorNode = Nothing,
+                _coreErrorLoc = defaultLoc
+              }
+      | otherwise =
+          return ()
 
     dynamicTypeError :: Node -> Maybe Location -> CoreError
     dynamicTypeError node loc =

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -1,13 +1,13 @@
 module Juvix.Compiler.Core.Transformation.CheckGeb where
 
 import Data.HashMap.Strict qualified as HashMap
-import Juvix.Compiler.Core.Transformation.Base
-import Juvix.Compiler.Core.Error
 import Juvix.Compiler.Core.Data.IdentDependencyInfo
+import Juvix.Compiler.Core.Error
 import Juvix.Compiler.Core.Extra
 import Juvix.Compiler.Core.Info.LocationInfo (getInfoLocation)
+import Juvix.Compiler.Core.Transformation.Base
 
-checkGeb :: forall r . Member (Error CoreError) r => InfoTable -> Sem r InfoTable
+checkGeb :: forall r. Member (Error CoreError) r => InfoTable -> Sem r InfoTable
 checkGeb tab = checkNoRecursion >> mapAllNodesM checkTypes tab
   where
     checkTypes :: Node -> Sem r Node
@@ -15,38 +15,42 @@ checkGeb tab = checkNoRecursion >> mapAllNodesM checkTypes tab
       where
         go :: Node -> Sem r Node
         go node = case node of
-          NIdt Ident {..} |
-            isDynamic (fromJust (HashMap.lookup _identSymbol (tab ^. infoIdentifiers)) ^. identifierType) ->
-              throw (dynamicTypeError node (getInfoLocation _identInfo))
-          NLam Lambda {..} | isDynamic (_lambdaBinder ^. binderType) ->
-              throw (dynamicTypeError node (_lambdaBinder ^. binderLocation))
-          NPi (Pi {..}) | isTypeConstr (_piBinder ^. binderType) ->
-            throw CoreError {
-              _coreErrorMsg = "polymorphism not supported for the GEB target",
-              _coreErrorNode = Just node,
-              _coreErrorLoc = fromMaybe defaultLoc (getInfoLocation _piInfo)
-            }
+          NIdt Ident {..}
+            | isDynamic (fromJust (HashMap.lookup _identSymbol (tab ^. infoIdentifiers)) ^. identifierType) ->
+                throw (dynamicTypeError node (getInfoLocation _identInfo))
+          NLam Lambda {..}
+            | isDynamic (_lambdaBinder ^. binderType) ->
+                throw (dynamicTypeError node (_lambdaBinder ^. binderLocation))
+          NPi (Pi {..})
+            | isTypeConstr (_piBinder ^. binderType) ->
+                throw
+                  CoreError
+                    { _coreErrorMsg = "polymorphism not supported for the GEB target",
+                      _coreErrorNode = Just node,
+                      _coreErrorLoc = fromMaybe defaultLoc (getInfoLocation _piInfo)
+                    }
           _ -> return node
 
         dynamicTypeError :: Node -> Maybe Location -> CoreError
         dynamicTypeError node loc =
-          CoreError {
-            _coreErrorMsg = "compilation for the GEB target requires full type information",
-            _coreErrorNode = Just node,
-            _coreErrorLoc = fromMaybe defaultLoc loc
-          }
+          CoreError
+            { _coreErrorMsg = "compilation for the GEB target requires full type information",
+              _coreErrorNode = Just node,
+              _coreErrorLoc = fromMaybe defaultLoc loc
+            }
 
     checkNoRecursion :: Sem r ()
     checkNoRecursion =
       if
-        | isCyclic (createIdentDependencyInfo tab) ->
-          throw CoreError {
-            _coreErrorMsg = "recursion not supported for the GEB target",
-            _coreErrorNode = Nothing,
-            _coreErrorLoc = defaultLoc
-          }
-        | otherwise ->
-          return ()
+          | isCyclic (createIdentDependencyInfo tab) ->
+              throw
+                CoreError
+                  { _coreErrorMsg = "recursion not supported for the GEB target",
+                    _coreErrorNode = Nothing,
+                    _coreErrorLoc = defaultLoc
+                  }
+          | otherwise ->
+              return ()
 
     mockFile :: Path Abs File
     mockFile = $(mkAbsFile "/core-to-geb")

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -27,7 +27,7 @@ checkGeb tab = checkNoRecursion >> mapAllNodesM checkTypes tab
                   CoreError
                     { _coreErrorMsg = "polymorphism not supported for the GEB target",
                       _coreErrorNode = Just node,
-                      _coreErrorLoc = fromMaybe defaultLoc (getInfoLocation _piInfo)
+                      _coreErrorLoc = fromMaybe defaultLoc (_piBinder ^. binderLocation)
                     }
           _ -> return node
 

--- a/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
+++ b/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
@@ -90,11 +90,11 @@ convertNode tab = rmap go
           maybeBranch = fromMaybe (mkBuiltinApp' OpFail [mkConstant' (ConstString "no matching branch")])
       NTyp TypeConstr {..} ->
         case ii ^. inductiveBuiltin of
-          Just (BuiltinTypeInductive BuiltinNat) -> End' mkTypeInteger'
-          _ -> Recur' (levels, node)
+          Just (BuiltinTypeInductive BuiltinNat) -> mkTypeInteger'
+          _ -> recur [] node
         where
           ii = fromJust $ tab ^. infoInductives . at _typeConstrSymbol
-      _ -> Recur' (levels, node)
+      _ -> recur [] node
 
     convertIdentApp :: Node -> ((Info -> Node -> Node -> Node) -> Node) -> Symbol -> Node
     convertIdentApp node f sym =

--- a/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
+++ b/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
@@ -88,7 +88,13 @@ convertNode tab = rmap go
                   _ -> impossible
           maybeBranch :: Maybe Node -> Node
           maybeBranch = fromMaybe (mkBuiltinApp' OpFail [mkConstant' (ConstString "no matching branch")])
-      _ -> recur [] node
+      NTyp TypeConstr {..} ->
+        case ii ^. inductiveBuiltin of
+          Just (BuiltinTypeInductive BuiltinNat) -> End' mkTypeInteger'
+          _ -> Recur' (levels, node)
+        where
+          ii = fromJust $ tab ^. infoInductives . at _typeConstrSymbol
+      _ -> Recur' (levels, node)
 
     convertIdentApp :: Node -> ((Info -> Node -> Node -> Node) -> Node) -> Symbol -> Node
     convertIdentApp node f sym =

--- a/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
+++ b/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
@@ -10,14 +10,6 @@ import Juvix.Compiler.Core.Extra
 import Juvix.Compiler.Core.Pretty
 import Juvix.Compiler.Core.Transformation.Base
 
-isTypeConstr :: InfoTable -> Type -> Bool
-isTypeConstr tab ty = case typeTarget ty of
-  NUniv {} ->
-    True
-  NIdt Ident {..} ->
-    isTypeConstr tab (fromJust $ HashMap.lookup _identSymbol (tab ^. identContext))
-  _ -> False
-
 convertNode :: InfoTable -> Node -> Node
 convertNode tab = convert mempty
   where

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -68,7 +68,6 @@ fromAbstract abstractResults = do
       abstractResults
         ^. Abstract.abstractResultEntryPoint
           . E.entryPointNoTermination
-    depInfo :: NameDependencyInfo
     depInfo = buildDependencyInfo (abstractResults ^. Abstract.resultModules) (abstractResults ^. Abstract.resultExports)
 
 fromAbstractExpression :: Members '[NameIdGen] r => Abstract.Expression -> Sem r Expression

--- a/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
+++ b/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
@@ -34,13 +34,13 @@ expressionContext _contextCoreResult = ExpressionContext {..}
     _contextInternalResult =
       _contextInternalTypedResult
         ^. InternalTyped.resultInternalArityResult
-        . InternalArity.resultInternalResult
+          . InternalArity.resultInternalResult
 
     _contextScoperResult :: Scoper.ScoperResult
     _contextScoperResult =
       _contextInternalResult
         ^. Internal.resultAbstract
-        . Abstract.resultScoper
+          . Abstract.resultScoper
 
     _contextScoperTable :: Scoper.InfoTable
     _contextScoperTable =

--- a/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
+++ b/src/Juvix/Compiler/Pipeline/ExpressionContext.hs
@@ -34,13 +34,13 @@ expressionContext _contextCoreResult = ExpressionContext {..}
     _contextInternalResult =
       _contextInternalTypedResult
         ^. InternalTyped.resultInternalArityResult
-          . InternalArity.resultInternalResult
+        . InternalArity.resultInternalResult
 
     _contextScoperResult :: Scoper.ScoperResult
     _contextScoperResult =
       _contextInternalResult
         ^. Internal.resultAbstract
-          . Abstract.resultScoper
+        . Abstract.resultScoper
 
     _contextScoperTable :: Scoper.InfoTable
     _contextScoperTable =

--- a/src/Juvix/Compiler/Reg/Extra.hs
+++ b/src/Juvix/Compiler/Reg/Extra.hs
@@ -37,13 +37,13 @@ computeMaxStackHeight lims = maximum . map go
             length _instrCallClosuresArgs
               + 1
               + lims
-                ^. limitsDispatchStackSize
+              ^. limitsDispatchStackSize
       CallClosures InstrCallClosures {..} ->
         length _instrCallClosuresLiveVars
           + length _instrCallClosuresArgs
           + 1
           + lims
-            ^. limitsDispatchStackSize
+          ^. limitsDispatchStackSize
       Return {} -> 0
       Branch InstrBranch {..} ->
         max

--- a/src/Juvix/Compiler/Reg/Extra.hs
+++ b/src/Juvix/Compiler/Reg/Extra.hs
@@ -37,13 +37,13 @@ computeMaxStackHeight lims = maximum . map go
             length _instrCallClosuresArgs
               + 1
               + lims
-              ^. limitsDispatchStackSize
+                ^. limitsDispatchStackSize
       CallClosures InstrCallClosures {..} ->
         length _instrCallClosuresLiveVars
           + length _instrCallClosuresArgs
           + 1
           + lims
-          ^. limitsDispatchStackSize
+            ^. limitsDispatchStackSize
       Return {} -> 0
       Branch InstrBranch {..} ->
         max

--- a/src/Juvix/Data/DependencyInfo.hs
+++ b/src/Juvix/Data/DependencyInfo.hs
@@ -3,7 +3,6 @@ module Juvix.Data.DependencyInfo where
 import Data.Graph qualified as Graph
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
-import GHC.Arr (Array, indices, (!))
 import Juvix.Prelude.Base
 
 -- DependencyInfo is polymorphic to anticipate future use with other identifier
@@ -57,22 +56,5 @@ isReachable depInfo n = HashSet.member n (depInfo ^. depInfoReachable)
 buildSCCs :: Ord n => DependencyInfo n -> [SCC n]
 buildSCCs = Graph.stronglyConnComp . (^. depInfoEdgeList)
 
-isCyclic :: DependencyInfo n -> Bool
-isCyclic DependencyInfo {..} =
-  run $ evalState (mempty :: HashSet Int) $ or <$> mapM (go _depInfoGraph mempty) (indices _depInfoGraph)
-  where
-    go :: Member (State (HashSet Int)) r => Array Int [Int] -> HashSet Int -> Int -> Sem r Bool
-    go graph vars v
-      | HashSet.member v vars = return True
-      | otherwise = do
-          s <- get
-          if
-              | HashSet.member v s ->
-                  return False
-              | otherwise -> do
-                  put (HashSet.insert v s)
-                  let vars' = HashSet.insert v vars
-                  foldr
-                    ((\v' acc -> go graph vars' v' >>= \b -> acc <&> (||) b))
-                    (return False)
-                    (graph ! v)
+isCyclic :: Ord n => DependencyInfo n -> Bool
+isCyclic = any (\case CyclicSCC _ -> True; _ -> False) . buildSCCs

--- a/src/Juvix/Data/DependencyInfo.hs
+++ b/src/Juvix/Data/DependencyInfo.hs
@@ -3,6 +3,7 @@ module Juvix.Data.DependencyInfo where
 import Data.Graph qualified as Graph
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
+import GHC.Arr (Array, (!))
 import Juvix.Prelude.Base
 
 -- DependencyInfo is polymorphic to anticipate future use with other identifier
@@ -55,3 +56,23 @@ isReachable depInfo n = HashSet.member n (depInfo ^. depInfoReachable)
 
 buildSCCs :: Ord n => DependencyInfo n -> [SCC n]
 buildSCCs = Graph.stronglyConnComp . (^. depInfoEdgeList)
+
+isCyclic :: DependencyInfo n -> Bool
+isCyclic DependencyInfo {..} =
+  run $ evalState (mempty :: HashSet Int) $ go _depInfoGraph mempty 0
+  where
+    go :: Member (State (HashSet Int)) r => Array Int [Int] -> HashSet Int -> Int -> Sem r Bool
+    go graph vars v
+      | HashSet.member v vars = return True
+      | otherwise = do
+          s <- get
+          if
+              | HashSet.member v s ->
+                  return False
+              | otherwise -> do
+                  put (HashSet.insert v s)
+                  let vars' = HashSet.insert v vars
+                  foldr
+                    ((\v' acc -> go graph vars' v' >>= \b -> acc <&> (||) b))
+                    (return False)
+                    (graph ! v)

--- a/src/Juvix/Data/DependencyInfo.hs
+++ b/src/Juvix/Data/DependencyInfo.hs
@@ -3,7 +3,7 @@ module Juvix.Data.DependencyInfo where
 import Data.Graph qualified as Graph
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
-import GHC.Arr (Array, (!))
+import GHC.Arr (Array, indices, (!))
 import Juvix.Prelude.Base
 
 -- DependencyInfo is polymorphic to anticipate future use with other identifier
@@ -59,7 +59,7 @@ buildSCCs = Graph.stronglyConnComp . (^. depInfoEdgeList)
 
 isCyclic :: DependencyInfo n -> Bool
 isCyclic DependencyInfo {..} =
-  run $ evalState (mempty :: HashSet Int) $ go _depInfoGraph mempty 0
+  run $ evalState (mempty :: HashSet Int) $ or <$> mapM (go _depInfoGraph mempty) (indices _depInfoGraph)
   where
     go :: Member (State (HashSet Int)) r => Array Int [Int] -> HashSet Int -> Int -> Sem r Bool
     go graph vars v

--- a/src/Juvix/Prelude/Lens.hs
+++ b/src/Juvix/Prelude/Lens.hs
@@ -5,3 +5,8 @@ import Juvix.Prelude.Base
 -- | points to the first element of a non-empty list.
 _head1 :: Lens' (NonEmpty a) a
 _head1 = singular each
+
+overM :: Applicative m => Lens' a b -> (b -> m b) -> a -> m a
+overM l f a = do
+  a' <- f (a ^. l)
+  return $ set l a' a

--- a/test/Compilation/Base.hs
+++ b/test/Compilation/Base.hs
@@ -19,6 +19,9 @@ compileAssertion onlyEval mainFile expectedFile step = do
   cwd <- getCurrentDir
   let entryPoint = defaultEntryPoint cwd mainFile
   tab <- (^. Core.coreResultTable) . snd <$> runIO' iniState entryPoint upToCore
-  coreEvalAssertion' (Core.toEval tab) mainFile expectedFile step
-  unless onlyEval $
-    coreCompileAssertion' tab mainFile expectedFile step
+  case run $ runError $ Core.toEval tab' of
+    Left err -> assertFailure (show (pretty (fromJuvixError @GenericError err)))
+    Right tab' -> do
+      coreEvalAssertion' tab' mainFile expectedFile step
+      unless onlyEval $
+        coreCompileAssertion' tab' mainFile expectedFile step

--- a/test/Compilation/Base.hs
+++ b/test/Compilation/Base.hs
@@ -7,6 +7,7 @@ import Juvix.Compiler.Builtins (iniState)
 import Juvix.Compiler.Core.Pipeline qualified as Core
 import Juvix.Compiler.Core.Translation.FromInternal.Data qualified as Core
 import Juvix.Compiler.Pipeline
+import Juvix.Data.PPOutput
 
 compileAssertion ::
   Bool ->
@@ -19,7 +20,7 @@ compileAssertion onlyEval mainFile expectedFile step = do
   cwd <- getCurrentDir
   let entryPoint = defaultEntryPoint cwd mainFile
   tab <- (^. Core.coreResultTable) . snd <$> runIO' iniState entryPoint upToCore
-  case run $ runError $ Core.toEval tab' of
+  case run $ runError $ Core.toEval tab of
     Left err -> assertFailure (show (pretty (fromJuvixError @GenericError err)))
     Right tab' -> do
       coreEvalAssertion' tab' mainFile expectedFile step

--- a/test/Core/Asm/Base.hs
+++ b/test/Core/Asm/Base.hs
@@ -49,5 +49,8 @@ coreAsmAssertion mainFile expectedFile step = do
       assertEqDiffText ("Check: EVAL output = " <> toFilePath expectedFile) "" expected
     Right (tabIni, Just node) -> do
       step "Translate"
-      let tab = Asm.fromCore $ Stripped.fromCore $ toStripped $ setupMainFunction tabIni node
-      Asm.asmRunAssertion' tab expectedFile step
+      case run $ runError $ toStripped $ setupMainFunction tabIni node of
+        Left err -> assertFailure (show (pretty (fromJuvixError @GenericError err)))
+        Right tab' -> do
+          let tab = Asm.fromCore $ Stripped.fromCore $ tab'
+          Asm.asmRunAssertion' tab expectedFile step

--- a/test/Core/Compile/Base.hs
+++ b/test/Core/Compile/Base.hs
@@ -43,9 +43,12 @@ coreCompileAssertion' ::
   Assertion
 coreCompileAssertion' tab mainFile expectedFile step = do
   step "Translate to JuvixAsm"
-  let tab' = Asm.fromCore $ Stripped.fromCore $ toStripped tab
-  length (fromText (Asm.ppPrint tab' tab') :: String) `seq`
-    Asm.asmCompileAssertion' tab' mainFile expectedFile step
+  case run $ runError $ toStripped tab of
+    Left err -> assertFailure (show (pretty (fromJuvixError @GenericError err)))
+    Right tab0 -> do
+      let tab' = Asm.fromCore $ Stripped.fromCore $ tab0
+      length (fromText (Asm.ppPrint tab' tab') :: String) `seq`
+        Asm.asmCompileAssertion' tab' mainFile expectedFile step
 
 coreCompileAssertion ::
   Path Abs File ->

--- a/test/Core/Eval/Base.hs
+++ b/test/Core/Eval/Base.hs
@@ -63,10 +63,12 @@ coreEvalAssertion mainFile expectedFile trans testTrans step = do
       step "Compare expected and actual program output"
       expected <- TIO.readFile (toFilePath expectedFile)
       assertEqDiffText ("Check: EVAL output = " <> toFilePath expectedFile) "" expected
-    Right (tabIni, Just node) -> do
-      let tab = applyTransformations trans (setupMainFunction tabIni node)
-      testTrans tab
-      coreEvalAssertion' tab mainFile expectedFile step
+    Right (tabIni, Just node) ->
+      case run $ runError $ applyTransformations trans (setupMainFunction tabIni node) of
+        Left err -> assertFailure (show (pretty (fromJuvixError @GenericError err)))
+        Right tab -> do
+          testTrans tab
+          coreEvalAssertion' tab mainFile expectedFile step
 
 coreEvalErrorAssertion :: Path Abs File -> (String -> IO ()) -> Assertion
 coreEvalErrorAssertion mainFile step = do


### PR DESCRIPTION
* Depends on #1832 
* Closes #1844
* Adds errors to the Core pipeline
* Checks for no recursion in the GEB pipeline
* Checks for no polymorphism in the GEB pipeline
* Checks for no dynamic type in the GEB pipeline
* Checks for no IO in the GEB pipeline
* Checks for no unsupported builtins in the GEB pipeline
