### PR TITLE
Recursion unrolling for functions

### DIFF
--- a/examples/midsquare/MidSquareHash.juvix
+++ b/examples/midsquare/MidSquareHash.juvix
@@ -3,118 +3,29 @@
 --- https://research.cs.vt.edu/AVresearch/hashing/midsquare.php
 
 --- The implementation is for hashing natural numbers with maximum 16 bits into 6
+--- bits.
+---
 
---- bits. In order to facilitate the translation to the current version of the
-
---- GEB backend, no recursion is used (it is manually unrolled).
 module MidSquareHash;
 
 open import Stdlib.Prelude;
 open import Stdlib.Data.Nat.Ord;
 
---- `powN` is 2 ^ N
-pow0 : Nat := 1;
+--- `pow N` is 2 ^ N
+pow : Nat -> Nat;
+pow zero := 1;
+pow (suc n) := 2 * pow n;
 
-pow1 : Nat := 2 * pow0;
-
-pow2 : Nat := 2 * pow1;
-
-pow3 : Nat := 2 * pow2;
-
-pow4 : Nat := 2 * pow3;
-
-pow5 : Nat := 2 * pow4;
-
-pow6 : Nat := 2 * pow5;
-
-pow7 : Nat := 2 * pow6;
-
-pow8 : Nat := 2 * pow7;
-
-pow9 : Nat := 2 * pow8;
-
-pow10 : Nat := 2 * pow9;
-
-pow11 : Nat := 2 * pow10;
-
-pow12 : Nat := 2 * pow11;
-
-pow13 : Nat := 2 * pow12;
-
-pow14 : Nat := 2 * pow13;
-
-pow15 : Nat := 2 * pow14;
-
-pow16 : Nat := 2 * pow15;
-
---- `hashN` hashes a number with max N bits (i.e. smaller than 2^N) into 6 bits
-
+--- `hash' N` hashes a number with max N bits (i.e. smaller than 2^N) into 6 bits
 --- (i.e. smaller than 64) using the mid-square algorithm.
