### PR TITLE
The `rmap` recursor

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -68,6 +68,9 @@ mkLet i bi v b = NLet (Let i (LetItem bi v) b)
 mkLet' :: Type -> Node -> Node -> Node
 mkLet' ty = mkLet Info.empty (mkBinder' ty)
 
+mkLets' :: [(Type, Node)] -> Node -> Node
+mkLets' tvs n = foldl' (\n' (ty, v) -> mkLet' ty v n') n (reverse tvs)
+
 mkLetRec :: Info -> NonEmpty LetItem -> Node -> Node
 mkLetRec i vs b = NRec (LetRec i vs b)
 

--- a/src/Juvix/Compiler/Core/Extra/Recursors.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors.hs
@@ -3,6 +3,8 @@ module Juvix.Compiler.Core.Extra.Recursors
     module Juvix.Compiler.Core.Extra.Recursors.Collector,
     module Juvix.Compiler.Core.Extra.Recursors.Map,
     module Juvix.Compiler.Core.Extra.Recursors.Map.Named,
+    module Juvix.Compiler.Core.Extra.Recursors.RMap,
+    module Juvix.Compiler.Core.Extra.Recursors.RMap.Named,
     module Juvix.Compiler.Core.Extra.Recursors.Fold.Named,
     module Juvix.Compiler.Core.Extra.Recursors.Recur,
   )
@@ -14,4 +16,6 @@ import Juvix.Compiler.Core.Extra.Recursors.Fold
 import Juvix.Compiler.Core.Extra.Recursors.Fold.Named
 import Juvix.Compiler.Core.Extra.Recursors.Map
 import Juvix.Compiler.Core.Extra.Recursors.Map.Named
