### PR TITLE
Fix PrettyCode (Maybe a) instance "Just" case

### DIFF
--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -288,7 +288,7 @@ ppCodeAtom c = do
 instance PrettyCode a => PrettyCode (Maybe a) where
   ppCode = \case
     Nothing -> return "Nothing"
-    Just p -> ("Nothing" <+>) <$> ppCode p
+    Just p -> ("Just" <+>) <$> ppCode p
 
 instance (PrettyCode a, PrettyCode b) => PrettyCode (a, b) where
   ppCode (x, y) = do


### PR DESCRIPTION
`PrettyCode (Maybe a)` should print "Just" instead of "Nothing" in the Just case.