### PR TITLE
Fix type synonym in let 

### DIFF
--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -336,10 +336,21 @@ ppCodeAtom c = do
   p' <- ppCode c
   return $ if isAtomic c then p' else parens p'
 
+instance PrettyCode a => PrettyCode (Maybe a) where
+  ppCode = \case
+    Nothing -> return "Nothing"
+    Just p -> ("Nothing" <+>) <$> ppCode p
+
+instance (PrettyCode a, PrettyCode b) => PrettyCode (a, b) where
+  ppCode (x, y) = do
+    x' <- ppCode x
+    y' <- ppCode y
+    return $ encloseSep "(" ")" ", " [x', y']
+
 instance (PrettyCode a) => PrettyCode [a] where
   ppCode x = do
     cs <- mapM ppCode (toList x)
-    return $ encloseSep "(" ")" ", " cs
+    return $ encloseSep "[" "]" ", " cs
 
 instance (PrettyCode a) => PrettyCode (NonEmpty a) where
   ppCode x = ppCode (toList x)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -55,7 +55,7 @@ typeCheckExpressionType ::
 typeCheckExpressionType InternalTypedResult {..} exp =
   mapError (JuvixError @TypeCheckerError)
     $ do
-      runReader _resultFunctions
+      evalState _resultFunctions
       . evalState _resultIdenTypes
       . runReader table
       . ignoreOutput @Example

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/FunctionsTable.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/FunctionsTable.hs
@@ -10,5 +10,5 @@ newtype FunctionsTable = FunctionsTable
 
 makeLenses ''FunctionsTable
 
-askFunctionDef :: (Member (Reader FunctionsTable) r) => FunctionName -> Sem r (Maybe Expression)
-askFunctionDef f = asks (^. functionsTable . at f)
+askFunctionDef :: (Member (State FunctionsTable) r) => FunctionName -> Sem r (Maybe Expression)
+askFunctionDef f = gets (^. functionsTable . at f)

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -384,9 +384,6 @@ nubHashable = HashSet.toList . HashSet.fromList
 allElements :: (Bounded a, Enum a) => [a]
 allElements = [minBound .. maxBound]
 
-readerState :: forall a r x. (Member (State a) r) => Sem (Reader a ': r) x -> Sem r x
-readerState m = get >>= (`runReader` m)
-
 infixr 3 .&&.
 
 (.&&.) :: (a -> Bool) -> (a -> Bool) -> a -> Bool

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -205,7 +205,11 @@ tests =
     posTest
       "Let shadowing"
       $(mkRelDir ".")
-      $(mkRelFile "LetShadow.juvix")
+      $(mkRelFile "LetShadow.juvix"),
+    posTest
+      "Type synonym inside let"
+      $(mkRelDir "issue1879")
+      $(mkRelFile "LetSynonym.juvix")
   ]
     <> [ compilationTest t | t <- Compilation.tests, t ^. Compilation.name /= "Self-application"
        ]

--- a/tests/positive/issue1879/LetSynonym.juvix
+++ b/tests/positive/issue1879/LetSynonym.juvix
@@ -1,0 +1,13 @@
+module LetSynonym;
+  type T :=
+    | t : T;
+
+  main : T;
+  main :=
+    let
+      A : Type;
+      A := T;
+      x : A;
+      x := t;
+    in x;
+end;


### PR DESCRIPTION
- Closes #1879 

The issue was possibly caused by the use of `readerState`:
```
readerState :: forall a r x. (Member (State a) r) => Sem (Reader a ': r) x -> Sem r x
readerState m = get >>= (`runReader` m)
```

I originally thought it would be a good idea to "freeze" some `State` effect into a `Reader` effect in the following situation:
- Some function `s` needs to update the state.
- Some function `f` only reads the state.
- Then you would have `g .. = ... readerState @MyState f`
- This way, it would be reflected in the type that `g` cannot update the state. However, for some reason I have not been able to clearly identify, this was not working as expected. 