### PR TITLE
Make keyword `end` optional for top modules

### DIFF
--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -102,6 +102,11 @@ type family ModulePathType s t = res | res -> t s where
   ModulePathType 'Parsed 'ModuleLocal = Symbol
   ModulePathType 'Scoped 'ModuleLocal = S.Symbol
 
+type ModuleEndType :: ModuleIsTop -> GHC.Type
+type family ModuleEndType t = res | res -> t where
+  ModuleEndType 'ModuleTop = ()
+  ModuleEndType 'ModuleLocal = KeywordRef
+
 --------------------------------------------------------------------------------
 -- Top level statement
 --------------------------------------------------------------------------------
@@ -396,7 +401,8 @@ data Module (s :: Stage) (t :: ModuleIsTop) = Module
   { _moduleKw :: KeywordRef,
     _modulePath :: ModulePathType s t,
     _moduleDoc :: Maybe (Judoc s),
-    _moduleBody :: [Statement s]
+    _moduleBody :: [Statement s],
+    _moduleKwEnd :: ModuleEndType t
   }
 
 deriving stock instance
@@ -407,6 +413,7 @@ deriving stock instance
     Show (IdentifierType s),
     Show (ModuleRefType s),
     Show (SymbolType s),
+    Show (ModuleEndType t),
     Show (ExpressionType s)
   ) =>
   Show (Module s t)
@@ -419,6 +426,7 @@ deriving stock instance
     Eq (IdentifierType s),
     Eq (ModuleRefType s),
     Eq (SymbolType s),
+    Eq (ModuleEndType t),
     Eq (ExpressionType s)
   ) =>
   Eq (Module s t)
@@ -431,6 +439,7 @@ deriving stock instance
     Ord (IdentifierType s),
     Ord (ModuleRefType s),
     Ord (SymbolType s),