+import Juvix.Compiler.Core.Extra.Recursors.RMap
+import Juvix.Compiler.Core.Extra.Recursors.RMap.Named
 import Juvix.Compiler.Core.Extra.Recursors.Recur

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Map/Named.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Map/Named.hs
@@ -145,8 +145,11 @@ dmapCNRM' f ini = nodeMapG' STopDown (pairCollector (identityCollector ini) (bin
 dmapCLM :: (Monad m) => (c -> BinderList Binder -> Node -> m (c, Node)) -> c -> Node -> m Node
 dmapCLM f = dmapCLM' (mempty, f)
 
+dmapCNM' :: (Monad m) => (Level, c -> Level -> Node -> m (c, Node)) -> c -> Node -> m Node
+dmapCNM' f ini = nodeMapG' STopDown (pairCollector (identityCollector ini) (binderNumCollector' (fst f))) (\(c, bi) -> fromPair bi . snd f c bi)
+
 dmapCNM :: (Monad m) => (c -> Level -> Node -> m (c, Node)) -> c -> Node -> m Node
-dmapCNM f ini = nodeMapG' STopDown (pairCollector (identityCollector ini) binderNumCollector) (\(c, bi) -> fromPair bi . f c bi)
+dmapCNM f = dmapCNM' (0, f)
 
 dmapCM :: (Monad m) => (c -> Node -> m (c, Node)) -> c -> Node -> m Node
 dmapCM f ini = nodeMapG' STopDown (identityCollector ini) (\c -> fmap Recur' . f c)
@@ -156,6 +159,9 @@ dmapCL' f ini = runIdentity . dmapCLM' (embedIden f) ini
 
 dmapCLR' :: (BinderList Binder, c -> BinderList Binder -> Node -> Recur' c) -> c -> Node -> Node
 dmapCLR' f ini = runIdentity . dmapCLRM' (embedIden f) ini
+
+dmapCN' :: (Level, c -> Level -> Node -> (c, Node)) -> c -> Node -> Node
+dmapCN' f ini = runIdentity . dmapCNM' (embedIden f) ini
 
 dmapCNR' :: (Level, c -> Level -> Node -> Recur' c) -> c -> Node -> Node
 dmapCNR' f ini = runIdentity . dmapCNRM' (embedIden f) ini

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Map/Named.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Map/Named.hs
@@ -7,32 +7,36 @@ import Juvix.Compiler.Core.Extra.Recursors.Parameters
 
 {-
 
-The mapping recursors come in two major variants: dmap and umap. They map each
-subterm of a given term. The invocation `dmap f t` goes through the node `t`
-top-down, applying the function `f` to `t` first, and then recursively
-descending into the children of `f t`. The invocation `umap f t` goes through
-the term `t` bottom-up, first recursively descending into the children of `t`
-and mapping them with `umap f`, then reassembling `t` with the mapped children
-into `t'`, and finally applying `f` to `t'`.
+The mapping recursors come in three major variants: dmap, umap and rmap. They
+map each subterm of a given term.
 
-The suffixes of `dmap` and `umap` indicate the exact form of the mapping
+1. `dmap f t` goes through the node `t` top-down, applying the function `f` to
+`t` first, and then recursively descending into the children of `f t`.
+
+2. `umap f t` goes through the term `t` bottom-up, first recursively descending
+into the children of `t` and mapping them with `umap f`, then reassembling `t`
+with the mapped children into `t'`, and finally applying `f` to `t'`.
+
+3. `rmap f t`: see Recursors.RMap.Named.
+
+The suffixes of `dmap`, `umap` and `rmap` indicate the exact form of the mapping
 function `f`, what arguments are provided to it and how its return value is
 interpreted.
 
-\* M: Monadic version. The return value of the mapping function `f` is wrapped in
+- M: Monadic version. The return value of the mapping function `f` is wrapped in
   a monad.
-\* L: The function `f` receives as an argument the list of binders upwards in the
+- L: The function `f` receives as an argument the list of binders upwards in the
   term. The n-th element of the binder list corresponds to the free variable of
   the current subterm with de Bruijn index n.
-\* N: The function `f` receives as an argument the number of binders upwards in
+- N: The function `f` receives as an argument the number of binders upwards in
   the term, i.e., the current de Bruijn level.
-\* ': When combined with L or N, makes it possible to supply the initial binder
+- ': When combined with L or N, makes it possible to supply the initial binder
   list or de Bruijn level. This is useful when mapping a subterm with free
   variables.
-\* R: The function `f` returns an element of the `Recur` (or `Recur'`) datatype,
+- R: The function `f` returns an element of the `Recur` (or `Recur'`) datatype,
   indicating whether `dmap` should descend into the children or stop the
   traversal.
-\* C: Enables collecting an arbitrary value while going downward in the term tree
+- C: Enables collecting an arbitrary value while going downward in the term tree
   with `dmap`. The initial value is provided to `dmap`. The function `f`
   receives as an argument the current collected value and returns the value for
   the children, in addition to the new node.

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap.hs
@@ -23,24 +23,30 @@ data BinderChange
     -- indices of `n` are with respect to the result
     BCRemove BinderRemove
 
+-- | Returns the binders in the original node skipped before a call to `recur`,
+-- as specified by the BinderChange list.
 bindersFromBinderChange :: [BinderChange] -> [Binder]
-bindersFromBinderChange =
-  reverse
-    . foldl'
-      ( \bs chg -> case chg of
-          BCAdd _ -> bs
-          BCKeep b -> b : bs
-          BCRemove (BinderRemove b _) -> b : bs
-      )
-      []
+bindersFromBinderChange = concatMap helper
+  where
+    helper = \case
+      BCAdd {} -> []
+      BCKeep b -> [b]
+      BCRemove (BinderRemove b _) -> [b]
 
+-- | Returns the number of skipped binders in the original node as specified by
+-- the BinderChange list.
 bindersNumFromBinderChange :: [BinderChange] -> Int
-bindersNumFromBinderChange =
+bindersNumFromBinderChange = length . bindersFromBinderChange
+
+-- | Returns the number of skipped binders in the result node as specified by
+-- the BinderChange list.
+resultBindersNumFromBinderChange :: [BinderChange] -> Int
+resultBindersNumFromBinderChange =
   foldl'
-    ( \n chg -> case chg of
-        BCAdd {} -> n
-        BCKeep {} -> n + 1
-        BCRemove {} -> n + 1
+    ( \acc -> \case
+        BCAdd k -> acc + k
+        BCKeep {} -> acc + 1
+        BCRemove {} -> acc
     )
     0
 

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap.hs
@@ -1,0 +1,73 @@
+module Juvix.Compiler.Core.Extra.Recursors.RMap where
+
+import Juvix.Compiler.Core.Data.BinderList qualified as BL
+import Juvix.Compiler.Core.Extra.Base
+import Juvix.Compiler.Core.Extra.Recursors.Base
+import Juvix.Compiler.Core.Extra.Recursors.Utils
+
+data BinderRemove = BinderRemove
+  { _binderRemoveBinder :: Binder,
+    _binderRemoveNode :: Node
+  }
+
+makeLenses ''BinderRemove
+
+data BinderChange
+  = -- | `BCAdd n` -- add `n` binders
+    BCAdd Int
+  | -- | `BCKeep b` -- keep the binder `b`
+    BCKeep Binder
+  | -- | `BCRemove (BinderRemove b n)` -- remove the binder `b` and replace the
+    -- occurrences of the bound variable with the node `n`; the de Bruijn
+    -- indices of `n` are with respect to the result
+    BCRemove BinderRemove
+
+rmapG ::
+  forall c m.
+  (Monad m) =>
+  Collector (Int, [Binder]) c ->
+  (([BinderChange] -> c -> Node -> m Node) -> c -> Node -> m Node) ->
+  Node ->
+  m Node
+rmapG coll f = go mempty 0 (coll ^. cEmpty)
+  where
+    -- `binders` maps input de Bruijn indices to result de Bruijn levels
+    -- (adjusted by the binder shift at their occurrence) plus the replacement
+    -- node; `bl` is the current binder level in the result node
+    go :: BinderList (Level, Maybe Node) -> Int -> c -> Node -> m Node
+    go binders bl c n = f recur c n
+      where
+        recur :: [BinderChange] -> c -> Node -> m Node
+        recur changes c' n' =
+          let ni = destruct n'
+           in adjustVar . reassembleDetails ni <$> mapM goChild (ni ^. nodeChildren)
+          where
+            goChild :: NodeChild -> m Node
+            goChild ch =
+              let (bl', rbs, rbs') =
+                    foldl'
+                      ( \(l, bs, acc) chg -> case chg of
+                          BCAdd k -> (l + k, bs, acc)
+                          BCKeep b -> (l + 1, b : bs, (l, Nothing) : acc)
+                          BCRemove (BinderRemove b node) -> (l, b : bs, (l, Just node) : acc)
+                      )
+                      (bl, [], [])
+                      changes
+                  cbs = map (\l -> (l, Nothing)) [bl' .. bl' + ch ^. childBindersNum - 1]
+                  binders' = BL.prependRev cbs (BL.prepend rbs' binders)
+               in go
+                    binders'
+                    bl'
+                    ((coll ^. cCollect) (length rbs + ch ^. childBindersNum, reverse rbs ++ ch ^. childBinders) c')
+                    (ch ^. childNode)
+
+        adjustVar :: Node -> Node
+        adjustVar = \case
+          NVar v ->
+            maybe
+              (NVar v {_varIndex = getBinderIndex bl lvl})
+              (shift (bl - lvl))
+              mnode
+            where
+              (lvl, mnode) = BL.lookup (v ^. varIndex) binders
+          node -> node

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
@@ -47,13 +47,13 @@ where
       mkLet
         _lambdaInfo
         (over binderType (cont []) _lambdaBinder)
-        (mkConstant' (ConstInteger k))
+        (mkConstant' (ConstInteger (fromIntegral k)))
         (cont [BCAdd 1, BCRemove (BinderRemove _lambdaBinder (mkVar' 0))] _lambdaBody)
     _ ->
       recur [] node
     where
-      cont :: [BinderChange] -> Node -> Node
-      cont bcs = go (recur . (bcs ++)) k
+      cont :: Level -> [BinderChange] -> Node -> Node
+      cont bcs = go (recur . (bcs ++)) (k + bindersNumFromBindersChange bcs)
 ```
 produces
 ```
@@ -69,7 +69,7 @@ where
     NLam lam1@(Lambda _ _ (NLam lam2)) ->
       mkLambda
         (lam1 ^. lambdaInfo)
-        (over lambdaBinder (over binderType (cont [])) lam1)
+        (over binderType (cont []) (lam1 ^. lambdaBinder))
         (cont
           [
             BCKeep (lam1 ^. lambdaBinder),

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
@@ -53,7 +53,7 @@ where
       recur [] node
     where
       cont :: Level -> [BinderChange] -> Node -> Node
-      cont bcs = go (recur . (bcs ++)) (k + bindersNumFromBindersChange bcs)
+      cont bcs = go (recur . (bcs ++)) (k + bindersNumFromBinderChange bcs)
 ```
 produces
 ```

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
@@ -40,16 +40,49 @@ where
   go :: ([BinderChange] -> Level -> Node -> Node) -> Node -> Node
   go recur k node = case node of
     NLam Lambda {..} ->
-      mkLet (ConstInt k) (cont [BCAdd 1, BCRemove (BinderRemove _lambdaBinder mkVar' 0)] k _lambdaBody)
+      mkLet
+        _lambdaInfo
+        (over binderType (cont []) _lambdaBinder)
+        (mkConstant' (ConstInteger k))
+        (cont [BCAdd 1, BCRemove (BinderRemove _lambdaBinder (mkVar' 0))] _lambdaBody)
     _ ->
       recur [] node
-
-  cont :: [BinderChange] -> Level -> Node -> Node
-  cont bcs = go (recur . (bcs ++))
+    where
+      cont :: [BinderChange] -> Node -> Node
+      cont bcs = go (recur . (bcs ++)) k
 ```
 produces
 ```
 let x := 0 in let y := 1 in x$1 + y$0
 ```
 
+The invocation
+```
+rmap go (\x \z \y \_ x$3 + y$1 + z$2)
+where
+  go :: ([BinderChange] -> Node -> Node) -> Node -> Node
+  go recur node = case node of
+    NLam lam1@(Lambda _ _ (NLam lam2)) ->
+      mkLambda
+        (lam1 ^. lambdaInfo)
+        (over lambdaBinder (over binderType (cont [])) lam1)
+        (cont
+          [
+            BCKeep (lam1 ^. lambdaBinder),
+            BCRemove (BinderRemove (lam2 ^. lambdaBinder) (mkVar' 0))
+          ]
+          (lam2 ^. lambdaBody))
+    _ ->
+      recur [] node
+    where
+      cont :: [BinderChange] -> Node -> Node
+      cont bcs = go (recur . (bcs ++))
+```
+produces
+```
+\x \y x$1 + y$0 + x$1
+```
+
+For the meaning of the suffixes to `rmap` see the comments in
+Core.Extra.Recursors.Map.Named
 -}

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
@@ -15,11 +15,12 @@ node.
 The first argument to `recur` specifies the changes in binders on top of the
 call to `recur`:
 - `BCAdd n` indicates that `n` new binders are added,
-- `BCKeep n` indicates that `n` original binders are preserved,
-- `BCRemove node` indicates that a binder is removed and all bound variables
-  referring to it replaced with `node`. The de Bruijn indices in `node` are
-  relative to the result at the point of `recur` invocation, i.e., adjusted by
-  the shifts caused by the binder changes before it in the binder change list.
+- `BCKeep b` indicates that an original binder `b` is preserved,
+- `BCRemove (BinderRemove b node)` indicates that a binder `b` is removed and
+  all bound variables referring to it replaced with `node`. The de Bruijn
+  indices in `node` are relative to the result at the point of `recur`
+  invocation, i.e., adjusted by the shifts caused by the binder changes before
+  it in the binder change list.
 
 The function `recur` automatically adjusts the de Bruijn indices in the result
 node, by shifting them according to the binder shift at their binding point. For

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap/Named.hs
@@ -1,0 +1,55 @@
+module Juvix.Compiler.Core.Extra.Recursors.RMap.Named where
+
+{-
+`rmap f t` goes through the node top-down, but in contrast to `dmap` the
+recursion must be performed explicitly with a function provided to `f`, and it
+is possible to specify the changes in binders. In `rmap f t` the function `f`
+receives as its first argument the function `recur :: [BinderChange] -> Node ->
+Node` which changes/shifts binders and recurses into the children of the given
+node.
+
+The first argument to `recur` specifies the changes in binders on top of the
+call to `recur`:
+- `BCAdd n` indicates that `n` new binders are added,
+- `BCKeep n` indicates that `n` original binders are preserved,
+- `BCRemove node` indicates that a binder is removed and all bound variables
+  referring to it replaced with `node`. The de Bruijn indices in `node` are
+  relative to the result at the point of `recur` invocation, i.e., adjusted by
+  the shifts caused by the binder changes before it in the binder change list.
+
+The function `recur` automatically adjusts the de Bruijn indices in the result
+node, by shifting them according to the binder shift at their binding point. For
+example, the invocation (in pseudocode)
+```
+rmap go (\x \y x$1 + y$0)
+where
+  go :: ([BinderChange] -> Node -> Node) -> Node -> Node
+  go recur node = case node of
+    NLam {} -> mkLambda' mkDynamic' (recur [BCAdd 1] node)
+    _ -> recur [] node
+```
+produces
+```
+\_ \x \_ \y x$2 + y$0
+```
+
+The invocation
+```
+rmapN go (\x \y x$1 + y$0)
+where
+  go :: ([BinderChange] -> Level -> Node -> Node) -> Node -> Node
+  go recur k node = case node of
+    NLam Lambda {..} ->
+      mkLet (ConstInt k) (cont [BCAdd 1, BCRemove (BinderRemove _lambdaBinder mkVar' 0)] k _lambdaBody)
+    _ ->
+      recur [] node
+
+  cont :: [BinderChange] -> Level -> Node -> Node
+  cont bcs = go (recur . (bcs ++))
+```
+produces
+```
+let x := 0 in let y := 1 in x$1 + y$0
+```
+
+-}

--- a/src/Juvix/Compiler/Core/Extra/Recursors/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/Utils.hs
@@ -1,0 +1,17 @@
+module Juvix.Compiler.Core.Extra.Recursors.Utils where
+
+import Juvix.Compiler.Core.Extra.Recursors.Map.Named
+import Juvix.Compiler.Core.Language
+
+shiftVar :: Index -> Var -> Var
+shiftVar m = over varIndex (+ m)
+
+-- | increase all free variable indices by a given value
+shift :: Index -> Node -> Node
+shift 0 = id
+shift m = umapN go
+  where
+    go k = \case
+      NVar v
+        | v ^. varIndex >= k -> NVar (shiftVar m v)
+      n -> n

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -6,6 +6,7 @@ module Juvix.Compiler.Core.Extra.Utils
     module Juvix.Compiler.Core.Extra.Equality,
     module Juvix.Compiler.Core.Extra.Recursors.Fold.Named,
     module Juvix.Compiler.Core.Extra.Recursors.Map.Named,
+    module Juvix.Compiler.Core.Extra.Recursors.RMap.Named,
     module Juvix.Compiler.Core.Extra.Recursors.Utils,
     module Juvix.Compiler.Core.Extra.Utils.Base,
   )
@@ -22,6 +23,7 @@ import Juvix.Compiler.Core.Extra.Info
 import Juvix.Compiler.Core.Extra.Recursors
 import Juvix.Compiler.Core.Extra.Recursors.Fold.Named
 import Juvix.Compiler.Core.Extra.Recursors.Map.Named
+import Juvix.Compiler.Core.Extra.Recursors.RMap.Named
 import Juvix.Compiler.Core.Extra.Recursors.Utils
 import Juvix.Compiler.Core.Extra.Utils.Base
 import Juvix.Compiler.Core.Language

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -6,6 +6,7 @@ module Juvix.Compiler.Core.Extra.Utils
     module Juvix.Compiler.Core.Extra.Equality,
     module Juvix.Compiler.Core.Extra.Recursors.Fold.Named,
     module Juvix.Compiler.Core.Extra.Recursors.Map.Named,
+    module Juvix.Compiler.Core.Extra.Recursors.Utils,
     module Juvix.Compiler.Core.Extra.Utils.Base,
   )
 where
@@ -21,6 +22,7 @@ import Juvix.Compiler.Core.Extra.Info
 import Juvix.Compiler.Core.Extra.Recursors
 import Juvix.Compiler.Core.Extra.Recursors.Fold.Named
 import Juvix.Compiler.Core.Extra.Recursors.Map.Named
+import Juvix.Compiler.Core.Extra.Recursors.Utils
 import Juvix.Compiler.Core.Extra.Utils.Base
 import Juvix.Compiler.Core.Language
 
@@ -42,16 +44,6 @@ nodeIdents f = ufoldA reassemble go
     go = \case
       NIdt i -> NIdt <$> f i
       n -> pure n
-
--- | increase all free variable indices by a given value
-shift :: Index -> Node -> Node
-shift 0 = id
-shift m = umapN go
-  where
-    go k = \case
-      NVar v
-        | v ^. varIndex >= k -> NVar (shiftVar m v)
-      n -> n
 
 -- | Prism for NRec
 _NRec :: SimpleFold Node LetRec

--- a/src/Juvix/Compiler/Core/Extra/Utils/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils/Base.hs
@@ -5,6 +5,7 @@ module Juvix.Compiler.Core.Extra.Utils.Base where
 
 import Juvix.Compiler.Core.Extra.Base
 import Juvix.Compiler.Core.Extra.Recursors
+import Juvix.Compiler.Core.Extra.Recursors.Utils
 import Juvix.Compiler.Core.Language
 
 -- | substitution of all free variables for values in an environment
@@ -25,9 +26,6 @@ freeVars f = ufoldNA reassemble go
       NVar var@Var {..}
         | _varIndex >= k -> NVar <$> f (shiftVar (-k) var)
       n -> pure n
-
-shiftVar :: Index -> Var -> Var
-shiftVar m = over varIndex (+ m)
 
 freeVarOccurrences :: Index -> SimpleFold Node Var
 freeVarOccurrences idx = freeVars . filtered ((== idx) . (^. varIndex))

--- a/src/Juvix/Compiler/Core/Language/Base.hs
+++ b/src/Juvix/Compiler/Core/Language/Base.hs
@@ -39,3 +39,9 @@ type Index = Int
 
 -- | de Bruijn level (reverse de Bruijn index)
 type Level = Int
+
+getBinderLevel :: Level -> Index -> Level
+getBinderLevel bl idx = bl - idx - 1
+
+getBinderIndex :: Level -> Level -> Index
+getBinderIndex bl lvl = bl - lvl - 1

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -331,6 +331,9 @@ makeLenses ''TypeConstr'
 makeLenses ''Dynamic'
 makeLenses ''LetItem'
 
+instance Eq ty => Eq (Binder' ty) where
+  (==) = eqOn (^. binderType)
+
 instance Eq (Var' i) where
   (Var _ idx1) == (Var _ idx2) = idx1 == idx2
 
@@ -386,20 +389,18 @@ instance Eq (Dynamic' i) where
 
 deriving stock instance (Eq a) => Eq (Pattern' i a)
 
-instance (Eq a) => Eq (LetItem' a ty) where
-  (==) = eqOn (^. letItemValue)
+instance (Eq a, Eq ty) => Eq (LetItem' a ty) where
+  (==) = eqOn (^. letItemValue) ..&&.. eqOn (^. letItemBinder)
 
--- | ignores the binder
-instance (Eq a) => Eq (Lambda' i a ty) where
-  (==) = eqOn (^. lambdaBody)
+instance (Eq a, Eq ty) => Eq (Lambda' i a ty) where
+  (Lambda _ bd1 body1) == (Lambda _ bd2 body2) = bd1 == bd2 && body1 == body2
 
--- | ignores the binder
-instance (Eq a) => Eq (Let' i a ty) where
+instance (Eq a, Eq ty) => Eq (Let' i a ty) where
   (==) =
     eqOn (^. letItem)
       ..&&.. eqOn (^. letBody)
 
-instance (Eq a) => Eq (LetRec' i a ty) where
+instance (Eq a, Eq ty) => Eq (LetRec' i a ty) where
   (==) =
     eqOn (^. letRecBody)
       ..&&.. eqOn (^. letRecValues)

--- a/test/Core.hs
+++ b/test/Core.hs
@@ -5,7 +5,8 @@ import Core.Asm qualified as Asm
 import Core.Compile qualified as Compile
 import Core.Eval qualified as Eval
 import Core.Print qualified as Print
+import Core.Recursor qualified as Rec
 import Core.Transformation qualified as Transformation
 
 allTests :: TestTree
-allTests = testGroup "JuvixCore tests" [Eval.allTests, Print.allTests, Transformation.allTests, Asm.allTests, Compile.allTests]
+allTests = testGroup "JuvixCore tests" [Rec.allTests, Eval.allTests, Print.allTests, Transformation.allTests, Asm.allTests, Compile.allTests]

--- a/test/Core/Recursor.hs
+++ b/test/Core/Recursor.hs
@@ -1,0 +1,7 @@
+module Core.Recursor where
+
+import Base
+import Core.Recursor.RMap qualified as RMap
+
+allTests :: TestTree
+allTests = testGroup "JuvixCore recursors" [RMap.allTests]

--- a/test/Core/Recursor/Base.hs
+++ b/test/Core/Recursor/Base.hs
@@ -1,0 +1,31 @@
+module Core.Recursor.Base where
+
+import Base
+import Juvix.Compiler.Core.Language
+import Juvix.Compiler.Core.Pretty
+
+data UnitTest = UnitTest
+  { _name :: String,
+    _function :: Node -> Node,
+    _inputOutputPairs :: [(Node, Node)]
+  }
+
+makeLenses ''UnitTest
+
+root :: Path Abs Dir
+root = relToProject $(mkRelDir "tests")
+
+testDescr :: UnitTest -> TestDescr
+testDescr test@UnitTest {..} =
+  TestDescr
+    { _testName = _name,
+      _testRoot = root,
+      _testAssertion = Steps $ unitTestAssertion test
+    }
+
+unitTestAssertion :: UnitTest -> (String -> IO ()) -> Assertion
+unitTestAssertion UnitTest {..} _ =
+  forM_ _inputOutputPairs $ \(i, o) -> do
+    assertBool
+      ("Unit test failed.\ngot:\n\t" <> fromText (ppTrace (_function i)) <> "\nexpected:\n\t" <> fromText (ppTrace o))
+      (_function i == o)

--- a/test/Core/Recursor/RMap.hs
+++ b/test/Core/Recursor/RMap.hs
@@ -1,0 +1,96 @@
+module Core.Recursor.RMap where
+
+import Base
+import Core.Recursor.Base
+import Juvix.Compiler.Core.Extra
+import Juvix.Compiler.Core.Language
+
+allTests :: TestTree
+allTests =
+  testGroup
+    "JuvixCore recursors rmap tests"
+    (map (mkTest . testDescr) tests)
+
+tests :: [UnitTest]
+tests =
+  [ UnitTest
+      "Identity"
+      (rmap (\recur -> recur []))
+      ( map
+          (\x -> (x, x))
+          [ mkLambda' mkDynamic' (mkLambda' mkDynamic' (mkVar' 1)),
+            mkLambda' mkDynamic' (mkLet' mkDynamic' (mkVar' 0) (mkLambda' mkDynamic' (mkApps' (mkLambdas' [mkDynamic', mkDynamic'] (mkVar' 1)) [mkVar' 1, mkVar' 2]))),
+            mkLambdas' [mkTypeInteger', mkTypeInteger'] (mkBuiltinApp' OpIntAdd [mkVar' 1, mkVar' 0])
+          ]
+      ),
+    UnitTest
+      "Add lambdas"
+      addLambdas
+      [ ( mkLambdas' [mkTypeInteger', mkTypeInteger'] (mkBuiltinApp' OpIntAdd [mkVar' 1, mkVar' 0]),
+          mkLambdas' [mkDynamic', mkTypeInteger', mkDynamic', mkTypeInteger'] (mkBuiltinApp' OpIntAdd [mkVar' 2, mkVar' 0])
+        )
+      ],
+    UnitTest
+      "Replace lambdas with lets"
+      replaceLambdasWithLets
+      [ ( mkLambdas' [mkTypeInteger', mkTypeInteger'] (mkBuiltinApp' OpIntAdd [mkVar' 1, mkVar' 0]),
+          mkLets' [(mkTypeInteger', mkConstant' (ConstInteger 0)), (mkTypeInteger', mkConstant' (ConstInteger 1))] (mkBuiltinApp' OpIntAdd [mkVar' 1, mkVar' 0])
+        ),
+        ( mkLambda' mkTypeInteger' $ mkLet' mkTypeInteger' (mkVar' 0) $ mkLambda' mkTypeInteger' $ mkBuiltinApp' OpIntAdd [mkVar' 2, mkVar' 0],
+          mkLets' [(mkTypeInteger', mkConstant' (ConstInteger 0)), (mkTypeInteger', mkVar' 0), (mkTypeInteger', mkConstant' (ConstInteger 2))] (mkBuiltinApp' OpIntAdd [mkVar' 2, mkVar' 0])
+        )
+      ],
+    UnitTest
+      "Remove lambdas"
+      removeLambdas
+      [ ( mkLambdas' [mkTypeInteger', mkTypeInteger', mkTypeInteger', mkTypeInteger'] (mkBuiltinApp' OpIntAdd [mkBuiltinApp' OpIntAdd [mkVar' 3, mkVar' 1], mkVar' 2]),
+          mkLambdas' [mkTypeInteger', mkTypeInteger'] (mkBuiltinApp' OpIntAdd [mkBuiltinApp' OpIntAdd [mkVar' 1, mkVar' 0], mkVar' 1])
+        )
+      ]
+  ]
+  where
+    addLambdas :: Node -> Node
+    addLambdas = rmap go
+      where
+        go :: ([BinderChange] -> Node -> Node) -> Node -> Node
+        go recur node = case node of
+          NLam {} -> mkLambda' mkDynamic' (recur [BCAdd 1] node)
+          _ -> recur [] node
+
+    replaceLambdasWithLets :: Node -> Node
+    replaceLambdasWithLets = rmapN go
+      where
+        go :: ([BinderChange] -> Node -> Node) -> Level -> Node -> Node
+        go recur k node = case node of
+          NLam Lambda {..} ->
+            mkLet
+              _lambdaInfo
+              (over binderType (cont []) _lambdaBinder)
+              (mkConstant' (ConstInteger (fromIntegral k)))
+              (cont [BCAdd 1, BCRemove (BinderRemove _lambdaBinder (mkVar' 0))] _lambdaBody)
+          _ ->
+            recur [] node
+          where
+            cont :: [BinderChange] -> Node -> Node
+            cont bcs = go (recur . (bcs ++)) (k + bindersNumFromBinderChange bcs)
+
+    removeLambdas :: Node -> Node
+    removeLambdas = rmap go
+      where
+        go :: ([BinderChange] -> Node -> Node) -> Node -> Node
+        go recur node = case node of
+          NLam lam1@(Lambda _ _ (NLam lam2)) ->
+            mkLambda
+              (lam1 ^. lambdaInfo)
+              (over binderType (cont []) (lam1 ^. lambdaBinder))
+              ( cont
+                  [ BCKeep (lam1 ^. lambdaBinder),
+                    BCRemove (BinderRemove (lam2 ^. lambdaBinder) (mkVar' 0))
+                  ]
+                  (lam2 ^. lambdaBody)
+              )
+          _ ->
+            recur [] node
+          where
+            cont :: [BinderChange] -> Node -> Node
+            cont bcs = go (recur . (bcs ++))


### PR DESCRIPTION
The `rmap` recursor allows to specify changes in binders while going downward through a Core node. This should help in implementing transformations on Core which need to add/remove/change binders.

* Depends on PR #1875 
* Adds unit tests for `rmap`
* Changes the `NatToInt` transformation to use `rmap`
