### PR TITLE
Check for recursive inductive types in the GEB pipeline

### DIFF
--- a/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
@@ -1,0 +1,32 @@
+module Juvix.Compiler.Core.Data.TypeDependencyInfo where
+
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
+import Juvix.Compiler.Core.Data.InfoTable
+import Juvix.Compiler.Core.Extra.Utils
+import Juvix.Compiler.Core.Language
+
+type TypeDependencyInfo = DependencyInfo Symbol
+
+createTypeDependencyInfo :: InfoTable -> TypeDependencyInfo
+createTypeDependencyInfo tab = createDependencyInfo graph startVertices
+  where
+    graph :: HashMap Symbol (HashSet Symbol)
+    graph =
+      fmap
+        ( \InductiveInfo {..} ->
+            foldr
+              (mappend . getInductives)
+              mempty
+              ( concatMap
+                  (\ci -> typeArgs (ci ^. constructorType))
+                  _inductiveConstructors
+              )
+        )
+        (HashMap.filter (isNothing . (^. inductiveBuiltin)) (tab ^. infoInductives))
+
+    startVertices :: HashSet Symbol
+    startVertices = HashSet.fromList syms
+
+    syms :: [Symbol]
+    syms = map (^. inductiveSymbol) (HashMap.elems (tab ^. infoInductives))

--- a/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
@@ -13,17 +13,14 @@ createTypeDependencyInfo tab = createDependencyInfo graph startVertices
   where
     graph :: HashMap Symbol (HashSet Symbol)
     graph =
-      fmap
-        ( \InductiveInfo {..} ->
-            foldr
-              (mappend . getInductives)
-              mempty
-              ( concatMap
-                  (\ci -> typeArgs (ci ^. constructorType))
-                  _inductiveConstructors
-              )
-        )
-        (HashMap.filter (isNothing . (^. inductiveBuiltin)) (tab ^. infoInductives))
+      HashSet.fromList . (^.. inductiveSymbols)
+        <$> HashMap.filter (isNothing . (^. inductiveBuiltin)) (tab ^. infoInductives)
+
+    constructorTypes :: SimpleFold ConstructorInfo Type
+    constructorTypes = constructorType . to typeArgs . each
+
+    inductiveSymbols :: SimpleFold InductiveInfo Symbol
+    inductiveSymbols = inductiveConstructors . each . constructorTypes . nodeInductives
 
     startVertices :: HashSet Symbol
     startVertices = HashSet.fromList syms

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -55,6 +55,14 @@ nodeIdents f = ufoldA reassemble go
       NIdt i -> NIdt <$> f i
       n -> pure n
 
+getInductives :: Node -> HashSet Symbol
+getInductives = ufold (foldr mappend) go
+  where
+    go :: Node -> HashSet Symbol
+    go = \case
+      NTyp TypeConstr {..} -> HashSet.singleton _typeConstrSymbol
+      _ -> mempty
+
 -- | Prism for NRec
 _NRec :: SimpleFold Node LetRec
 _NRec f = \case

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -55,13 +55,12 @@ nodeIdents f = ufoldA reassemble go
       NIdt i -> NIdt <$> f i
       n -> pure n
 
-getInductives :: Node -> HashSet Symbol
-getInductives = ufold (foldr mappend) go
+nodeInductives :: Traversal' Node Symbol
+nodeInductives f = ufoldA reassemble go
   where
-    go :: Node -> HashSet Symbol
     go = \case
-      NTyp TypeConstr {..} -> HashSet.singleton _typeConstrSymbol
-      _ -> mempty
+      NTyp ty -> NTyp <$> traverseOf typeConstrSymbol f ty
+      n -> pure n
 
 -- | Prism for NRec
 _NRec :: SimpleFold Node LetRec

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -70,28 +70,24 @@ checkGeb tab =
           _ -> return node
 
     checkNoRecursion :: Sem r ()
-    checkNoRecursion
-      | isCyclic (createIdentDependencyInfo tab) =
+    checkNoRecursion =
+      when (isCyclic (createIdentDependencyInfo tab)) $
           throw
             CoreError
               { _coreErrorMsg = "recursion not supported for the GEB target",
                 _coreErrorNode = Nothing,
                 _coreErrorLoc = defaultLoc
               }
-      | otherwise =
-          return ()
 
     checkNoRecursiveTypes :: Sem r ()
-    checkNoRecursiveTypes
-      | isCyclic (createTypeDependencyInfo tab) =
+    checkNoRecursiveTypes =
+      when (isCyclic (createTypeDependencyInfo tab)) $
           throw
             CoreError
               { _coreErrorMsg = "recursive types not supported for the GEB target",
                 _coreErrorNode = Nothing,
                 _coreErrorLoc = defaultLoc
               }
-      | otherwise =
-          return ()
 
     dynamicTypeError :: Node -> Maybe Location -> CoreError
     dynamicTypeError node loc =

--- a/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
+++ b/src/Juvix/Compiler/Core/Transformation/CheckGeb.hs
@@ -72,22 +72,22 @@ checkGeb tab =
     checkNoRecursion :: Sem r ()
     checkNoRecursion =
       when (isCyclic (createIdentDependencyInfo tab)) $
-          throw
-            CoreError
-              { _coreErrorMsg = "recursion not supported for the GEB target",
-                _coreErrorNode = Nothing,
-                _coreErrorLoc = defaultLoc
-              }
+        throw
+          CoreError
+            { _coreErrorMsg = "recursion not supported for the GEB target",
+              _coreErrorNode = Nothing,
+              _coreErrorLoc = defaultLoc
+            }
 
     checkNoRecursiveTypes :: Sem r ()
     checkNoRecursiveTypes =
       when (isCyclic (createTypeDependencyInfo tab)) $
-          throw
-            CoreError
-              { _coreErrorMsg = "recursive types not supported for the GEB target",
-                _coreErrorNode = Nothing,
-                _coreErrorLoc = defaultLoc
-              }
+        throw
+          CoreError
+            { _coreErrorMsg = "recursive types not supported for the GEB target",
+              _coreErrorNode = Nothing,
+              _coreErrorLoc = defaultLoc
+            }
 
     dynamicTypeError :: Node -> Maybe Location -> CoreError
     dynamicTypeError node loc =


### PR DESCRIPTION
Currently, only recursion in functions is checked. This PR also adds some utilities (TypeDependencyInfo) that will be useful for issue #1907.