### PR TITLE
Option `--show-args-num`

### DIFF
--- a/app/Commands/Dev/Core/Eval/Options.hs
+++ b/app/Commands/Dev/Core/Eval/Options.hs
@@ -9,6 +9,7 @@ data CoreEvalOptions = CoreEvalOptions
     _coreEvalInputFile :: AppPath File,
     _coreEvalShowDeBruijn :: Bool,
     _coreEvalShowIdentIds :: Bool,
+    _coreEvalShowArgsNum :: Bool,
     _coreEvalNoDisambiguate :: Bool
   }
   deriving stock (Data)
@@ -19,7 +20,8 @@ instance CanonicalProjection CoreEvalOptions Core.Options where
   project c =
     Core.defaultOptions
       { Core._optShowDeBruijnIndices = c ^. coreEvalShowDeBruijn,
-        Core._optShowIdentIds = c ^. coreEvalShowIdentIds
+        Core._optShowIdentIds = c ^. coreEvalShowIdentIds,
+        Core._optShowArgsNum = c ^. coreEvalShowArgsNum
       }
 
 instance CanonicalProjection CoreEvalOptions Eval.EvalOptions where
@@ -39,6 +41,7 @@ parseCoreEvalOptions = do
       )
   _coreEvalShowDeBruijn <- optDeBruijn
   _coreEvalShowIdentIds <- optIdentIds
+  _coreEvalShowArgsNum <- optArgsNum
   _coreEvalNoDisambiguate <- optNoDisambiguate
   _coreEvalInputFile <- parseInputJuvixCoreFile
   pure CoreEvalOptions {..}

--- a/app/Commands/Dev/Core/FromConcrete/Options.hs
+++ b/app/Commands/Dev/Core/FromConcrete/Options.hs
@@ -9,6 +9,7 @@ data CoreFromConcreteOptions = CoreFromConcreteOptions
   { _coreFromConcreteTransformations :: [TransformationId],
     _coreFromConcreteShowDeBruijn :: Bool,
     _coreFromConcreteShowIdentIds :: Bool,
+    _coreFromConcreteShowArgsNum :: Bool,
     _coreFromConcreteNoDisambiguate :: Bool,
     _coreFromConcreteFilter :: Bool,
     _coreFromConcreteNoIO :: Bool,
@@ -24,7 +25,8 @@ instance CanonicalProjection CoreFromConcreteOptions Core.Options where
   project c =
     Core.defaultOptions
       { Core._optShowDeBruijnIndices = c ^. coreFromConcreteShowDeBruijn,
-        Core._optShowIdentIds = c ^. coreFromConcreteShowIdentIds
+        Core._optShowIdentIds = c ^. coreFromConcreteShowIdentIds,
+        Core._optShowArgsNum = c ^. coreFromConcreteShowArgsNum
       }
 
 instance CanonicalProjection CoreFromConcreteOptions Eval.EvalOptions where
@@ -40,6 +42,7 @@ parseCoreFromConcreteOptions = do
   _coreFromConcreteTransformations <- optTransformationIds
   _coreFromConcreteShowDeBruijn <- optDeBruijn
   _coreFromConcreteShowIdentIds <- optIdentIds
+  _coreFromConcreteShowArgsNum <- optArgsNum
   _coreFromConcreteNoDisambiguate <- optNoDisambiguate
   _coreFromConcreteFilter <-
     switch

--- a/app/Commands/Dev/Core/Read/Options.hs
+++ b/app/Commands/Dev/Core/Read/Options.hs
@@ -10,6 +10,7 @@ data CoreReadOptions = CoreReadOptions
   { _coreReadTransformations :: [TransformationId],
     _coreReadShowDeBruijn :: Bool,
     _coreReadShowIdentIds :: Bool,
+    _coreReadShowArgsNum :: Bool,
     _coreReadNoDisambiguate :: Bool,
     _coreReadEval :: Bool,
     _coreReadNoPrint :: Bool,
@@ -23,7 +24,8 @@ instance CanonicalProjection CoreReadOptions Core.Options where
   project c =
     Core.defaultOptions
       { Core._optShowDeBruijnIndices = c ^. coreReadShowDeBruijn,
-        Core._optShowIdentIds = c ^. coreReadShowIdentIds
+        Core._optShowIdentIds = c ^. coreReadShowIdentIds,
+        Core._optShowArgsNum = c ^. coreReadShowArgsNum
       }
 
 instance CanonicalProjection CoreReadOptions Eval.CoreEvalOptions where
@@ -33,6 +35,7 @@ instance CanonicalProjection CoreReadOptions Eval.CoreEvalOptions where
         _coreEvalInputFile = c ^. coreReadInputFile,
         _coreEvalShowDeBruijn = c ^. coreReadShowDeBruijn,
         _coreEvalShowIdentIds = c ^. coreReadShowIdentIds,
+        _coreEvalShowArgsNum = c ^. coreReadShowArgsNum,
         _coreEvalNoDisambiguate = c ^. coreReadNoDisambiguate
       }
 
@@ -48,6 +51,7 @@ parseCoreReadOptions :: Parser CoreReadOptions
 parseCoreReadOptions = do
   _coreReadShowDeBruijn <- optDeBruijn
   _coreReadShowIdentIds <- optIdentIds
+  _coreReadShowArgsNum <- optArgsNum
   _coreReadNoDisambiguate <- optNoDisambiguate
   _coreReadNoPrint <-
     switch

--- a/app/Commands/Dev/Core/Repl/Options.hs
+++ b/app/Commands/Dev/Core/Repl/Options.hs
@@ -5,7 +5,8 @@ import Juvix.Compiler.Core.Pretty.Options qualified as Core
 
 data CoreReplOptions = CoreReplOptions
   { _coreReplShowDeBruijn :: Bool,
-    _coreReplShowIdentIds :: Bool
+    _coreReplShowIdentIds :: Bool,
+    _coreReplShowArgsNum :: Bool
   }
   deriving stock (Data)
 
@@ -15,11 +16,13 @@ instance CanonicalProjection CoreReplOptions Core.Options where
   project c =
     Core.defaultOptions
       { Core._optShowDeBruijnIndices = c ^. coreReplShowDeBruijn,
-        Core._optShowIdentIds = c ^. coreReplShowIdentIds
+        Core._optShowIdentIds = c ^. coreReplShowIdentIds,
+        Core._optShowArgsNum = c ^. coreReplShowArgsNum
       }
 
 parseCoreReplOptions :: Parser CoreReplOptions
 parseCoreReplOptions = do
   _coreReplShowDeBruijn <- optDeBruijn
   _coreReplShowIdentIds <- optIdentIds
+  _coreReplShowArgsNum <- optArgsNum
   pure CoreReplOptions {..}

--- a/app/CommonOptions.hs
+++ b/app/CommonOptions.hs
@@ -248,6 +248,13 @@ optIdentIds =
         <> help "Show identifier IDs"
     )
 