-hash0 : Nat -> Nat;
-hash0 x := 0;
+hash' : Nat -> Nat -> Nat;
+hash' (suc n@(suc (suc m))) x :=
+  if (x < pow n)
+     (hash' n x)
+     (mod (div (x * x) (pow m)) (pow 6));
+hash' _ x := x * x;
 
-hash1 : Nat -> Nat;
-hash1 x := x * x;
-
-hash2 : Nat -> Nat;
-hash2 x := x * x;
-
-hash3 : Nat -> Nat;
-hash3 x := x * x;
-
-hash4 : Nat -> Nat;
-hash4 x :=
-  if (x < pow3) (hash3 x) (mod (div (x * x) pow1) pow6);
-
-hash5 : Nat -> Nat;
-hash5 x :=
-  if (x < pow4) (hash4 x) (mod (div (x * x) pow2) pow6);
-
-hash6 : Nat -> Nat;
-hash6 x :=
-  if (x < pow5) (hash5 x) (mod (div (x * x) pow3) pow6);
-
-hash7 : Nat -> Nat;
-hash7 x :=
-  if (x < pow6) (hash6 x) (mod (div (x * x) pow4) pow6);
-
-hash8 : Nat -> Nat;
-hash8 x :=
-  if (x < pow7) (hash7 x) (mod (div (x * x) pow5) pow6);
-
-hash9 : Nat -> Nat;
-hash9 x :=
-  if (x < pow8) (hash8 x) (mod (div (x * x) pow6) pow6);
-
-hash10 : Nat -> Nat;
-hash10 x :=
-  if (x < pow9) (hash9 x) (mod (div (x * x) pow7) pow6);
-
-hash11 : Nat -> Nat;
-hash11 x :=
-  if (x < pow10) (hash10 x) (mod (div (x * x) pow8) pow6);
-
-hash12 : Nat -> Nat;
-hash12 x :=
-  if (x < pow11) (hash11 x) (mod (div (x * x) pow9) pow6);
-
-hash13 : Nat -> Nat;
-hash13 x :=
-  if (x < pow12) (hash12 x) (mod (div (x * x) pow10) pow6);
-
-hash14 : Nat -> Nat;
-hash14 x :=
-  if (x < pow13) (hash13 x) (mod (div (x * x) pow11) pow6);
-
-hash15 : Nat -> Nat;
-hash15 x :=
-  if (x < pow14) (hash14 x) (mod (div (x * x) pow12) pow6);
-
-hash16 : Nat -> Nat;
-hash16 x :=
-  if (x < pow15) (hash15 x) (mod (div (x * x) pow13) pow6);
-
-hash : Nat -> Nat := hash16;
+hash : Nat -> Nat := hash' 16;
 
 main : Nat;
 main := hash 1367;

--- a/examples/midsquare/MidSquareHash.jvc
+++ b/examples/midsquare/MidSquareHash.jvc
@@ -2,50 +2,23 @@
 -- https://research.cs.vt.edu/AVresearch/hashing/midsquare.php
 --
 -- The implementation is for hashing natural numbers with maximum 16 bits into 6
--- bits. In order to facilitate the translation to the current version of the
--- GEB backend, no recursion is used (it is manually unrolled).
+-- bits.
 --
 
--- `powN` is 2 ^ N
-def pow0 : Int := 1;
-def pow1 : Int := 2 * pow0;
-def pow2 : Int := 2 * pow1;
-def pow3 : Int := 2 * pow2;
-def pow4 : Int := 2 * pow3;
-def pow5 : Int := 2 * pow4;
-def pow6 : Int := 2 * pow5;
-def pow7 : Int := 2 * pow6;
-def pow8 : Int := 2 * pow7;
-def pow9 : Int := 2 * pow8;
-def pow10 : Int := 2 * pow9;
-def pow11 : Int := 2 * pow10;
-def pow12 : Int := 2 * pow11;
-def pow13 : Int := 2 * pow12;
-def pow14 : Int := 2 * pow13;
-def pow15 : Int := 2 * pow14;
-def pow16 : Int := 2 * pow15;
+-- `pow N` is 2 ^ N
+def pow : Int -> Int := \(x : Int) if x = 0 then 1 else 2 * pow (x - 1);
 
--- `hashN` hashes a number with max N bits (i.e. smaller than 2^N) into 6 bits
+-- `hash' N` hashes a number with max N bits (i.e. smaller than 2^N) into 6 bits
 -- (i.e. smaller than 64) using the mid-square algorithm.
-def hash0 : Int -> Int := \(x : Int) 0;
-def hash1 : Int -> Int := \(x : Int) x * x;
-def hash2 : Int -> Int := \(x : Int) x * x;
-def hash3 : Int -> Int := \(x : Int) x * x;
-def hash4 : Int -> Int := \(x : Int) if x < pow3 then hash3 x else ((x * x) / pow1) % pow6;
-def hash5 : Int -> Int := \(x : Int) if x < pow4 then hash4 x else ((x * x) / pow2) % pow6;
-def hash6 : Int -> Int := \(x : Int) if x < pow5 then hash5 x else ((x * x) / pow3) % pow6;
-def hash7 : Int -> Int := \(x : Int) if x < pow6 then hash6 x else ((x * x) / pow4) % pow6;
-def hash8 : Int -> Int := \(x : Int) if x < pow7 then hash7 x else ((x * x) / pow5) % pow6;
-def hash9 : Int -> Int := \(x : Int) if x < pow8 then hash8 x else ((x * x) / pow6) % pow6;
-def hash10 : Int -> Int := \(x : Int) if x < pow9 then hash9 x else ((x * x) / pow7) % pow6;
-def hash11 : Int -> Int := \(x : Int) if x < pow10 then hash10 x else ((x * x) / pow8) % pow6;
-def hash12 : Int -> Int := \(x : Int) if x < pow11 then hash11 x else ((x * x) / pow9) % pow6;
-def hash13 : Int -> Int := \(x : Int) if x < pow12 then hash12 x else ((x * x) / pow10) % pow6;
-def hash14 : Int -> Int := \(x : Int) if x < pow13 then hash13 x else ((x * x) / pow11) % pow6;
-def hash15 : Int -> Int := \(x : Int) if x < pow14 then hash14 x else ((x * x) / pow12) % pow6;
-def hash16 : Int -> Int := \(x : Int) if x < pow15 then hash15 x else ((x * x) / pow13) % pow6;
+def hash' : Int -> Int -> Int := \(n : Int) \(x : Int)
+    if n <= 3 then
+        x * x
+    else if x < pow (n - 1) then
+        hash' (n - 1) x
+    else
+        ((x * x) / pow (n - 3)) % pow 6;
 
-def hash : Int -> Int := hash16;
+def hash : Int -> Int := hash' 16;
 
 hash 1367
 -- result: 3

--- a/examples/midsquare/MidSquareHashUnrolled.juvix
+++ b/examples/midsquare/MidSquareHashUnrolled.juvix
@@ -1,0 +1,91 @@
+--- This file implements the mid-square hashing function in Juvix. See:
+--- https://research.cs.vt.edu/AVresearch/hashing/midsquare.php
+---
+--- The implementation is for hashing natural numbers with maximum 16 bits into 6
+--- bits. In order to facilitate the translation to the current version of the
+--- GEB backend, no recursion is used (it is manually unrolled).
+---
+module MidSquareHashUnrolled;
+
+open import Stdlib.Prelude;
+open import Stdlib.Data.Nat.Ord;
+
+--- `powN` is 2 ^ N
+pow0 : Nat := 1;
+pow1 : Nat := 2 * pow0;
+pow2 : Nat := 2 * pow1;
+pow3 : Nat := 2 * pow2;
+pow4 : Nat := 2 * pow3;
+pow5 : Nat := 2 * pow4;
+pow6 : Nat := 2 * pow5;
+pow7 : Nat := 2 * pow6;
+pow8 : Nat := 2 * pow7;
+pow9 : Nat := 2 * pow8;
+pow10 : Nat := 2 * pow9;
+pow11 : Nat := 2 * pow10;
+pow12 : Nat := 2 * pow11;
+pow13 : Nat := 2 * pow12;
+pow14 : Nat := 2 * pow13;
+pow15 : Nat := 2 * pow14;
+pow16 : Nat := 2 * pow15;
+
+--- `hashN` hashes a number with max N bits (i.e. smaller than 2^N) into 6 bits
+--- (i.e. smaller than 64) using the mid-square algorithm.
+hash0 : Nat -> Nat;
+hash0 x := 0;
+
+hash1 : Nat -> Nat;
+hash1 x := x * x;
+
+hash2 : Nat -> Nat;
+hash2 x := x * x;
+
+hash3 : Nat -> Nat;
+hash3 x := x * x;
+
+hash4 : Nat -> Nat;
+hash4 x := if (x < pow3) (hash3 x) (mod (div (x * x) pow1) pow6);
+
+hash5 : Nat -> Nat;
+hash5 x := if (x < pow4) (hash4 x) (mod (div (x * x) pow2) pow6);
+
+hash6 : Nat -> Nat;
+hash6 x := if (x < pow5) (hash5 x) (mod (div (x * x) pow3) pow6);
+
+hash7 : Nat -> Nat;
+hash7 x := if (x < pow6) (hash6 x) (mod (div (x * x) pow4) pow6);
+
+hash8 : Nat -> Nat;
+hash8 x := if (x < pow7) (hash7 x) (mod (div (x * x) pow5) pow6);
+
+hash9 : Nat -> Nat;
+hash9 x := if (x < pow8) (hash8 x) (mod (div (x * x) pow6) pow6);
+
+hash10 : Nat -> Nat;
+hash10 x := if (x < pow9) (hash9 x) (mod (div (x * x) pow7) pow6);
+
+hash11 : Nat -> Nat;
+hash11 x := if (x < pow10) (hash10 x) (mod (div (x * x) pow8) pow6);
+
+hash12 : Nat -> Nat;
+hash12 x := if (x < pow11) (hash11 x) (mod (div (x * x) pow9) pow6);
+
+hash13 : Nat -> Nat;
+hash13 x := if (x < pow12) (hash12 x) (mod (div (x * x) pow10) pow6);
+
+hash14 : Nat -> Nat;
+hash14 x := if (x < pow13) (hash13 x) (mod (div (x * x) pow11) pow6);
+
+hash15 : Nat -> Nat;
+hash15 x := if (x < pow14) (hash14 x) (mod (div (x * x) pow12) pow6);
+
+hash16 : Nat -> Nat;
+hash16 x := if (x < pow15) (hash15 x) (mod (div (x * x) pow13) pow6);
+
+hash : Nat -> Nat := hash16;
+
+main : Nat;
+main := hash 1367;
+-- result: 3
+
+end;

--- a/examples/midsquare/MidSquareHashUnrolled.jvc
+++ b/examples/midsquare/MidSquareHashUnrolled.jvc
@@ -1,0 +1,51 @@
+-- This file implements the mid-square hashing function in JuvixCore. See:
+-- https://research.cs.vt.edu/AVresearch/hashing/midsquare.php
+--
+-- The implementation is for hashing natural numbers with maximum 16 bits into 6
+-- bits. In order to facilitate the translation to the current version of the
+-- GEB backend, no recursion is used (it is manually unrolled).
+--
+
+-- `powN` is 2 ^ N
+def pow0 : Int := 1;
+def pow1 : Int := 2 * pow0;
+def pow2 : Int := 2 * pow1;
+def pow3 : Int := 2 * pow2;
+def pow4 : Int := 2 * pow3;
+def pow5 : Int := 2 * pow4;
+def pow6 : Int := 2 * pow5;
+def pow7 : Int := 2 * pow6;
+def pow8 : Int := 2 * pow7;
+def pow9 : Int := 2 * pow8;
+def pow10 : Int := 2 * pow9;
+def pow11 : Int := 2 * pow10;
+def pow12 : Int := 2 * pow11;
+def pow13 : Int := 2 * pow12;
+def pow14 : Int := 2 * pow13;
+def pow15 : Int := 2 * pow14;
+def pow16 : Int := 2 * pow15;
+
+-- `hashN` hashes a number with max N bits (i.e. smaller than 2^N) into 6 bits
+-- (i.e. smaller than 64) using the mid-square algorithm.
+def hash0 : Int -> Int := \(x : Int) 0;
+def hash1 : Int -> Int := \(x : Int) x * x;
+def hash2 : Int -> Int := \(x : Int) x * x;
+def hash3 : Int -> Int := \(x : Int) x * x;
+def hash4 : Int -> Int := \(x : Int) if x < pow3 then hash3 x else ((x * x) / pow1) % pow6;
+def hash5 : Int -> Int := \(x : Int) if x < pow4 then hash4 x else ((x * x) / pow2) % pow6;
+def hash6 : Int -> Int := \(x : Int) if x < pow5 then hash5 x else ((x * x) / pow3) % pow6;
+def hash7 : Int -> Int := \(x : Int) if x < pow6 then hash6 x else ((x * x) / pow4) % pow6;
+def hash8 : Int -> Int := \(x : Int) if x < pow7 then hash7 x else ((x * x) / pow5) % pow6;
+def hash9 : Int -> Int := \(x : Int) if x < pow8 then hash8 x else ((x * x) / pow6) % pow6;
+def hash10 : Int -> Int := \(x : Int) if x < pow9 then hash9 x else ((x * x) / pow7) % pow6;
+def hash11 : Int -> Int := \(x : Int) if x < pow10 then hash10 x else ((x * x) / pow8) % pow6;
+def hash12 : Int -> Int := \(x : Int) if x < pow11 then hash11 x else ((x * x) / pow9) % pow6;
+def hash13 : Int -> Int := \(x : Int) if x < pow12 then hash12 x else ((x * x) / pow10) % pow6;
+def hash14 : Int -> Int := \(x : Int) if x < pow13 then hash13 x else ((x * x) / pow11) % pow6;
+def hash15 : Int -> Int := \(x : Int) if x < pow14 then hash14 x else ((x * x) / pow12) % pow6;
+def hash16 : Int -> Int := \(x : Int) if x < pow15 then hash15 x else ((x * x) / pow13) % pow6;
+
+def hash : Int -> Int := hash16;
+
+hash 1367
+-- result: 3

--- a/src/Juvix/Compiler/Core/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTable.hs
@@ -167,7 +167,7 @@ filterByFile f t =
     matchesLocation :: Maybe Location -> Bool
     matchesLocation l = l ^? _Just . intervalFile == Just f
 
--- Prunes the orphaned entries of identMap and indentContext, i.e., ones that
+-- | Prunes the orphaned entries of identMap and indentContext, i.e., ones that
 -- have no corresponding entries in infoIdentifiers or infoInductives
 pruneInfoTable :: InfoTable -> InfoTable
 pruneInfoTable tab =

--- a/src/Juvix/Compiler/Core/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTable.hs
@@ -166,3 +166,21 @@ filterByFile f t =
   where
     matchesLocation :: Maybe Location -> Bool
     matchesLocation l = l ^? _Just . intervalFile == Just f
+
+-- Prunes the orphaned entries of identMap and indentContext, i.e., ones that
+-- have no corresponding entries in infoIdentifiers or infoInductives
+pruneInfoTable :: InfoTable -> InfoTable
+pruneInfoTable tab =
+  over
+    identMap
+    ( HashMap.filter
+        ( \case
+            IdentFun s -> HashMap.member s (tab ^. infoIdentifiers)
+            IdentInd s -> HashMap.member s (tab ^. infoInductives)
+            IdentConstr tag -> HashMap.member tag (tab ^. infoConstructors)
+        )
+    )
+    $ over
+      identContext
+      (HashMap.filterWithKey (\s _ -> HashMap.member s (tab ^. infoIdentifiers)))
+      tab

--- a/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
@@ -118,6 +118,9 @@ runInfoTableBuilder tab =
       GetInfoTable ->
         get
 
+execInfoTableBuilder :: InfoTable -> Sem (InfoTableBuilder ': r) a -> Sem r InfoTable
+execInfoTableBuilder tab = fmap fst . runInfoTableBuilder tab
+
 --------------------------------------------
 -- Builtin declarations
 --------------------------------------------

--- a/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
@@ -14,6 +14,7 @@ data InfoTableBuilder m a where
   RegisterInductive :: Text -> InductiveInfo -> InfoTableBuilder m ()
   RegisterIdentNode :: Symbol -> Node -> InfoTableBuilder m ()
   RegisterMain :: Symbol -> InfoTableBuilder m ()
+  RemoveSymbol :: Symbol -> InfoTableBuilder m ()
   OverIdentArgsInfo :: Symbol -> ([ArgumentInfo] -> [ArgumentInfo]) -> InfoTableBuilder m ()
   GetIdent :: Text -> InfoTableBuilder m (Maybe IdentKind)
   GetInfoTable :: InfoTableBuilder m InfoTable
@@ -101,6 +102,11 @@ runInfoTableBuilder tab =
         modify' (over identContext (HashMap.insert sym node))
       RegisterMain sym -> do
         modify' (set infoMain (Just sym))
+      RemoveSymbol sym -> do
+        modify' (over infoMain (maybe Nothing (\sym' -> if sym' == sym then Nothing else Just sym')))
+        modify' (over infoIdentifiers (HashMap.delete sym))
+        modify' (over identContext (HashMap.delete sym))
+        modify' (over infoInductives (HashMap.delete sym))
       OverIdentArgsInfo sym f -> do
         argsInfo <- f <$> gets (^. infoIdentifiers . at sym . _Just . identifierArgsInfo)
         modify' (set (infoIdentifiers . at sym . _Just . identifierArgsInfo) argsInfo)

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -39,7 +39,7 @@ isTypeConstr tab ty = case typeTarget ty of
     isTypeConstr tab (fromJust $ HashMap.lookup _identSymbol (tab ^. identContext))
   _ -> False
 
