### PR TITLE
Fix: format  juvix files in test/positive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SKIP: ormolu,format-juvix-examples,typecheck-juvix-examples
+  SKIP: ormolu,format-juvix-files,typecheck-juvix-examples
 
 jobs:
   pre-commit:
@@ -119,7 +119,7 @@ jobs:
         continue-on-error: true
         run: |
           cd main
-          make check-format-juvix-examples
+          make check-format-juvix-files
           make typecheck-juvix-examples
 
       - name: Add ~/.local/bin to PATH
@@ -317,7 +317,7 @@ jobs:
         if: ${{ success() }}
         run: |
           cd main
-          make -s check-format-juvix-examples
+          make -s check-format-juvix-files
           make -s typecheck-juvix-examples
 
       - name: Install Smoke

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,9 @@ repos:
 
   - repo: local
     hooks:
-      - id: format-juvix-examples
+      - id: format-juvix-files
         name: format Juvix examples
-        entry: make -s format-juvix-examples
+        entry: make -s format-juvix-files
         language: system
         verbose: false
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ EXAMPLES= Collatz/Collatz.juvix \
 	HelloWorld/HelloWorld.juvix \
 	PascalsTriangle/PascalsTriangle.juvix \
 	TicTacToe/CLI/TicTacToe.juvix \
-	Tutorial/Tutorial.juvix \
+	Tutorial/Tutorial.juvix
 
 DEMO_EXAMPLE=examples/demo/Demo.juvix
 
@@ -130,20 +130,26 @@ format:
 clang-format:
 	@cd runtime && ${MAKE} format
 
-JUVIXEXAMPLEFILES=$(shell find ./examples -name "*.juvix" -print)
+JUVIXFILESTOFORMAT=$(shell find ./examples \
+																./tests/positive \
+																-type d -name ".juvix-build" -prune -o \
+																-type f -name "*.juvix" \
+																-print)
 JUVIXFORMATFLAGS?=--in-place
 JUVIXTYPECHECKFLAGS?=--only-errors
 
-.PHONY: format-juvix-examples
-format-juvix-examples:
-	@for file in $(JUVIXEXAMPLEFILES); do \
-		${JUVIXBIN} format $(JUVIXFORMATFLAGS) "$$file"; \
+.PHONY: format-juvix-files
+format-juvix-files:
+	@for file in $(JUVIXFILESTOFORMAT); do \
+		juvix format $(JUVIXFORMATFLAGS) "$$file"; \
 	done
 
-.PHONY: check-format-juvix-examples
-check-format-juvix-examples:
+.PHONY: check-format-juvix-files
+check-format-juvix-files:
 	@export JUVIXFORMATFLAGS=--check
-	@${MAKE} format-juvix-examples
+	@make format-juvix-files
+
+JUVIXEXAMPLEFILES=$(shell find ./examples  -name "*.juvix" -print)
 
 .PHONY: typecheck-juvix-examples
 typecheck-juvix-examples:

--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,7 @@ format:
 clang-format:
 	@cd runtime && ${MAKE} format
 
-JUVIXFILESTOFORMAT=$(shell find ./examples \
-																./tests/positive \
-																-type d -name ".juvix-build" -prune -o \
-																-type f -name "*.juvix" \
-																-print)
+JUVIXFILESTOFORMAT=$(shell find ./examples ./tests/positive -type d -name ".juvix-build" -prune -o -type f -name "*.juvix" -print)
 JUVIXFORMATFLAGS?=--in-place
 JUVIXTYPECHECKFLAGS?=--only-errors
 

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -82,7 +82,7 @@ groupStatements = reverse . map reverse . uncurry cons . foldl' aux ([], [])
       (StatementOpenModule {}, _) -> False
       (StatementInductive {}, _) -> False
       (StatementModule {}, _) -> False
