### PR TITLE
Use lenses to improve readability and performance

### DIFF
--- a/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
@@ -13,17 +13,14 @@ createTypeDependencyInfo tab = createDependencyInfo graph startVertices
   where
     graph :: HashMap Symbol (HashSet Symbol)
     graph =
-      fmap
-        ( \InductiveInfo {..} ->
-            foldr
-              (mappend . getInductives)
-              mempty
-              ( concatMap
-                  (\ci -> typeArgs (ci ^. constructorType))
-                  _inductiveConstructors
-              )
-        )
-        (HashMap.filter (isNothing . (^. inductiveBuiltin)) (tab ^. infoInductives))
+      HashSet.fromList . (^.. inductiveSymbols)
+        <$> HashMap.filter (isNothing . (^. inductiveBuiltin)) (tab ^. infoInductives)
+
+    constructorTypes :: SimpleFold ConstructorInfo Type
+    constructorTypes = constructorType . to typeArgs . each
+
+    inductiveSymbols :: SimpleFold InductiveInfo Symbol
+    inductiveSymbols = inductiveConstructors . each . constructorTypes . nodeInductives
 
     startVertices :: HashSet Symbol
     startVertices = HashSet.fromList syms

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -55,13 +55,12 @@ nodeIdents f = ufoldA reassemble go
       NIdt i -> NIdt <$> f i
       n -> pure n
 
-getInductives :: Node -> HashSet Symbol
-getInductives = ufold (foldr mappend) go
+nodeInductives :: Traversal' Node Symbol
+nodeInductives f = ufoldA reassemble go
   where
-    go :: Node -> HashSet Symbol
     go = \case
-      NTyp TypeConstr {..} -> HashSet.singleton _typeConstrSymbol
-      _ -> mempty
+      NTyp ty -> NTyp <$> traverseOf typeConstrSymbol f ty
+      n -> pure n
 
 -- | Prism for NRec
 _NRec :: SimpleFold Node LetRec


### PR DESCRIPTION
The small problem with the original implementation is that it does a lot of `Hashset.union` (through `foldr mappend`)
The cost of [`HashSet.union`](https://hackage.haskell.org/package/unordered-containers-0.2.19.1/docs/Data-HashSet.html#v:union)  is $O(m + n)$, so it will add up and scale poorly. This is probably not a big problem since this is only run once and types tend to be small, but it is still nice to find a better alternative.
We can solve that by defining `SimpleFold`s over the types and then building a `HashSet` from that.
I'd argue that it also improves readability