--- True for nodes whose evaluation immediately returns a constant value, i.e.,
+-- True for nodes whose evaluation immediately returns a value, i.e.,
 -- no reduction or memory allocation in the runtime is required.
 isImmediate :: Node -> Bool
 isImmediate = \case

--- a/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
+++ b/src/Juvix/Compiler/Core/Transformation/NatToInt.hs
@@ -134,18 +134,7 @@ filterNatBuiltins tab =
           infoIdentifiers
           (HashMap.filter (isNotNatBuiltin . (^. identifierBuiltin)))
           tab
-   in over
-        identMap
-        ( HashMap.filter
-            ( \case
-                IdentFun s -> HashMap.member s (tab' ^. infoIdentifiers)
-                _ -> True
-            )
-        )
-        $ over
-          identContext
-          (HashMap.filterWithKey (\s _ -> HashMap.member s (tab' ^. infoIdentifiers)))
-          tab'
+   in pruneInfoTable tab'
   where
     isNotNatBuiltin :: Maybe BuiltinFunction -> Bool
     isNotNatBuiltin = \case

--- a/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
+++ b/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
@@ -84,5 +84,5 @@ unrollRecursion tab =
             go :: Int -> Node -> Node
             go limit = \case
               NIdt idt@Ident {..} ->
-                NIdt idt {_identSymbol = fromJust $ HashMap.lookup (_identSymbol, limit - 1) freshSyms}
+                NIdt idt {_identSymbol = fromMaybe _identSymbol $ HashMap.lookup (_identSymbol, limit - 1) freshSyms}
               node -> node

--- a/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
+++ b/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
@@ -43,7 +43,7 @@ unrollRecursion tab =
       modify (\mp -> foldr (mapSymbol freshSyms) mp syms)
       where
         unrollLimit :: Int
-        unrollLimit = 100
+        unrollLimit = 140
 
         mapSymbol :: HashMap (Symbol, Int) Symbol -> Symbol -> HashMap Symbol Symbol -> HashMap Symbol Symbol
         mapSymbol freshSyms sym = HashMap.insert sym (fromJust $ HashMap.lookup (sym, unrollLimit) freshSyms)

--- a/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
+++ b/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
@@ -1,7 +1,88 @@
 module Juvix.Compiler.Core.Transformation.UnrollRecursion (unrollRecursion) where
 
+import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Core.Data.IdentDependencyInfo
+import Juvix.Compiler.Core.Data.InfoTableBuilder
+import Juvix.Compiler.Core.Extra
 import Juvix.Compiler.Core.Transformation.Base
 
--- TODO: not yet implemented / at first only check for recursion and give an error
 unrollRecursion :: InfoTable -> InfoTable
-unrollRecursion tab = tab
+unrollRecursion tab =
+  let (mp, (tab', ())) =
+        run $
+          runState @(HashMap Symbol Symbol) mempty $
+            runInfoTableBuilder tab $
+              forM_ (buildSCCs (createIdentDependencyInfo tab)) goSCC
+   in mapIdentSymbols mp $ pruneInfoTable tab'
+  where
+    mapIdentSymbols :: HashMap Symbol Symbol -> InfoTable -> InfoTable
+    mapIdentSymbols mp = over infoMain adjustMain . mapAllNodes (umap go)
+      where
+        go :: Node -> Node
+        go = \case
+          NIdt idt@Ident {..} ->
+            case HashMap.lookup _identSymbol mp of
+              Just sym' -> NIdt idt {_identSymbol = sym'}
+              Nothing -> NIdt idt
+          node -> node
+
+        adjustMain :: Maybe Symbol -> Maybe Symbol
+        adjustMain = \case
+          Just sym -> Just $ fromMaybe sym (HashMap.lookup sym mp)
+          Nothing -> Nothing
+
+    goSCC :: Members '[InfoTableBuilder, State (HashMap Symbol Symbol)] r => SCC Symbol -> Sem r ()
+    goSCC = \case
+      CyclicSCC syms -> unrollSCC syms
+      AcyclicSCC _ -> return ()
+
+    unrollSCC :: Members '[InfoTableBuilder, State (HashMap Symbol Symbol)] r => [Symbol] -> Sem r ()
+    unrollSCC syms = do
+      freshSyms <- genSyms
+      forM_ syms (unroll freshSyms)
+      modify (\mp -> foldr (mapSymbol freshSyms) mp syms)
+      where
+        unrollLimit :: Int
+        unrollLimit = 100
+
+        mapSymbol :: HashMap (Symbol, Int) Symbol -> Symbol -> HashMap Symbol Symbol -> HashMap Symbol Symbol
+        mapSymbol freshSyms sym = HashMap.insert sym (fromJust $ HashMap.lookup (sym, unrollLimit) freshSyms)
+
+        genSyms :: forall r. Member InfoTableBuilder r => Sem r (HashMap (Symbol, Int) Symbol)
+        genSyms = foldr go (return mempty) syms
+          where
+            go :: Symbol -> Sem r (HashMap (Symbol, Int) Symbol) -> Sem r (HashMap (Symbol, Int) Symbol)
+            go sym m = foldr (go' sym) m [0 .. unrollLimit]
+
+            go' :: Symbol -> Int -> Sem r (HashMap (Symbol, Int) Symbol) -> Sem r (HashMap (Symbol, Int) Symbol)
+            go' sym limit m = do
+              mp <- m
+              sym' <- freshSymbol
+              return $ HashMap.insert (sym, limit) sym' mp
+
+        unroll :: forall r. Member InfoTableBuilder r => HashMap (Symbol, Int) Symbol -> Symbol -> Sem r ()
+        unroll freshSyms sym = do
+          forM_ [0 .. unrollLimit] goUnroll
+          removeSymbol sym
+          where
+            ii = fromJust $ HashMap.lookup sym (tab ^. infoIdentifiers)
+
+            goUnroll :: Int -> Sem r ()
+            goUnroll limit = do
+              let sym' = fromJust $ HashMap.lookup (sym, limit) freshSyms
+                  name' = ii ^. identifierName <> "__" <> show limit
+                  ii' = ii {_identifierSymbol = sym', _identifierName = name'}
+              registerIdent name' ii'
+              let node =
+                    if
+                        | limit == 0 ->
+                            etaExpand (typeArgs (ii ^. identifierType)) (mkBuiltinApp' OpFail [mkConstant' (ConstString "recursion limit reached")])
+                        | otherwise ->
+                            umap (go limit) (fromJust $ HashMap.lookup sym (tab ^. identContext))
+              registerIdentNode sym' node
+
+            go :: Int -> Node -> Node
+            go limit = \case
+              NIdt idt@Ident {..} ->
+                NIdt idt {_identSymbol = fromJust $ HashMap.lookup (_identSymbol, limit - 1) freshSyms}
+              node -> node

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -362,10 +362,12 @@ data Indexed a = Indexed
   { _indexedIx :: Int,
     _indexedThing :: a
   }
-  deriving stock (Show, Eq, Ord, Foldable, Traversable)
+  deriving stock (Generic, Show, Eq, Ord, Foldable, Traversable)
 
 instance Functor Indexed where
   fmap f (Indexed i a) = Indexed i (f a)
+
+instance Hashable a => Hashable (Indexed a)
 
 indexFrom :: Int -> [a] -> [Indexed a]
 indexFrom i = zipWith Indexed [i ..]

--- a/test/Core/Transformation.hs
+++ b/test/Core/Transformation.hs
@@ -5,6 +5,7 @@ import Core.Transformation.Identity qualified as Identity
 import Core.Transformation.Lifting qualified as Lifting
 import Core.Transformation.Pipeline qualified as Pipeline
 import Core.Transformation.TopEtaExpand qualified as TopEtaExpand
+import Core.Transformation.Unrolling qualified as Unrolling
 
 allTests :: TestTree
 allTests =
@@ -13,5 +14,6 @@ allTests =
     [ Identity.allTests,
       TopEtaExpand.allTests,
       Lifting.allTests,
-      Pipeline.allTests
+      Pipeline.allTests,
+      Unrolling.allTests
     ]

--- a/test/Core/Transformation/Unrolling.hs
+++ b/test/Core/Transformation/Unrolling.hs
@@ -42,8 +42,7 @@ liftTest _testEval =
       }
 
 checkNoRecursion :: InfoTable -> Assertion
-checkNoRecursion tab
-  | isCyclic (createIdentDependencyInfo tab) =
-      assertFailure "recursion detected"
-  | otherwise =
-      return ()
+checkNoRecursion tab =
+  when
+    (isCyclic (createIdentDependencyInfo tab))
+    (assertFailure "recursion detected")

--- a/test/Core/Transformation/Unrolling.hs
+++ b/test/Core/Transformation/Unrolling.hs
@@ -1,0 +1,49 @@
+module Core.Transformation.Unrolling (allTests) where
+
+import Base
+import Core.Eval.Positive qualified as Eval
+import Core.Transformation.Base
+import Juvix.Compiler.Core.Data.IdentDependencyInfo
+import Juvix.Compiler.Core.Transformation
+
+allTests :: TestTree
+allTests =
+  testGroup
+    "Recursion unrolling"
+    ( map
+        liftTest
+        ( -- filter out tests which require recursion deeper than 140
+          Eval.filterOutTests
+            [ "Recursion",
+              "Tail recursion",
+              "Tail recursion: Fibonacci numbers in linear time",
+              "Tail recursion through higher-order functions",
+              "Recursive functions: McCarthy's 91 function, subtraction by increments",
+              "Lists",
+              "Streams without memoization",
+              "Ackermann function (higher-order definition)",
+              "Merge sort",
+              "Big numbers"
+            ]
+            Eval.tests
+        )
+    )
+
+pipe :: [TransformationId]
+pipe = [UnrollRecursion]
+
+liftTest :: Eval.PosTest -> TestTree
+liftTest _testEval =
+  fromTest
+    Test
+      { _testTransformations = pipe,
+        _testAssertion = checkNoRecursion,
+        _testEval
+      }
+
+checkNoRecursion :: InfoTable -> Assertion
+checkNoRecursion tab
+  | isCyclic (createIdentDependencyInfo tab) =
+      assertFailure "recursion detected"
+  | otherwise =
+      return ()


### PR DESCRIPTION
* Depends on PR #1909 
* Closes #1750 
* Adds recursion unrolling tests on JuvixCore
* Adds a version of the mid-square hash example without the recursion manually unrolled

For now, the recursion is always unrolled to a fixed depth (140). In the future, we want to add a global option to override this depth, as well as a mechanism to specify it on a per-function basis. In a more distant future, we might want to try deriving the unrolling depth heuristically for each function.
