### PR TITLE
Adsd the tracing library and the sexp library to the project

### DIFF
--- a/library/Sexp/.gitignore
+++ b/library/Sexp/.gitignore
@@ -1,0 +1,2 @@
+.stack-work/
+*~

--- a/library/Sexp/README.org
+++ b/library/Sexp/README.org
@@ -1,0 +1,35 @@
+* Sexp
+The S-Expression library for data manipulation. It is sadly tied to a
+notion of =Namesymbols= that may not be useful for one's project
+
+However, the library provides tools for automatically deriving a
+s-expression serialization for one's Data types, along with default
+instances to serialize from and to S-expressions
+
+** Example Usage for predefined type
+#+begin_src haskell
+  λ> (Sexp.serialize (Sexp.number <$> [1..5] :: [Sexp.T]))
+  (1 2 3 4 5)
+
+  λ> deserialize (Sexp.serialize (Sexp.number <$> [1..5] :: [Sexp.T])) :: Maybe [Int]
+  Just [1,2,3,4,5]
+#+end_src
+** Deriving For One's Datatype
+#+begin_src haskell
+  data Test a
+    = Test
+    | Test2 a
+    | TestRec a (Test a)
+    | TestRec' (Test a)
+    | Test3 {fstt :: a, sndd :: Integer}
+    deriving (Show, Generic)
+
+  -- let's turn this to deriving via
+  instance Sexp.DefaultOptions (Test a)
+
+  instance (Sexp.Serialize a) => Sexp.Serialize (Test a)
+
+  λ> Sexp.serialize (TestRec 3 (Test2 3))
+
+  (":test-rec" 3 (":test2" 3))
+#+end_src

--- a/library/Sexp/Setup.hs
+++ b/library/Sexp/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+
+main = defaultMain

--- a/library/Sexp/package.yaml
+++ b/library/Sexp/package.yaml
@@ -1,0 +1,92 @@
+name:                sexp
+version:             0.1.0.0
+github:              "mariari/Misc-ML-Scripts"
+license:             GPL-3
+author:              "Mariari <mariari@protonmail.ch>"
+maintainer:          "Mariari <mariari@protonmail.ch>"
+copyright:           "2022 Mariari"
+
+extra-source-files:
+- README.org
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         Please see the README on GitHub at <https://github.com/githubuser/Sexp#readme>
+
+dependencies:
+- aeson
+- base >= 4.7 && < 5
+- standard-library
+- containers
+- lens
+- text
+- megaparsec
+- hashable
+- word8
+- generic-deriving
+- unordered-containers
+- recursion-schemes
+- data-fix
+- prettyprinter
+
+default-extensions:
+  - NoImplicitPrelude
+  - OverloadedStrings
+  - NoMonomorphismRestriction
+  - RankNTypes
+  - LambdaCase
+  - UnicodeSyntax
+  - GADTs
+  - DerivingVia
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - DataKinds
+  - TypeApplications
+  - ConstraintKinds
+  - PatternSynonyms
+  - FlexibleContexts
+  - FlexibleInstances
+  - QuasiQuotes
+  - TemplateHaskell
+  - TypeFamilies
+  - NamedFieldPuns
+  - DisambiguateRecordFields
+  - TupleSections
+  - DeriveGeneric
+  - DeriveDataTypeable
+  - GeneralizedNewtypeDeriving
+  - StandaloneDeriving
+  - BlockArguments
+  - FunctionalDependencies
+  - ScopedTypeVariables
+
+ghc-options:
+  - -ferror-spans
+  - -Wall
+  - -fno-warn-orphans
+  - -fno-warn-name-shadowing
+  - -fno-warn-missing-pattern-synonym-signatures
+  - -j
+  - -static
+  - -fwrite-ide-info
+
+library:
+  source-dirs: src
+
+tests:
+  sexp-test:
+    main:                Main.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - sexp
+    - tasty
+    - tasty-hunit

--- a/library/Sexp/src/Data/Sexp.hs
+++ b/library/Sexp/src/Data/Sexp.hs
@@ -1,0 +1,512 @@
+-- | This module serves as the main sexpression import it contains the
+-- sexp type and all the various helper functionality one can need.
+-- The star affix stands for a play on a theme. In this case the theme
+-- is that they recurse on the structure itself calling itself on very
+-- nested structures.
+module Data.Sexp
+  ( module Data.Sexp.Types,
+    module Data.Sexp.Parser,
+    module Data.Sexp.Serialize,
+    B,
+    Opt (..),
+
+    -- * Traversal Functionality
+    mapPredStar,
+    traversePredStar,
+    traversePredOptStar,
+    autoRecurse,
+    map,
+    traverse,
+    foldM,
+    foldr,
+    foldr1,
+
+    -- * Partial Serialization Functionality
+    Serialize (..),
+    partiallyDeserialize,
+    fullySerialize,
+    withSerialization,
+    mapSerialize,
+    traverseSerialize,
+    transformSerialize,
+    onSerialize,
+    traverseOnAtoms,
+    mapOnAtoms,
+
+    -- * General Functionality
+    butLast,
+    last,
+    init,
+    list,
+    listStar,
+    addMetaToCar,
+    car,
+    cdr,
+    primOp,
+    atom,
+    actualAtom,
+    suffixAtom,
+    number,
+    double,
+    string,
+    isAtomNamed,
+    nameFromT,
+    atomFromT,
+    atomErr,
+    doubleFromT,
+    stringFromT,
+    groupBy2,
+    assoc,
+    cadr,
+    unGroupBy2,
+    snoc,
+    findKey,
+    flatten,
+  )
+where
+
+import Mari.Library hiding (foldM, foldr, init, list, map, reverse, show, toList, traverse)
+import qualified Mari.Library as Std
+import qualified Mari.Library.NameSymbol as NameSymbol
+import Data.Sexp.Parser
+import Data.Sexp.Serialize
+import Data.Sexp.Types hiding (double)
+import Prelude (error)
+
+-- Just for Ease of writing
+type B a = Base a
+
+-- | @Opt@ is a record controlling some extra features for some choice
+-- functions
+data Opt a b = Op
+  { atomF :: Maybe (Atom a -> Atom b),
+    onAtom :: Bool
+  }
+  deriving (Show)
+
+instance Semigroup (Opt a b) where
+  Op f onF <> Op g onB = Op (f <|> g) (onF || onB)
+
+instance Monoid (Opt a b) where
+  mempty = Op Nothing False
+
+--------------------------------------------------------------------------------
+-- Manual Serializing instances
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Folding Capabilities
+--------------------------------------------------------------------------------
+
+-- | @traversePredStar@ is like @mapPredStar@ with some notable exceptions.
+-- 1. The @f@ function now takes an extra argument, recurse, which will
+--    recurse the given form with @traversePredOptStar@
+-- 2. Instead of recusing on the changed match expression automatically,
+--    it must be done through @autoRecurse@ or calling the extra recursion
+--    function automatically
+-- 3. If the @Opt@ function has the @onAtom@ field being true
+--    then the function will also be ran on the atom
+traversePredOptStar ::
+  Monad f =>
+  B a ->
+  (NameSymbol.T -> Bool) ->
+  (B a -> (B a -> f (B a)) -> f (B a)) ->
+  Opt a a ->
+  f (B a)
+traversePredOptStar t predChange f opt =
+  case t of
+    Cons (Atom (A name _)) _
+      | predChange name ->
+        f t recurseDown
+    Cons {} -> traverse recurseDown t
+    Nil {} -> pure Nil
+    Atom a
+      | onAtom opt -> f t recurseDown
+      | otherwise -> pure (Atom a)
+  where
+    recurseDown sexp = traversePredOptStar sexp predChange f opt
+
+-- | @traversePredStar@ is just like @traversePredOptStar@ except the
+-- empty option set is given, meaning that the function will not match
+-- on atoms.
+traversePredStar ::
+  Monad f => B a -> (NameSymbol.T -> Bool) -> (B a -> (B a -> f (B a)) -> f (B a)) -> f (B a)
+traversePredStar t predChange automaticF =
+  traversePredOptStar t predChange automaticF mempty
+
+autoRecurse ::
+  Monad m => (B a -> m (B a)) -> B a -> (B a -> m (B a)) -> m (B a)
+autoRecurse automaticF xs recurse = do
+  newCons <- automaticF xs
+  case newCons of
+    Cons {} -> traverse recurse newCons
+    _______ -> pure newCons
+
+-- | @mapPredStar@ searches the sexp structure given to it with a
+-- given predicate. This predicate is ran on the @car@ of every list
+-- structure. This simulates searches for the head of a function
+-- call. When the predicate returns true, the function passed to
+-- @mapPredStar@ (which we shall refer to as f), is then called on the
+-- @car@, and the @cdr@ of the list, giving back a new sexp
+-- structure. This new sexp structure is then recursed upon by
+-- @mapPredStar@. NOTE that this does mean the structure handed back
+-- by f.
+mapPredStar :: B a -> (NameSymbol.T -> Bool) -> (B a -> B a) -> B a
+mapPredStar t pred f =
+  case t of
+    Cons (Atom (A name _)) _
+      | pred name -> mapPredStar (f t) pred f
+    Cons _ _ -> map (\t -> mapPredStar t pred f) t
+    Atom ato -> Atom ato
+    Nil -> Nil
+
+traverse :: Monad m => (B a -> m (B b)) -> B a -> m (B b)
+traverse f xs =
+  foldM (\acc x -> Cons <$> f x <*> pure acc) Nil xs
+    >>| reverse
+
+foldM :: Monad m => (p -> B a -> m p) -> p -> B a -> m p
+foldM f acc ts =
+  case ts of
+    Cons a as -> f acc a >>= (\accum -> foldM f accum as)
+    Atom ____ -> f acc ts
+    Nil -> pure acc
+
+-- | @map@ works the same as it does in Haskell. However instead of
+-- running it on the generic of the Sexp, it instead runs it on the
+-- elements on the Sexp structure itself. Thus the @a -> b@ signature
+-- can only occur if the function recuses to change the sexp
+-- recursively
+map :: (B a -> B b) -> B a -> B b
+map f = foldr (Cons . f) Nil
+
+-- | @foldr@ works the same way as it does in Haskell. If the list is
+-- terminated improperly with an atom (called a dotted list), that is
+-- considered to be the last element of the list, as if it weren't a
+-- dotted list.
+foldr :: (B a -> p -> p) -> p -> B a -> p
+foldr f acc ts =
+  case ts of
+    Cons a as -> f a (foldr f acc as)
+    Atom ____ -> f ts acc
+    Nil -> acc
+
+-- | @foldr1@ works the same as it does in Haskell. Upon a dotted list,
+-- it behaves like foldr. If the list is empty or nil, we return nothing
+foldr1 :: (B a -> B a -> B a) -> B a -> Maybe (B a)
+foldr1 f (Cons x xs) = Just $ unsafe (Cons x xs)
+  where
+    unsafe ts =
+      case ts of
+        Cons a Nil -> a
+        Cons a cds -> f a (unsafe cds)
+        Atom a -> (Atom a)
+        Nil -> error "doesn't happen"
+foldr1 _ _empty = Nothing
+
+--------------------------------------------------------------------------------
+-- Partial Serialization Functions
+--------------------------------------------------------------------------------
+
+-- | @partiallyDeserialize@ serializes a S-expression term with no
+-- serialization, into a de-serialization over a generic a. It is the
+-- responsibility of the partial deserializer itself to deal with the
+-- arguments.
+partiallyDeserialize :: forall a. Serialize a => T -> B a
+partiallyDeserialize Nil = Nil
+partiallyDeserialize sexp@Cons {} =
+  case deserialize sexp of
+    Just partial ->
+      Atom (P partial Nothing)
+    Nothing -> map partiallyDeserialize sexp
+partiallyDeserialize atom@(Atom p) =
+  case deserialize atom of
+    Just serialize ->
+      Atom (P serialize Nothing)
+    Nothing ->
+      case p of
+        -- this should never happen, as all P's have no meaning with T
+        P _ _ -> Nil
+        D n l -> Atom (D n l)
+        S n l -> Atom (S n l)
+        N n l -> Atom (N n l)
+        A n l -> Atom (A n l)
+
+-- | @fullySerialize@ removes the partial deserialization of a
+-- structure, into the fully serialized form.
+fullySerialize :: forall a. Serialize a => B a -> T
+fullySerialize Nil = Nil
+fullySerialize sexp@Cons {} =
+  map fullySerialize sexp
+fullySerialize (Atom p) =
+  case p of
+    P t _ -> serialize t
+    D n l -> Atom (D n l)
+    S n l -> Atom (S n l)
+    N n l -> Atom (N n l)
+    A n l -> Atom (A n l)
+
+-- | @withSerialization@ Temporarily de-serializes the given
+-- s-expression
+withSerialization ::
+  forall a m. (Monad m, Serialize a) => T -> (B a -> m (B a)) -> m T
+withSerialization sexp func =
+  partiallyDeserialize sexp
+    |> func
+    >>| fullySerialize
+
+---------------------------------------------
+-- Partial Serialization Mapping Functions
+---------------------------------------------
+
+-- | @mapSerialize@ traverses the list like a star function, searching
+-- for any constructor of the partial deserialization to apply the
+-- given function to. The function takes two arguments. the
+-- deserialized structure itself, and a recursive function to call for
+-- any nested Sexp structures that may exist in the partial deserialization
+mapSerialize :: B a -> (a -> (B a -> B b) -> b) -> B b
+mapSerialize xs f = transformSerialize xs newF
+  where
+    newF sexp rec' = Atom (P (f sexp rec') Nothing)
+
+-- | @traverseSerialize@ works just like @mapSerialize@ except the
+-- function is effectful
+traverseSerialize :: Monad m => B a -> (a -> (B a -> m (B b)) -> m b) -> m (B b)
+traverseSerialize xs f = onSerialize xs newF
+  where
+    newF x rec' = Atom . (`P` Nothing) <$> f x rec'
+
+-- | @onSerialize@ acts like @traverseSerialize@ however, instead of
+-- returning the deserialized it returns an arbitrary S-expression
+-- that contains the deserialization. Overall this function is more
+-- general than @traverseSerialize@ and should be used when one wants
+-- to potentially return an s-expression and not a deserialized form
+onSerialize :: Monad m => B a -> (a -> (B a -> m (B b)) -> m (B b)) -> m (B b)
+onSerialize xs f = traverseOnAtoms xs newF
+  where
+    newF a rec' =
+      case a of
+        P t _ -> f t rec'
+        D n l -> pure $ Atom (D n l)
+        S n l -> pure $ Atom (S n l)
+        N n l -> pure $ Atom (N n l)
+        A n l -> pure $ Atom (A n l)
+
+-- | @transformSerialize@ acts like @mapSerialize@ however, instead of
+-- returning the deserialized it returns an arbitrary S-expression
+-- that contains the deserialization. Overall this function is more
+-- general than @mapSerialize@ and should be used when one wants to
+-- potentially return an s-expression and not a deserialized form
+transformSerialize :: B a -> (a -> (B a -> B b) -> B b) -> B b
+transformSerialize xs f = runIdentity (onSerialize xs newF)
+  where
+    newF sexp rec' = pure $ f sexp (runIdentity . rec')
+
+-- | @traverseOnAtoms@ is like @onSerialize@, however it executes on
+-- all atoms instead of just the serialized data. This is useful for
+-- operating on Symbols, and partial de-serializations at the same
+-- time.
+traverseOnAtoms ::
+  Monad f => B a -> (Atom a -> (B a -> f (B b)) -> f (B b)) -> f (B b)
+traverseOnAtoms xs@Cons {} f = traverse (`traverseOnAtoms` f) xs
+traverseOnAtoms Nil _______f = pure Nil
+traverseOnAtoms (Atom a) f = f a (`traverseOnAtoms` f)
+
+-- | @mapOnAtoms@ is a pure vesrion of @traverseOnAtoms@
+mapOnAtoms :: B a -> (Atom a -> (B a -> B b) -> (B b)) -> B b
+mapOnAtoms t f =
+  runIdentity (traverseOnAtoms t newF)
+  where
+    newF xs rec' = pure (f xs (runIdentity . rec'))
+
+--------------------------------------------------------------------------------
+-- General Functionality
+--------------------------------------------------------------------------------
+
+reverse :: B a -> B a
+reverse xs = go xs Nil
+  where
+    go (Cons a as) acc = go as (Cons a acc)
+    go Nil acc = acc
+    go (Atom a) acc = Cons (Atom a) acc
+
+-- | @butLast@ takes a list and removes the last element of the list,
+-- if handed an atom, it will return the atom
+butLast :: B a -> B a
+butLast (Cons _ Nil) = Nil
+butLast (Cons x xs) = Cons x (butLast xs)
+butLast (Atom a) = Atom a
+butLast Nil = Nil
+
+-- | @last@ gives back the last element of the list, for an atom or nil
+-- it will be the identity
+last :: B a -> B a
+last (Cons x Nil) = x
+last (Cons _ xs) = last xs
+last (Atom a) = Atom a
+last Nil = Nil
+
+-- | @init@ gives back the list back minus the last element, for an atom or nil
+-- it will be the identity
+init :: B a -> B a
+init (Cons _ Nil) = Nil
+init (Cons x xs) = Cons x (init xs)
+init (Atom a) = Atom a
+init Nil = Nil
+
+-- | @list@ takes a foldable structure of Sexps and gives back a list of
+-- those structures
+list :: Foldable t => t (B a) -> B a
+list = Std.foldr Cons Nil
+
+-- | @listStar@ is a lot like @list@, but, it will automatically @Cons@
+-- into the last structure
+-- Example:
+-- >>> listStar [atom "list", atom "a", atom "b", list [atom "c", atom "d"]]
+-- ("list" "a" "b" "c" "d")
+listStar :: [B a] -> B a
+listStar = fromMaybe Nil . foldr1May Cons
+
+-- | @addMetaToCar@ moves the meta information from a given atom into
+-- the car of the given sexpression. If it's not a @Cons@ then it is
+-- ignored.
+addMetaToCar :: Atom a -> B a -> B a
+addMetaToCar (A _ lineInfo) (Cons (Atom (A term _)) xs) =
+  Cons (Atom (A term lineInfo)) xs
+addMetaToCar _ xs = xs
+
+-- | @car@ grabs the head of the list
+car :: B a -> B a
+car (Cons x _) = x
+car Nil = Nil
+car (Atom a) = Atom a
+
+-- | @cdr@ grabs the tail of the list
+cdr :: B a -> B a
+cdr (Cons _ xs) = xs
+cdr Nil = Nil
+cdr (Atom a) = Atom a
+
+-- | @cadr@ grabs the second element of the list
+cadr :: B a -> B a
+cadr = car . cdr
+
+-- | @primOp@ creates a deserialized value in a @Sexp@
+primOp :: a -> B a
+primOp x = Atom $ P x Nothing
+
+-- | @atom@ creates a @Sexp@ @Atom@ from a @NameSymbol.T@
+atom :: NameSymbol.T -> B a
+atom x = Atom $ A x Nothing
+
+-- | @actualAtom@ creates an @Atom@ from a @NameSymbol.T@
+actualAtom :: NameSymbol.T -> Atom a
+actualAtom x = A x Nothing
+
+suffixAtom :: NameSymbol.T -> B a -> B a
+suffixAtom name (Atom (A name' cdr)) = (Atom (A (NameSymbol.append name' name) cdr))
+suffixAtom _ sexp = sexp
+
+-- | @number@ creates a @Sexp@ @Number@ from an @Integer@
+number :: Integer -> B a
+number n = Atom $ N n Nothing
+
+-- | @double@ creates a @Sexp@ @Double@ from a @Double@
+double :: Double -> B a
+double d = Atom $ D d Nothing
+
+-- | @string@ creates a @Sexp@ @String@ from a @Text@
+string :: Text -> B a
+string t = Atom $ S t Nothing
+
+-- | @isAtomNamed@ asks if an atom is named a particular name. Cons and
+-- Nil both return False
+isAtomNamed :: B a -> NameSymbol.T -> Bool
+isAtomNamed (Atom (A name _)) name2 = name == name2
+isAtomNamed _ _ = False
+
+atomErr :: B a -> Atom a
+atomErr (Atom a) = a
+atomErr _ = error "the value is not an atom"
+
+-- | @atomFromT@ returns the Atom from the list, will returning
+-- @Nothing@ if it is not an @Atom@
+atomFromT :: B a -> Maybe (Atom a)
+atomFromT (Atom a) = Just a
+atomFromT _ = Nothing
+
+-- | @nameFromT@ is similar to @atomFromT@ but it grabs the
+-- @NameSymbol.T@ out of the @Atom@
+nameFromT :: B a -> Maybe NameSymbol.T
+nameFromT (Atom (A name _)) = Just name
+nameFromT _ = Nothing
+
+-- | @doubleFromT@ is similar to @atomFromT@ but it grabs the
+-- @dobule@ out of the @Atom@
+doubleFromT :: B a -> Maybe Double
+doubleFromT (Atom (D d _)) = Just d
+doubleFromT _ = Nothing
+
+-- | @stringFromT@ is similar to @atomFromT@ but it grabs the
+-- @string@ out of the @Atom@
+stringFromT :: B a -> Maybe Text
+stringFromT (Atom (S s _)) = Just s
+stringFromT _ = Nothing
+
+-- | @assoc@ takes two sexps. First being a sexp that is to be found in
+-- the second argument. The other is a sexp list that is grouped into
+-- twos. If the search for element is found in the grouped list, then
+-- the second element of that sexp is returned. Otherwise @Nothing@ is
+-- returned.
+-- Example:
+-- >>> fmap (assoc (number 2)) (parse "((1 a) (2 b) (3 c))")
+-- Right (Just "b")
+assoc :: Eq a => B a -> B a -> Maybe (B a)
+assoc t xs = cadr <$> findKey car t xs
+
+-- | @groupBy2@ groups the given sexp structure into pairs. If the list
+-- is not even, then the last element is dropped.
+-- Example
+-- >>> fmap groupBy2 (parse "(1 a 2 b 3 c)")
+-- Right ((1 "a") (2 "b") (3 "c"))
+groupBy2 :: B a -> B a
+groupBy2 (a1 :> a2 :> rest) =
+  list [a1, a2] :> groupBy2 rest
+groupBy2 _ = Nil
+
+-- | @unGroupBy2@ does the opposite of @groupBy2@. If the given list is
+-- even then
+-- @unGroupBy2 . groupBy2 = idl@ ∧ @groupBy2 .  unGroupBy2 = idr@
+unGroupBy2 :: B a -> B a
+unGroupBy2 (List [a1, a2] :> rest) =
+  a1 :> a2 :> unGroupBy2 rest
+unGroupBy2 (a :> rest) =
+  a :> unGroupBy2 rest
+unGroupBy2 a = a
+
+-- | @snoc@ is cons but backwards. Thus it conses on the end of a given list
+snoc :: B a -> B a -> B a
+snoc e (Cons x y) = Cons x (snoc e y)
+snoc e a@(Atom _) = Cons a e
+snoc e Nil = e
+
+-- | @findKey searches a Sexpression structure for a particular
+-- structure. the given key allows us to zoom in on a particular subset
+-- of that structure.
+-- >>> fmap (findKey car (number 2)) (parse "((1 a) (2 b) (3 c))")
+-- Right (Just (2 "b"))
+findKey :: Eq a => (B a -> B a) -> B a -> B a -> Maybe (B a)
+findKey f k (x :> xs)
+  | f x == k = Just x
+  | otherwise = findKey f k xs
+findKey _ _ _ = Nothing
+
+-- | @flatten@ totally flattens a list, removing any extra Nils as well
+-- >>> fmap flatten (parse "((1) (2 3 4) (1 2) () (1 2 (3 ())))")
+-- Right (1 2 3 4 1 2 1 2 3)
+flatten :: B a -> B a
+flatten xs = rec xs Nil
+  where
+    rec Nil acc = acc
+    rec (Atom a) acc = Cons (Atom a) acc
+    rec (Cons x xs) acc = rec x (rec xs acc)

