### PR TITLE
Test numbering

### DIFF
--- a/test/Asm/Run/Positive.hs
+++ b/test/Asm/Run/Positive.hs
@@ -33,187 +33,187 @@ allTests =
 tests :: [PosTest]
 tests =
   [ PosTest
-      "Arithmetic opcodes"
+      "Test001: Arithmetic opcodes"
       $(mkRelDir ".")
       $(mkRelFile "test001.jva")
       $(mkRelFile "out/test001.out"),
     PosTest
-      "Direct call"
+      "Test002: Direct call"
       $(mkRelDir ".")
       $(mkRelFile "test002.jva")
       $(mkRelFile "out/test002.out"),
     PosTest
-      "Indirect call"
+      "Test003: Indirect call"
       $(mkRelDir ".")
       $(mkRelFile "test003.jva")
       $(mkRelFile "out/test003.out"),
     PosTest
-      "Tail calls"
+      "Test004: Tail calls"
       $(mkRelDir ".")
       $(mkRelFile "test004.jva")
       $(mkRelFile "out/test004.out"),
     PosTest
-      "Tracing IO"
+      "Test005: Tracing IO"
       $(mkRelDir ".")
       $(mkRelFile "test005.jva")
       $(mkRelFile "out/test005.out"),
     PosTest
-      "IO builtins"
+      "Test006: IO builtins"
       $(mkRelDir ".")
       $(mkRelFile "test006.jva")
       $(mkRelFile "out/test006.out"),
     PosTest
-      "Higher-order functions"
+      "Test007: Higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test007.jva")
       $(mkRelFile "out/test007.out"),
     PosTest
-      "Branch"
+      "Test008: Branch"
       $(mkRelDir ".")
       $(mkRelFile "test008.jva")
       $(mkRelFile "out/test008.out"),
     PosTest
-      "Case"
+      "Test009: Case"
       $(mkRelDir ".")
       $(mkRelFile "test009.jva")
       $(mkRelFile "out/test009.out"),
     PosTest
-      "Recursion"
+      "Test010: Recursion"
       $(mkRelDir ".")
       $(mkRelFile "test010.jva")
       $(mkRelFile "out/test010.out"),
     PosTest
-      "Tail recursion"
+      "Test011: Tail recursion"
       $(mkRelDir ".")
       $(mkRelFile "test011.jva")
       $(mkRelFile "out/test011.out"),
     PosTest
-      "Temporary stack"
+      "Test012: Temporary stack"
       $(mkRelDir ".")
       $(mkRelFile "test012.jva")
       $(mkRelFile "out/test012.out"),
     PosTest
-      "Fibonacci numbers in linear time"
+      "Test013: Fibonacci numbers in linear time"
       $(mkRelDir ".")
       $(mkRelFile "test013.jva")
       $(mkRelFile "out/test013.out"),
     PosTest
-      "Trees"
+      "Test014: Trees"
       $(mkRelDir ".")
       $(mkRelFile "test014.jva")
       $(mkRelFile "out/test014.out"),
     PosTest
-      "Functions returning functions"
+      "Test015: Functions returning functions"
       $(mkRelDir ".")
       $(mkRelFile "test015.jva")
       $(mkRelFile "out/test015.out"),
     PosTest
-      "Arithmetic"
+      "Test016: Arithmetic"
       $(mkRelDir ".")
       $(mkRelFile "test016.jva")
       $(mkRelFile "out/test016.out"),
     PosTest
-      "Closures as arguments"
+      "Test017: Closures as arguments"
       $(mkRelDir ".")
       $(mkRelFile "test017.jva")
       $(mkRelFile "out/test017.out"),
     PosTest
-      "Closure extension"
+      "Test018: Closure extension"
       $(mkRelDir ".")
       $(mkRelFile "test018.jva")
       $(mkRelFile "out/test018.out"),
     PosTest
-      "Recursion through higher-order functions"
+      "Test019: Recursion through higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test019.jva")
       $(mkRelFile "out/test019.out"),
     PosTest
