### PR TITLE
repl: Run disambiguateNames on result node

### DIFF
--- a/app/Commands/Repl/Options.hs
+++ b/app/Commands/Repl/Options.hs
@@ -25,7 +25,7 @@ parseRepl :: Parser ReplOptions
 parseRepl = do
   let _replTransformations = toEvalTransformations
       _replShowDeBruijn = False
-      _replNoDisambiguate = True
+      _replNoDisambiguate = False
   _replInputFile <- optional parseInputJuvixFile
   _replNoPrelude <-
     switch

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -266,6 +266,15 @@ tests:
         evaluation error: failure: Enough
     exit-status: 0
 
+  - name: disambiguate-names
+    command:
+      - juvix
+      - repl
+    stdin: "nil"
+    stdout:
+      contains: "λ(_X : Type) nil _X"
+    exit-status: 0
+
   - name: core-repl-type
     command:
       - juvix


### PR DESCRIPTION
There were two bugs here:

1. The _replNoDisambiguate option was set to True for `juvix repl`.
2. The disambiguateNames pass was being applied after the result node had already been fetched from the infotable.

* Closes https://github.com/anoma/juvix/issues/1958