--- a/library/Sexp/src/Data/Sexp/Parser.hs
+++ b/library/Sexp/src/Data/Sexp/Parser.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Data.Sexp.Parser
+  ( parse,
+  )
+where
+
+import qualified Data.Text.Encoding as Encoding
+import Mari.Library hiding (list)
+import qualified Mari.Library.NameSymbol as NameSymbol
+import qualified Mari.Library.Parser as J
+import Mari.Library.Parser.Internal (Parser, ParserError)
+import qualified Mari.Library.Parser.Token as Token
+import qualified Data.Sexp.Types as Sexp
+import qualified Text.Megaparsec as P
+
+-- | @parse@ parses any sexp expression into the Sexp type
+parse :: ByteString -> Either ParserError Sexp.T
+parse = P.parse (J.eatSpaces sexp) ""
+
+--------------------------------------------------------------------------------
+-- Sexp Main Parsers
+--------------------------------------------------------------------------------
+sexp :: Parser Sexp.T
+sexp = J.spaceLiner (list <|> (Sexp.Atom <$> atom))
+
+list :: Parser Sexp.T
+list = do
+  d <- parens (many sexp)
+  case d of
+    [] -> pure Sexp.Nil
+    _ -> pure (foldr Sexp.Cons Sexp.Nil d)
+
+atom :: Parser (Sexp.Atom ())
+atom = P.try double <|> number <|> name <|> string
+
+name :: Parser (Sexp.Atom ())
+name = do
+  sym <- symbol
+  pure (Sexp.A sym Nothing)
+
+number :: Parser (Sexp.Atom ())
+number = do
+  int <- J.integer
+  pure (Sexp.N int Nothing)
+
+double :: Parser (Sexp.Atom ())
+double = do
+  double <- J.double
+  pure (Sexp.D double Nothing)
+
+string :: Parser (Sexp.Atom ())
+string = do
+  text <-
+    J.between
+      Token.doubleQuote
+      (P.takeWhile1P (Just "Not quote") (/= J.doubleQuote))
+      Token.doubleQuote
+  pure (Sexp.S (Encoding.decodeUtf8 text) Nothing)
+
+symbol :: Parser NameSymbol.T
+symbol = do
+  s <-
+    P.takeWhile1P
+      (Just "Valid symbol")
+      ( \x ->
+          J.validStartSymbol x
+            || J.validMiddleSymbol x
+            || J.validInfixSymbol x
+      )
+  Encoding.decodeUtf8 s |> internText |> NameSymbol.fromSymbol |> pure
+
+--------------------------------------------------------------------------------
+-- Helpers taken from the other parser
+--------------------------------------------------------------------------------
+
+-- edited a bit from the other parser
+between :: Word8 -> Parser p -> Word8 -> Parser p
+between fst p end = J.skipLiner fst *> J.spaceLiner p <* J.skipLiner end
+
+parens :: Parser p -> Parser p
+parens p = between J.openParen p J.closeParen