-      "Tail recursion through higher-order functions"
+      "Test020: Tail recursion through higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test020.jva")
       $(mkRelFile "out/test020.out"),
     PosTest
-      "Higher-order functions and recursion"
+      "Test021: Higher-order functions and recursion"
       $(mkRelDir ".")
       $(mkRelFile "test021.jva")
       $(mkRelFile "out/test021.out"),
     PosTest
-      "Self-application"
+      "Test022: Self-application"
       $(mkRelDir ".")
       $(mkRelFile "test022.jva")
       $(mkRelFile "out/test022.out"),
     PosTest
-      "McCarthy's 91 function"
+      "Test023: McCarthy's 91 function"
       $(mkRelDir ".")
       $(mkRelFile "test023.jva")
       $(mkRelFile "out/test023.out"),
     PosTest
-      "Higher-order recursive functions"
+      "Test024: Higher-order recursive functions"
       $(mkRelDir ".")
       $(mkRelFile "test024.jva")
       $(mkRelFile "out/test024.out"),
     PosTest
-      "Dynamic closure extension"
+      "Test025: Dynamic closure extension"
       $(mkRelDir ".")
       $(mkRelFile "test025.jva")
       $(mkRelFile "out/test025.out"),
     PosTest
-      "Currying & uncurrying"
+      "Test026: Currying & uncurrying"
       $(mkRelDir ".")
       $(mkRelFile "test026.jva")
       $(mkRelFile "out/test026.out"),
     PosTest
-      "Fast exponentiation"
+      "Test027: Fast exponentiation"
       $(mkRelDir ".")
       $(mkRelFile "test027.jva")
       $(mkRelFile "out/test027.out"),
     PosTest
-      "Lists"
+      "Test028: Lists"
       $(mkRelDir ".")
       $(mkRelFile "test028.jva")
       $(mkRelFile "out/test028.out"),
     PosTest
-      "Structural equality"
+      "Test029: Structural equality"
       $(mkRelDir ".")
       $(mkRelFile "test029.jva")
       $(mkRelFile "out/test029.out"),
     PosTest
-      "Mutual recursion"
+      "Test030: Mutual recursion"
       $(mkRelDir ".")
       $(mkRelFile "test030.jva")
       $(mkRelFile "out/test030.out"),
     PosTest
-      "Temporary stack with branching"
+      "Test031: Temporary stack with branching"
       $(mkRelDir ".")
       $(mkRelFile "test031.jva")
       $(mkRelFile "out/test031.out"),
     PosTest
-      "Church numerals"
+      "Test032: Church numerals"
       $(mkRelDir ".")
       $(mkRelFile "test032.jva")
       $(mkRelFile "out/test032.out"),
     PosTest
-      "Ackermann function"
+      "Test033: Ackermann function"
       $(mkRelDir ".")
       $(mkRelFile "test033.jva")
       $(mkRelFile "out/test033.out"),
     PosTest
-      "Higher-order function composition"
+      "Test034: Higher-order function composition"
       $(mkRelDir ".")
       $(mkRelFile "test034.jva")
       $(mkRelFile "out/test034.out"),
     PosTest
-      "Nested lists"
+      "Test035: Nested lists"
       $(mkRelDir ".")
       $(mkRelFile "test035.jva")
       $(mkRelFile "out/test035.out"),
     PosTest
-      "Streams without memoization"
+      "Test036: Streams without memoization"
       $(mkRelDir ".")
       $(mkRelFile "test036.jva")
       $(mkRelFile "out/test036.out"),
     PosTest
-      "String instructions"
+      "Test037: String instructions"
       $(mkRelDir ".")
       $(mkRelFile "test037.jva")
       $(mkRelFile "out/test037.out")

--- a/test/Core/Asm/Positive.hs
+++ b/test/Core/Asm/Positive.hs
@@ -8,7 +8,7 @@ allTests :: TestTree
 allTests = testGroup "JuvixCore to JuvixAsm positive tests" (map liftTest (Eval.filterOutTests ignoredTests Eval.tests))
 
 ignoredTests :: [String]
