### PR TITLE
Preserve name and location information in Internal-to-Core

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -202,6 +202,9 @@ typeArgs = fst . unfoldPi'
 typeTarget :: Type -> Type
 typeTarget = snd . unfoldPi
 
+typeArgsBinders :: Type -> [Binder]
+typeArgsBinders = map (^. piLhsBinder) . fst . unfoldPi
+
 isDynamic :: Type -> Bool
 isDynamic = \case
   NDyn {} -> True

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -383,10 +383,10 @@ instance HasLoc Let where
   getLoc l = getLocSpan (l ^. letClauses) <> getLoc (l ^. letExpression)
 
 instance HasLoc CaseBranch where
-  getLoc c = getLoc (c ^. caseBranchExpression)
+  getLoc c = getLoc (c ^. caseBranchPattern) <> getLoc (c ^. caseBranchExpression)
 
 instance HasLoc Case where
-  getLoc c = getLoc (c ^. caseBranches . to last)
+  getLoc c = getLocSpan (c ^. caseBranches)
 
 instance HasLoc Expression where
   getLoc = \case

--- a/test/Compilation/Negative.hs
+++ b/test/Compilation/Negative.hs
@@ -33,5 +33,13 @@ tests =
   [ NegTest
       "Pattern matching coverage"
       $(mkRelDir ".")
-      $(mkRelFile "test001.juvix")
+      $(mkRelFile "test001.juvix"),
+    NegTest
+      "Pattern matching coverage in cases"
+      $(mkRelDir ".")
+      $(mkRelFile "test002.juvix"),
+    NegTest
+      "Pattern matching coverage in lambdas"
+      $(mkRelDir ".")
+      $(mkRelFile "test003.juvix")
   ]

--- a/tests/Compilation/negative/test002.juvix
+++ b/tests/Compilation/negative/test002.juvix
@@ -1,0 +1,12 @@
+-- pattern matching coverage in cases
+module test002;
+
+open import Stdlib.Prelude;
+
+f : List Nat -> Nat;
+f x := case x
+  | nil := 0
+  | x :: y :: _ := x + y;
+
+main : Nat;
+main := f (1 :: 2 :: nil);

--- a/tests/Compilation/negative/test003.juvix
+++ b/tests/Compilation/negative/test003.juvix
@@ -1,0 +1,7 @@
+-- pattern matching coverage in lambdas
+module test003;
+
+open import Stdlib.Prelude;
+
+main : Nat;
+main := λ{ zero := 1 | (suc (suc _)) := 2 } 1;


### PR DESCRIPTION
* Closes #1846 
* Preserves location information for all created `Match` nodes so that match-to-case always has a location available.
