### PR TITLE
Fix a bug in closure traversal

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -714,10 +714,12 @@ destruct = \case
     NodeDetails
       { _nodeInfo = i,
         _nodeSubinfos = [],
-        _nodeChildren = oneBinder bi b : map noBinders env,
+        _nodeChildren = manyBinders binders b : map noBinders env,
         _nodeReassemble = someChildren $ \i' (b' :| env') ->
           Closure env' (Lambda i' bi b')
       }
+    where
+      binders = replicate (length env) (mkBinder' mkDynamic') ++ [bi]
 
 reassembleDetails :: NodeDetails -> [Node] -> Node
 reassembleDetails d ns = (d ^. nodeReassemble) (d ^. nodeInfo) (d ^. nodeSubinfos) ns


### PR DESCRIPTION
The number of binders was not correct, which made the evaluator crash sometimes when printing error messages.