-ignoredTests = []
+ignoredTests = ["Test034: Evaluation order"]
 
 liftTest :: Eval.PosTest -> TestTree
 liftTest _testEval =

--- a/test/Core/Compile/Positive.hs
+++ b/test/Core/Compile/Positive.hs
@@ -10,12 +10,13 @@ allTests = testGroup "JuvixCore compilation tests" (map liftTest (Eval.filterOut
 -- Arbitrary precision integers not yet supported
 ignoredTests :: [String]
 ignoredTests =
-  [ "Tail recursion: Fibonacci numbers in linear time",
-    "Fast exponentiation",
-    "Nested 'case', 'let' and 'if' with variable capture",
-    "Mutual recursion",
-    "LetRec - fib, fact",
-    "Big numbers"
+  [ "Test011: Tail recursion: Fibonacci numbers in linear time",
+    "Test022: Fast exponentiation",
+    "Test025: Mutual recursion",
+    "Test026: Nested 'case', 'let' and 'if' with variable capture",
+    "Test034: Evaluation order",
+    "Test036: Big numbers",
+    "Test040: LetRec - fib, fact"
   ]
 
 liftTest :: Eval.PosTest -> TestTree

--- a/test/Core/Eval/Positive.hs
+++ b/test/Core/Eval/Positive.hs
@@ -38,297 +38,297 @@ allTests =
 tests :: [PosTest]
 tests =
   [ PosTest
-      "Arithmetic operators"
+      "Test001: Arithmetic operators"
       $(mkRelDir ".")
       $(mkRelFile "test001.jvc")
       $(mkRelFile "out/test001.out"),
     PosTest
-      "Arithmetic operators inside lambdas"
+      "Test002: Arithmetic operators inside lambdas"
       $(mkRelDir ".")
       $(mkRelFile "test002.jvc")
       $(mkRelFile "out/test002.out"),
     PosTest
-      "Empty program with comments"
+      "Test003: Empty program with comments"
       $(mkRelDir ".")
       $(mkRelFile "test003.jvc")
       $(mkRelFile "out/test003.out"),
     PosTest
-      "IO builtins"
+      "Test004: IO builtins"
       $(mkRelDir ".")
       $(mkRelFile "test004.jvc")
       $(mkRelFile "out/test004.out"),
     PosTest
-      "Higher-order functions"
+      "Test005: Higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test005.jvc")
       $(mkRelFile "out/test005.out"),
     PosTest
-      "If-then-else"
+      "Test006: If-then-else"
       $(mkRelDir ".")
       $(mkRelFile "test006.jvc")
       $(mkRelFile "out/test006.out"),
     PosTest
-      "Case"
+      "Test007: Case"
       $(mkRelDir ".")
       $(mkRelFile "test007.jvc")
       $(mkRelFile "out/test007.out"),
     PosTest
-      "Recursion"
+      "Test008: Recursion"
       $(mkRelDir ".")
       $(mkRelFile "test008.jvc")
       $(mkRelFile "out/test008.out"),
     PosTest
-      "Tail recursion"
+      "Test009: Tail recursion"
       $(mkRelDir ".")
       $(mkRelFile "test009.jvc")
       $(mkRelFile "out/test009.out"),
     PosTest
-      "Let"
+      "Test010: Let"
       $(mkRelDir ".")
       $(mkRelFile "test010.jvc")
       $(mkRelFile "out/test010.out"),
     PosTest
-      "Tail recursion: Fibonacci numbers in linear time"
+      "Test011: Tail recursion: Fibonacci numbers in linear time"
       $(mkRelDir ".")
       $(mkRelFile "test011.jvc")
       $(mkRelFile "out/test011.out"),
     PosTest
-      "Trees"
+      "Test012: Trees"
       $(mkRelDir ".")
       $(mkRelFile "test012.jvc")
       $(mkRelFile "out/test012.out"),
     PosTest
-      "Functions returning functions with variable capture"
+      "Test013: Functions returning functions with variable capture"
       $(mkRelDir ".")
       $(mkRelFile "test013.jvc")
       $(mkRelFile "out/test013.out"),
     PosTest
-      "Arithmetic"
+      "Test014: Arithmetic"
       $(mkRelDir ".")
       $(mkRelFile "test014.jvc")
       $(mkRelFile "out/test014.out"),
     PosTest
-      "Local functions with free variables"
+      "Test015: Local functions with free variables"
       $(mkRelDir ".")
       $(mkRelFile "test015.jvc")
       $(mkRelFile "out/test015.out"),
     PosTest
-      "Recursion through higher-order functions"
+      "Test016: Recursion through higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test016.jvc")
       $(mkRelFile "out/test016.out"),
     PosTest
-      "Tail recursion through higher-order functions"
+      "Test017: Tail recursion through higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test017.jvc")
       $(mkRelFile "out/test017.out"),
     PosTest
-      "Higher-order functions and recursion"
+      "Test018: Higher-order functions and recursion"
       $(mkRelDir ".")
       $(mkRelFile "test018.jvc")
       $(mkRelFile "out/test018.out"),
     PosTest
-      "Self-application"
+      "Test019: Self-application"
       $(mkRelDir ".")
       $(mkRelFile "test019.jvc")
       $(mkRelFile "out/test019.out"),
     PosTest
-      "Recursive functions: McCarthy's 91 function, subtraction by increments"
+      "Test020: McCarthy's 91 function, subtraction by increments"
       $(mkRelDir ".")
       $(mkRelFile "test020.jvc")
       $(mkRelFile "out/test020.out"),
     PosTest
-      "Higher-order recursive functions"
+      "Test021: Higher-order recursive functions"
       $(mkRelDir ".")
       $(mkRelFile "test021.jvc")
       $(mkRelFile "out/test021.out"),
     PosTest
-      "Fast exponentiation"
+      "Test022: Fast exponentiation"
       $(mkRelDir ".")
       $(mkRelFile "test022.jvc")
       $(mkRelFile "out/test022.out"),
     PosTest
-      "Lists"
+      "Test023: Lists"
       $(mkRelDir ".")
       $(mkRelFile "test023.jvc")
       $(mkRelFile "out/test023.out"),
     PosTest
-      "Structural equality"
+      "Test024: Structural equality"
       $(mkRelDir ".")
       $(mkRelFile "test024.jvc")
       $(mkRelFile "out/test024.out"),
     PosTest
-      "Mutual recursion"
+      "Test025: Mutual recursion"
       $(mkRelDir ".")
       $(mkRelFile "test025.jvc")
       $(mkRelFile "out/test025.out"),
     PosTest
-      "Nested 'case', 'let' and 'if' with variable capture"
+      "Test026: Nested 'case', 'let' and 'if' with variable capture"
       $(mkRelDir ".")
       $(mkRelFile "test026.jvc")
       $(mkRelFile "out/test026.out"),
     PosTest
-      "Euclid's algorithm"
+      "Test027: Euclid's algorithm"
       $(mkRelDir ".")
       $(mkRelFile "test027.jvc")
       $(mkRelFile "out/test027.out"),
     PosTest
-      "Functional queues"
+      "Test028: Functional queues"
       $(mkRelDir ".")
       $(mkRelFile "test028.jvc")
       $(mkRelFile "out/test028.out"),
     PosTest
-      "Church numerals"
+      "Test029: Church numerals"
       $(mkRelDir ".")
       $(mkRelFile "test029.jvc")
       $(mkRelFile "out/test029.out"),
     PosTest
-      "Streams without memoization"
+      "Test030: Streams without memoization"
       $(mkRelDir ".")
       $(mkRelFile "test030.jvc")
       $(mkRelFile "out/test030.out"),
     PosTest
-      "Ackermann function"
+      "Test031: Ackermann function"
       $(mkRelDir ".")
       $(mkRelFile "test031.jvc")
       $(mkRelFile "out/test031.out"),
     PosTest
-      "Ackermann function (higher-order definition)"
+      "Test032: Ackermann function (higher-order definition)"
       $(mkRelDir ".")
       $(mkRelFile "test032.jvc")
       $(mkRelFile "out/test032.out"),
     PosTest
-      "Nested lists"
+      "Test033: Nested lists"
       $(mkRelDir ".")
       $(mkRelFile "test033.jvc")
       $(mkRelFile "out/test033.out"),
-    {-    PosTest
-          "Evaluation order"
-          $(mkRelDir ".")
-          $(mkRelFile "test034.jvc")
-          $(mkRelFile "out/test034.out"), -}
     PosTest
-      "Merge sort"
+      "Test034: Evaluation order"
+      $(mkRelDir ".")
+      $(mkRelFile "test034.jvc")
+      $(mkRelFile "out/test034.out"),
+    PosTest
+      "Test035: Merge sort"
       $(mkRelDir ".")
       $(mkRelFile "test035.jvc")
       $(mkRelFile "out/test035.out"),
     PosTest
-      "Big numbers"
+      "Test036: Big numbers"
       $(mkRelDir ".")
       $(mkRelFile "test036.jvc")
       $(mkRelFile "out/test036.out"),
     PosTest
-      "Global variables"
+      "Test037: Global variables"
       $(mkRelDir ".")
       $(mkRelFile "test037.jvc")
       $(mkRelFile "out/test037.out"),
     PosTest
-      "Global variables and forward declarations"
+      "Test038: Global variables and forward declarations"
       $(mkRelDir ".")
       $(mkRelFile "test038.jvc")
       $(mkRelFile "out/test038.out"),
     PosTest
-      "Eta-expansion of builtins and constructors"
+      "Test039: Eta-expansion of builtins and constructors"
       $(mkRelDir ".")
       $(mkRelFile "test039.jvc")
       $(mkRelFile "out/test039.out"),
     PosTest
-      "LetRec - fib, fact"
+      "Test040: LetRec - fib, fact"
       $(mkRelDir ".")
       $(mkRelFile "test040.jvc")
       $(mkRelFile "out/test040.out"),
     PosTest
-      "Match with complex patterns"
+      "Test041: Match with complex patterns"
       $(mkRelDir ".")
       $(mkRelFile "test041.jvc")
       $(mkRelFile "out/test041.out"),
     PosTest
-      "Type annotations"
+      "Test042: Type annotations"
       $(mkRelDir ".")
       $(mkRelFile "test042.jvc")
       $(mkRelFile "out/test042.out"),
     PosTest
-      "Dependent lambda-abstractions"
+      "Test043: Dependent lambda-abstractions"
       $(mkRelDir ".")
       $(mkRelFile "test043.jvc")
       $(mkRelFile "out/test043.out"),
     PosTest
-      "Eta-expansion"
+      "Test044: Eta-expansion"
       $(mkRelDir ".")
       $(mkRelFile "test044.jvc")
       $(mkRelFile "out/test044.out"),
     PosTest
-      "Type application and abstraction"
+      "Test045: Type application and abstraction"
       $(mkRelDir ".")
       $(mkRelFile "test045.jvc")
       $(mkRelFile "out/test045.out"),
     PosTest
-      "Applications with lets and cases in function position"
+      "Test046: Applications with lets and cases in function position"
       $(mkRelDir ".")
       $(mkRelFile "test046.jvc")
       $(mkRelFile "out/test046.out"),
     PosTest
-      "Builtin natural numbers"
+      "Test047: Builtin natural numbers"
       $(mkRelDir ".")
       $(mkRelFile "test047.jvc")
       $(mkRelFile "out/test047.out"),
     PosTest
-      "String builtins"
+      "Test048: String builtins"
       $(mkRelDir ".")
       $(mkRelFile "test048.jvc")
       $(mkRelFile "out/test048.out"),
     PosTest
-      "Lifting and polymorphism"
+      "Test049: Lifting and polymorphism"
       $(mkRelDir ".")
       $(mkRelFile "test049.jvc")
       $(mkRelFile "out/test049.out"),
     PosTest
-      "Church numerals with pattern matching"
+      "Test050: Church numerals with pattern matching"
       $(mkRelDir ".")
       $(mkRelFile "test050.jvc")
       $(mkRelFile "out/test050.out"),
     PosTest
-      "Type annotations for patterns"
+      "Test051: Type annotations for patterns"
       $(mkRelDir ".")
       $(mkRelFile "test051.jvc")
       $(mkRelFile "out/test051.out"),
     PosTest
-      "foldl with match"
+      "Test052: foldl with match"
       $(mkRelDir ".")
       $(mkRelFile "test052.jvc")
       $(mkRelFile "out/test052.out"),
     PosTest
-      "Match with higher-order polymorphic functions"
+      "Test053: Match with higher-order polymorphic functions"
       $(mkRelDir ".")
       $(mkRelFile "test053.jvc")
       $(mkRelFile "out/test053.out"),
     PosTest
-      "Typed match"
+      "Test054: Typed match"
       $(mkRelDir ".")
       $(mkRelFile "test054.jvc")
       $(mkRelFile "out/test054.out"),
     PosTest
-      "Eta-expansion of polymorphic constructors"
+      "Test055: Eta-expansion of polymorphic constructors"
       $(mkRelDir ".")
       $(mkRelFile "test055.jvc")
       $(mkRelFile "out/test055.out"),
     PosTest
-      "LetRec with type annotations"
+      "Test056: LetRec with type annotations"
       $(mkRelDir ".")
       $(mkRelFile "test056.jvc")
       $(mkRelFile "out/test056.out"),
     PosTest
-      "Type synonyms"
+      "Test057: Type synonyms"
       $(mkRelDir ".")
       $(mkRelFile "test057.jvc")
       $(mkRelFile "out/test057.out"),
     PosTest
-      "Lifting and partial application"
+      "Test058: Lifting and partial application"
       $(mkRelDir ".")
       $(mkRelFile "test058.jvc")
       $(mkRelFile "out/test058.out"),
     PosTest
-      "Polymorphic type arguments"
+      "Test059: Polymorphic type arguments"
       $(mkRelDir ".")
       $(mkRelFile "test059.jvc")
       $(mkRelFile "out/test059.out")

--- a/test/Core/Transformation/Unrolling.hs
+++ b/test/Core/Transformation/Unrolling.hs
@@ -14,16 +14,16 @@ allTests =
         liftTest
         ( -- filter out tests which require recursion deeper than 140
           Eval.filterOutTests
-            [ "Recursion",
-              "Tail recursion",
-              "Tail recursion: Fibonacci numbers in linear time",
-              "Tail recursion through higher-order functions",
-              "Recursive functions: McCarthy's 91 function, subtraction by increments",
-              "Lists",
-              "Streams without memoization",
-              "Ackermann function (higher-order definition)",
-              "Merge sort",
-              "Big numbers"
+            [ "Test008: Recursion",
+              "Test009: Tail recursion",
+              "Test011: Tail recursion: Fibonacci numbers in linear time",
+              "Test017: Tail recursion through higher-order functions",
+              "Test020: McCarthy's 91 function, subtraction by increments",
+              "Test023: Lists",
+              "Test030: Streams without memoization",
+              "Test032: Ackermann function (higher-order definition)",
+              "Test035: Merge sort",
+              "Test036: Big numbers"
             ]
             Eval.tests
         )

--- a/test/Runtime/Positive.hs
+++ b/test/Runtime/Positive.hs
@@ -35,102 +35,102 @@ allTests =
 tests :: [PosTest]
 tests =
   [ PosTest
-      "HelloWorld"
+      "Test001: HelloWorld"
       $(mkRelDir ".")
       $(mkRelFile "test001.c")
       $(mkRelFile "out/test001.out"),
     PosTest
-      "Page allocation"
+      "Test002: Page allocation"
       $(mkRelDir ".")
       $(mkRelFile "test002.c")
       $(mkRelFile "out/test002.out"),
     PosTest
-      "Printing of integers"
+      "Test003: Printing of integers"
       $(mkRelDir ".")
       $(mkRelFile "test003.c")
       $(mkRelFile "out/test003.out"),
     PosTest
-      "Allocator for unstructured objects"
+      "Test004: Allocator for unstructured objects"
       $(mkRelDir ".")
       $(mkRelFile "test004.c")
       $(mkRelFile "out/test004.out"),
     PosTest
-      "Allocator for unstructured objects (macro API)"
+      "Test005: Allocator for unstructured objects (macro API)"
       $(mkRelDir ".")
       $(mkRelFile "test005.c")
       $(mkRelFile "out/test005.out"),
     PosTest
-      "Stack"
+      "Test006: Stack"
       $(mkRelDir ".")
       $(mkRelFile "test006.c")
       $(mkRelFile "out/test006.out"),
     PosTest
-      "Prologue and epilogue"
+      "Test007: Prologue and epilogue"
       $(mkRelDir ".")
       $(mkRelFile "test007.c")
       $(mkRelFile "out/test007.out"),
     PosTest
-      "Basic arithmetic"
+      "Test008: Basic arithmetic"
       $(mkRelDir ".")
       $(mkRelFile "test008.c")
       $(mkRelFile "out/test008.out"),
     PosTest
-      "Direct call"
+      "Test009: Direct call"
       $(mkRelDir ".")
       $(mkRelFile "test009.c")
       $(mkRelFile "out/test009.out"),
     PosTest
-      "Indirect call"
+      "Test010: Indirect call"
       $(mkRelDir ".")
       $(mkRelFile "test010.c")
       $(mkRelFile "out/test010.out"),
     PosTest
-      "Tail calls"
+      "Test011: Tail calls"
       $(mkRelDir ".")
       $(mkRelFile "test011.c")
       $(mkRelFile "out/test011.out"),
     PosTest
-      "Tracing and strings"
+      "Test012: Tracing and strings"
       $(mkRelDir ".")
       $(mkRelFile "test012.c")
       $(mkRelFile "out/test012.out"),
     PosTest
-      "IO builtins"
+      "Test013: IO builtins"
       $(mkRelDir ".")
       $(mkRelFile "test013.c")
       $(mkRelFile "out/test013.out"),
     PosTest
-      "Higher-order functions"
+      "Test014: Higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test014.c")
       $(mkRelFile "out/test014.out"),
     PosTest
-      "Branching, matching and recursion on lists"
+      "Test015: Branching, matching and recursion on lists"
       $(mkRelDir ".")
       $(mkRelFile "test015.c")
       $(mkRelFile "out/test015.out"),
     PosTest
-      "Closure extension"
+      "Test016: Closure extension"
       $(mkRelDir ".")
       $(mkRelFile "test016.c")
       $(mkRelFile "out/test016.out"),
     PosTest
-      "Recursion through higher-order functions"
+      "Test017: Recursion through higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test017.c")
       $(mkRelFile "out/test017.out"),
     PosTest
-      "Tail recursion through higher-order functions"
+      "Test018: Tail recursion through higher-order functions"
       $(mkRelDir ".")
       $(mkRelFile "test018.c")
       $(mkRelFile "out/test018.out"),
     PosTest
-      "Dynamic closure extension"
+      "Test019: Dynamic closure extension"
       $(mkRelDir ".")
       $(mkRelFile "test019.c")
       $(mkRelFile "out/test019.out"),
     PosTest
-      "Higher-order function composition"
+      "Test020: Higher-order function composition"
       $(mkRelDir ".")
       $(mkRelFile "test020.c")
       $(mkRelFile "out/test020.out")


### PR DESCRIPTION
Add test numbers in the test names for Core, Asm and Runtime. This makes it easier to see which test failed.