--- a/library/Sexp/src/Data/Sexp/Pretty/Base.hs
+++ b/library/Sexp/src/Data/Sexp/Pretty/Base.hs
@@ -1,0 +1,96 @@
+-- | This module implements a pretty printer for S-expressions using the
+--   prettyprinter library.
+--
+-- __Examples:__
+--
+-- @
+-- import qualified Data.Sexp as Sexp
+-- import qualified Data.Sexp.Pretty.Base as Sexp
+-- import Prettyprinter
+-- import Prettyprinter.Util (putDocW)
+--
+-- mkAtom n = Sexp.Atom $ Sexp.N n Nothing
+-- mkCons = foldr Sexp.Cons
+-- mkList = mkCons Sexp.Nil
+--
+-- -- A basic list
+-- ppSexp $ mkList [mkAtom 1, mkAtom 2, mkAtom 3]
+-- -- > (1 2 3)
+--
+-- -- A basic cons
+-- ppSexp $ mkCons (mkAtom 3) [mkAtom 1, mkAtom 2]
+-- -- > (1 2 . 3)
+--
+-- -- Nested list
+-- ppSexp $ mkList [mkAtom 1, mkList [mkAtom 2, mkAtom 3], mkAtom 4]
+-- -- > (1 (2 3) 4)
+--
+-- -- An example showing aligning and wrapping (using an artificial width)
+-- putDocW 5 $ ppSexp $ mkList [mkAtom n | n <- [0..4]]
+-- -- >
+-- -- (0 1
+-- --    2
+-- --    3
+-- --    4
+-- @
+module Data.Sexp.Pretty.Base
+  ( ppSexp,
+    ppSexpBase,
+    ppAtomBase,
+  )
+where
+
+import Mari.Library
+import qualified Mari.Library.NameSymbol as NameSymbol
+import qualified Data.Sexp as Sexp
+import Prettyprinter
+
+--------------------------------------------------------------------------------
+-- Pretty functions
+--------------------------------------------------------------------------------
+
+ppSexpBase :: Pretty a => Sexp.Base a -> Doc ann
+ppSexpBase (Sexp.Atom at) = ppAtomBase at
+ppSexpBase (Sexp.Cons car cdr) = parens $ align $ ppCons car cdr
+ppSexpBase Sexp.Nil = parens emptyDoc
+
+ppAtomBase :: Pretty a => Sexp.Atom a -> Doc ann
+ppAtomBase (Sexp.A n _) = name n
+ppAtomBase (Sexp.N i _) = number i
+ppAtomBase (Sexp.D d _) = number d
+ppAtomBase (Sexp.S t _) = text t
+ppAtomBase (Sexp.P x _) = "P#" <> parens (pretty x)
+
+ppSexp :: Sexp.T -> Doc ann
+ppSexp = ppSexpBase
+
+--------------------------------------------------------------------------------
+-- Pretty instances
+--------------------------------------------------------------------------------
+
+instance (Pretty a) => Pretty (Sexp.Base a) where
+  pretty = ppSexpBase
+
+instance (Pretty a) => Pretty (Sexp.Atom a) where
+  pretty = ppAtomBase
+
+--------------------------------------------------------------------------------
+-- Helper functions
+--------------------------------------------------------------------------------
+
+name :: NameSymbol.T -> Doc ann
+name = pretty . NameSymbol.toText
+
+number :: Pretty a => a -> Doc ann
+number = pretty
+
+text :: Pretty a => a -> Doc ann
+text = dquotes . pretty
+
+ppCons :: Pretty a => Sexp.Base a -> Sexp.Base a -> Doc ann
+ppCons car cdr = ppSexpBase car <+> Prettyprinter.group (nest 2 (consCdr cdr))
+  where
+    consCdr Sexp.Nil = emptyDoc
+    consCdr a@(Sexp.Atom _) = dot <+> ppSexpBase a
+    consCdr (Sexp.Cons cadr Sexp.Nil) = ppSexpBase cadr
+    consCdr (Sexp.Cons cadr cddr) = ppSexpBase cadr <> line <> consCdr cddr

--- a/library/Sexp/src/Data/Sexp/Serialize.hs
+++ b/library/Sexp/src/Data/Sexp/Serialize.hs
@@ -1,0 +1,382 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | @Data.Sexp.Serialize@ serves as the automatic serialization of
+-- Haskell Data-structures. One can derive a default instance by
+-- simply having
+--
+-- @
+-- Data Foo = Foo deriving(Generic)
+-- @
+--
+-- then writing
+--
+-- @
+-- instance DefaultOptions Foo
+-- instance Serialize Foo
+-- @
+--
+-- There are two parts to this derivation. The first is the
+-- @Serialize@ derivation, which gives on the ability to write
+-- @serialize@ and @deserialize@.
+--
+-- However one needs to also derive @DefaultOptions@ as, in order to
+-- get an efficient serialization, default options are needed to
+-- inform the system how it ought to serialize the structre. An
+-- example of what the constructor renaming looks like as follows
+-- @
+-- data Foo = Foo Int | FooBar Int | Bar
+--
+-- -- Gets turned into
+-- -- Foo 3
+-- (:foo 3)
+--
+-- -- FooBar 5
+-- (:foo-bar 5)
+--
+-- -- Bar
+-- :bar
+-- @
+--
+-- An example of giving a renaming is as follows
+--
+-- @
+-- data Infix
+--   = Infix
+--       { infixOp :: NameSymbol.T,
+--         infixLt :: (Sexp.B (Bind.BinderPlus Infix)),
+--         infixInf :: Infix
+--       }
+--   | InfixNoMore
+--       { infixOp :: NameSymbol.T,
+--         infixLt :: (Sexp.B (Bind.BinderPlus Infix)),
+--         infixRt :: (Sexp.B (Bind.BinderPlus Infix))
+--       }
+--   deriving (Show, Generic, Eq)
+--
+-- infixRename :: Sexp.Options
+-- infixRename =
+--   Sexp.changeName
+--     (Sexp.defaultOptions @Infix)
+--     (Map.fromList [("InfixNoMore", ":infix")])
+--
+-- instance Sexp.DefaultOptions Infix
+--
+-- instance Sexp.Serialize Infix where
+--   serialize = Sexp.serializeOpt infixRename
+--   deserialize = Sexp.deserializeOpt infixRename
+-- @
+--
+-- In this example, we make an @Infix@ data structure with two almost
+-- identical looking constructor and arguments. Indeed we state they
+-- stand for the same s-expression, with one just having a chain of
+-- infixs, we can see this by @infixRename@. Finally we derive the
+-- serialization based on these consturctors. And thus in practice the
+-- serializer will automatically give us a chain of @Infix@ before
+-- ending in an @InfixNoMore@
+module Data.Sexp.Serialize
+  ( Serialize (..),
+    DefaultOptions (..),
+    Options (..),
+    changeName,
+    serializeOpt,
+    deserializeOpt,
+  )
+where
+
+import qualified Data.Char8 as Char8
+import qualified Data.HashSet as Set
+import GHC.Generics as Generics
+import qualified Generics.Deriving.ConNames as ConNames
+import Mari.Library hiding (foldr)
+import qualified Mari.Library.HashMap as Map
+import qualified Mari.Library.NameSymbol as NameSymbol
+import Data.Sexp.Types as Sexp hiding (double)
+
+class Serialize a where
+  serialize :: a -> T
+  default serialize :: (Generic a, GSerializeOptions (Rep a), DefaultOptions a) => a -> T
+  serialize = serializeOpt (defaultOptions @a)
+
+  deserialize :: T -> Maybe a
+  default deserialize :: (Generic a, GSerializeOptions (Rep a), DefaultOptions a) => T -> Maybe a
+  deserialize = deserializeOpt (defaultOptions @a)
+
+data Options = Options
+  { -- this decides if the constructors should be renamed, by default
+    -- it maps them all to the lisp variants
+    constructorMapping :: Map.T [Char] NameSymbol.T,
+    consturctorNameSet :: Set.HashSet NameSymbol.T
+  }
+  deriving (Show)
+
+class DefaultOptions a where
+  defaultOptions :: Options
+  default defaultOptions :: (Generic a, ConNames.ConNames (Rep a)) => Options
+  defaultOptions = defaultOptions' @a
+
+defaultOptions' :: forall a. (Generic a, ConNames.ConNames (Rep a)) => Options
+defaultOptions' =
+  Options map nameSet
+  where
+    nameMapping =
+      ConNames.conNames @a undefined
+    namesList =
+      nameMapping
+        |> fmap mlNameToReservedLispName
+    nameSet =
+      namesList
+        |> Set.fromList
+    map = Map.fromList (zip nameMapping namesList)
+
+changeName :: Options -> Map.T [Char] NameSymbol.T -> Options
+changeName (Options hashMapOpt _) hashmap =
+  Options newMap (Map.elems newMap |> Set.fromList)
+  where
+    newMap = hashmap <> hashMapOpt
+
+class GSerializeOptions f where
+  gputOpt :: Options -> f a -> T
+  ggetOpt :: Options -> T -> Maybe (T, (f a))
+
+serializeOpt :: (GSerializeOptions (Rep a), Generic a) => Options -> a -> T
+serializeOpt opt t =
+  gputOpt opt (from t)
+
+deserializeOpt :: (Generic b, GSerializeOptions (Rep b)) => Options -> T -> Maybe b
+deserializeOpt opt t =
+  to . snd <$> ggetOpt opt t
+
+----------------------------------------
+-- U1
+----------------------------------------
+
+instance GSerializeOptions U1 where
+  gputOpt __ U1 = Nil
+  ggetOpt _ xs = Just (xs, U1)
+
+----------------------------------------
+-- M1
+----------------------------------------
+
+instance (GSerializeOptions a) => GSerializeOptions (D1 i a) where
+  gputOpt opt (M1 x) =
+    gputOpt opt x
+  ggetOpt opt xs =
+    second M1 <$> ggetOpt opt xs
+
+-- Make an alternative version that cares about the selector
+-- constructor
+instance (Selector i, GSerializeOptions a) => GSerializeOptions (S1 i a) where
+  gputOpt opt (M1 x) =
+    gputOpt opt x
+  ggetOpt opt xs =
+    -- see if car is correct
+    second M1 <$> ggetOpt opt xs
+
+-- can we make consturctors with no arguments not be a list!?  for
+-- example if we have @| Test@ We want it not to be (:test), but :test
+instance (Constructor i, GSerializeOptions a) => GSerializeOptions (C1 i a) where
+  gputOpt opt y@(M1 x) =
+    let name =
+          case constructorMapping opt Map.!? (conName y) of
+            Nothing ->
+              -- Should never happen, as we bind all constructor names
+              panic "we should never hit here"
+            -- mlNameToReservedLispName (conName y)
+            Just name ->
+              name
+     in case gputOpt opt x of
+          Sexp.Nil -> Sexp.Atom (A name Nothing)
+          otherwis -> Cons (Sexp.Atom (A name Nothing)) otherwis
+  ggetOpt opt xs =
+    case xs of
+      Cons (Atom (A nameOf _)) _
+        | check nameOf ->
+          logic (ggetOpt opt (cdr xs)) nameOf
+      Atom (A nameOfSingleCon _)
+        | check nameOfSingleCon ->
+          logic (ggetOpt opt Nil) nameOfSingleCon
+      _ ->
+        Nothing
+    where
+      -- still slow, we should check the M1 constructed agrees before
+      -- even trying.
+      check name =
+        Set.member name (consturctorNameSet opt)
+      logic caseOn name1 =
+        case caseOn of
+          Just (rest, t) ->
+            let m1 = M1 t
+                name =
+                  case constructorMapping opt Map.!? (conName m1) of
+                    Nothing ->
+                      -- Should never happen, as we bind all constructor names
+                      panic "we should never hit here"
+                    -- mlNameToReservedLispName (conName m1)
+                    Just name ->
+                      name
+             in if
+                    | name1 == name -> Just (rest, m1)
+                    | otherwise -> Nothing
+          Nothing -> Nothing
+
+----------------------------------------
+-- Sum
+----------------------------------------
+
+instance (GSerializeOptions a, GSerializeOptions b) => GSerializeOptions (a :+: b) where
+  gputOpt opt (L1 x) = gputOpt opt x
+  gputOpt opt (R1 x) = gputOpt opt x
+
+  -- is this correct?
+  ggetOpt opt xs = (second L1 <$> ggetOpt opt xs) <|> (second R1 <$> ggetOpt opt xs)
+
+instance (GSerializeOptions a, GSerializeOptions b) => GSerializeOptions (a :*: b) where
+  gputOpt opt (a :*: b) = append (gputOpt opt a) (gputOpt opt b)
+
+  -- is this correct also!?
+  ggetOpt opt xs = do
+    (ret, firstSetOfSlot) <- ggetOpt opt xs
+    (rest, secondSetOfSlot) <- ggetOpt opt ret
+    Just (rest, firstSetOfSlot :*: secondSetOfSlot)
+
+----------------------------------------
+-- K1
+----------------------------------------
+
+instance Serialize a => GSerializeOptions (K1 i a) where
+  gputOpt _ (K1 x) = Sexp.Cons (serialize x) Nil
+  ggetOpt _ xs =
+    deserialize (car xs) >>| \des -> (cdr xs, K1 des)
+
+mlNameToReservedLispName :: [Char] -> NameSymbol.T
+mlNameToReservedLispName [] = NameSymbol.fromString ""
+mlNameToReservedLispName (x : xs) =
+  let upperToDash x
+        | Char8.isUpper x = ['-', Char8.toLower x]
+        | otherwise = [x]
+      properName =
+        xs >>= upperToDash
+   in NameSymbol.fromString (':' : Char8.toLower x : properName)
+
+----------------------------------------
+-- Base Instances
+----------------------------------------
+
+instance Serialize a => Serialize (Base a) where
+  serialize (Sexp.Cons x xs) = Sexp.Cons (serialize x) (serialize xs)
+  serialize Sexp.Nil = Sexp.Nil
+  serialize (Sexp.Atom a) = serialize a
+
+  deserialize sexp@(Sexp.Cons x xs) =
+    case deserialize sexp :: Serialize a => Maybe a of
+      Just ps -> Just (Atom (P ps Nothing))
+      Nothing -> Sexp.Cons <$> deserialize x <*> deserialize xs
+  deserialize Sexp.Nil = Just Sexp.Nil
+  deserialize (Atom i) =
+    Atom
+      <$>
+      -- why can't I dispatch to the atom call?
+      case i of
+        A n i -> Just $ A n i
+        N n i -> Just $ N n i
+        D n i -> Just $ D n i
+        S n i -> Just $ S n i
+        P () _ -> Nothing
+
+instance Serialize a => Serialize (Atom a) where
+  serialize i =
+    case i of
+      A n i -> Atom $ A n i
+      N n i -> Atom $ N n i
+      D n i -> Atom $ D n i
+      S n i -> Atom $ S n i
+      P n _ -> serialize n
+  deserialize (Atom i) =
+    case i of
+      A n i -> Just $ A n i
+      N n i -> Just $ N n i
+      D n i -> Just $ D n i
+      S n i -> Just $ S n i
+      P () _ -> Nothing
+  deserialize _ = Nothing
+
+instance Serialize a => Serialize [a] where
+  serialize xs = foldr' (Cons . serialize) Sexp.Nil xs
+  deserialize c@Cons {} =
+    foldr (\x xs -> flip (:) <$> xs <*> deserialize x) (Just []) c
+  deserialize Nil = Just []
+  deserialize _ = Nothing
+
+instance (Eq a, Hashable a, Serialize a) => Serialize (Set.HashSet a) where
+  serialize = serialize . Set.toList
+  deserialize = fmap Set.fromList . deserialize
+
+instance Serialize Text where
+  serialize i = Atom (S i Nothing)
+  deserialize (Atom (S i Nothing)) = Just i
+  deserialize _ = Nothing
+
+instance Serialize Double where
+  serialize i = Atom (D i Nothing)
+  deserialize (Atom (D i Nothing)) = Just i
+  deserialize _ = Nothing
+
+instance Serialize Symbol where
+  serialize i = Atom (A (NameSymbol.fromSym i) Nothing)
+  deserialize (Atom (A i Nothing)) = Just (NameSymbol.toSym i)
+  deserialize _ = Nothing
+
+instance Serialize NameSymbol.T where
+  serialize i = Atom (A i Nothing)
+  deserialize (Atom (A i Nothing)) = Just i
+  deserialize _ = Nothing
+
+instance Serialize Integer where
+  serialize i = Atom (N i Nothing)
+  deserialize (Atom (N i Nothing)) = Just i
+  deserialize _ = Nothing
+
+instance Serialize Natural where
+  serialize i = Atom (N (toInteger i) Nothing)
+  deserialize (Atom (N i Nothing)) = Just $ fromInteger i
+  deserialize _ = Nothing
+
+instance Serialize Int where
+  serialize i = serialize (toInteger i)
+  deserialize s = fmap fromIntegral (deserialize @Integer s)
+
+instance Serialize () where
+  serialize () = Nil
+  deserialize Nil = Just ()
+  deserialize _ = Nothing
+
+----------------------------------------
+-- Sexp helper functions
+----------------------------------------
+
+foldr :: (Base a -> p -> p) -> p -> Base a -> p
+foldr f acc ts =
+  case ts of
+    Cons a as -> f a (foldr f acc as)
+    Atom ____ -> f ts acc
+    Nil -> acc
+
+append :: Base a -> Base a -> Base a
+append xs ys = foldr Cons ys xs
+
+-- | @car@ grabs the head of the list
+car :: Base a -> Base a
+car (Cons x _) = x
+car Nil = Nil
+car (Atom a) = Atom a
+
+-- | @cdr@ grabs the tail of the list
+cdr :: Base a -> Base a
+cdr (Cons _ xs) = xs
+cdr Nil = Nil
+cdr (Atom a) = Atom a

--- a/library/Sexp/src/Data/Sexp/Types.hs
+++ b/library/Sexp/src/Data/Sexp/Types.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Data.Sexp.Types where
+
+import Control.Lens hiding (List, from, (:>), (|>))
+import qualified Data.Aeson as A
+import qualified Data.Fix as Fix
+import qualified Data.Functor.Foldable as Foldable
+import qualified Data.Functor.Foldable.TH as FunctorTemplates
+import Data.Hashable ()
+import Mari.Library hiding (show, toList)
+import qualified Mari.Library.LineNum as LineNum
+import qualified Mari.Library.NameSymbol as NameSymbol
+import Prelude (Show (..), String)
+
+type T = Base ()
+
+-- TODO ∷ make Atom generic, and have it conform to an interface?
+-- This way we can erase information later!
+data Base a
+  = Atom (Atom a)
+  | Cons {tCar :: Base a, tCdr :: Base a}
+  | Nil
+  deriving
+    ( Eq,
+      Ord,
+      Generic,
+      Typeable,
+      Data,
+      NFData,
+      Read,
+      Functor,
+      Foldable,
+      Traversable
+    )
+
+instance (A.ToJSON a) => A.ToJSON (Base a) where
+  toJSON = A.genericToJSON (A.defaultOptions {A.sumEncoding = A.ObjectWithSingleField})
+
+instance (A.FromJSON a) => A.FromJSON (Base a) where
+  parseJSON = A.genericParseJSON (A.defaultOptions {A.sumEncoding = A.ObjectWithSingleField})
+
+deriving anyclass instance (A.ToJSON a) => A.ToJSONKey (Base a)
+
+deriving anyclass instance (A.FromJSON a) => A.FromJSONKey (Base a)
+
+data Atom a
+  = A {atomName :: NameSymbol.T, atomLineNum :: Maybe LineNum.T}
+  | N {atomNum :: Integer, atomLineNum :: Maybe LineNum.T}
+  | D {atomDouble :: Double, atomLineNum :: Maybe LineNum.T}
+  | S {atomText :: Text, atomLineNum :: Maybe LineNum.T}
+  | P {atomTerm :: a, atomLineNum :: Maybe LineNum.T}
+  deriving
+    ( Generic,
+      Typeable,
+      Data,
+      NFData,
+      Read,
+      Show,
+      Functor,
+      Foldable,
+      Traversable
+    )
+
+instance A.ToJSON a => A.ToJSON (Atom a) where
+  toJSON = A.genericToJSON (A.defaultOptions {A.sumEncoding = A.ObjectWithSingleField})
+
+instance A.FromJSON a => A.FromJSON (Atom a) where
+  parseJSON = A.genericParseJSON (A.defaultOptions {A.sumEncoding = A.ObjectWithSingleField})
+
+deriving anyclass instance (A.ToJSON a) => A.ToJSONKey (Atom a)
+
+deriving anyclass instance (A.FromJSON a) => A.FromJSONKey (Atom a)
+
+noLoc :: Atom a -> Atom a
+noLoc a = a {atomLineNum = Nothing}
+
+instance Eq a => Eq (Atom a) where
+  (==) = (==) `on` from . noLoc
+
+instance Ord a => Ord (Atom a) where
+  compare = compare `on` from . noLoc
+
+instance Hashable a => Hashable (Atom a) where
+  hash (D {atomDouble}) = hash ('D', atomDouble)
+  hash (P {atomTerm}) = hash ('P', atomTerm)
+  hash (S {atomText}) = hash ('S', atomText)
+  hash (A {atomName}) = hash ('A', atomName)
+  hash (N {atomNum}) = hash ('N', atomNum)
+
+instance (Hashable a) => Hashable (Base a) where
+  hash (Atom atom) = hash atom
+  hash Nil = 1
+  hash (Cons {tCar, tCdr}) = hash (hash tCar, hash tCdr)
+
+makeLensesWith camelCaseFields ''Atom
+
+toList' :: Base a -> ([Base a], Maybe (Atom a))
+toList' (Cons x xs) = first (x :) $ toList' xs
+toList' Nil = ([], Nothing)
+toList' (Atom a) = ([], Just a)
+
+toList :: Alternative f => T -> f [T]
+toList s = case toList' s of (xs, Nothing) -> pure xs; _ -> empty
+
+infixr 5 :>
+
+pattern (:>) :: Base a -> Base a -> Base a
+pattern x :> xs = Cons x xs
+
+{-# COMPLETE (:>), Atom, Nil #-}
+
+pattern List :: [Base a] -> Base a
+pattern List xs <-
+  (toList' -> (xs, Nothing))
+  where
+    List xs = foldr Cons Nil xs
+
+pattern IList :: [Base a] -> Atom a -> Base a
+pattern IList xs a <-
+  (toList' -> (xs, Just a))
+  where
+    IList xs a = foldr Cons (Atom a) xs
+
+{-# COMPLETE List, IList, Atom #-}
+
+-- TODO ∷ make reader instance
+
+-- TODO ∷ this is poorly written, please simplify
+
+instance Show a => Show (Base a) where
+  show (Cons car (Atom a)) =
+    "(" <> show car <> " . " <> show (Atom a) <> ")"
+  show (Cons car cdr)
+    | take 1 (showNoParens cdr) == ")" =
+      "(" <> show car <> showNoParens cdr
+    | otherwise =
+      "(" <> show car <> " " <> showNoParens cdr
+  show (Atom (A x _)) =
+    show (NameSymbol.toSymbol x)
+  show (Atom (N x _)) =
+    show x
+  show (Atom (D x _)) =
+    show x
+  show (Atom (S x _)) =
+    show x
+  show (Atom (P x _)) =
+    "#S(" <> show x <> ")"
+  show Nil = "()"
+
+showNoParens :: Show a => Base a -> String
+showNoParens (Cons car (Atom a)) =
+  show car <> " . " <> show (Atom a) <> ")"
+showNoParens (Cons car cdr)
+  | showNoParens cdr == ")" =
+    show car <> showNoParens cdr
+  | otherwise =
+    show car <> " " <> showNoParens cdr
+showNoParens Nil = ")"
+showNoParens xs = show xs
+
+---------------------------
+---- Recursion schemes ----
+---------------------------
+
+-- Define fixpoint versions of Sexp.Base, which provide instances of
+-- Recursive and Corecursive, and thereby allow the use of recursion-schemes.
+
+FunctorTemplates.makeBaseFunctor ''Base
+
+type instance Foldable.Base (Base a) = BaseF a
+
+-- Define explicit general fixpoints, least fixpoints, and greatest fixpoints
+-- of BaseF (they are all isomorphic to each other and to Base).
+type FixBase a = Fix.Fix (BaseF a)
+
+type MuBase a = Fix.Mu (BaseF a)
+
+type NuBase a = Fix.Nu (BaseF a)

--- a/library/Sexp/stack.yaml
+++ b/library/Sexp/stack.yaml
@@ -1,0 +1,27 @@
+resolver: lts-18.26
+
+packages:
+- .
+- ../StandardLibrary
+
+extra-deps:
+
+########################
+# General Dependencies #
+########################
+- capability-0.4.0.0@sha256:d86d85a1691ef0165c77c47ea72eac75c99d21fb82947efe8b2f758991cf1837,3345
+- github: jyp/prettiest
+  commit: e5ce6cd6b4da71860c3d97da84bed4a827fa00ef
+- git: https://github.com/serokell/galois-field.git
+  commit: 576ba98ec947370835a1f308895037c7aa7f8b71
+- bitvec-1.0.3.0@sha256:f69ed0e463045cb497a7cf1bc808a2e84ea0ce286cf9507983bb6ed8b4bd3993,3977
+- git: https://github.com/serokell/elliptic-curve.git
+  commit: b8a3d0cf8f7bacfed77dc3b697f5d08bd33396a8
+
+#####################################
+# Standard Library Extra Dependency #
+#####################################
+- github: phile314/tasty-silver
+  commit: f1f90ac3113cd445e2a7ade43ebb29f0db38ab9b
+- tasty-1.4.1@sha256:69e90e965543faf0fc2c8e486d6c1d8cf81fd108e2c4541234c41490f392f94f,2638
+

--- a/library/Sexp/test/Main.hs
+++ b/library/Sexp/test/Main.hs
@@ -1,0 +1,22 @@
+module Main where
+
+import Mari.Library
+import qualified Sexp
+import qualified Sexp.Parser
+import qualified Sexp.Serialize
+import qualified Sexp.SimplifiedPasses
+import qualified Test.Tasty as T
+
+allCheckedTests :: T.TestTree
+allCheckedTests =
+  T.testGroup
+    "All tests that are checked"
+    [ Sexp.top,
+      Sexp.Parser.top,
+      Sexp.SimplifiedPasses.top,
+      Sexp.Serialize.top
+    ]
+
+main :: IO ()
+main =
+  T.defaultMain allCheckedTests

--- a/library/Sexp/test/Sexp.hs
+++ b/library/Sexp/test/Sexp.hs
@@ -1,0 +1,207 @@
+module Sexp (top) where
+
+import qualified Data.IORef as IORef
+import Mari.Library
+import qualified Data.Sexp as Sexp
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+
+top :: T.TestTree
+top =
+  T.testGroup
+    "sexp pass tests:"
+    [ lastWorksAsExpected,
+      foldrWorksAsExpted,
+      mapPredStarWorksAsExpted,
+      mapPredStarWorksAsExpted2,
+      mapPredStarWorksAsExpted3,
+      listWorksAsExpected,
+      listStarWorksAsExpected,
+      traversePredWorksAsExpected,
+      subsetSeralization
+    ]
+
+--------------------------------------------------------------------------------
+-- Tests not exported
+--------------------------------------------------------------------------------
+
+lastWorksAsExpected :: T.TestTree
+lastWorksAsExpected =
+  T.testGroup
+    "last works as expected"
+    [ T.testCase
+        "last on Cons"
+        (fmap Sexp.last (Sexp.parse "(1 2 3 4)") T.@=? Sexp.parse "4"),
+      T.testCase
+        "last on atom"
+        (fmap Sexp.last (Sexp.parse "4") T.@=? Sexp.parse "4"),
+      T.testCase
+        "last on Nil"
+        (fmap Sexp.last (Sexp.parse "()") T.@=? Sexp.parse "()")
+    ]
+
+foldrWorksAsExpted :: T.TestTree
+foldrWorksAsExpted =
+  T.testGroup
+    "foldr works as epxected"
+    [ T.testCase
+        "foldr on (1 2 3 4 5) properly adds"
+        (Sexp.foldr (\(Sexp.Atom (Sexp.N n Nothing)) acc -> n + acc) 0 ns T.@=? 15)
+    ]
+  where
+    Right ns = Sexp.parse "(1 2 3 4 5)"
+
+mapPredStarWorksAsExpted :: T.TestTree
+mapPredStarWorksAsExpted =
+  T.testGroup
+    "mapPredStar works as Exptected"
+    [ T.testCase
+        "mapPredStar properly recurses and does not change the non car position"
+        ( Sexp.mapPredStar nest (== "if") (Sexp.Cons (Sexp.atom ":if") . Sexp.cdr)
+            T.@=? expectedNest
+        )
+    ]
+  where
+    Right nest =
+      Sexp.parse "(if x y (if if l))"
+    Right expectedNest =
+      Sexp.parse "(:if x y (:if if l))"
+
+mapPredStarWorksAsExpted2 :: T.TestTree
+mapPredStarWorksAsExpted2 =
+  T.testGroup
+    "mapPredStar works as Exptected"
+    [ T.testCase
+        "mapPredStar properly searches"
+        ( Sexp.mapPredStar nest (== "if") (Sexp.Cons (Sexp.atom ":if") . Sexp.cdr)
+            T.@=? expectedNest
+        )
+    ]
+  where
+    Right nest =
+      Sexp.parse "(g x y (f z l))"
+    Right expectedNest =
+      Sexp.parse "(g x y (f z l))"
+
+mapPredStarWorksAsExpted3 :: T.TestTree
+mapPredStarWorksAsExpted3 =
+  T.testGroup
+    "mapPredStar works as Exptected"
+    [ T.testCase
+        "mapPredStar can deal with bigger sexp"
+        ( Sexp.mapPredStar
+            nest
+            (== ":defop")
+            (\sexp -> Sexp.Cons (Sexp.atom ":op") (Sexp.cdr sexp))
+            T.@=? expectedNest
+        )
+    ]
+  where
+    Right nest =
+      Sexp.parse
+        ( "(:defmodule Printer ()                     "
+            <> "   (:defhandler printer                     "
+            <> "    ((:defop print () printLn)              "
+            <> "     (:defop pure (x) (toString x))))       "
+            <> "   (:defun prog (a)                         "
+            <> "      (:do                                  "
+            <> "          (:do-body (:do-op print (a)))     "
+            <> "          (:do-body (:do-pure a))))         "
+            <> "   (:defun foo ()                           "
+            <> "      (:via printer prog)))))"
+        )
+    Right expectedNest =
+      Sexp.parse
+        ( "(:defmodule Printer ()                       "
+            <> "   (:defhandler printer                     "
+            <> "    ((:op print () printLn)                 "
+            <> "     (:op pure (x) (toString x))))          "
+            <> "   (:defun prog (a)                         "
+            <> "      (:do                                  "
+            <> "          (:do-body (:do-op print (a)))     "
+            <> "          (:do-body (:do-pure a))))         "
+            <> "   (:defun foo ()                           "
+            <> "      (:via printer prog)))))"
+        )
+
+listWorksAsExpected :: T.TestTree
+listWorksAsExpected =
+  T.testGroup
+    "list works as epctected"
+    [ T.testCase
+        "list on a term is correct"
+        (Sexp.parse "(1 2 3)" T.@=? Right manualList)
+    ]
+  where
+    manualList =
+      Sexp.list [Sexp.number 1, Sexp.number 2, Sexp.number 3]
+
+listStarWorksAsExpected :: T.TestTree
+listStarWorksAsExpected =
+  T.testGroup
+    "list* works as epctected"
+    [ T.testCase
+        "list* on a list properly removes the last list"
+        (Sexp.parse "(1 2 3)" T.@=? Right manualList)
+    ]
+  where
+    manualList =
+      Sexp.listStar [Sexp.number 1, Sexp.number 2, Sexp.list [Sexp.number 3]]
+
+traversePredWorksAsExpected :: T.TestTree
+traversePredWorksAsExpected =
+  T.testGroup
+    "traversePredOptStar works as expected"
+    [ T.testCase
+        "traversePredOpStar properly matches on car application"
+        $ do
+          y <- IORef.newIORef Sexp.Nil
+          let f :: Sexp.T -> IO Sexp.T
+              f rest = do
+                IORef.modifyIORef' y (rest Sexp.:>)
+                pure (Sexp.Cons (Sexp.atom "bob") (Sexp.cdr rest))
+              Right xs =
+                Sexp.parse "(let let (let))"
+          _ <- Sexp.traversePredOptStar xs (== "let") (Sexp.autoRecurse f) mempty
+          v <- IORef.readIORef y
+          Sexp.parse "((let) (let let (let)))" T.@=? Right v
+    ]
+
+data SubSet
+  = Add (Sexp.B SubSet) (Sexp.B SubSet)
+  | Mul (Sexp.B SubSet) (Sexp.B SubSet)
+  deriving (Show, Generic, Eq)
+
+instance Sexp.DefaultOptions SubSet
+
+instance Sexp.Serialize SubSet
+
+subsetSeralization :: T.TestTree
+subsetSeralization =
+  T.testGroup
+    "partial serialization works"
+    [ T.testCase
+        "Deeply Nested Serializers work as one ought to expect"
+        $ do
+          let expected =
+                Sexp.list
+                  [ Sexp.atom ":sub",
+                    Sexp.primOp $
+                      Add
+                        (Sexp.primOp (Mul (Sexp.number 3) (Sexp.number 6)))
+                        (Sexp.primOp (Add (Sexp.number 4) (Sexp.number 5))),
+                    Sexp.primOp $
+                      Add
+                        ( Sexp.list
+                            [ Sexp.atom ":sub",
+                              Sexp.number 3,
+                              Sexp.primOp (Add (Sexp.number 5) (Sexp.number 6))
+                            ]
+                        )
+                        (Sexp.number 5)
+                  ]
+              Right term =
+                Sexp.parse
+                  "(:sub (:add (:mul 3 6) (:add 4 5)) (:add (:sub 3 (:add 5 6)) 5))"
+          expected T.@=? Sexp.partiallyDeserialize @SubSet term
+    ]

--- a/library/Sexp/test/Sexp/Parser.hs
+++ b/library/Sexp/test/Sexp/Parser.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Sexp.Parser where
+
+import Mari.Library
+import qualified Data.Sexp as Sexp
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+
+top :: T.TestTree
+top =
+  T.testGroup
+    "sexp parser tests"
+    [ staringParenSpaceDoesntEffectParser,
+      endingParenSpaceDoesntEffectParser,
+      uncidoeParserCorrectly,
+      numbersParseCorrectly,
+      doublesParseCorrectly,
+      stringParseCorrectly
+    ]
+
+staringParenSpaceDoesntEffectParser :: T.TestTree
+staringParenSpaceDoesntEffectParser =
+  T.testCase
+    "space after () works as expected"
+    (Sexp.parse "(1 2 3)" T.@=? Sexp.parse " (       1 2 3)")
+
+endingParenSpaceDoesntEffectParser :: T.TestTree
+endingParenSpaceDoesntEffectParser =
+  T.testCase
+    "space after () works as expected"
+    (Sexp.parse "(1 2 3)" T.@=? Sexp.parse " (1 2 3              )       ")
+
+uncidoeParserCorrectly :: T.TestTree
+uncidoeParserCorrectly =
+  T.testCase
+    "space after () works as expected"
+    ("Foo" :| ["X:Y<Z", "A---B-C"] T.@=? atomName)
+  where
+    Right (Sexp.Atom Sexp.A {Sexp.atomName}) = Sexp.parse "Foo.X:Y<Z.A---B-C"
+
+numbersParseCorrectly :: T.TestTree
+numbersParseCorrectly =
+  T.testCase
+    "Numbers parse correctly"
+    (Right (Sexp.Atom (Sexp.N 3 Nothing)) T.@=? Sexp.parse "3")
+
+doublesParseCorrectly :: T.TestTree
+doublesParseCorrectly =
+  T.testCase
+    "doubles parse correctly"
+    (Right (Sexp.Atom (Sexp.D 3.4 Nothing)) T.@=? Sexp.parse "3.4")
+
+stringParseCorrectly :: T.TestTree
+stringParseCorrectly =
+  T.testCase
+    "String parse correctly"
+    (Right (Sexp.Atom (Sexp.S "hi" Nothing)) T.@=? Sexp.parse "\"hi\"")

--- a/library/Sexp/test/Sexp/Serialize.hs
+++ b/library/Sexp/test/Sexp/Serialize.hs
@@ -1,0 +1,121 @@
+module Sexp.Serialize where
+
+import Mari.Library hiding (identity)
+import qualified Mari.Library.HashMap as Map
+import qualified Data.Sexp as Sexp
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+
+data Test a
+  = Test
+  | Test2 a
+  | TestRec a (Test a)
+  | TestRec' (Test a)
+  | Test3 {fstt :: a, sndd :: Integer}
+  deriving (Show, Generic)
+
+-- let's turn this to deriving via
+instance Sexp.DefaultOptions (Test a)
+
+instance (Sexp.Serialize a) => Sexp.Serialize (Test a)
+
+data TestRename
+  = TestRename
+  | TestRename1 Integer
+  deriving (Show, Generic, Data)
+
+testRenameConsturoctrs :: Sexp.Options
+testRenameConsturoctrs =
+  Sexp.changeName
+    (Sexp.defaultOptions @TestRename)
+    (Map.fromList [("TestRename", ":test"), ("TestRename1", ":test-1")])
+
+data Infix a
+  = Infix
+      { infixOp :: (Sexp.B (Infix a)),
+        infixLt :: (Sexp.B (Infix a)),
+        infixInf :: (Infix a)
+      }
+  | InfixNoMore
+      { infixOp :: (Sexp.B (Infix a)),
+        infixLt :: (Sexp.B (Infix a)),
+        infixRt :: (Sexp.B (Infix a))
+      }
+  deriving (Show, Generic, Eq)
+
+-- Right xs = Sexp.parse "(+ 2 (:infix + 2 (:infix * (:infix * 5 (:infix - 2 3)) (:infix * 6 7 8))))"
+-- λ> Sexp.partiallyDeserialize @(Infix Integer) xs
+
+infixRename :: Sexp.Options
+infixRename =
+  Sexp.changeName
+    (Sexp.defaultOptions @(Infix ()))
+    (Map.fromList [("InfixNoMore", ":infix")])
+
+instance Sexp.DefaultOptions (Infix a)
+
+instance Sexp.Serialize a => Sexp.Serialize (Infix a) where
+  serialize = Sexp.serializeOpt infixRename
+  deserialize = Sexp.deserializeOpt infixRename
+
+instance Sexp.DefaultOptions TestRename
+
+instance Sexp.Serialize TestRename where
+  serialize = Sexp.serializeOpt testRenameConsturoctrs
+  deserialize = Sexp.deserializeOpt testRenameConsturoctrs
+
+top :: T.TestTree
+top =
+  T.testGroup
+    "automatic serialization"
+    [ compositionIsJust,
+      serializerTest
+    ]
+
+type TInt = Test Integer
+
+compositionIsJust :: T.TestTree
+compositionIsJust =
+  T.testGroup
+    "Composing Serialize and Deserialize is Just"
+    [ T.testCase "No Argument" (idCheck Test),
+      T.testCase "One Argument" (idCheck (Test2 3)),
+      T.testCase "2 named arguments" (idCheck (Test3 4 5)),
+      T.testCase "recursive constructor" (idCheck (TestRec 3 (Test2 2))),
+      T.testCase "nested serialize" (isJust (identityRec (Test2 (Test2 3))) T.@=? True),
+      T.testCase "testing renmaing" (isJust (identityRename (TestRename1 5)) T.@=? True)
+    ]
+  where
+    idCheck x =
+      x
+        |> identity
+        |> isJust
+        |> (T.@=? True)
+
+serializerTest :: T.TestTree
+serializerTest =
+  T.testGroup
+    "Serialization form testing"
+    [ T.testCase "name is expected" $
+        Right (Sexp.serialize (TestRec (3 :: Integer) Test))
+          T.@=? Sexp.parse "(:test-rec 3 :test)",
+      T.testCase "name is expected for renaming" $
+        Right (Sexp.serialize (TestRename1 5))
+          T.@=? Sexp.parse "(:test-1 5)"
+    ]
+
+identityRec :: Test (Test Integer) -> Maybe (Test (Test Integer))
+identityRec = Sexp.deserialize . Sexp.serialize
+
+identityRename :: TestRename -> Maybe TestRename
+identityRename = Sexp.deserialize . Sexp.serialize
+
+identity :: TInt -> Maybe TInt
+identity = Sexp.deserialize . Sexp.serialize
+
+-- test ::
+--   Maybe (C1 ('MetaCons "Test" 'PrefixI 'False) U1 p)
+-- test = do
+--   let M1 t = from (Test :: Test ())
+--       L1 t2 = t
+--   (Sexp.gput t2 |> Sexp.gget :: Maybe (C1 ('MetaCons "Test" 'PrefixI 'False) U1 p))

--- a/library/Sexp/test/Sexp/SimplifiedPasses.hs
+++ b/library/Sexp/test/Sexp/SimplifiedPasses.hs
@@ -1,0 +1,309 @@
+module Sexp.SimplifiedPasses where
+
+import qualified Data.Set as Set
+import Mari.Library
+import qualified Data.Sexp as Sexp
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import Prelude (error)
+
+--------------------------------------------------------------------------------
+-- Exported Tests
+--------------------------------------------------------------------------------
+
+top :: T.TestTree
+top =
+  T.testGroup
+    "sexp simplified pass tests:"
+    [ condWorksAsExpected,
+      ifWorksAsExpected,
+      letWorksAsExpected,
+      recordWorksAsExpected,
+      sigandDefunWorksAsExpetcted,
+      moduleExpandsAsExpected
+    ]
+
+--------------------------------------------------------------------------------
+-- Simple Passes
+--------------------------------------------------------------------------------
+
+moduleTransform :: Sexp.T -> Sexp.T
+moduleTransform xs = Sexp.mapPredStar xs (== "defmodule") moduleToRecord
+  where
+    moduleToRecord (Sexp.Atom atom Sexp.:> name Sexp.:> args Sexp.:> body) =
+      Sexp.list [Sexp.atom "defun", name, args, Sexp.foldr combine generatedRecord body]
+        |> Sexp.addMetaToCar atom
+      where
+        generatedRecord =
+          Sexp.list (Sexp.atom "record" : fmap (\x -> Sexp.list [Sexp.Atom x]) names)
+        combine (form Sexp.:> name Sexp.:> xs) expression
+          | Sexp.isAtomNamed form "defun" =
+            -- we crunch the xs in a list
+            Sexp.list [Sexp.atom "let", name, xs, expression]
+          | Sexp.isAtomNamed form "type" =
+            Sexp.list [Sexp.atom "let-type", name, xs, expression]
+        combine (form Sexp.:> name Sexp.:> xs Sexp.:> Sexp.Nil) expression
+          | Sexp.isAtomNamed form "defsig" =
+            Sexp.list [Sexp.atom "let-sig", name, xs, expression]
+        combine (form Sexp.:> declaration) expression
+          | Sexp.isAtomNamed form "declare" =
+            Sexp.list [Sexp.atom "declaim", declaration, expression]
+        combine (Sexp.List [form, open]) expression
+          | Sexp.isAtomNamed form "open" =
+            Sexp.list [Sexp.atom "open-in", open, expression]
+        combine (form Sexp.:> xs) expression
+          | Sexp.isAtomNamed form "defmodule" =
+            -- have to recurse by hand here ☹
+            let (_ Sexp.:> name Sexp.:> rest) = moduleToRecord (form Sexp.:> xs)
+             in Sexp.list [Sexp.atom "let", name, rest, expression]
+        -- ignore other forms
+        combine _ expression = expression
+        --
+        names = Sexp.foldr f [] body |> Set.fromList |> Set.toList
+        --
+        f (form Sexp.:> name Sexp.:> _) acc
+          | Sexp.isAtomNamed form "defun"
+              || Sexp.isAtomNamed form "type"
+              || Sexp.isAtomNamed form "defmodule"
+              || Sexp.isAtomNamed form "defsig",
+            Just name <- Sexp.atomFromT name =
+            name : acc
+        f _ acc = acc
+    moduleToRecord _ = error "malformed record"
+
+condTransform :: Sexp.T -> Sexp.T
+condTransform xs = Sexp.mapPredStar xs (== "cond") condToIf
+  where
+    condToIf sexp =
+      let acc =
+            generation (Sexp.last sexp) Sexp.Nil
+              |> Sexp.butLast
+       in Sexp.foldr generation acc (Sexp.butLast (Sexp.cdr sexp))
+            |> Sexp.addMetaToCar (Sexp.atomErr (Sexp.car sexp))
+    --
+    generation (Sexp.Cons condition body) acc =
+      Sexp.list [Sexp.atom "if", condition, Sexp.car body, acc]
+    generation _ _ =
+      error "malformed cond"
+
+ifTransform :: Sexp.T -> Sexp.T
+ifTransform xs = Sexp.mapPredStar xs (== "if") ifToCase
+  where
+    ifToCase sexp =
+      case Sexp.cdr sexp of
+        Sexp.List [pred, then', else'] ->
+          Sexp.list (caseListElse pred then' else')
+        Sexp.List [pred, then'] ->
+          Sexp.list (caseList pred then')
+        _ ->
+          error "malformed if"
+            |> Sexp.addMetaToCar (Sexp.atomErr (Sexp.car sexp))
+    caseList pred then' =
+      [Sexp.atom "case", pred, Sexp.list [Sexp.atom "true", then']]
+    caseListElse pred then' else' =
+      caseList pred then' <> [Sexp.list [Sexp.atom "false", else']]
+
+-- This one and sig combining are odd mans out, as they happen on a
+-- list of transforms
+-- We will get rid of this as this should be the job of Code -> Context!
+multipleTransDefun :: [Sexp.T] -> [Sexp.T]
+multipleTransDefun = search
+  where
+    combineMultiple name xs =
+      Sexp.list ([Sexp.atom "defun-match", Sexp.atom name] <> (Sexp.cdr . Sexp.cdr <$> xs))
+    sameName name (Sexp.List (defun1 : name1 : _))
+      | Sexp.isAtomNamed defun1 "defun" && Sexp.isAtomNamed name1 name =
+        True
+    sameName _ _ =
+      False
+    grabSimilar _nam [] = ([], [])
+    grabSimilar name (defn : xs)
+      | sameName name defn =
+        let (same, rest) = grabSimilar name xs
+         in (defn : same, rest)
+      | otherwise =
+        ([], defn : xs)
+    search (defun@(Sexp.List (defun1 : name1@(Sexp.Atom a) : _)) : xs)
+      | Sexp.isAtomNamed defun1 "defun",
+        Just name <- Sexp.nameFromT name1 =
+        let (sameDefun, toSearch) = grabSimilar name xs
+         in combineMultiple name (defun : sameDefun)
+              |> Sexp.addMetaToCar a
+              |> (: search toSearch)
+    search (x : xs) = x : search xs
+    search [] = []
+
+-- This pass will also be removed, but is here for comparability
+-- reasons we just drop sigs with no defuns for now ☹. Fix this up when
+-- we remove this pass
+combineSig :: [Sexp.T] -> [Sexp.T]
+combineSig
+  ( Sexp.List [Sexp.Atom (Sexp.A "defsig" _), name, sig]
+      : (Sexp.Atom a@(Sexp.A "defun-match" _) Sexp.:> defName Sexp.:> body)
+      : xs
+    )
+    | defName == name =
+      Sexp.addMetaToCar a (Sexp.listStar [Sexp.atom "defsig-match", name, sig, body]) :
+      combineSig xs
+combineSig (Sexp.List [Sexp.Atom (Sexp.A "defsig" _), _, _] : xs) =
+  combineSig xs
+combineSig (x : xs) = x : combineSig xs
+combineSig [] = []
+
+multipleTransLet :: Sexp.T -> Sexp.T
+multipleTransLet xs = Sexp.mapPredStar xs (== "let") letToLetMatch
+  where
+    letToLetMatch (Sexp.List [Sexp.Atom atom, a@(Sexp.Atom (Sexp.A name _)), bindingsBody, rest]) =
+      let (grabbed, notMatched) = grabSimilar name rest
+       in Sexp.list
+            [ Sexp.atom "let-match",
+              a,
+              putTogetherSplices (bindingsBody : grabbed),
+              notMatched
+            ]
+            |> Sexp.addMetaToCar atom
+    letToLetMatch _ =
+      error "malformed let"
+    --
+    grabSimilar name (Sexp.List [let1, name1, bindingsBody, rest])
+      | Sexp.isAtomNamed let1 "let" && Sexp.isAtomNamed name1 name =
+        grabSimilar name rest
+          |> first (bindingsBody :)
+    grabSimilar _name xs = ([], xs)
+    --
+    putTogetherSplices =
+      foldr spliceBindingBody Sexp.Nil
+    --
+    spliceBindingBody (Sexp.List [bindings, body]) acc =
+      Sexp.Cons bindings (Sexp.Cons body acc)
+    spliceBindingBody _ _ =
+      error "doesn't happen"
+
+removePunnedRecords :: Sexp.T -> Sexp.T
+removePunnedRecords xs = Sexp.mapPredStar xs (== "record") removePunned
+  where
+    removePunned (Sexp.Atom atom Sexp.:> sexp) =
+      Sexp.listStar
+        [ Sexp.atom "record-no-pun",
+          Sexp.foldr f Sexp.Nil sexp
+        ]
+        |> Sexp.addMetaToCar atom
+      where
+        f (Sexp.List [field, bind]) acc =
+          field Sexp.:> bind Sexp.:> acc
+        f (Sexp.List [pun]) acc =
+          pun Sexp.:> pun Sexp.:> acc
+        f _ _ = error "malformed record"
+    removePunned _ = error "does not happen"
+
+--------------------------------------------------------------------------------
+-- Pass Tests
+--------------------------------------------------------------------------------
+
+condWorksAsExpected :: T.TestTree
+condWorksAsExpected =
+  T.testCase
+    "cond properly desguars cond"
+    (Sexp.parse expected T.@=? Right (condTransform testData))
+  where
+    expected =
+      "(if (g x) true (if (p x) true (if else false)))"
+
+ifWorksAsExpected :: T.TestTree
+ifWorksAsExpected =
+  T.testCase
+    "if expansion to match works properly"
+    (Sexp.parse expected T.@=? Right (ifTransform (condTransform testData)))
+  where
+    expected =
+      "(case (g x) \
+      \  (true true) \
+      \  (false (case (p x) \
+      \            (true true) \
+      \            (false (case else (true false))))))"
+
+letWorksAsExpected :: T.TestTree
+letWorksAsExpected =
+  T.testCase
+    "let expansion to match works properly"
+    (Sexp.parse expected T.@=? Right (multipleTransLet testLet))
+  where
+    expected =
+      "(let-match foo ((Nil b) body-1 ((Cons a xs) b) body-2) \
+      \   (let-match bar (((Cons a xs) b) body-2) \
+      \     &rest))"
+
+recordWorksAsExpected :: T.TestTree
+recordWorksAsExpected =
+  T.testCase
+    "removing punned names works as expected"
+    (Sexp.parse expected T.@=? Right (removePunnedRecords testRecord))
+  where
+    expected =
+      "(record-no-pun name value field-pun field-pun name2 value2)"
+
+sigandDefunWorksAsExpetcted :: T.TestTree
+sigandDefunWorksAsExpetcted =
+  T.testCase
+    "desugaring defuns and sigs work as epected"
+    (expected T.@=? (multipleTransDefun testDefun |> combineSig))
+  where
+    expected =
+      [ "(defsig-match f (-> a b) (((Cons a as) b) b1) ((Nil b) b2))",
+        "(defun-match g ((a b) new-b))"
+      ]
+        >>| Sexp.parse
+        >>| rightErr
+
+moduleExpandsAsExpected :: T.TestTree
+moduleExpandsAsExpected =
+  T.testCase
+    "module properly goes to record"
+    (Sexp.parse expected T.@=? Right (moduleTransform moduleTest))
+  where
+    expected =
+      "(defun fun-name () \
+      \   (let-sig f (-> a b) \
+      \       (let f (((Cons a as) b) b1) \
+      \          (let f ((Nil b) b2) \
+      \             (record (f))))))"
+
+--------------------------------------------------------------------------------
+-- Pass Test Data
+--------------------------------------------------------------------------------
+
+moduleTest :: Sexp.T
+moduleTest =
+  Sexp.listStar
+    ([Sexp.atom "defmodule", Sexp.atom "fun-name", Sexp.list []] <> testDefun)
+
+testData :: Sexp.T
+testData =
+  rightErr $ Sexp.parse "(cond ((g x) true) ((p x) true) (else false))"
+
+testDefun :: [Sexp.T]
+testDefun =
+  [ Sexp.parse "(defsig f (-> a b))",
+    Sexp.parse "(defun f ((Cons a as) b) b1)",
+    Sexp.parse "(defun f (Nil b) b2)",
+    Sexp.parse "(defun g (a b) new-b)"
+  ]
+    >>| rightErr
+
+testLet :: Sexp.T
+testLet =
+  "(let foo ((Nil b) body-1)\
+  \   (let foo (((Cons a xs) b) body-2) \
+  \      (let bar (((Cons a xs) b) body-2) &rest)))"
+    |> Sexp.parse
+    |> rightErr
+
+testRecord :: Sexp.T
+testRecord =
+  "(record (name value) (field-pun) (name2 value2))"
+    |> Sexp.parse
+    |> rightErr
+
+rightErr :: Either a p -> p
+rightErr (Right r) = r
+rightErr (Left _) = error "improper right"

--- a/library/StandardLibrary/.gitignore
+++ b/library/StandardLibrary/.gitignore
@@ -1,0 +1,2 @@
+.stack-work/
+*~

--- a/library/StandardLibrary/LICENSE
+++ b/library/StandardLibrary/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/library/StandardLibrary/README.org
+++ b/library/StandardLibrary/README.org
@@ -1,0 +1,123 @@
+* Standard Library
+This package is responsible for defining the standard library for the
+rest of the code-base. Due to this, this library relies on no other
+part of the code-base, but everything relies on it.
+
+Standard library is broken up into a few parts.
+
+1. [[file:src/Mari/Library.hs][The default prelude]]
+   - This is included by default when one imports
+     =Mari.Library=. Names here are unqualified as they are
+     considered part the code base's standard library
+2. Extra modules
+   - These are the rest of the modules, they all export important
+     helper functionality, but are best to be in a qualified package
+     rather than be implicit in our prelude.
+
+** Useful Extras
+- [[file:src/Mari/Library/Trace.hs][Trace]]
+  + Adds tracing to Haskell, properly maintains a call stack that can
+    be filtered by the user when one wishes to use it
+  + See [[file:test/Trace.hs][The Trace Tests]] to see how it is used
+    #+begin_src haskell
+      λ> example2
+      (factorial 5 1)
+      ·· (Prelude.multiply 5 1) ↦ 5
+      ·· (factorial 4 5)
+      ···· (Prelude.multiply 4 5) ↦ 20
+      ···· (factorial 3 20)
+      ······ (Prelude.multiply 3 20) ↦ 60
+      ······ (factorial 2 60)
+      ········ (Prelude.multiply 2 60) ↦ 120
+      ········ (factorial 1 120)
+      ·········· (Prelude.multiply 1 120) ↦ 120
+      ·········· (factorial 0 120) ↦ 120
+      ········ (factorial 1 120) ↦ 120
+      ······ (factorial 2 60) ↦ 120
+      ···· (factorial 3 20) ↦ 120
+      ·· (factorial 4 5) ↦ 120
+      (factorial 5 1) ↦ 120
+    #+end_src
+- [[file:src/Mari/Library/Parser/][Parser]]
+  + This provides generic utilities for the Frontend parser and the
+    S-expression parser.
+** Useful Idioms in the standard library
+- Capability is our replacement for MTL
+  + [[https://www.tweag.io/blog/2018-10-04-capability/][Tweag explains how their library works here.]]
+  + Here is a quick example of setting up an environment stolen from [[file:./../Translate/src/Mari/FreeVars.hs][FreeVars in Translate]]
+    #+begin_src haskell
+
+      -- Define the data type we wish to work on
+      data Env
+        = Env
+            { closure :: Closure.T,
+              free :: Set.HashSet NameSymbol.T
+            }
+        deriving (Generic, Show)
+
+      -- define a type alias to work under
+      type EnvAlias =
+        (State Env)
+
+      -- Create our effect
+      newtype EnvM a = Ctx {_run :: EnvAlias a}
+        deriving (Functor, Applicative, Monad)
+        -- Create the various effects we must satisfy
+        -- This one is a reader!
+        deriving
+          ( HasReader "closure" Closure.T,
+            HasSource "closure" Closure.T
+          )
+          via ReaderField "closure" EnvAlias
+        -- This one is a state effect
+        deriving
+          ( HasState "free" (Set.HashSet NameSymbol.T),
+            HasSource "free" (Set.HashSet NameSymbol.T),
+            HasSink "free" (Set.HashSet NameSymbol.T)
+          )
+          via StateField "free" EnvAlias
+
+      -- Make a runner for our effect
+      runM :: EnvM a -> (a, Env)
+      runM (Ctx c) =
+        runState c (Env Closure.empty (Set.fromList Env.namedForms))
+
+
+      -- An example function that we can run on it
+      freeVarPass ::
+        ( HasReader "closure" Closure.T f,
+          HasState "free" (Set.HashSet NameSymbol.T) f
+        ) =>
+        Sexp.T ->
+        f Sexp.T
+      freeVarPass form =
+        Env.onExpression form (== ":atom") freeVarRes
+
+      -- Example usage note we get back more frees than what are here, as we
+      -- just include the primitives as requires, so the code is a bit misleading
+      λ> (runM . freeVarPass) x
+      ((":lambda" ("x") ("+" "x" "y"))
+        ,Env {closure = T (fromList [])
+             , free = fromList
+                  [":open-in" :| [],
+                   ":lambda" :| [],
+                   "type" :| [],
+                   ":declaim" :| [],
+                   ":tuple" :| [],
+                   ":primitive" :| [],
+                   ":lambda-case" :| [],
+                   "case" :| [],
+                   ":record-no-pun" :| [],
+                   ":progn" :| [],
+                   "declare" :| [],
+                   ":list" :| [],
+                   -- Y is recorded which is correct
+                   "y" :| [],
+                   ":let-match" :| [],
+                   ":let-type" :| [],
+                   ":infix" :| [],
+                   ":paren" :| [],
+                   ":block" :| [],
+                   "+" :| []]})
+    #+end_src
+

--- a/library/StandardLibrary/Setup.hs
+++ b/library/StandardLibrary/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+
+main = defaultMain

--- a/library/StandardLibrary/package.yaml
+++ b/library/StandardLibrary/package.yaml
@@ -1,0 +1,111 @@
+name:                standard-library
+version:             0.1.0.0
+github:              "mariari/Misc-ML-Scripts"
+license:             GPL-3
+author:              "Mariari <mariari@protonmail.ch>"
+maintainer:          "Mariari <mariari@protonmail.ch>"
+copyright:           "2022 Mariari"
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         Please see the README on GitHub at <https://github.com/githubuser/StandardLibrary#readme>
+
+dependencies:
+- aeson
+- base >= 4.11 && < 5
+- bytestring
+- capability
+- containers
+- directory
+# - elliptic-curve >= 0.3.0
+- filepath
+# - galois-field >= 1.0.2
+- generic-lens
+- lens
+- lens-aeson
+- megaparsec
+- mtl
+- pretty-simple
+- pretty-compact
+- protolude
+- scientific
+- text
+- time
+- unordered-containers
+- word8
+- wreq
+# Testing
+- tasty
+- tasty-silver
+
+default-extensions:
+  - BlockArguments
+  - ConstraintKinds
+  - DataKinds
+  - DefaultSignatures
+  - DeriveGeneric
+  - FlexibleContexts
+  - FlexibleInstances
+  - LambdaCase
+  - NoImplicitPrelude
+  - OverloadedStrings
+  - RankNTypes
+  - TupleSections
+  - TypeApplications
+  - TypeFamilies
+  - TypeSynonymInstances
+  - KindSignatures
+  - DefaultSignatures
+  - DeriveDataTypeable
+  - FunctionalDependencies
+
+ghc-options:
+  - -ferror-spans
+  - -Wall
+  - -fno-warn-orphans
+  - -fno-warn-name-shadowing
+  - -fno-warn-missing-pattern-synonym-signatures
+  - -j
+  - -static
+  - -fwrite-ide-info
+
+# TODO: Specify which packages are exported
+
+when:
+  condition: flag(incomplete-error)
+  ghc-options:
+    - -Werror=incomplete-patterns
+    - -Werror=missing-fields
+    - -Werror=missing-methods
+
+flags:
+  incomplete-error:
+    description: >
+      Incomplete patterns, missing record fields, and missing class methods are
+      an error
+    manual: true
+    default: false
+
+library:
+  source-dirs: src
+
+tests:
+  standard-library-test:
+    main:                Main.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - standard-library
+    - tasty
+    - tasty-hunit
+    - tasty-silver
+    - tasty-quickcheck
+    - pretty-simple

--- a/library/StandardLibrary/src/Mari/Library.hs
+++ b/library/StandardLibrary/src/Mari/Library.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- |
+-- - The standard Library for the project
+--   + Thus all code will depend on this module without stating otherwise
+-- - Is mostly =Protolude= except with a few changes
+--   + _Additions_
+--     * ∨   :: Serves as an or function
+--     * ∧   :: Serves as an and function
+--     * |<< :: Serves as a map function
+--     * >>| :: Serves as the flip map function
+--   + _Changes_
+--     * The Capability library is imported and replaces the standard =MTL=
+--       constructs in =Protolude=
+module Mari.Library
+  ( module Protolude,
+    module Capability.State,
+    module Capability.Reader,
+    module Capability.Error,
+    module Capability.Writer,
+    module Capability.Sink,
+    module Capability.Source,
+    module Numeric.Natural,
+    undefined,
+    Data,
+    (∨),
+    (∧),
+    (|<<),
+    (>>|),
+    (|>),
+    (...),
+    traverseAccumM,
+    foldMapA,
+    traverseM,
+    Symbol (..),
+    toUpperFirst,
+    internText,
+    intern,
+    unintern,
+    textify,
+    uninternText,
+    unixTime,
+    Flip (..),
+    untilNothingNTimesM,
+    untilNothing,
+    sortOnFlip,
+    uncurry3,
+    curry3,
+    dup,
+    lengthN,
+    StateField,
+    ReaderField,
+    WriterField,
+    init,
+  )
+where
+
+import Capability.Error
+import Capability.Reader
+import Capability.Sink
+import Capability.Source
+import Capability.State
+import Capability.Writer
+import qualified Data.Aeson as A
+import Data.Data (Data)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.String (fromString)
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX
+import GHC.Stack
+import Numeric.Natural
+import Protolude hiding
+  ( Constraint,
+    Fixity (..),
+    MonadError (..),
+    MonadReader (..),
+    MonadState (..),
+    SomeSymbol,
+    Symbol,
+    ask,
+    asks,
+    catch,
+    catchJust,
+    get,
+    gets,
+    isDigit,
+    isSpace,
+    local,
+    modify,
+    moduleName,
+    pass,
+    put,
+    reader,
+    state,
+    typeOf,
+    undefined,
+    yield,
+    (:.:),
+  )
+import Prelude (Show (..), String, error, init)
+
+(∨) :: Bool -> Bool -> Bool
+(∨) = (||)
+
+infixr 2 ∨
+
+(∧) :: Bool -> Bool -> Bool
+(∧) = (&&)
+
+infixr 3 ∧
+
+(|<<) :: forall a b f. (Functor f) => (a -> b) -> f a -> f b
+(|<<) = fmap
+
+infixr 1 |<<
+
+(>>|) :: forall a b f. (Functor f) => f a -> (a -> b) -> f b
+(>>|) = flip fmap
+
+infixl 1 >>|
+
+(|>) :: a -> (a -> b) -> b
+(|>) = (&)
+
+infixl 1 |>
+
+undefined :: HasCallStack => a
+undefined =
+  Prelude.error $ "undefined\n" ++ prettyCallStack callStack
+
+--------------------------------------------------------------------------------
+-- Generic Traversal Function
+--------------------------------------------------------------------------------
+
+traverseAccumM ::
+  (Monad m, Traversable t) => (a -> b -> m (a, c)) -> a -> t b -> m (a, t c)
+traverseAccumM f init trav =
+  runStateT (traverse (StateT . newF) trav) init
+    >>| swap
+  where
+    newF b a = f a b >>| swap
+
+traverseM ::
+  (Monad m, Traversable m, Applicative f) =>
+  (a1 -> f (m a2)) ->
+  m a1 ->
+  f (m a2)
+traverseM f = fmap join . traverse f
+
+foldMapA ::
+  (Applicative f, Foldable t, Monoid a) =>
+  (b -> f a) ->
+  t b ->
+  f a
+foldMapA f = foldl' (\acc x -> liftA2 (<>) acc (f x)) (pure mempty)
+
+instance Show (a -> b) where
+  show _ = "fun"
+
+newtype Symbol = Sym Text
+  deriving newtype (Eq, Show, Read, Hashable, Semigroup, Ord, NFData, A.ToJSON, A.FromJSON, A.ToJSONKey, A.FromJSONKey)
+  deriving stock (Data, Generic)
+
+instance IsString Symbol where
+  fromString = intern
+
+toUpperFirst :: String -> String
+toUpperFirst [] = []
+toUpperFirst (x : xs) = toUpper x : xs
+
+internText :: Text -> Symbol
+internText = Sym
+
+intern :: String -> Symbol
+intern = Sym . T.pack
+
+unintern :: Symbol -> String
+unintern (Sym s) = T.unpack s
+
+uninternText :: Symbol -> Text
+uninternText (Sym s) = s
+
+textify :: Symbol -> Text
+textify (Sym s) = s
+
+unixTime :: IO Double
+unixTime = fromRational . realToFrac |<< getPOSIXTime
+
+newtype Flip p a b = Flip {runFlip :: p b a}
+  deriving (Show, Generic, Eq, Ord, Typeable)
+
+untilNothingNTimesM :: (Num t, Ord t, Enum t, Monad f) => f Bool -> t -> f ()
+untilNothingNTimesM f n
+  | n <= 0 = pure ()
+  | otherwise =
+    f >>= \case
+      True -> untilNothingNTimesM f (pred n)
+      False -> pure ()
+
+untilNothing :: (t -> Maybe t) -> t -> t
+untilNothing f a = case f a of
+  Nothing -> a
+  Just a -> untilNothing f a
+
+-- | like sortOn from the stdlib, is an optimized version of `sortBy (comparing f)`
+-- However instead of sorting from lowest to highest, this sorts from higher to lowest
+sortOnFlip :: Ord b => (a -> b) -> [a] -> [a]
+sortOnFlip f =
+  fmap snd . sortBy (flip (comparing fst))
+    . fmap
+      ( \x ->
+          let y = f x
+           in y `seq` (y, x)
+      )
+
+uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
+uncurry3 fn (a, b, c) = fn a b c
+
+curry3 :: ((a, b, c) -> d) -> a -> b -> c -> d
+curry3 fn a b c = fn (a, b, c)
+
+(...) :: (b -> c) -> (a1 -> a2 -> b) -> a1 -> a2 -> c
+(...) = (.) . (.)
+
+dup :: a -> (a, a)
+dup x = (x, x)
+
+-- | Same as 'length' but returning a 'Natural'.
+lengthN :: Foldable f => f a -> Natural
+lengthN = foldl' (\n _ -> n + 1) 0
+
+-- | Select a field in a state monad, for example:
+--
+-- @
+-- data Foo = Foo {x, y :: 'Int'}
+-- newtype M a = M ('State' 'Foo' a)
+--   deriving ('HasState' \"x\" 'Int') via StateField "x" ('State' 'Foo')
+-- @
+type StateField fld m = Field fld () (MonadState m)
+
+-- | Reader version of 'StateField'.
+type ReaderField fld m = ReadStatePure (StateField fld m)
+
+-- | Writer version of 'StateField'.
+type WriterField fld m = WriterLog (StateField fld m)
+
+instance (A.ToJSON a) => A.ToJSONKey (NonEmpty.NonEmpty a)
+
+instance (A.FromJSON a) => A.FromJSONKey (NonEmpty.NonEmpty a)

--- a/library/StandardLibrary/src/Mari/Library/HashMap.hs
+++ b/library/StandardLibrary/src/Mari/Library/HashMap.hs
@@ -1,0 +1,18 @@
+-- |
+-- - The HashMap for the codebase.
+-- - Basically just imports Data.HashMap.Strict
+--   + While giving the operation =!?=.
+-- - Every hash in the code base should use this, except when it needs
+--   to compare keys by the =Ordering= metric instead.
+module Mari.Library.HashMap
+  ( module Data.HashMap.Strict,
+    Map,
+    T,
+  )
+where
+
+import Data.HashMap.Strict
+
+type Map = HashMap
+
+type T = Map

--- a/library/StandardLibrary/src/Mari/Library/LineNum.hs
+++ b/library/StandardLibrary/src/Mari/Library/LineNum.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Mari.Library.LineNum where
+
+import Control.Lens
+import qualified Data.Aeson as A
+import Mari.Library
+  ( Data,
+    Eq,
+    Generic,
+    Hashable (hash),
+    Int,
+    NFData,
+    Ord,
+    Read,
+    Show,
+    Typeable,
+  )
+
+data T = T {tLine :: Int, tCol :: Int}
+  deriving
+    ( Show,
+      Eq,
+      Ord,
+      Data,
+      Generic,
+      NFData,
+      Read,
+      Typeable
+    )
+
+instance A.ToJSON T where
+  toJSON = A.genericToJSON (A.defaultOptions {A.sumEncoding = A.ObjectWithSingleField})
+
+instance A.FromJSON T where
+  parseJSON = A.genericParseJSON (A.defaultOptions {A.sumEncoding = A.ObjectWithSingleField})
+
+instance Hashable T where
+  hash T {tLine, tCol} = hash (hash tLine, hash tCol)
+
+makeLensesWith camelCaseFields ''T

--- a/library/StandardLibrary/src/Mari/Library/NameSymbol.hs
+++ b/library/StandardLibrary/src/Mari/Library/NameSymbol.hs
@@ -1,0 +1,141 @@
+module Mari.Library.NameSymbol
+  ( module Mari.Library.NameSymbol,
+    fromString,
+  )
+where
+
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.String (IsString (..))
+import qualified Data.Text as Text
+import Mari.Library
+import qualified Mari.Library.Parser.Token as Tok
+import qualified Mari.Library.PrettyPrint as PP
+import qualified Prelude (foldr1)
+
+type T = NonEmpty Symbol
+
+type Base = Symbol
+
+type Mod = [Symbol]
+
+class Name a where
+  toSym :: a -> Symbol
+  fromSym :: Symbol -> a
+
+instance Name T where
+  toSym = toSymbol
+  fromSym = fromSymbol
+
+instance Name Symbol where
+  toSym x = x
+  fromSym x = x
+
+toNonEmptySymbol :: T -> NonEmpty Symbol
+toNonEmptySymbol = identity
+
+toSymbol :: T -> Symbol
+toSymbol =
+  Prelude.foldr1 (\x acc -> x <> "." <> acc)
+
+fromSymbol :: Symbol -> T
+fromSymbol =
+  NonEmpty.fromList . fmap internText . handleInfix . Text.splitOn "." . textify
+
+fromText :: Text -> T
+fromText = fromSymbol . internText
+
+-- TODO ∷ make this a fold!?
+handleInfix :: [Text] -> [Text]
+handleInfix [] = []
+handleInfix (x : xs) = rec' (x : xs) ""
+  where
+    rec' ("" : xs) currentInfixSymbol =
+      rec' xs (Text.snoc currentInfixSymbol '.')
+    rec' (x : xs) build
+      -- case 1)
+      | Tok.validInfixSymbol (Tok.charToWord8 (Text.head x)) =
+        rec' xs (build <> Text.cons '.' x)
+      | Text.null build =
+        x : rec' xs build
+      | otherwise =
+        -- case 3)
+        -- we must tail x, as we add an extra .
+        -- at the start of every infix symbol.
+        -- we do this because even a symbol like
+        -- "-" triggers case 1) which adds a '.'
+        -- to the front even when it shouldn't!
+        -- this is the correct behavior IFF we
+        -- are in the middle of a infix symbol!
+        Text.tail build : x : xs
+    rec' [] "" =
+      []
+    rec' [] acc =
+      -- see case 3)
+      [Text.tail acc]
+
+instance IsString T where
+  fromString = fromSymbol . intern
+
+toText :: T -> Text
+toText = uninternText . toSymbol
+
+prefixOf :: T -> T -> Bool
+prefixOf smaller larger =
+  case takePrefixOfInternal smaller larger of
+    Just _ -> True
+    Nothing -> False
+
+takePrefixOf :: T -> T -> Maybe T
+takePrefixOf smaller larger =
+  case takePrefixOfInternal smaller larger of
+    Just [] -> Nothing
+    Nothing -> Nothing
+    Just (x : xs) -> Just (x :| xs)
+
+takePrefixOfInternal :: T -> T -> Maybe [Symbol]
+takePrefixOfInternal (s :| smaller) (b :| bigger)
+  | b == s = recurse smaller bigger
+  | otherwise = Nothing
+  where
+    recurse [] ys = Just ys
+    recurse _ [] = Nothing
+    recurse (x : xs) (y : ys)
+      | x == y = recurse xs ys
+      | otherwise = Nothing
+
+cons :: Symbol -> T -> T
+cons = NonEmpty.cons
+
+append :: T -> T -> T
+append = (<>)
+
+hd :: T -> Symbol
+hd = NonEmpty.head
+
+qualify :: Foldable t => t Symbol -> T -> T
+qualify m n = foldr cons n m
+
+qualify1 :: Foldable t => t Symbol -> Base -> T
+qualify1 m b = qualify m (b :| [])
+
+qualified :: T -> Bool
+qualified (_ :| xs) = not $ null xs
+
+split :: T -> (Mod, Base)
+split n = (NonEmpty.init n, NonEmpty.last n)
+
+mod :: T -> Mod
+mod = fst . split
+
+base :: T -> Base
+base = snd . split
+
+applyBase :: (Base -> Base) -> T -> T
+applyBase f n = let (m, b) = split n in qualify1 m (f b)
+
+type instance PP.Ann T = ()
+
+instance PP.PrettySyntax T
+
+instance PP.PrettyText T where
+  prettyT = PP.text . textify . toSymbol

--- a/library/StandardLibrary/src/Mari/Library/Parser.hs
+++ b/library/StandardLibrary/src/Mari/Library/Parser.hs
@@ -1,0 +1,10 @@
+module Mari.Library.Parser
+  ( module Mari.Library.Parser.Internal,
+    module Mari.Library.Parser.Token,
+    module Mari.Library.Parser.Lexer,
+  )
+where
+
+import Mari.Library.Parser.Internal (Parser, ParserError)
+import Mari.Library.Parser.Lexer
+import Mari.Library.Parser.Token

--- a/library/StandardLibrary/src/Mari/Library/Parser/Internal.hs
+++ b/library/StandardLibrary/src/Mari/Library/Parser/Internal.hs
@@ -1,0 +1,16 @@
+module Mari.Library.Parser.Internal
+  ( Parser,
+    ParserError,
+  )
+where
+
+import Protolude
+import qualified Text.Megaparsec as P
+
+type Parser = P.Parsec Void ByteString
+
+--                   ^    ^
+--                   |    |
+-- Custom error component Type of input stream
+
+type ParserError = P.ParseErrorBundle ByteString Void

--- a/library/StandardLibrary/src/Mari/Library/Parser/Lexer.hs
+++ b/library/StandardLibrary/src/Mari/Library/Parser/Lexer.hs
@@ -1,0 +1,91 @@
+module Mari.Library.Parser.Lexer
+  ( spacer,
+    spaceLiner,
+    skipLiner,
+    parens,
+    brackets,
+    between,
+    curly,
+    many1H,
+    sepBy1H,
+    sepBy1HFinal,
+    maybeParend,
+    emptyCheck,
+    eatSpaces,
+    integer,
+    double,
+  )
+where
+
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Text.Encoding as Encoding
+import qualified Data.Text.Read as Read
+import Data.Word8 (isDigit, isSpace)
+import Mari.Library
+import Mari.Library.Parser.Internal (Parser)
+import qualified Mari.Library.Parser.Token as Tok
+import qualified Text.Megaparsec as P
+import qualified Text.Megaparsec.Byte as P
+import Prelude (fail)
+
+emptyCheck :: Word8 -> Bool
+emptyCheck x = isSpace x || x == Tok.newLine
+
+spacer :: Parser p -> Parser p
+spacer p = P.takeWhileP (Just "spacer") isSpace *> p
+
+spaceLiner :: Parser p -> Parser p
+spaceLiner p = do
+  p <* P.takeWhileP (Just "space liner") emptyCheck
+
+eatSpaces :: Parser p -> Parser p
+eatSpaces p = P.takeWhileP (Just "eat spaces") emptyCheck *> p
+
+between :: Word8 -> Parser p -> Word8 -> Parser p
+between fst p end = skipLiner fst *> spaceLiner p <* P.satisfy (== end)
+
+parens :: Parser p -> Parser p
+parens p = between Tok.openParen p Tok.closeParen
+
+brackets :: Parser p -> Parser p
+brackets p = between Tok.openBracket p Tok.closeBracket
+
+curly :: Parser p -> Parser p
+curly p = between Tok.openCurly p Tok.closeCurly
+
+many1H :: Parser a -> Parser (NonEmpty a)
+many1H = fmap NonEmpty.fromList . P.some
+
+-- | 'sepBy1HFinal' is like 'sepBy1H' but also tries to parse a last separator
+sepBy1HFinal :: Parser a -> Parser s -> Parser (NonEmpty a)
+sepBy1HFinal parse sep = sepBy1H parse sep <* P.optional sep
+
+sepBy1 :: Parser a -> Parser s -> Parser [a]
+sepBy1 p sep = liftA2 (:) p (many (P.try $ sep *> p))
+
+sepBy1H :: Parser a -> Parser s -> Parser (NonEmpty a)
+sepBy1H parse sep = NonEmpty.fromList <$> sepBy1 parse sep
+
+skipLiner :: Word8 -> Parser ()
+skipLiner p = spaceLiner (P.skipCount 1 (P.char p))
+
+maybeParend :: Parser a -> Parser a
+maybeParend p = p <|> parens p
+
+integer :: Parser Integer
+integer = do
+  digits <- P.takeWhileP (Just "digits") isDigit
+  case Char8.readInteger digits of
+    Just (x, _) -> pure x
+    Nothing -> fail $ "didn't parse an int"
+
+double :: Parser Double
+double = do
+  digits <- P.takeWhileP (Just "digits") isDigit
+  ______ <- P.char Tok.dot
+  moreDi <- P.takeWhileP (Just "digits") isDigit
+  let text = Encoding.decodeUtf8 (digits <> "." <> moreDi)
+  case Read.rational text of
+    Right (x, _) -> pure x
+    Left _ -> fail "didn't parse a double"

--- a/library/StandardLibrary/src/Mari/Library/Parser/Token.hs
+++ b/library/StandardLibrary/src/Mari/Library/Parser/Token.hs
@@ -1,0 +1,205 @@
+module Mari.Library.Parser.Token
+  ( charToWord8,
+    wordToChr,
+    dash,
+    under,
+    space,
+    colon,
+    semi,
+    comma,
+    hash,
+    backSlash,
+    quote,
+    doubleQuote,
+    pipe,
+    equals,
+    at,
+    question,
+    dot,
+    bang,
+    amper,
+    times,
+    exp,
+    backtick,
+    div,
+    percent,
+    newLine,
+    openBracket,
+    closeBracket,
+    openParen,
+    closeParen,
+    openCurly,
+    closeCurly,
+    validStartSymbol,
+    validMiddleSymbol,
+    validInfixSymbol,
+    validUpperSymbol,
+    reservedSymbols,
+    reservedWords,
+    endOfLine,
+  )
+where
+
+import qualified Data.Set as Set
+import Data.Word8 (isDigit)
+import qualified GHC.Unicode as Unicode
+import Mari.Library hiding (div, exp, hash, maybe, option, takeWhile)
+
+charToWord8 :: Char -> Word8
+charToWord8 = fromIntegral . ord
+{-# INLINE charToWord8 #-}
+
+wordToChr :: Integral a => a -> Char
+wordToChr = chr . fromIntegral
+
+-- Hopefully this is fast!
+validStartSymbol' :: Integral a => a -> Bool
+validStartSymbol' = Unicode.isAlpha . wordToChr
+
+-- Unicode.isUpper 'İ' = True!
+validUpperSymbol :: Integral a => a -> Bool
+validUpperSymbol = Unicode.isUpper . wordToChr
+
+dash :: Word8
+dash = charToWord8 '-'
+
+under :: Word8
+under = charToWord8 '_'
+
+space :: Word8
+space = charToWord8 ' '
+
+colon :: Word8
+colon = charToWord8 ':'
+
+semi :: Word8
+semi = charToWord8 ';'
+
+comma :: Word8
+comma = charToWord8 ','
+
+hash :: Word8
+hash = charToWord8 '#'
+
+openParen :: Word8
+openParen = charToWord8 '('
+
+closeParen :: Word8
+closeParen = charToWord8 ')'
+
+openCurly :: Word8
+openCurly = charToWord8 '{'
+
+closeCurly :: Word8
+closeCurly = charToWord8 '}'
+
+openBracket :: Word8
+openBracket = charToWord8 '['
+
+closeBracket :: Word8
+closeBracket = charToWord8 ']'
+
+backSlash :: Word8
+backSlash = charToWord8 '\\'
+
+quote :: Word8
+quote = charToWord8 '\''
+
+doubleQuote :: Word8
+doubleQuote = charToWord8 '\"'
+
+pipe :: Word8
+pipe = charToWord8 '|'
+
+equals :: Word8
+equals = charToWord8 '='
+
+at :: Word8
+at = charToWord8 '@'
+
+dot :: Word8
+dot = charToWord8 '.'
+
+question :: Word8
+question = charToWord8 '?'
+
+bang :: Word8
+bang = charToWord8 '!'
+
+amper :: Word8
+amper = charToWord8 '&'
+
+times :: Word8
+times = charToWord8 '*'
+
+exp :: Word8
+exp = charToWord8 '^'
+
+backtick :: Word8
+backtick = charToWord8 '`'
+
+newLine :: Word8
+newLine = charToWord8 '\n'
+
+div :: Word8
+div = charToWord8 '/'
+
+percent :: Word8
+percent = charToWord8 '%'
+
+validStartSymbol :: Word8 -> Bool
+validStartSymbol w =
+  validStartSymbol' w || w == under
+
+validInfixSymbol :: Word8 -> Bool
+validInfixSymbol w =
+  Unicode.isSymbol (wordToChr w)
+    || w == times
+    || w == exp
+    || w == dash
+    || w == amper
+    || w == colon
+    || w == div
+    || w == percent
+    || w == dot
+
+validMiddleSymbol :: Word8 -> Bool
+validMiddleSymbol w =
+  validStartSymbol w
+    || isDigit w
+    || w == dash
+    || w == bang
+    || w == question
+    || w == percent
+
+-- check for \r or \n
+endOfLine :: (Eq a, Num a) => a -> Bool
+endOfLine w = w == 13 || w == 10
+
+reservedWords :: (Ord a, IsString a) => Set a
+reservedWords =
+  Set.fromList
+    [ "let",
+      "val",
+      "type",
+      "case",
+      "in",
+      "open",
+      "if",
+      "cond",
+      "end",
+      "of",
+      "begin",
+      "sig",
+      "mod",
+      "declare",
+      "where",
+      "via",
+      "handler",
+      "effect"
+    ]
+
+reservedSymbols :: (Ord a, IsString a) => Set a
+reservedSymbols =
+  Set.fromList
+    ["=", "|", "", "--"]

--- a/library/StandardLibrary/src/Mari/Library/PrettyPrint.hs
+++ b/library/StandardLibrary/src/Mari/Library/PrettyPrint.hs
@@ -1,0 +1,328 @@
+module Mari.Library.PrettyPrint
+  ( module Text.PrettyPrint.Compact,
+
+    -- * Precedence
+    Prec (..),
+    PrecReader,
+
+    -- * Classes
+    Ann,
+    PrettySyntax (..),
+    PrettyText (..),
+    runPretty,
+    runPretty0,
+    pretty,
+    pretty0,
+    withPrec,
+    show,
+    string,
+    text,
+
+    -- * Extensions
+    renderIO,
+    prettyIO,
+    prettyTIO,
+    noAnn,
+    annotate',
+    hangs,
+    hangsA,
+    hangsWith,
+    parens,
+    parens',
+    parensP,
+    parensP',
+    app,
+    app',
+    indentWidth,
+    sepIndent,
+    sepIndent',
+    sepIndentA,
+    sepIndentA',
+    punctuate,
+
+    -- ** Combinators lifted over an 'Applicative'
+    hsepA,
+    sepA,
+    hcatA,
+    vcatA,
+    punctuateA,
+    hangA,
+  )
+where
+
+import Data.Text (unpack)
+import Mari.Library hiding (show)
+import Text.PrettyPrint.Compact hiding
+  ( angles,
+    backslash,
+    braces,
+    brackets,
+    colon,
+    comma,
+    dot,
+    dquote,
+    equals,
+    langle,
+    lbrace,
+    lbracket,
+    lparen,
+    parens,
+    punctuate,
+    rangle,
+    rbrace,
+    rbracket,
+    rparen,
+    semi,
+    space,
+    squote,
+    string,
+    text,
+  )
+import qualified Text.PrettyPrint.Compact as Base
+import Text.PrettyPrint.Compact.Core (groupingBy)
+import qualified Text.Show as Show
+import Prelude (String)
+
+-- | Annotations, which can be used for e.g. syntax highlighting
+type family Ann a :: *
+
+data Prec
+  = -- | Outermost expression; no parens needed
+    Outer
+  | -- | Argument of infix function, with the same meaning as the argument of
+    -- 'Text.Show.showsPrec'
+    Infix Natural
+  | -- | Argument (or head) of nonfix function; all non-atomic expressions need
+    -- parens
+    FunArg
+  deriving (Eq, Ord, Show, Generic)
+
+type PrecReader = HasReader "prec" Prec
+
+-- | Class for pretty-printing syntax-like types, which need to keep track of
+-- the surrounding precedence level.
+class Monoid (Ann a) => PrettySyntax a where
+  -- | Pretty-prints a syntax value, given the current precedence value in
+  -- a reader environment.
+  pretty' :: PrecReader m => a -> m (Doc (Ann a))
+  default pretty' ::
+    (PrettyText a, PrecReader m) => a -> m (Doc (Ann a))
+  pretty' = pure . prettyT
+
+-- | Class for text-like types (e.g. messages), which don't have a concept of
+-- precedence.
+class Monoid (Ann a) => PrettyText a where
+  -- | Pretty-print a value as human-readable text.
+  prettyT :: a -> Doc (Ann a)
+  default prettyT :: Show a => a -> Doc (Ann a)
+  prettyT = string . Show.show
+
+runPretty :: Prec -> (forall m. PrecReader m => m a) -> a
+runPretty prec m = let MonadReader x = m in runReader x prec
+
+runPretty0 :: (forall m. PrecReader m => m a) -> a
+runPretty0 = runPretty Outer
+
+-- | Pretty-print at the given precedence level.
+pretty :: PrettySyntax a => Prec -> a -> Doc (Ann a)
+pretty prec x = runPretty prec (pretty' x)
+
+-- | Pretty-print at the initial precedence level.
+pretty0 :: PrettySyntax a => a -> Doc (Ann a)
+pretty0 = pretty Outer
+
+withPrec :: PrecReader m => Prec -> m a -> m a
+withPrec p = local @"prec" \_ -> p
+
+show :: (Monoid ann, Show a) => a -> Doc ann
+show = string . Show.show
+
+string :: Monoid ann => String -> Doc ann
+string = Base.text
+
+text :: Monoid ann => Text -> Doc ann
+text = string . unpack
+
+noAnn :: Monoid ann2 => Doc ann1 -> Doc ann2
+noAnn d = mempty <$ d
+
+hsepA ::
+  (Applicative f, Foldable t, Monoid ann) =>
+  t (f (Doc ann)) ->
+  f (Doc ann)
+hsepA = fmap hsep . sequenceA . toList
+
+sepA ::
+  (Applicative f, Foldable t, Monoid ann) =>
+  t (f (Doc ann)) ->
+  f (Doc ann)
+sepA = fmap sep . sequenceA . toList
+
+hcatA ::
+  (Applicative f, Foldable t, Monoid ann) =>
+  t (f (Doc ann)) ->
+  f (Doc ann)
+hcatA = fmap hcat . sequenceA . toList
+
+vcatA ::
+  (Applicative f, Foldable t, Monoid ann) =>
+  t (f (Doc ann)) ->
+  f (Doc ann)
+vcatA = fmap vcat . sequenceA . toList
+
+-- Same as 'Base.punctuate' but accepts any 'Foldable' type.
+punctuate :: (Foldable t, Monoid ann) => Doc ann -> t (Doc ann) -> [Doc ann]
+punctuate s = Base.punctuate s . toList
+
+punctuateA ::
+  (Applicative f, Foldable t, Monoid ann) =>
+  f (Doc ann) ->
+  t (f (Doc ann)) ->
+  [f (Doc ann)]
+punctuateA s = go . toList
+  where
+    go [] = []
+    go [d] = [d]
+    go (d : ds) = hcatA [d, s] : go ds
+
+hangA ::
+  (Applicative f, Monoid ann) =>
+  Int ->
+  f (Doc ann) ->
+  f (Doc ann) ->
+  f (Doc ann)
+hangA i = liftA2 $ hang i
+
+-- | Same as 'hangWith', but with multiple hanging elements.
+--
+-- @
+-- >>> hangsWith "*" 2 "hello" ["cool", "world"]
+-- hello*cool*world
+-- -- or --
+-- hello
+--   cool
+--   world
+-- @
+hangsWith ::
+  (Foldable t, Monoid ann) =>
+  String ->
+  Int ->
+  Doc ann ->
+  t (Doc ann) ->
+  Doc ann
+hangsWith sep n a bs =
+  groupingBy sep $ (0, a) : map (n,) (toList bs)
+
+hangs :: (Foldable t, Monoid ann) => Int -> Doc ann -> t (Doc ann) -> Doc ann
+hangs = hangsWith " "
+
+hangsA ::
+  (Applicative f, Foldable t, Monoid ann) =>
+  Int ->
+  f (Doc ann) ->
+  t (f (Doc ann)) ->
+  f (Doc ann)
+hangsA i a bs = hangs i <$> a <*> sequenceA (toList bs)
+
+-- | Surrounds a doc with parens with the given annotation
+parens :: Monoid ann => ann -> Doc ann -> Doc ann
+parens ann = annotate ann "(" `enclose` annotate ann ")"
+
+parens' :: ann -> Doc (Last ann) -> Doc (Last ann)
+parens' = parens . Last . Just
+
+-- | Surrounds with parens if the current precedence level is less than the
+-- given one (the same behaviour as 'Text.Show.showsPrec').
+parensP ::
+  (Monoid ann, PrecReader m) => ann -> Prec -> m (Doc ann) -> m (Doc ann)
+parensP ann p d = do
+  p' <- ask @"prec"
+  if p > p' then d else parens ann <$> d
+
+parensP' ::
+  PrecReader m => ann -> Prec -> m (Doc (Last ann)) -> m (Doc (Last ann))
+parensP' = parensP . Last . Just
+
+-- | Usually our annotations are 'Last' of some syntax highlighting
+-- representation.
+annotate' :: ann -> Doc (Last ann) -> Doc (Last ann)
+annotate' = annotate . Last . Just
+
+-- | Formats an application, by aligning the arguments and adjusting the
+-- precedence level of the subterms.
+--
+-- @
+-- fun arg1 arg2 arg3
+-- -- or --
+-- fun
+--   arg1
+--   arg2
+--   arg3
+-- @
+app ::
+  ( PrecReader m,
+    Foldable t,
+    Monoid ann
+  ) =>
+  ann ->
+  m (Doc ann) ->
+  t (m (Doc ann)) ->
+  m (Doc ann)
+app ann f xs = parensP ann FunArg $ withPrec FunArg $ hangsA indentWidth f xs
+
+-- | Same as 'app' but with a 'Last' for an annotation.
+app' ::
+  ( PrecReader m,
+    Foldable t
+  ) =>
+  ann ->
+  m (Doc (Last ann)) ->
+  t (m (Doc (Last ann))) ->
+  m (Doc (Last ann))
+app' = app . Last . Just
+
+-- | Default indent width.
+indentWidth :: Int
+indentWidth = 2
+
+-- | Like 'sep', but indenting each item the given amount if they are laid out
+-- vertically.
+sepIndent :: (Monoid ann, Foldable t) => t (Int, Doc ann) -> Doc ann
+sepIndent = groupingBy " " . toList
+
+-- | Like 'sepIndent', indenting by 'indentWidth' if the first part is
+-- 'True'
+sepIndent' :: (Monoid ann, Foldable t) => t (Bool, Doc ann) -> Doc ann
+sepIndent' = sepIndent . map (first toIndent) . toList
+
+toIndent :: Bool -> Int
+toIndent b = if b then indentWidth else 0
+
+sepIndentA ::
+  (Monoid ann, Foldable t, Applicative f) =>
+  t (Int, f (Doc ann)) ->
+  f (Doc ann)
+sepIndentA = fmap (groupingBy " ") . sequenceA . map sequenceA . toList
+
+sepIndentA' ::
+  (Monoid ann, Foldable t, Functor t, Applicative f) =>
+  t (Bool, f (Doc ann)) ->
+  f (Doc ann)
+sepIndentA' = sepIndentA . fmap (first toIndent)
+
+renderIO :: (MonadIO m, Monoid ann) => Doc ann -> m ()
+renderIO = putStrLn . render
+
+prettyIO :: (MonadIO m, PrettySyntax a) => a -> m ()
+prettyIO = renderIO . pretty0
+
+prettyTIO :: (MonadIO m, PrettyText a) => a -> m ()
+prettyTIO = renderIO . prettyT
+
+-- TODO: use syntax highlighting
+
+type instance Ann Void = ()
+
+instance PrettySyntax Void
+
+instance PrettyText Void where prettyT = absurd

--- a/library/StandardLibrary/src/Mari/Library/Trace.hs
+++ b/library/StandardLibrary/src/Mari/Library/Trace.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | The Trace library represents the ability to properly trace code
+-- throughout Haskell.
+--
+-- - The structure requires your code to exist in the =Trace.Eff=
+--   effect.
+-- - The =Eff= Variant of functions are over the =Trace.Eff= effect
+--   rather than the =Trace.T= type itself.
+--   + It is just as valid to use the non =Eff= version of the
+--     functions
+module Mari.Library.Trace
+  ( module Mari.Library.Trace.Types,
+
+    -- * Core API
+    withScope,
+    info,
+    stackTrace,
+    finishedAtPoint,
+    fullTrace,
+    break,
+
+    -- ** Trace Enabling/Disabling
+    enableEff,
+    disableEff,
+    disableRecursiveEff,
+    enable,
+    disable,
+    disableRecursive,
+    traceAll,
+    traceAllEff,
+
+    -- ** Initialization
+    empty,
+
+    -- ** Trace Level Setup
+    setLevel,
+
+    -- * Functions for testing
+    traceInfo,
+    traceStmt,
+  )
+where
+
+import Control.Lens (over, set, (^.))
+import Mari.Library hiding (break, empty)
+import qualified Mari.Library.HashMap as HashMap
+import qualified Mari.Library.NameSymbol as NameSymbol
+import qualified Mari.Library.Trace.Format as Format
+import Mari.Library.Trace.Types hiding (enable)
+import qualified Mari.Library.Trace.Types as Lens (enable)
+
+--------------------------------------------------------------------------------
+-- Core API
+--------------------------------------------------------------------------------
+
+withScope :: (Eff m, Show b) => NameSymbol.T -> [Text] -> m b -> m b
+withScope name args f = do
+  let newStack =
+        Stack
+          { stackName = name,
+            stackStart = args,
+            stackBetween = [],
+            stackOutput = Nothing
+          }
+  modify @"trace" (`startScope` newStack)
+  ret <- f
+  modify @"trace" (finishScope . (`registerOutput` show ret))
+  pure ret
+
+-- | @stackTrace@ dumps the current Stack Trace, Ignoring any disabling behavior
+stackTrace :: (Eff m, MonadIO m) => m ()
+stackTrace = do
+  trace <- get @"trace"
+  putStrLn (traceStmt trace)
+
+-- | @finishedAtPoint@ dumps the finished trace calls at point. like
+-- @stackTrace@ the printed out terms are done immediately, rather
+-- than being introspected on after computation has finished/aborted.
+finishedAtPoint :: (Eff m, MonadIO m) => m ()
+finishedAtPoint = do
+  trace <- get @"trace"
+  fullTrace trace
+
+-- | @empty@ is the empty stack trace with no functions enabled
+empty :: T
+empty = T Empty [] mempty Nothing
+
+-- | @info@ is called on the computational trace, if we exit early,
+-- then we dump the stack trace, if computation finishes we then trace
+-- all the finished calls. @info@ can be called with @fullTrace@ when
+-- computation ends early to have a good idea of the computation stack
+-- by the point of failure.
+info :: MonadIO m => T -> m ()
+info = putStrLn . traceInfo
+
+-- | @break@ dumps the stack by throwing an exception and returning the
+-- call stack to that point
+break :: (Eff m, HasThrow "error" Error m) => m b
+break = get @"trace" >>= throw @"error" . Error
+
+-- | @fullTrace@ dumps the finished calls from the Trace
+fullTrace :: MonadIO m => T -> m ()
+fullTrace = putStrLn . traceFullStack
+
+-- | @enableEff@ allows you to enable more traced functions while
+-- in the middle of effectful computations, rather than before or after
+-- having a complete trace.
+enableEff :: (Eff m, Traversable f) => f NameSymbol.T -> m ()
+enableEff xs = modify @"trace" (`enable` xs)
+
+-- | @disableEff@ see @enableEff@ except this removes the current
+-- call from being traced (default behavior)
+disableEff :: (Eff m, Traversable f) => f NameSymbol.T -> m ()
+disableEff xs = modify @"trace" (`disable` xs)
+
+-- | @disableRecursiveEff@ see @enableEff@ except this
+-- removes any recursive call of the trace
+disableRecursiveEff :: (Eff m, Traversable f) => f NameSymbol.T -> m ()
+disableRecursiveEff xs = modify @"trace" (`disableRecursive` xs)
+
+-- | @traceAllEff@ enables tracing for every single function that has
+-- been called. Warning this is quite a lot of functions
+traceAllEff :: Eff m => m ()
+traceAllEff = modify @"trace" traceAll
+
+-- | @traceAll@ enables tracing for every single function that has
+-- been called. Warning this is quite a lot of functions
+traceAll :: T -> T
+traceAll =
+  set debugLevel (Just 10000)
+
+-- | @enable@ allows you to enable traces before or after
+-- commencing a trace.
+enable :: Traversable f => T -> f NameSymbol.T -> T
+enable t =
+  overEnabled t (set Lens.enable Enabled)
+
+-- | @disable@ see @enable@ except this removes the current
+-- call from being traced (default behavior)
+disable :: Traversable f => T -> f NameSymbol.T -> T
+disable t =
+  overEnabled t (set Lens.enable Disabled)
+
+-- | @disableRecursive@ see @enable@ except this
+-- removes any recursive call of the trace
+disableRecursive :: Traversable f => T -> f NameSymbol.T -> T
+disableRecursive t =
+  overEnabled t (set Lens.enable DisableRecursive)
+
+-- | @setLevel@ sets the trace
+setLevel :: Traversable f => T -> Natural -> f NameSymbol.T -> T
+setLevel t lev =
+  overEnabled t (set level lev)
+
+--------------------------------------------------------------------------------
+-- Helper Functionality
+--------------------------------------------------------------------------------
+
+overEnabled ::
+  Traversable f => T -> (MetaInfo -> MetaInfo) -> f NameSymbol.T -> T
+overEnabled t f xs =
+  over enabled (\enabled -> foldr (HashMap.alter fDefault) enabled xs) t
+  where
+    fDefault Nothing = Just (f (MetaInfo Disabled defaultTrace))
+    fDefault (Just m) = Just (f m)
+
+-- Put in mitigation logic that either dumps the current stack if we
+-- are corrupted or the logs if we finish
+traceInfo :: T -> [Char]
+traceInfo t =
+  case t ^. current of
+    Empty -> traceFullStack t
+    StackChain {} -> traceStmt t
+
+traceFullStack :: T -> [Char]
+traceFullStack t =
+  Format.fullTrace t (+ 2)
+    |> intersperse "\n"
+    |> fold
+
+traceStmt :: HasCurrent s StackChain => s -> [Char]
+traceStmt trace =
+  "Stack Trace:" :
+  Format.currentStackChain (trace ^. current) (const 1)
+    |> intersperse "\n"
+    |> fold
+
+registerOutput :: T -> Text -> T
+registerOutput t result =
+  case t ^. current of
+    Empty -> t
+    StackChain a stack ->
+      set current (StackChain a (set output (Just result) stack)) t
+
+startScope :: T -> Stack -> T
+startScope t stack =
+  over current (`StackChain` stack) t
+
+finishScope :: T -> T
+finishScope t =
+  case t ^. current of
+    Empty -> t
+    StackChain Empty stack ->
+      t |> over traces (<> [stack]) |> set current Empty
+    StackChain (StackChain grandParent parent) stack ->
+      set current (StackChain grandParent (consLog stack parent)) t
+
+consLog :: HasBetween t [a] => a -> t -> t
+consLog currentStack =
+  over between (<> [currentStack])

--- a/library/StandardLibrary/src/Mari/Library/Trace/Environment.hs
+++ b/library/StandardLibrary/src/Mari/Library/Trace/Environment.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | This module gives a minimal environment to run Traces, best used
+-- for testing
+module Mari.Library.Trace.Environment where
+
+import Mari.Library
+import Mari.Library.Trace.Types
+
+newtype Minimal = Minimal
+  { trace :: T
+  }
+  deriving (Generic, Show)
+
+type MinimalAlias = State Minimal
+
+type MinimalAliasIO = StateT Minimal IO
+
+newtype MinimalM a = Ctx {_run :: MinimalAlias a}
+  deriving (Functor, Applicative, Monad)
+  deriving
+    ( HasState "trace" T,
+      HasSource "trace" T,
+      HasSink "trace" T
+    )
+    via StateField "trace" MinimalAlias
+
+newtype MinimalMIO a = CtxIO (MinimalAliasIO a)
+  deriving (Functor, Applicative, Monad, MonadIO)
+  deriving
+    ( HasState "trace" T,
+      HasSource "trace" T,
+      HasSink "trace" T
+    )
+    via StateField "trace" MinimalAliasIO
+
+run :: MinimalM a -> Minimal -> (a, Minimal)
+run (Ctx c) = runState c
+
+runEmpty :: MinimalM a -> (a, Minimal)
+runEmpty c = run c (Minimal (T Empty [] mempty Nothing))
+
+runIO :: MinimalMIO a -> Minimal -> IO (a, Minimal)
+runIO (CtxIO c) = runStateT c
+
+runEmptyIO :: MinimalMIO a -> IO (a, Minimal)
+runEmptyIO c = runIO c (Minimal (T Empty [] mempty Nothing))
+
+runEmptyTraceAll :: MinimalM a -> (a, Minimal)
+runEmptyTraceAll c = run c (Minimal (T Empty [] mempty (Just 10000)))
+
+runEmptyTraceAllIO :: MinimalMIO a -> IO (a, Minimal)
+runEmptyTraceAllIO c = runIO c (Minimal (T Empty [] mempty (Just 10000)))

--- a/library/StandardLibrary/src/Mari/Library/Trace/Format.hs
+++ b/library/StandardLibrary/src/Mari/Library/Trace/Format.hs
@@ -1,0 +1,113 @@
+module Mari.Library.Trace.Format where
+
+import Control.Lens ((^.))
+import qualified Data.Text as Text
+import Mari.Library
+import qualified Mari.Library.HashMap as HashMap
+import qualified Mari.Library.NameSymbol as NameSymbol
+import Mari.Library.Trace.Types
+import Prelude (String)
+
+--------------------------------------------------------------------------------
+-- Main Functionality
+--------------------------------------------------------------------------------
+
+currentStackChain :: StackChain -> (Integer -> Integer) -> [String]
+currentStackChain chain indentationIncrement =
+  chain
+    |> stackChainToList
+    -- Let's start with the parent
+    |> foldr f ([], 0)
+    |> fst
+  where
+    f current (formattedString, indentation) =
+      ( formattedString
+          <> [ spacing indentation
+                 <> functionCall (current ^. name) (current ^. start)
+             ],
+        indentationIncrement indentation
+      )
+
+fullTrace :: T -> (Integer -> Integer) -> [String]
+fullTrace t indentationIncrement =
+  traceLog t 0 indentationIncrement (t ^. traces)
+
+traceLog ::
+  T -> Integer -> (Integer -> Integer) -> [Stack] -> [String]
+traceLog t level indentationIncrement stacks =
+  (stacks >>= traceStack t level indentationIncrement)
+
+traceStack :: T -> Integer -> (Integer -> Integer) -> Stack -> [String]
+traceStack t currentLevel indentationIncrement stack =
+  case HashMap.lookup (stack ^. name) (t ^. enabled) of
+    Just metaInfo
+      | (t ^. debugLevel) >= Just (metaInfo ^. level) ->
+        callFull
+    Just metaInfo ->
+      case metaInfo ^. enable of
+        Disabled ->
+          callIgnoreCurrent
+        Enabled ->
+          callFull
+        DisableRecursive ->
+          []
+    Nothing
+      | (t ^. debugLevel) >= Just maxTrace ->
+        callFull
+    Nothing ->
+      callIgnoreCurrent
+  where
+    callFull =
+      -- Bad case, make it better as we may end up
+      -- ·· (Prelude.add2 12.0)
+      -- ·· (Prelude.add2 12.0) ↦ 14.0
+      -- if we filter our between list
+      let inc = indentationIncrement
+          traceBetween = traceLog t (inc currentLevel) inc (stack ^. between)
+       in case traceBetween of
+            [] ->
+              [spacing currentLevel <> returnResult stack]
+            _ : _ ->
+              [spacing currentLevel <> functionCall (stack ^. name) (stack ^. start)]
+                <> traceBetween
+                <> [spacing currentLevel <> returnResult stack]
+    callIgnoreCurrent =
+      traceLog t currentLevel indentationIncrement (stack ^. between)
+
+--------------------------------------------------------------------------------
+-- Formatting Helpers
+--------------------------------------------------------------------------------
+
+customSpacing :: Char -> Int -> [Char]
+customSpacing = flip replicate
+
+spacing :: Integer -> [Char]
+spacing 0 = ""
+spacing n = customSpacing '·' (fromInteger n) <> " "
+
+functionCall :: NameSymbol.T -> [Text] -> [Char]
+functionCall f args =
+  "("
+    <> unintern (NameSymbol.toSymbol f)
+    <> space
+    <> foldMap Text.unpack (intersperse " " args)
+    <> ")"
+  where
+    space =
+      case args of
+        [] -> ""
+        _ : _ -> " "
+
+returnResult :: Stack -> [Char]
+returnResult stack =
+  let res = maybe "No Return" Text.unpack (stack ^. output)
+   in functionCall (stack ^. name) (stack ^. start) <> " ↦ " <> res
+
+--------------------------------------------------------------------------------
+-- Utility Helpers
+--------------------------------------------------------------------------------
+
+stackChainToList :: StackChain -> [Stack]
+stackChainToList Empty = []
+stackChainToList StackChain {parent = cdr, currentStack = car} =
+  car : stackChainToList cdr

--- a/library/StandardLibrary/src/Mari/Library/Trace/Types.hs
+++ b/library/StandardLibrary/src/Mari/Library/Trace/Types.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Mari.Library.Trace.Types where
+
+import qualified Control.Lens as Lens hiding ((|>))
+import qualified Data.Text as T
+import Mari.Library
+import qualified Mari.Library.HashMap as HashMap
+import qualified Mari.Library.NameSymbol as NameSymbol
+
+data T = T
+  { -- | @tCurrent@ represents the current stack-trace we are computing
+    -- under, We use a StackChain to determine the trace the current
+    -- trace is computing under.
+    tCurrent :: StackChain,
+    -- | @tTraces@ represents our current trace log of all completed
+    -- functions
+    tTraces :: Log,
+    -- | @tEnabled@ represents meta information our system has regards
+    -- to if particular trace functions are enabled and if there is a
+    -- general debug level we can print out instead.
+    tEnabled :: HashMap.T NameSymbol.T MetaInfo,
+    -- | @tDebugLevel@ represents the debug level we care about
+    tDebugLevel :: Maybe Natural
+  }
+  deriving (Show, Eq)
+
+type Log = [Stack]
+
+data StackChain
+  = Empty
+  | StackChain
+      { parent :: StackChain,
+        currentStack :: Stack
+      }
+  deriving (Show, Eq)
+
+-- | @Stack@ represents a stack-trace for a particular function
+data Stack = Stack
+  { -- | @stackName@ represents the name of the stackd function
+    stackName :: NameSymbol.T,
+    -- | @stackdStart@ represents the incoming function arguments
+    stackStart :: [T.Text],
+    -- | @stackBetween@ represents the Traces that have happened
+    -- between this call and the end of the call
+    stackBetween :: Log,
+    -- | @stackOutput@ represents the output result. Maybe as we could
+    -- stop before it's finished!
+    stackOutput :: Maybe T.Text
+  }
+  deriving (Show, Eq)
+
+data MetaInfo = MetaInfo
+  { metaInfoEnable :: Enable,
+    metaInfoLevel :: Natural
+  }
+  deriving (Show, Eq)
+
+data Enable
+  = -- | @Enabled@ represents a trace enabled function
+    Enabled
+  | -- | @Disabled@ represents that the function is disabled
+    Disabled
+  | -- | @DisableRecursive@ represents that we shouldn't trace any
+    -- Enabled functions inside the scope of the Trace
+    DisableRecursive
+  deriving (Show, Eq)
+
+newtype Error = Error T
+
+Lens.makeLensesWith Lens.camelCaseFields ''Stack
+Lens.makeLensesWith Lens.camelCaseFields ''T
+Lens.makeLensesWith Lens.camelCaseFields ''MetaInfo
+
+type Eff m = HasState "trace" T m
+
+maxTrace :: Natural
+maxTrace = 10
+
+defaultTrace :: Natural
+defaultTrace = 3

--- a/library/StandardLibrary/src/Mari/Library/Usage.hs
+++ b/library/StandardLibrary/src/Mari/Library/Usage.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+-- | Each binder and local context element in Mari is annotated with
+-- a /usage/, which tracks how many times it is needed in a
+-- runtime-relevant way.
+module Mari.Library.Usage
+  ( -- Usage type
+    Usage (..),
+    T,
+    -- Utils
+    allows,
+    isNotZero,
+    isZero,
+    minus,
+    pred,
+    predPosUsage,
+    toUsage,
+  )
+where
+
+------------------------------------------------------------------------------
+
+import qualified Data.Aeson as A
+import Data.Maybe (fromJust)
+import Mari.Library hiding (pred, show)
+import qualified Mari.Library.PrettyPrint as PP
+
+------------------------------------------------------------------------------
+
+-- A usage is either a natural number specifying an exact usage (i.e.,
+-- not an upper bound), or "any", meaning that usage is not tracked
+-- for that variable and any number of usages is allowed.
+data Usage = SNat Natural | SAny
+  deriving (Eq, Show, Read, Generic, Data, NFData)
+
+type T = Usage
+
+------------------------------------------------------------------------------
+-- The type of usages forms an ordered semiring.
+------------------------------------------------------------------------------
+
+instance Monoid Usage where
+  mempty = SNat 0
+
+instance Semigroup Usage where
+  SNat π <> SNat ρ = SNat (π + ρ)
+  SAny <> _ = SAny
+  _ <> SAny = SAny
+
+instance Semiring Usage where
+  one = SNat 1
+
+  SNat 0 <.> _ = SNat 0
+  _ <.> SNat 0 = SNat 0
+  SNat π <.> SNat ρ = SNat (π * ρ)
+  SAny <.> _ = SAny
+  _ <.> SAny = SAny
+
+instance Ord Usage where
+  compare (SNat a) (SNat b) = compare a b
+  compare (SNat _) SAny = LT
+  compare SAny (SNat _) = GT
+  compare SAny SAny = EQ
+
+------------------------------------------------------------------------------
+
+type instance PP.Ann Usage = ()
+
+instance PP.PrettySyntax Usage where
+  pretty' (SNat π) = pure . PP.show $ π
+  pretty' SAny = pure "ω"
+
+instance A.ToJSON Usage where
+  toJSON =
+    A.genericToJSON
+      ( A.defaultOptions
+          { A.sumEncoding = A.ObjectWithSingleField
+          }
+      )
+
+instance A.FromJSON Usage where
+  parseJSON =
+    A.genericParseJSON
+      ( A.defaultOptions
+          { A.sumEncoding = A.ObjectWithSingleField
+          }
+      )
+
+------------------------------------------------------------------------------
+-- Utils
+------------------------------------------------------------------------------
+
+isZero :: Usage -> Bool
+isZero (SNat 0) = True
+isZero _ = False
+
+isNotZero :: Usage -> Bool
+isNotZero = not . isZero
+
+toUsage :: Integer -> Usage
+toUsage = SNat . fromInteger
+
+infixl 6 `minus`
+
+minus :: Usage -> Usage -> Maybe Usage
+minus SAny _ = Just SAny
+minus (SNat π) (SNat ρ)
+  | π >= ρ = Just . SNat $ π - ρ
+minus _ _ = Nothing
+
+pred :: Usage -> Maybe Usage
+pred π = π `minus` SNat 1
+
+predPosUsage :: Usage -> Usage
+predPosUsage = fromJust . pred
+
+-- | Usage compatibility.
+allows :: Usage -> Usage -> Bool
+allows (SNat x) (SNat y) = x == y
+allows (SNat _) SAny = False
+allows SAny (SNat _) = True
+allows SAny SAny = True
+
+infix 4 `allows`

--- a/library/StandardLibrary/stack.yaml
+++ b/library/StandardLibrary/stack.yaml
@@ -1,0 +1,26 @@
+resolver: lts-18.26
+
+packages:
+- .
+
+extra-deps:
+
+########################
+# General Dependencies #
+########################
+- capability-0.4.0.0@sha256:d86d85a1691ef0165c77c47ea72eac75c99d21fb82947efe8b2f758991cf1837,3345
+- github: jyp/prettiest
+  commit: e5ce6cd6b4da71860c3d97da84bed4a827fa00ef
+- git: https://github.com/serokell/galois-field.git
+  commit: 576ba98ec947370835a1f308895037c7aa7f8b71
+- bitvec-1.0.3.0@sha256:f69ed0e463045cb497a7cf1bc808a2e84ea0ce286cf9507983bb6ed8b4bd3993,3977
+- git: https://github.com/serokell/elliptic-curve.git
+  commit: b8a3d0cf8f7bacfed77dc3b697f5d08bd33396a8
+
+#####################################
+# Standard Library Extra Dependency #
+#####################################
+- github: phile314/tasty-silver
+  commit: f1f90ac3113cd445e2a7ade43ebb29f0db38ab9b
+- tasty-1.4.1@sha256:69e90e965543faf0fc2c8e486d6c1d8cf81fd108e2c4541234c41490f392f94f,2638
+

--- a/library/StandardLibrary/test/Golden.hs
+++ b/library/StandardLibrary/test/Golden.hs
@@ -1,0 +1,21 @@
+module Golden where
+
+import Mari.Library
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+
+absurdTestAll :: T.TestTree
+absurdTestAll =
+  T.testGroup
+    "Two Failing test groups"
+    [ T.testCase "(2 T.@=? 3)" ((2 :: Integer) T.@=? 3),
+      T.testCase "(4 T.@=? 3)" ((4 :: Integer) T.@=? 3)
+    ]
+
+absurdTestSome :: T.TestTree
+absurdTestSome =
+  T.testGroup
+    "One succeeding, one failing test group"
+    [ T.testCase "(2 T.@=? 2)" ((2 :: Integer) T.@=? 2),
+      T.testCase "(4 T.@=? 3)" ((4 :: Integer) T.@=? 3)
+    ]

--- a/library/StandardLibrary/test/Main.hs
+++ b/library/StandardLibrary/test/Main.hs
@@ -1,0 +1,18 @@
+module Main where
+
+import Mari.Library
+import qualified NameSymb
+import qualified Pretty
+import qualified Test.Tasty as T
+
+allCheckedTests :: T.TestTree
+allCheckedTests =
+  T.testGroup
+    "All tests that are checked"
+    [ NameSymb.top,
+      Pretty.top
+    ]
+
+main :: IO ()
+main = do
+  T.defaultMain allCheckedTests

--- a/library/StandardLibrary/test/NameSymb.hs
+++ b/library/StandardLibrary/test/NameSymb.hs
@@ -1,0 +1,65 @@
+module NameSymb where
+
+--------------------------------------------------------------------------------
+
+import Mari.Library
+import qualified Mari.Library.NameSymbol as NameSymbol
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import qualified Test.Tasty.QuickCheck as T
+
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Top Level Test
+--------------------------------------------------------------------------------
+
+top :: T.TestTree
+top =
+  T.testGroup
+    "NameSymbol tests:"
+    [idIsId, infixSymbolCase]
+
+--------------------------------------------------------------------------------
+-- Functions
+--------------------------------------------------------------------------------
+
+idL :: Symbol -> Symbol
+idL = NameSymbol.toSymbol . NameSymbol.fromSymbol
+
+idR :: NameSymbol.T -> NameSymbol.T
+idR = NameSymbol.fromSymbol . NameSymbol.toSymbol
+
+--------------------------------------------------------------------------------
+-- Tests
+--------------------------------------------------------------------------------
+
+idIsId :: T.TestTree
+idIsId =
+  T.forAll (T.listOf T.arbitraryUnicodeChar) (appenDot . intern)
+    |> T.testProperty "toSymbol and fromSymbol are inverses"
+
+------------------
+-- IdL subset
+------------------
+
+infixSymbolCase :: T.TestTree
+infixSymbolCase =
+  let str = "Foo.Bar._Foo_-_.-..->.Bar.(Foo)...-..>.."
+   in T.testCase
+        "infix functions are properly reserved"
+        (idL str T.@=? str)
+
+--------------------------------------------------------------------------------
+-- property Helpers
+--------------------------------------------------------------------------------
+
+appenDot :: Symbol -> T.Property
+appenDot symb =
+  eq symb T..&&. eq dotEnd T..&&. eq dotMiddle T..&&. eq dotStart
+  where
+    eq s = idL s T.=== s
+    --
+    dotEnd = symb <> "."
+    dotStart = "." <> symb
+    dotMiddle = symb <> "." <> symb

--- a/library/StandardLibrary/test/Pretty.hs
+++ b/library/StandardLibrary/test/Pretty.hs
@@ -1,0 +1,48 @@
+module Pretty
+  ( top,
+  )
+where
+
+import Data.String (String)
+import Mari.Library
+import qualified Mari.Library.PrettyPrint as PP
+import qualified Test.Tasty as T
+import Test.Tasty.HUnit ((@?=))
+import qualified Test.Tasty.HUnit as T
+
+top :: T.TestTree
+top = T.testGroup "pretty printer tests" [testHangsWith, testHangs]
+
+testHangsWith :: T.TestTree
+testHangsWith =
+  T.testGroup
+    "hangsWith"
+    [ T.testCase "wide" $
+        renderWide hcw @?= "hello*cool*world",
+      T.testCase "narrow" $
+        renderNarrow hcw @?= "hello\n  cool\n  world"
+    ]
+  where
+    hcw = PP.hangsWith "*" 2 "hello" ["cool", "world"]
+
+testHangs :: T.TestTree
+testHangs =
+  T.testGroup
+    "hangs"
+    [ T.testCase "wide" $
+        renderWide hcw @?= "hello cool world",
+      T.testCase "narrow" $
+        renderNarrow hcw @?= "hello\n  cool\n  world"
+    ]
+  where
+    hcw = PP.hangs 2 "hello" ["cool", "world"]
+
+type Doc = PP.Doc ()
+
+renderWidth :: Int -> Doc -> String
+renderWidth n =
+  PP.renderWith $ PP.defaultOptions {PP.optsPageWidth = n}
+
+renderNarrow, renderWide :: Doc -> String
+renderNarrow = renderWidth 5
+renderWide = renderWidth 5000

--- a/library/StandardLibrary/test/Trace.hs
+++ b/library/StandardLibrary/test/Trace.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE MultiWayIf #-}
+
+module Trace where
+
+import Mari.Library
+import qualified Mari.Library.Trace as Trace
+import qualified Mari.Library.Trace.Environment as Env
+
+add1 :: (Trace.Eff m, Show b, Enum b) => b -> m b
+add1 n =
+  Trace.withScope "Prelude.add1" [show n] $ do
+    pure (succ n)
+
+add2 :: (Trace.Eff m, Show b, Enum b) => b -> m b
+add2 n =
+  Trace.withScope "Prelude.add2" [show n] $ do
+    n <- add1 n
+    add1 n
+
+addBreak :: (Trace.Eff m, Show b, Num b, MonadIO m) => b -> b -> m b
+addBreak x y =
+  Trace.withScope "Prelude.add" [show x, show y] $ do
+    Trace.stackTrace
+    pure (x + y)
+
+multiply :: (Trace.Eff m, Show b, Num b) => b -> b -> m b
+multiply x y =
+  Trace.withScope "Prelude.multiply" [show x, show y] $ do
+    pure (x * y)
+
+formula :: (Trace.Eff m, Show b, MonadIO m, Fractional b) => b -> b -> m b
+formula x y =
+  Trace.withScope "multiply-add" [show x, show y] $ do
+    addSquares <- addBreak (x ^ 2) (y ^ 2)
+    pure (addSquares / 2)
+
+complexFormula :: (Trace.Eff m, Show b, MonadIO m, Fractional b, Enum b) => b -> b -> m b
+complexFormula x y =
+  Trace.withScope "complex-formula" [show x, show y] $ do
+    mult <- multiply x y
+    aded <- add2 mult
+    multiply aded mult
+
+factorialBreak ::
+  (Trace.Eff m, Show t, Eq t, Num t, HasThrow "error" Trace.Error m) => t -> t -> m t
+factorialBreak x y =
+  Trace.withScope "factorial" [show x, show y] $ do
+    if
+        | x == 0 ->
+          Trace.break
+        | otherwise -> do
+          mult <- multiply x y
+          factorial (x - 1) mult
+
+factorial ::
+  (Trace.Eff m, Show t, Eq t, Num t) => t -> t -> m t
+factorial x y =
+  Trace.withScope "factorial" [show x, show y] $ do
+    if
+        | x == 0 ->
+          pure y
+        | otherwise -> do
+          mult <- multiply x y
+          factorial (x - 1) mult
+
+example1 :: IO ()
+example1 = do
+  (_, t) <- Env.runEmptyIO (Trace.traceAllEff >> complexFormula (3 :: Double) 4)
+  Trace.info (Env.trace t)
+
+example2 :: IO ()
+example2 =
+  ["factorial", "Prelude.multiply"]
+    |> Trace.enable (Env.trace (snd (Env.runEmpty (factorial (5 :: Integer) 1))))
+    |> Trace.info
+
+example3 :: IO ()
+example3 = do
+  _ <- Env.runEmptyIO (formula (3 :: Float) 4)
+  pure ()


### PR DESCRIPTION
Was told to just create a PR with them.

This PR adds two libraries, 

The Sexp library has the Sexp derivation code.

The StandardLibrary library adds the tracing code in `Trace.hs` and the `Trace` subfolder. It's also needed for the Sexp code, it can be decoupled from each other with some smart shuffling 