### PR TITLE
CI: Ignore errors linux typecheck / format examples step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,11 @@ jobs:
 
       - name: Typecheck and format Juvix examples
         if: ${{ success() }}
+        continue-on-error: true
         run: |
           cd main
-          make -s check-format-juvix-examples
-          make -s typecheck-juvix-examples
+          make check-format-juvix-examples
+          make typecheck-juvix-examples
 
       - name: Add ~/.local/bin to PATH
         run: |


### PR DESCRIPTION
There's an error with this step on linux only, but we cannot see it because of the `-s` flag on the Makefile call.

This commit removes the `-s` flag so we can diagnose the problem, but also temporarily ignores the error to avoid blocking other PRs.

NB: This step passes on macOS.