+optArgsNum :: Parser Bool
+optArgsNum =
+  switch
+    ( long "show-args-num"
+        <> help "Show identifier arguments number"
+    )
+
 optNoDisambiguate :: Parser Bool
 optNoDisambiguate =
   switch

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -443,13 +443,15 @@ instance PrettyCode InfoTable where
         case mii of
           Nothing -> return Nothing
           Just ii -> do
-            let ty = ii ^. identifierType
+            showArgsNum <- asks (^. optShowArgsNum)
+            let argsNum = if showArgsNum then brackets (pretty (ii ^. identifierArgsNum)) else mempty
+                ty = ii ^. identifierType
             ty' <- ppCode ty
             let tydoc
                   | isDynamic ty = mempty
                   | otherwise = space <> colon <+> ty'
                 blt = if isJust (ii ^. identifierBuiltin) then (Str.builtin <+> mempty) else mempty
-            return (Just (blt <> kwDef <+> sym' <> tydoc))
+            return (Just (blt <> kwDef <+> sym' <> argsNum <> tydoc))
 
       ppSigs :: [IdentifierInfo] -> Sem r (Doc Ann)
       ppSigs idents = do

--- a/src/Juvix/Compiler/Core/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Options.hs
@@ -23,7 +23,7 @@ traceOptions =
   Options
     { _optShowIdentIds = False,
       _optShowDeBruijnIndices = True,
-      _optShowArgsNum = False
+      _optShowArgsNum = True
     }
 
 fromGenericOptions :: GenericOptions -> Options

--- a/src/Juvix/Compiler/Core/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Options.hs
@@ -4,7 +4,8 @@ import Juvix.Prelude
 
 data Options = Options
   { _optShowIdentIds :: Bool,
-    _optShowDeBruijnIndices :: Bool
+    _optShowDeBruijnIndices :: Bool,
+    _optShowArgsNum :: Bool
   }
 
 makeLenses ''Options
@@ -13,14 +14,16 @@ defaultOptions :: Options
 defaultOptions =
   Options
     { _optShowIdentIds = False,
-      _optShowDeBruijnIndices = False
+      _optShowDeBruijnIndices = False,
+      _optShowArgsNum = False
     }
 
 traceOptions :: Options
 traceOptions =
   Options
     { _optShowIdentIds = False,
-      _optShowDeBruijnIndices = True
+      _optShowDeBruijnIndices = True,
+      _optShowArgsNum = False
     }
 
 fromGenericOptions :: GenericOptions -> Options

--- a/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
+++ b/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
@@ -114,7 +114,7 @@ convertIdent tab ii =
           zipExact tyargs' $
             map fst $
               filter (not . isTypeConstr tab . snd) (zipExact (ii ^. identifierArgsInfo) tyargs),
-      _identifierArgsNum = length (typeArgs ty')
+      _identifierArgsNum = length tyargs'
     }
   where
     tyargs = typeArgs (ii ^. identifierType)


### PR DESCRIPTION
* Adds an options to display the `_identifierArgsNum` field when printing Core definitions.