-      (StatementAxiom {}, StatementAxiom {}) -> True
+      (StatementAxiom {}, StatementAxiom {}) -> False
       (StatementAxiom {}, _) -> False
       (StatementTypeSignature sig, StatementFunctionClause fun) ->
         case sing :: SStage s of

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -177,11 +177,10 @@ instance PrettyPrint (AxiomDef 'Scoped) where
     axiomName' <- P.annDef _axiomName <$> P.ppSymbol _axiomName
     let builtin' :: Maybe (Sem r ()) = (<> line) . (\x -> P.ppCode x >>= morpheme (getLoc x)) <$> _axiomBuiltin
         _axiomDoc' :: Maybe (Sem r ()) = ppCode <$> _axiomDoc
-        axiom' = (<> line) . ppCode $ _axiomKw
     _axiomDoc'
       ?<> builtin'
-      ?<> axiom'
-      <> morpheme (getLoc _axiomName) axiomName'
+      ?<> ppCode _axiomKw
+      <+> morpheme (getLoc _axiomName) axiomName'
       <+> noLoc P.kwColon
       <+> ppCode _axiomType
 

--- a/tests/positive/265/M.juvix
+++ b/tests/positive/265/M.juvix
@@ -1,14 +1,12 @@
 module M;
 
 type Bool :=
-     true : Bool
+  | true : Bool
   | false : Bool;
 
 type Pair (A : Type) (B : Type) :=
-  mkPair : A → B → Pair A B;
+  | mkPair : A → B → Pair A B;
 
 f : _ → _;
 f (mkPair false true) := true;
 f _ := false;
-
-end;

--- a/tests/positive/272/M.juvix
+++ b/tests/positive/272/M.juvix
@@ -1,14 +1,14 @@
 module M;
 
 type Bool :=
-     true : Bool
+  | true : Bool
   | false : Bool;
 
 type T :=
-t : T;
+  | t : T;
 
 type Nat :=
-  zero : Nat
+  | zero : Nat
   | suc : Nat → Nat;
 
 f : _;
@@ -16,9 +16,7 @@ f false false := true;
 f true _ := false;
 
 type Pair (A : Type) (B : Type) :=
-  mkPair : A → B → Pair A B;
+  | mkPair : A → B → Pair A B;
 
 g : _;
 g (mkPair (mkPair zero false) true) := mkPair false zero;
-
-end;

--- a/tests/positive/Ape.juvix
+++ b/tests/positive/Ape.juvix
@@ -1,36 +1,30 @@
 module Ape;
 
 builtin string
-axiom
-String : Type;
+axiom String : Type;
 
 infixl 7 *;
-axiom
-* : String → String → String;
+axiom * : String → String → String;
 
 infixr 3 -;
-axiom
-- : String → String → String;
+axiom - : String → String → String;
 
 infixl 1 >>;
-axiom
->> : String → String → String;
+axiom >> : String → String → String;
 
 infixl 6 +;
-axiom
-+ : String → String → String;
+axiom + : String → String → String;
 
 infixr 6 ++;
-axiom
-++ : String → String → String;
-axiom
-f : String → String;
+axiom ++ : String → String → String;
+
+axiom f : String → String;
 
 x : String;
 x := "" + ("" ++ "");
 
-axiom
-wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww : String → String;
+axiom wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww : String
+  → String;
 
 nesting : String;
 nesting :=

--- a/tests/positive/Axiom.juvix
+++ b/tests/positive/Axiom.juvix
@@ -1,4 +1,3 @@
 module Axiom;
 
-axiom
-Action : Type;
+axiom Action : Type;

--- a/tests/positive/BuiltinsMultiImport/A.juvix
+++ b/tests/positive/BuiltinsMultiImport/A.juvix
@@ -1,5 +1,3 @@
 module A;
 
 import Nat;
-
-end;

--- a/tests/positive/BuiltinsMultiImport/Input.juvix
+++ b/tests/positive/BuiltinsMultiImport/Input.juvix
@@ -2,5 +2,3 @@ module Input;
 
 import A;
 import Nat;
-
-end;

--- a/tests/positive/BuiltinsMultiImport/Nat.juvix
+++ b/tests/positive/BuiltinsMultiImport/Nat.juvix
@@ -2,7 +2,5 @@ module Nat;
 
 builtin nat
 type Nat :=
-  zero : Nat
+  | zero : Nat
   | suc : Nat → Nat;
-
-end;

--- a/tests/positive/BuiltinsMultiOpenImport/A.juvix
+++ b/tests/positive/BuiltinsMultiOpenImport/A.juvix
@@ -1,5 +1,3 @@
 module A;
 
 open import Nat;
-
-end;

--- a/tests/positive/BuiltinsMultiOpenImport/Input.juvix
+++ b/tests/positive/BuiltinsMultiOpenImport/Input.juvix
@@ -2,5 +2,3 @@ module Input;
 
 open import A;
 open import Nat;
-
-end;

--- a/tests/positive/BuiltinsMultiOpenImport/Nat.juvix
+++ b/tests/positive/BuiltinsMultiOpenImport/Nat.juvix
@@ -2,7 +2,5 @@ module Nat;
 
 builtin nat
 type Nat :=
-  zero : Nat
+  | zero : Nat
   | suc : Nat → Nat;
-
-end;

--- a/tests/positive/Dependencies/.libs/Base/Base.juvix
+++ b/tests/positive/Dependencies/.libs/Base/Base.juvix
@@ -1,5 +1,3 @@
 module Base;
 
-  axiom Base : Type;
-
-end;
+axiom Base : Type;

--- a/tests/positive/Dependencies/.libs/Extra/Extra.juvix
+++ b/tests/positive/Dependencies/.libs/Extra/Extra.juvix
@@ -5,5 +5,3 @@ open import Base;
 axiom Extra : Type;
 
 axiom _A : Base;
-
-end;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -13,8 +13,7 @@ go n s :=
 
 module M;
   infixr 4 ,;
-  axiom
-  , : String → String → String;
+  axiom , : String → String → String;
 end;
 
 -- qualified commas
@@ -48,24 +47,19 @@ t3 :=
     , "1234";
 
 infixl 7 +l7;
-axiom
-+l7 : String → String → String;
+axiom +l7 : String → String → String;
 
 infixr 3 +r3;
-axiom
-+r3 : String → String → String;
+axiom +r3 : String → String → String;
 
 infixl 1 +l1;
-axiom
-+l1 : String → String → String;
+axiom +l1 : String → String → String;
 
 infixl 6 +l6;
-axiom
-+l6 : String → String → String;
+axiom +l6 : String → String → String;
 
 infixr 6 +r6;
-axiom
-+r6 : String → String → String;
+axiom +r6 : String → String → String;
 
 -- nesting of chains
 t : String;

--- a/tests/positive/Imports/A.juvix
+++ b/tests/positive/Imports/A.juvix
@@ -8,8 +8,7 @@ module M;
   end;
 
   infixr 2 +;
-  axiom
-  + : Type → Type → Type;
+  axiom + : Type → Type → Type;
 end;
 
 import M;

--- a/tests/positive/Internal/AsPattern.juvix
+++ b/tests/positive/Internal/AsPattern.juvix
@@ -11,12 +11,14 @@ infixr 9 ∘;
     → C;
 ∘ {_} {B} {_} f g x := f (g x);
 
-builtin nat type Nat :=
+builtin nat
+type Nat :=
   | zero : Nat
   | suc : Nat → Nat;
 
 infixl 6 +;
-builtin nat-plus + : Nat → Nat → Nat;
+builtin nat-plus
++ : Nat → Nat → Nat;
 + zero b := b;
 + (suc a) b := suc (a + b);
 

--- a/tests/positive/Internal/LiteralString.juvix
+++ b/tests/positive/Internal/LiteralString.juvix
@@ -1,6 +1,7 @@
 module LiteralString;
 
-builtin string axiom String : Type;
+builtin string
+axiom String : Type;
 
 type A :=
   | a : A;

--- a/tests/positive/Internal/Positivity/E5.juvix
+++ b/tests/positive/Internal/Positivity/E5.juvix
@@ -1,14 +1,13 @@
 module E5;
 
 type T0 (A : Type) :=
-c0 : (A -> T0 A) -> T0 A;
+  | c0 : (A -> T0 A) -> T0 A;
 
 axiom B : Type;
+
 type T1 (A : Type) :=
-c1 : (B -> T0 A) -> T1 A;
+  | c1 : (B -> T0 A) -> T1 A;
 
 positive
 type T2 :=
-c2 : (B -> (B -> T1 T2)) -> T2;
-
-end;
+  | c2 : (B -> B -> T1 T2) -> T2;

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -1,6 +1,7 @@
 module Judoc;
 
 axiom A : Type;
+
 axiom b : Type;
 
 type T :=

--- a/tests/positive/Literals.juvix
+++ b/tests/positive/Literals.juvix
@@ -1,11 +1,10 @@
 module Literals;
 
-axiom
-Int : Type;
-axiom
-String : Type;
-axiom
-+ : Int → Int → Int;
+axiom Int : Type;
+
+axiom String : Type;
+
+axiom + : Int → Int → Int;
 
 a : Int;
 a := 12313;

--- a/tests/positive/Operators.juvix
+++ b/tests/positive/Operators.juvix
@@ -1,8 +1,7 @@
 module Operators;
 
 infixl 5 +;
-axiom
-+ : Type → Type → Type;
+axiom + : Type → Type → Type;
 
 plus : Type → Type → Type;
 plus := (+);

--- a/tests/positive/QualifiedConstructor/M.juvix
+++ b/tests/positive/QualifiedConstructor/M.juvix
@@ -1,8 +1,7 @@
 module M;
 
 module O;
-  axiom
-  A : Type;
+  axiom A : Type;
 end;
 
 open O;

--- a/tests/positive/QualifiedSymbol/M.juvix
+++ b/tests/positive/QualifiedSymbol/M.juvix
@@ -2,8 +2,7 @@ module M;
 
 module N;
   module O;
-    axiom
-    A : Type;
+    axiom A : Type;
   end;
 end;
 
@@ -13,5 +12,4 @@ module O;
   
 end;
 
-axiom
-B : O.A;
+axiom B : O.A;

--- a/tests/positive/QualifiedSymbol2/N.juvix
+++ b/tests/positive/QualifiedSymbol2/N.juvix
@@ -3,9 +3,7 @@ module N;
 import M;
 
 module M;
-  axiom
-  A : Type;
+  axiom A : Type;
 end;
 
-axiom
-B : M.A;
+axiom B : M.A;

--- a/tests/positive/Reachability/Data/Bool.juvix
+++ b/tests/positive/Reachability/Data/Bool.juvix
@@ -1,20 +1,17 @@
 module Data.Bool;
-  type Bool :=
-    true : Bool |
-    false : Bool;
 
-  not : Bool → Bool;
-  not true := false;
-  not false := true;
+type Bool :=
+  | true : Bool
+  | false : Bool;
 
-  -- infixr 2 ||;
-  -- || : Bool → Bool → Bool;
-  -- || false a := a;
-  -- || true _ := true;
-
-  -- infixr 2 &&;
-  -- && : Bool → Bool → Bool;
-  -- && false _ := false;
-  -- && true a := a;
-
-end;
+not : Bool → Bool;
+not true := false;
+not false := true;
+-- infixr 2 ||;
+-- || : Bool → Bool → Bool;
+-- || false a := a;
+-- || true _ := true;
+-- infixr 2 &&;
+-- && : Bool → Bool → Bool;
+-- && false _ := false;
+-- && true a := a;

--- a/tests/positive/Reachability/Data/Maybe.juvix
+++ b/tests/positive/Reachability/Data/Maybe.juvix
@@ -1,7 +1,5 @@
 module Data.Maybe;
 
-  type Maybe (a : Type) :=
-     nothing : Maybe a |
-     just : a → Maybe a;
-
-end;
+type Maybe (a : Type) :=
+  | nothing : Maybe a
+  | just : a → Maybe a;

--- a/tests/positive/Reachability/Data/Nat.juvix
+++ b/tests/positive/Reachability/Data/Nat.juvix
@@ -1,16 +1,15 @@
 module Data.Nat;
-  type ℕ  :=
-    zero : ℕ |
-    suc : ℕ → ℕ;
 
-  infixl 6 +;
-  + : ℕ → ℕ → ℕ;
-  + zero b := b;
-  + (suc a) b := suc (a + b);
+type ℕ :=
+  | zero : ℕ
+  | suc : ℕ → ℕ;
 
-  infixl 7 *;
-  * : ℕ → ℕ → ℕ;
-  * zero b := zero;
-  * (suc a) b := b + a * b;
+infixl 6 +;
++ : ℕ → ℕ → ℕ;
++ zero b := b;
++ (suc a) b := suc (a + b);
 
-end;
+infixl 7 *;
+* : ℕ → ℕ → ℕ;
+* zero b := zero;
+* (suc a) b := b + a * b;

--- a/tests/positive/Reachability/Data/Ord.juvix
+++ b/tests/positive/Reachability/Data/Ord.juvix
@@ -1,6 +1,6 @@
 module Data.Ord;
-    type Ordering :=
-      LT : Ordering |
-      EQ : Ordering |
-      GT : Ordering;
-end;
+
+type Ordering :=
+  | LT : Ordering
+  | EQ : Ordering
+  | GT : Ordering;

--- a/tests/positive/Reachability/Data/Product.juvix
+++ b/tests/positive/Reachability/Data/Product.juvix
@@ -2,6 +2,4 @@ module Data.Product;
 
 infixr 2 ×;
 type × (a : Type) (b : Type) :=
-  , : a → b → a × b;
-
-end;
+  | , : a → b → a × b;

--- a/tests/positive/Reachability/M.juvix
+++ b/tests/positive/Reachability/M.juvix
@@ -14,5 +14,3 @@ g x y := f y;
 
 h : {A : Type} -> A -> Maybe Bool;
 h x := nothing;
-
-end;

--- a/tests/positive/Reachability/N.juvix
+++ b/tests/positive/Reachability/N.juvix
@@ -7,6 +7,4 @@ test : {A : Type} -> A -> A;
 test x := x;
 
 type Unit :=
-  unit : Unit;
-
-end;
+  | unit : Unit;

--- a/tests/positive/Reachability/O.juvix
+++ b/tests/positive/Reachability/O.juvix
@@ -5,5 +5,3 @@ open import Stdlib.Prelude;
 
 k : Bool;
 k := true;
-
-end;

--- a/tests/positive/ShadowPublicOpen.juvix
+++ b/tests/positive/ShadowPublicOpen.juvix
@@ -2,8 +2,7 @@ module ShadowPublicOpen;
 
 module M;
   module N;
-    axiom
-    A : Type;
+    axiom A : Type;
   end;
 
   open N public;
@@ -11,5 +10,4 @@ end;
 
 open M;
 
-axiom
-A : Type;
+axiom A : Type;

--- a/tests/positive/StdlibImport/A.juvix
+++ b/tests/positive/StdlibImport/A.juvix
@@ -1,5 +1,4 @@
 module A;
 
-type Foo := bar : Foo;
-
-end;
+type Foo :=
+  | bar : Foo;

--- a/tests/positive/StdlibImport/StdlibImport.juvix
+++ b/tests/positive/StdlibImport/StdlibImport.juvix
@@ -1,11 +1,11 @@
 module StdlibImport;
-  open import Stdlib.Prelude;
 
-  import A;
+open import Stdlib.Prelude;
 
-  two : Nat;
-  two := 1 + 1;
+import A;
 
-  foo : A.Foo;
-  foo := A.bar;
-end;
+two : Nat;
+two := 1 + 1;
+
+foo : A.Foo;
+foo := A.bar;

--- a/tests/positive/Symbols.juvix
+++ b/tests/positive/Symbols.juvix
@@ -29,8 +29,7 @@ infixl 7 ·;
 主功能 : Nat;
 主功能 := （0）;
 
-axiom
-= : Type;
+axiom = : Type;
 
 K : Nat → Nat → Nat;
 K =a@zero (=) := =a · =;

--- a/tests/positive/Termination/Ack.juvix
+++ b/tests/positive/Termination/Ack.juvix
@@ -1,10 +1,9 @@
 module Ack;
-  import Data.Nat;
-  open Data.Nat;
 
-  ack : ℕ → ℕ → ℕ;
-  ack zero n := suc n;
-  ack (suc m) zero := ack m (suc zero);
-  ack (suc m) (suc n) := ack m (ack (suc m) n);
+import Data.Nat;
+open Data.Nat;
 
-end;
+ack : ℕ → ℕ → ℕ;
+ack zero n := suc n;
+ack (suc m) zero := ack m (suc zero);
+ack (suc m) (suc n) := ack m (ack (suc m) n);

--- a/tests/positive/Termination/Data/Bool.juvix
+++ b/tests/positive/Termination/Data/Bool.juvix
@@ -1,24 +1,23 @@
 module Data.Bool;
-  type Bool :=
-    true : Bool |
-    false : Bool;
 
-  not : Bool → Bool;
-  not true := false;
-  not false := true;
+type Bool :=
+  | true : Bool
+  | false : Bool;
 
-  infixr 2 ||;
-  || : Bool → Bool → Bool;
-  || false a := a;
-  || true _ := true;
+not : Bool → Bool;
+not true := false;
+not false := true;
 
-  infixr 2 &&;
-  && : Bool → Bool → Bool;
-  && false _ := false;
-  && true a := a;
+infixr 2 ||;
+|| : Bool → Bool → Bool;
+|| false a := a;
+|| true _ := true;
 
-  ite : {a : Type} → Bool → a → a → a;
-  ite true a _ := a;
-  ite false _ b := b;
+infixr 2 &&;
+&& : Bool → Bool → Bool;
+&& false _ := false;
+&& true a := a;
 
-end;
+ite : {a : Type} → Bool → a → a → a;
+ite true a _ := a;
+ite false _ b := b;

--- a/tests/positive/Termination/Data/List.juvix
+++ b/tests/positive/Termination/Data/List.juvix
@@ -7,16 +7,18 @@ import Data.Nat;
 open Data.Nat;
 
 type List (A : Type) :=
-  nil : List A |
-  cons : A → List A → List A;
+  | nil : List A
+  | cons : A → List A → List A;
 
 -- Do not remove implicit arguments. Useful for testing.
-foldr : {A : Type} → {B : Type} → (A → B → B) → B → List A → B;
+foldr :
+  {A : Type} → {B : Type} → (A → B → B) → B → List A → B;
 foldr _ z nil := z;
 foldr f z (cons h hs) := f h (foldr {_} f z hs);
 
-foldl : {A : Type} → {B : Type} → (B → A → B) → B → List A → B;
-foldl f z nil := z ;
+foldl :
+  {A : Type} → {B : Type} → (B → A → B) → B → List A → B;
+foldl f z nil := z;
 foldl {_} {_} f z (cons h hs) := foldl {_} f (f z h) hs;
 
 map : {A : Type} → {B : Type} → (A → B) → List A → List B;
@@ -25,9 +27,8 @@ map f (cons h hs) := cons (f h) (map f hs);
 
 filter : {A : Type} → (A → Bool) → List A → List A;
 filter f nil := nil;
-filter f (cons h hs) := ite (f h)
-  (cons h (filter {_} f hs))
-  (filter f hs);
+filter f (cons h hs) :=
+  ite (f h) (cons h (filter {_} f hs)) (filter f hs);
 
 length : {A : Type} → List A → ℕ;
 length nil := zero;
@@ -51,5 +52,3 @@ take _ _ := nil;
 concat : {A : Type} → List A → List A → List A;
 concat nil ys := ys;
 concat (cons x xs) ys := cons x (concat xs ys);
-
-end;

--- a/tests/positive/Termination/Data/Nat.juvix
+++ b/tests/positive/Termination/Data/Nat.juvix
@@ -1,27 +1,28 @@
 module Data.Nat;
-  type ℕ  :=
-    zero : ℕ |
-    suc : ℕ → ℕ;
 
-  infixl 6 +;
-  + : ℕ → ℕ → ℕ;
-  + zero b := b;
-  + (suc a) b := suc (a + b);
+type ℕ :=
+  | zero : ℕ
+  | suc : ℕ → ℕ;
 
-  infixl 7 *;
-  * : ℕ → ℕ → ℕ;
-  * zero b := zero;
-  * (suc a) b := b + a * b;
+infixl 6 +;
++ : ℕ → ℕ → ℕ;
++ zero b := b;
++ (suc a) b := suc (a + b);
 
-  import Data.Bool;
-  open Data.Bool;
+infixl 7 *;
+* : ℕ → ℕ → ℕ;
+* zero b := zero;
+* (suc a) b := b + a * b;
 
-  even : ℕ → Bool;
-  odd : ℕ → Bool;
+import Data.Bool;
+open Data.Bool;
 
-  even zero := true;
-  even (suc n) := odd n;
+even : ℕ → Bool;
 
-  odd zero := false;
-  odd (suc n) := even n;
-end;
+odd : ℕ → Bool;
+
+even zero := true;
+even (suc n) := odd n;
+
+odd zero := false;
+odd (suc n) := even n;

--- a/tests/positive/Termination/Fib.juvix
+++ b/tests/positive/Termination/Fib.juvix
@@ -1,7 +1,7 @@
 module Fib;
 
 type Nat :=
-  zero : Nat
+  | zero : Nat
   | suc : Nat → Nat;
 
 infixl 6 +;
@@ -11,7 +11,5 @@ infixl 6 +;
 
 fib : Nat -> Nat;
 fib zero := zero;
-fib (suc (zero)) := suc zero;
+fib (suc zero) := suc zero;
 fib (suc (suc n)) := fib (suc n) + fib n;
-
-end;

--- a/tests/positive/Termination/Mutual.juvix
+++ b/tests/positive/Termination/Mutual.juvix
@@ -2,10 +2,11 @@ module Mutual;
 
 axiom A : Type;
 
-terminating f : A -> A -> A;
-terminating g : A -> A -> A;
+terminating
+f : A -> A -> A;
 
+terminating
+g : A -> A -> A;
 g x y := f x x;
-f x y := g x (f x x);
 
-end;
+f x y := g x (f x x);

--- a/tests/positive/Termination/TreeGen.juvix
+++ b/tests/positive/Termination/TreeGen.juvix
@@ -1,17 +1,17 @@
 module TreeGen;
-  open import Stdlib.Prelude;
 
-  type Tree :=
-    | leaf : Tree
-    | node : Tree → Tree → Tree;
+open import Stdlib.Prelude;
 
-  gen : Nat → Tree;
-  gen zero := leaf;
-  gen (suc zero) := node leaf leaf;
-  gen (suc (suc n')) := node (gen n') (gen (suc n'));
+type Tree :=
+  | leaf : Tree
+  | node : Tree → Tree → Tree;
 
-  gen2 : Nat → Tree;
-  gen2 zero := leaf;
-  gen2 (suc zero) := node leaf leaf;
-  gen2 (suc n@(suc n')) := node (gen2 n') (gen2 n);
-end;
+gen : Nat → Tree;
+gen zero := leaf;
+gen (suc zero) := node leaf leaf;
+gen (suc (suc n')) := node (gen n') (gen (suc n'));
+
+gen2 : Nat → Tree;
+gen2 zero := leaf;
+gen2 (suc zero) := node leaf leaf;
+gen2 (suc n@(suc n')) := node (gen2 n') (gen2 n);

--- a/tests/positive/Termination/Undefined.juvix
+++ b/tests/positive/Termination/Undefined.juvix
@@ -1,7 +1,7 @@
 module Undefined;
 
 axiom A : Type;
-terminating undefined : A;
-undefined := undefined;
 
-end;
+terminating
+undefined : A;
+undefined := undefined;

--- a/tests/positive/issue1333/M.juvix
+++ b/tests/positive/issue1333/M.juvix
@@ -1,6 +1,4 @@
 module M;
 
 type T (A : Type) :=
-c : T _;
-
-end;
+  | c : T _;

--- a/tests/positive/issue1466/M.juvix
+++ b/tests/positive/issue1466/M.juvix
@@ -1,8 +1,8 @@
 module M;
 
 type ℕ :=
-  z : ℕ |
-  s : ℕ → ℕ;
+  | z : ℕ
+  | s : ℕ → ℕ;
 
 nat : Type;
 nat := ℕ;
@@ -14,5 +14,3 @@ infixl 1 +;
 + : nat2 → nat → nat;
 + z b := b;
 + (s a) b := s (a + b);
-
-end;

--- a/tests/positive/issue1693/M.juvix
+++ b/tests/positive/issue1693/M.juvix
@@ -1,22 +1,29 @@
 module M;
-  open import Stdlib.Prelude;
 
-  S : {A : Type} → {B : Type} → {C : Type} → (A → B → C) → (A → B) → A → C;
-  S x y z := x z (y z);
+open import Stdlib.Prelude;
 
-  K : {A : Type} → {B : Type} → A → B → A;
-  K x y := x;
+S :
+  {A : Type}
+    → {B : Type}
+    → {C : Type}
+    → (A → B → C)
+    → (A → B)
+    → A
+    → C;
+S x y z := x z (y z);
 
-  I : {A : Type} → A → A;
-  I := S K (K {_} {Bool});
+K : {A : Type} → {B : Type} → A → B → A;
+K x y := x;
 
-  main : IO;
-  main := printNatLn
+I : {A : Type} → A → A;
+I := S K (K {_} {Bool});
+
+main : IO;
+main :=
+  printNatLn
     $ I {Nat} 1
       + I I 1
       + I (I 1)
       + I 1
       + I (I I) I (I I I) 1
       + I I I (I I I (I I)) I (I I) I I I 1;
-
-end;

--- a/tests/positive/issue1731/builtinFail.juvix
+++ b/tests/positive/issue1731/builtinFail.juvix
@@ -1,11 +1,13 @@
 module builtinFail;
-  open import Stdlib.Data.String;
-  open import Stdlib.System.IO;
 
-  builtin fail axiom fail : {A : Type} → String → A;
+open import Stdlib.Data.String;
+open import Stdlib.System.IO;
 
-  main : IO;
-  main := printStringLn "Get"
+builtin fail
+axiom fail : {A : Type} → String → A;
+
+main : IO;
+main :=
+  printStringLn "Get"
     >> fail "Enough"
     >> printStringLn "Sleep";
-end;

--- a/tests/positive/issue1731/builtinTrace.juvix
+++ b/tests/positive/issue1731/builtinTrace.juvix
@@ -1,12 +1,14 @@
 module builtinTrace;
-  open import Stdlib.Prelude;
-  open import Stdlib.Data.Nat.Ord;
 
-  builtin trace axiom trace : {A : Type} → {B : Type} → A → B → B;
+open import Stdlib.Prelude;
+open import Stdlib.Data.Nat.Ord;
 
-  terminating
-  f : Nat → Nat → Nat;
-  f x y := if (x == 0) y (trace x (f (sub x 1) y));
+builtin trace
+axiom trace : {A : Type} → {B : Type} → A → B → B;
+
+terminating
+f : Nat → Nat → Nat;
+f x y := if (x == 0) y (trace x (f (sub x 1) y));
 
 {-
 f 4 0 =
@@ -20,6 +22,5 @@ trace 4 (f 3 0)
 𝔸 β \X \Y . Apply (Apply trace X) Y
 
 -}
-  main : IO;
-  main := printNatLn $ f 4 0;
-end;
+main : IO;
+main := printNatLn $ f 4 0;

--- a/tests/positive/issue1879/LetSynonym.juvix
+++ b/tests/positive/issue1879/LetSynonym.juvix
@@ -1,13 +1,13 @@
 module LetSynonym;
-  type T :=
-    | t : T;
 
-  main : T;
-  main :=
-    let
-      A : Type;
-      A := T;
-      x : A;
-      x := t;
-    in x;
-end;
+type T :=
+  | t : T;
+
+main : T;
+main :=
+  let
+    A : Type;
+    A := T;
+    x : A;
+    x := t;
+  in x;


### PR DESCRIPTION
This PR fixes a formatting issue that drops blank lines between axiom declarations.

It goes after:

- #1980
- Closes https://github.com/anoma/juvix/issues/1986