### PR TITLE
Add juvix dev repl command

### DIFF
--- a/app/Commands/Dev.hs
+++ b/app/Commands/Dev.hs
@@ -16,6 +16,7 @@ import Commands.Dev.Parse qualified as Parse
 import Commands.Dev.Runtime qualified as Runtime
 import Commands.Dev.Scope qualified as Scope
 import Commands.Dev.Termination qualified as Termination
+import Commands.Repl qualified as Repl
 
 runCommand :: (Members '[Embed IO, App] r) => DevCommand -> Sem r ()
 runCommand = \case
@@ -29,3 +30,4 @@ runCommand = \case
   Asm opts -> Asm.runCommand opts
   Runtime opts -> Runtime.runCommand opts
   DisplayRoot opts -> DisplayRoot.runCommand opts
+  JuvixDevRepl opts -> Repl.runCommand opts

--- a/app/Commands/Dev/Options.hs
+++ b/app/Commands/Dev/Options.hs
@@ -19,9 +19,11 @@ import Commands.Dev.Geb.Options
 import Commands.Dev.Highlight.Options
 import Commands.Dev.Internal.Options
 import Commands.Dev.Parse.Options
+import Commands.Dev.Repl.Options
 import Commands.Dev.Runtime.Options
 import Commands.Dev.Scope.Options
 import Commands.Dev.Termination.Options
+import Commands.Repl.Options
 import CommonOptions
 
 data DevCommand
@@ -35,6 +37,7 @@ data DevCommand
   | Parse ParseOptions
   | Scope ScopeOptions
   | Termination TerminationCommand
+  | JuvixDevRepl ReplOptions
   deriving stock (Data)
 
 parseDevCommand :: Parser DevCommand
@@ -50,7 +53,8 @@ parseDevCommand =
           commandParse,
           commandScope,
           commandShowRoot,
-          commandTermination
+          commandTermination,
+          commandJuvixDevRepl
         ]
     )
 
@@ -123,3 +127,12 @@ commandTermination =
     info
       (Termination <$> parseTerminationCommand)
       (progDesc "Subcommands related to termination checking")
+
+commandJuvixDevRepl :: Mod CommandFields DevCommand
+commandJuvixDevRepl =
+  command
+    "repl"
+    ( info
+        (JuvixDevRepl <$> parseDevRepl)
+        (progDesc "Run the Juvix dev REPL")
+    )

--- a/app/Commands/Dev/Repl/Options.hs
+++ b/app/Commands/Dev/Repl/Options.hs
@@ -1,0 +1,27 @@
+module Commands.Dev.Repl.Options where
+
+import Commands.Repl.Options
+import CommonOptions
+import Juvix.Compiler.Core.Data.TransformationId (toEvalTransformations)
+
+parseDevRepl :: Parser ReplOptions
+parseDevRepl = do
+  _replInputFile <- optional parseInputJuvixFile
+  _replTransformations <- do
+    ts <- optTransformationIds
+    pure $
+      if
+          | null ts -> toEvalTransformations
+          | otherwise -> ts
+  _replNoDisambiguate <- optNoDisambiguate
+  _replShowDeBruijn <-
+    switch
+      ( long "show-de-bruijn"
+          <> help "Show variable de Bruijn indices"
+      )
+  _replNoPrelude <-
+    switch
+      ( long "no-prelude"
+          <> help "Do not load the Prelude module on launch"
+      )
+  pure ReplOptions {..}

--- a/app/Commands/Repl/Options.hs
+++ b/app/Commands/Repl/Options.hs
@@ -8,7 +8,8 @@ data ReplOptions = ReplOptions
   { _replInputFile :: Maybe (AppPath File),
     _replShowDeBruijn :: Bool,
     _replNoPrelude :: Bool,
-    _replTransformations :: Maybe (NonEmpty TransformationId)
+    _replTransformations :: [TransformationId],
+    _replNoDisambiguate :: Bool
   }
   deriving stock (Data)
 