+    Ord (ModuleEndType t),
     Ord (ExpressionType s)
   ) =>
   Ord (Module s t)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -69,6 +69,7 @@ instance SingI t => PrettyPrint (Module 'Scoped t) where
         <> line
         <> topSpace
         <> moduleBody'
+        <> line
         <>? ending
     where
       topSpace :: Sem r ()
@@ -84,7 +85,7 @@ instance SingI t => PrettyPrint (Module 'Scoped t) where
       ending :: Maybe (Sem r ())
       ending = case sing :: SModuleIsTop t of
         SModuleLocal -> Just (ppCode _moduleKwEnd)
-        SModuleTop -> Nothing
+        SModuleTop -> Just end
 
 instance PrettyPrint [Statement 'Scoped] where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => [Statement 'Scoped] -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -59,7 +59,7 @@ ppModulePathType x = case sing :: SStage s of
 instance SingI t => PrettyPrint (Module 'Scoped t) where
   ppCode :: forall r. (Members '[ExactPrint, Reader Options] r) => Module 'Scoped t -> Sem r ()
   ppCode Module {..} = do
-    let moduleBody' = indent (ppCode _moduleBody)
+    let moduleBody' = localIndent (ppCode _moduleBody)
         modulePath' = ppModulePathType _modulePath
         moduleDoc' :: Sem r () = maybe (return ()) ppCode _moduleDoc
     moduleDoc'
@@ -67,15 +67,24 @@ instance SingI t => PrettyPrint (Module 'Scoped t) where
       <+> modulePath'
         <> ppCode kwSemicolon
         <> line
+        <> topSpace
         <> moduleBody'
-        <> line
-        <> ppCode kwEnd
-        <> lastSemicolon
+        <>? ending
     where
-      lastSemicolon :: Sem r ()
-      lastSemicolon = case sing :: SModuleIsTop t of
-        SModuleLocal -> return ()
-        SModuleTop -> semicolon <> line <> end
+      topSpace :: Sem r ()
+      topSpace = case sing :: SModuleIsTop t of
+        SModuleLocal -> mempty
+        SModuleTop -> line
+
+      localIndent :: Sem r () -> Sem r ()
+      localIndent = case sing :: SModuleIsTop t of
+        SModuleLocal -> indent
+        SModuleTop -> id
+
+      ending :: Maybe (Sem r ())
+      ending = case sing :: SModuleIsTop t of
+        SModuleLocal -> Just (ppCode _moduleKwEnd)
+        SModuleTop -> Nothing
 
 instance PrettyPrint [Statement 'Scoped] where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => [Statement 'Scoped] -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -70,7 +70,7 @@ instance SingI t => PrettyPrint (Module 'Scoped t) where
         <> topSpace
         <> moduleBody'
         <> line
-        <>? ending
+        <> ending
     where
       topSpace :: Sem r ()
       topSpace = case sing :: SModuleIsTop t of
@@ -82,10 +82,10 @@ instance SingI t => PrettyPrint (Module 'Scoped t) where
         SModuleLocal -> indent
         SModuleTop -> id
 
-      ending :: Maybe (Sem r ())
+      ending :: Sem r ()
       ending = case sing :: SModuleIsTop t of
-        SModuleLocal -> Just (ppCode _moduleKwEnd)
-        SModuleTop -> Just end
+        SModuleLocal -> ppCode _moduleKwEnd
+        SModuleTop -> end
 
 instance PrettyPrint [Statement 'Scoped] where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => [Statement 'Scoped] -> Sem r ()

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -1,131 +1,131 @@
 module Format;
-  open import Stdlib.Prelude hiding {,};
-  open import Stdlib.Data.Nat.Ord;
 
-  terminating
-  go : Nat → Nat → Nat;
-  go n s :=
-    if
-      (s < n)
-      (go (sub n 1) s)
-      (go n (sub s n) + go (sub n 1) s);
+open import Stdlib.Prelude hiding {,};
+open import Stdlib.Data.Nat.Ord;
 
-  module M;
-    infixr 4 ,;
-    axiom , : String → String → String;
-  end;
+terminating
+go : Nat → Nat → Nat;
+go n s :=
+  if
+    (s < n)
+    (go (sub n 1) s)
+    (go n (sub s n) + go (sub n 1) s);
 
-  -- qualified commas
-  t4 : String;
-  t4 := "a" M., "b" M., "c" M., "d";
+module M;
+  infixr 4 ,;
+  axiom , : String → String → String;
+end;
 
-  open M;
+-- qualified commas
+t4 : String;
+t4 := "a" M., "b" M., "c" M., "d";
 
-  -- mix qualified and unqualified commas
-  t5 : String;
-  t5 := "a" M., "b" M., "c", "d";
+open M;
 
-  -- comma chain fits in a line
-  t2 : String;
-  t2 := "a", "b", "c", "d";
+-- mix qualified and unqualified commas
+t5 : String;
+t5 := "a" M., "b" M., "c", "d";
 
-  -- comma chain does not fit in a line
-  t3 : String;
-  t3 :=
-    "a"
-      , "b"
-      , "c"
-      , "d"
-      , "e"
-      , "f"
-      , "g"
-      , "h"
-      , "i"
-      , "j"
-      , "k"
-      , "1234";
+-- comma chain fits in a line
+t2 : String;
+t2 := "a", "b", "c", "d";
 
-  infixl 7 +l7;
-  axiom +l7 : String → String → String;
+-- comma chain does not fit in a line
+t3 : String;
+t3 :=
+  "a"
+    , "b"
+    , "c"
+    , "d"
+    , "e"
+    , "f"
+    , "g"
+    , "h"
+    , "i"
+    , "j"
+    , "k"
+    , "1234";
 
-  infixr 3 +r3;
-  axiom +r3 : String → String → String;
+infixl 7 +l7;
+axiom +l7 : String → String → String;
 
-  infixl 1 +l1;
-  axiom +l1 : String → String → String;
+infixr 3 +r3;
+axiom +r3 : String → String → String;
 
-  infixl 6 +l6;
-  axiom +l6 : String → String → String;
+infixl 1 +l1;
+axiom +l1 : String → String → String;
 
-  infixr 6 +r6;
-  axiom +r6 : String → String → String;
+infixl 6 +l6;
+axiom +l6 : String → String → String;
 
-  -- nesting of chains
-  t : String;
-  t :=
-    "Hellooooooooo"
-      +l1 "Hellooooooooo"
-      +l1 "Hellooooooooo"
-          +l6 "Hellooooooooo"
-          +l6 ("Hellooooooooo"
-            +r6 "Hellooooooooo"
-            +r6 "Hellooooooooo")
-          +l6 "Hellooooooooo"
-          +l6 "Hellooooooooo"
-            +l7 "Hellooooooooo"
-            +l7 "Hellooooooooo"
-            +l7 "Hellooooooooo"
-        , "hi"
-        , "hi";
+infixr 6 +r6;
+axiom +r6 : String → String → String;
 
-  -- function with single wildcard parameter
-  g : (_ : Type) -> Nat;
-  g _ := 1;
+-- nesting of chains
+t : String;
+t :=
+  "Hellooooooooo"
+    +l1 "Hellooooooooo"
+    +l1 "Hellooooooooo"
+        +l6 "Hellooooooooo"
+        +l6 ("Hellooooooooo"
+          +r6 "Hellooooooooo"
+          +r6 "Hellooooooooo")
+        +l6 "Hellooooooooo"
+        +l6 "Hellooooooooo"
+          +l7 "Hellooooooooo"
+          +l7 "Hellooooooooo"
+          +l7 "Hellooooooooo"
+      , "hi"
+      , "hi";
 
-  -- grouping of type arguments
-  exampleFunction1 :
-    {A : Type}
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> Nat;
-  exampleFunction1 _ _ _ _ _ _ _ := 1;
+-- function with single wildcard parameter
+g : (_ : Type) -> Nat;
+g _ := 1;
 
-  -- 200 in the body is idented with respect to the start of the chain
-  -- (at {A : Type})
-  exampleFunction2 :
-    {A : Type}
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> List A
-      -> Nat :=
-      200
-        + 100
-        + 100
-        + 100
-        + 100
-        + 100
-        + 100
-        + 100
-        + 100
-        + 100
-        + 100;
+-- grouping of type arguments
+exampleFunction1 :
+  {A : Type}
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> Nat;
+exampleFunction1 _ _ _ _ _ _ _ := 1;
 
-  module Patterns;
-    infixr 4 ,;
-    type Pair :=
-      | , : String → String → String;
+-- 200 in the body is idented with respect to the start of the chain
+-- (at {A : Type})
+exampleFunction2 :
+  {A : Type}
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> Nat :=
+    200
+      + 100
+      + 100
+      + 100
+      + 100
+      + 100
+      + 100
+      + 100
+      + 100
+      + 100
+      + 100;
 
-    -- Commas in patterns
-    f : _;
-    f (a, b, c, d) := a;
-  end;
+module Patterns;
+  infixr 4 ,;
+  type Pair :=
+    | , : String → String → String;
+
+  -- Commas in patterns
+  f : _;
+  f (a, b, c, d) := a;
 end;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -129,3 +129,4 @@ module Patterns;
   f : _;
   f (a, b, c, d) := a;
 end;
+-- Comment at the end of a module


### PR DESCRIPTION
Changes in this PR:
1. The keyword `end` is now optional for top level modules. 
2. When pretty printing, `end` is never printed for top level modules.
3. When pretty printing, top level modules do not have indentation.

These changes only affect `Concrete` syntax.