@@ -22,13 +23,10 @@ instance CanonicalProjection ReplOptions Core.Options where
 
 parseRepl :: Parser ReplOptions
 parseRepl = do
-  _replTransformations <- nonEmpty <$> optTransformationIds
+  let _replTransformations = toEvalTransformations
+      _replShowDeBruijn = False
+      _replNoDisambiguate = True
   _replInputFile <- optional parseInputJuvixFile
-  _replShowDeBruijn <-
-    switch
-      ( long "show-de-bruijn"
-          <> help "Show variable de Bruijn indices"
-      )
   _replNoPrelude <-
     switch
       ( long "no-prelude"

--- a/tests/smoke/Commands/dev/repl.smoke.yaml
+++ b/tests/smoke/Commands/dev/repl.smoke.yaml
@@ -1,0 +1,299 @@
+working-directory: ./../../../../tests/
+
+tests:
+  - name: open
+    command:
+      - juvix
+      - dev
+      - repl
+    stdout:
+      contains: "Juvix REPL"
+    exit-status: 0
+
+  - name: infer-mutually-recursive-let-expression
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: ":type let even : _; odd : _; odd zero := false; odd (suc n) := not (even n); even zero := true; even (suc n) := not (odd n) in even 10"
+    stdout:
+      contains:
+        "Bool"
+    exit-status: 0
+
+  - name: eval-mutually-recursive-let-expression
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: "let even : Nat → Bool; odd : _; odd zero := false; odd (suc n) := not (even n); even zero := true; even (suc n) := not (odd n) in even 10"
+    stdout:
+      contains:
+        "true"
+    exit-status: 0
+
+  - name: quit
+    command:
+      - juvix
+      - dev
+      - repl
+    stdout:
+      contains: "Juvix REPL"
+    stdin: ":quit"
+    exit-status: 0
+
+  - name: load-stdlib-by-default
+    command:
+      - juvix
+      - dev
+      - repl
+    stdout:
+      matches:
+        regex: |
+          Juvix REPL .*
+          OK loaded: .*/tests/.juvix-build/stdlib/Stdlib/Prelude.juvix
+    exit-status: 0
+
+  - name: version-shows-same-juvix-version
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: ":version"
+    stdout:
+      matches:
+        regex: |
+          Juvix REPL version ([0-9]+\.[0-9]+\.[0-9]\-[a-z0-9]+): .*
+          OK loaded: .*
+          Stdlib.Prelude> \1
+    exit-status: 0
+
+  - name: check-type-null
+    command:
+      - juvix
+      - dev
+      - repl
+    stdout:
+      contains: "{A : Type} → List A → Bool"
+    stdin: ":type null"
+    exit-status: 0
+
+  - name: check-type-suc
+    command:
+      - juvix
+      - dev
+      - repl
+    stdout:
+      contains: "Nat → Nat"
+    stdin: ":type suc"
+    exit-status: 0
+
+  - name: check-type-suc-short
+    command:
+      - juvix
+      - dev
+      - repl
+    stdout:
+      contains: "Nat → Nat"
+    stdin: ":t suc"
+    exit-status: 0
+
+  - name: check-type-suc-short-stdlib
+    command:
+      shell:
+        - bash
+      script: |
+        cd ./../juvix-stdlib && juvix repl
+    stdout:
+      contains: "Nat → Nat"
+    stdin: ":t suc"
+    exit-status: 0
+
+  - name: eval-and-operations
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: "true && false"
+    stdout:
+      matches: |
+        Juvix REPL .*
+        OK loaded: .*
+        Stdlib.Prelude> false
+    exit-status: 0
+
+  - name: eval-and-operations-with-spaces
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: "   true    &&    false"
+    stdout:
+      contains:
+        "false"
+    exit-status: 0
+
+  - name: eval-suc-true
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: "suc true"
+    stdout:
+      contains:
+        "Stdlib.Prelude> "
+    stderr:
+      contains: |
+        The expression true has type:
+          Bool
+        but is expected to have type:
+          Nat
+    exit-status: 0
+
+  - name: eval-let-expression
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: "let x : Nat; x := 2 + 1 in x"
+    stdout:
+      contains:
+        "3"
+    exit-status: 0
+
+  - name: load-builtin-bool
+    command:
+      shell:
+        - bash
+      script: |
+        cd ./Internal/positive/ && juvix repl
+    stdin: ":load BuiltinBool.juvix"
+    stdout:
+      contains:
+        "BuiltinBool>"
+    exit-status: 0
+
+  - name: load-builtin-bool-with-spaces
+    command:
+      shell:
+        - bash
+      script: |
+        cd ./Internal/positive/ && juvix repl
+    stdin: ":load    BuiltinBool.juvix"
+    stdout:
+      contains:
+        BuiltinBool>
+    exit-status: 0
+
+  - name: load-builtin-bool-short-form
+    command:
+      shell:
+        - bash
+      script: |
+        cd ./Internal/positive/ && juvix repl
+    stdin: |
+      :l BuiltinBool.juvix
+      main
+    stdout:
+      contains: |
+        true
+    exit-status: 0
+
+  - name: repl-file
+    command:
+      - juvix
+      - dev
+      - repl
+    args:
+      - Internal/positive/BuiltinBool.juvix
+    stdin: main
+    stdout:
+      contains: |
+        true
+    exit-status: 0
+
+  - name: root
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: ":root"
+    stdout:
+      matches: |
+        Juvix REPL .*
+        OK loaded: .*
+        Stdlib.Prelude> .*/tests/
+    exit-status: 0
+
+  - name: eval-adding-two-literal-nats
+    command:
+      - juvix
+      - dev
+      - repl
+    stdin: "1 + 2"
+    stdout:
+      contains: |
+        3
+    exit-status: 0
+
+  - name: repl-trace
+    command:
+      - juvix
+      - dev
+      - repl
+    args:
+      - positive/issue1731/builtinTrace.juvix
+    stdin: trace 2 (printNatLn 3)
+    stdout:
+      contains: |
+        3
+    stderr: |
+        2
+    exit-status: 0
+
+  - name: repl-trace-file
+    command:
+      - juvix
+      - dev
+      - repl
+    args:
+      - positive/issue1731/builtinTrace.juvix
+    stdin: f 4 0
+    stdout:
+      contains: |
+       0
+    stderr: |
+       4
+       3
+       2
+       1
+    exit-status: 0
+
+  - name: repl-fail
+    command:
+      - juvix
+      - dev
+      - repl
+    args:
+      - positive/issue1731/builtinFail.juvix
+    stdin: main
+    stdout:
+      contains: |
+        Get
+    stderr:
+      contains: |
+        evaluation error: failure: Enough
+    exit-status: 0
+
+  - name: repl-transformations
+    command:
+      - juvix
+      - dev
+      - repl
+      - -t
+      - identity
+    stdin: "0"
+    stdout:
+      contains: |
+        zero
+    exit-status: 0


### PR DESCRIPTION
The new `juvix dev repl` command is a copy of the `juvix repl` with the addition of `--no-disambiguate` flag that is present on the `juvix dev core from-concrete` command.

The `juvix repl` command now does not have the `--transforms`, `--show-de-bruijn` flags as these are only relevant for compiler developers. The eval transforms are always applied.

By default `juvix dev repl` uses the eval transforms. You can override this by specifying the `-t` flag.

Also we now run `disambiguateNames` transform on the info table in the `dev repl` (unless the `--no-disambiguate-names` flag is set). This is so the output of the `juvix dev repl` will match that of `juvix dev core from-concrete` and also so the output can be parsed by back the core parser.

* Closes https://github.com/anoma/juvix/issues/1914