### PR TITLE
Fix: pprint positive kw for data types

### DIFF
--- a/docs/reference/language/axioms.md
+++ b/docs/reference/language/axioms.md
@@ -6,10 +6,13 @@ a type, and there exists a term _x_ that inhabits _A_. Then the program
 would look like the following.
 
 ```juvix
-    module Example;
-     axiom A : Type;
-     axiom x : A;
-    end;
+module Example;
+axiom
+A : Type;
+
+axiom
+x : A;
+end;
 ```
 
 Terms introduced by the `axiom` keyword lack any computational content.

--- a/docs/reference/language/modules.md
+++ b/docs/reference/language/modules.md
@@ -33,8 +33,11 @@ qualified.
 ```juvix
 -- A.juvix
 module A;
-   axiom Nat : Type;
-   axiom zero : Nat;
+   axiom
+   Nat : Type;
+
+   axiom
+   zero : Nat;
 end;
 
 -- B.juvix
@@ -50,8 +53,11 @@ all its names by their unqualified name.
 ```juvix
 -- A.juvix
 module A;
-   axiom Nat : Type;
-   axiom zero : Nat;
+   axiom
+   Nat : Type;
+
+   axiom
+   zero : Nat;
 end;
 
 -- B.juvix
@@ -71,15 +77,21 @@ ambiguous. For example, in module `B` below, the name `a` is ambiguous.
 ```juvix
 -- A.juvix
 module A;
-axiom A : Type;
-axiom a : A;
+axiom
+A : Type;
+
+axiom
+a : A;
 end;
 
 -- B.juvix
 module B;
+
 import A;
 open A;
-axiom a : A;
+
+axiom
+a : A;
 
 x := a;
 end;
@@ -93,7 +105,10 @@ module B;
 import A;
 open A hiding {a};
 
-axiom a : A;
+axiom
+a : A;
+
+
 x := a;
 
 end;
@@ -121,7 +136,10 @@ The `hiding` keyword can be used within an `open-import` statement.
 -- B.juvix
 module A;
 open import A hiding {a};
-axiom a : A;
+
+axiom
+a : A;
+
 x := a;
 end;
 ```
@@ -139,8 +157,12 @@ module `B`.
 ```juvix
 -- A.juvix
 module A;
-axiom A : Type;
-axiom a : A;
+axiom
+A : Type;
+
+axiom
+a : A;
+
 end;
 
 -- B.juvix

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -326,8 +326,12 @@ ppInductiveSignature InductiveDef {..} = do
       ty' = case _inductiveType of
         Nothing -> Nothing
         Just e -> Just (noLoc P.kwColon <+> ppCode e)
+      positive'
+        | _inductivePositive = (<> line) <$> Just (noLoc P.kwPositive)
+        | otherwise = Nothing
   builtin'
-    <?+> ppCode _inductiveKw
+    ?<> positive'
+    ?<> ppCode _inductiveKw
     <+> name'
     <+?> params'
     <+?> ty'

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -206,12 +206,12 @@ instance PrettyPrint (TypeSignature 'Scoped) where
       ?<> builtin'
       ?<> termin'
       ?<> ( name'
-                <+> noLoc P.kwColon
-                  <> oneLineOrNext
-                    ( type'
-                        <+?> body'
-                    )
-            )
+              <+> noLoc P.kwColon
+                <> oneLineOrNext
+                  ( type'
+                      <+?> body'
+                  )
+          )
 
 instance PrettyPrint Pattern where
   ppCode = ppMorpheme

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -175,14 +175,15 @@ instance PrettyPrint (AxiomDef 'Scoped) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => AxiomDef 'Scoped -> Sem r ()
   ppCode AxiomDef {..} = do
     axiomName' <- P.annDef _axiomName <$> P.ppSymbol _axiomName
-    let builtin' :: Maybe (Sem r ()) = (\x -> P.ppCode x >>= morpheme (getLoc x)) <$> _axiomBuiltin
+    let builtin' :: Maybe (Sem r ()) = (<> line) . (\x -> P.ppCode x >>= morpheme (getLoc x)) <$> _axiomBuiltin
         _axiomDoc' :: Maybe (Sem r ()) = ppCode <$> _axiomDoc
+        axiom' = (<> line) . ppCode $ _axiomKw
     _axiomDoc'
       ?<> builtin'
-      <?+> ppCode _axiomKw
-        <+> morpheme (getLoc _axiomName) axiomName'
-        <+> noLoc P.kwColon
-        <+> ppCode _axiomType
+      ?<> axiom'
+      <> morpheme (getLoc _axiomName) axiomName'
+      <+> noLoc P.kwColon
+      <+> ppCode _axiomType
 
 instance PrettyPrint (WithLoc BuiltinInductive) where
   ppCode b = P.ppCode (b ^. withLocParam) >>= morpheme (getLoc b)
@@ -195,7 +196,7 @@ instance PrettyPrint (TypeSignature 'Scoped) where
   ppCode TypeSignature {..} = do
     let termin' :: Maybe (Sem r ()) = (<> line) . ppCode <$> _sigTerminating
         doc' :: Maybe (Sem r ()) = ppCode <$> _sigDoc
-        builtin' :: Maybe (Sem r ()) = ppCode <$> _sigBuiltin
+        builtin' :: Maybe (Sem r ()) = (<> line) . ppCode <$> _sigBuiltin
         type' = ppCode _sigType
         name' = region (P.annDef _sigName) (ppCode _sigName)
         body' = case _sigBody of
@@ -203,8 +204,8 @@ instance PrettyPrint (TypeSignature 'Scoped) where
           Just body -> Just (noLoc P.kwAssign <> oneLineOrNext (ppCode body))
     doc'
       ?<> builtin'
-      <?+> termin'
-        ?<> ( name'
+      ?<> termin'
+      ?<> ( name'
                 <+> noLoc P.kwColon
                   <> oneLineOrNext
                     ( type'
@@ -320,7 +321,7 @@ instance PrettyPrint (InductiveConstructorDef 'Scoped) where
 
 ppInductiveSignature :: forall r. Members '[ExactPrint, Reader Options] r => InductiveDef 'Scoped -> Sem r ()
 ppInductiveSignature InductiveDef {..} = do
-  let builtin' = ppCode <$> _inductiveBuiltin
+  let builtin' = (<> line) . ppCode <$> _inductiveBuiltin
       name' = region (P.annDef _inductiveName) (ppCode _inductiveName)
       params' = ppCode <$> nonEmpty _inductiveParameters
       ty' = case _inductiveType of

--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -164,6 +164,9 @@ kwSemicolon = delimiter Str.semicolon
 kwTerminating :: Doc Ann
 kwTerminating = keyword Str.terminating
 
+kwPositive :: Doc Ann
+kwPositive = keyword Str.positive
+
 kwBraceL :: Doc Ann
 kwBraceL = delimiter "{"
 

--- a/tests/positive/Ape.juvix
+++ b/tests/positive/Ape.juvix
@@ -1,28 +1,36 @@
 module Ape;
 
-builtin string axiom String : Type;
+builtin string
+axiom
+String : Type;
 
 infixl 7 *;
-axiom * : String → String → String;
+axiom
+* : String → String → String;
 
 infixr 3 -;
-axiom - : String → String → String;
+axiom
+- : String → String → String;
 
 infixl 1 >>;
-axiom >> : String → String → String;
+axiom
+>> : String → String → String;
 
 infixl 6 +;
-axiom + : String → String → String;
+axiom
++ : String → String → String;
 
 infixr 6 ++;
-axiom ++ : String → String → String;
-axiom f : String → String;
+axiom
+++ : String → String → String;
+axiom
+f : String → String;
 
 x : String;
 x := "" + ("" ++ "");
 
-axiom wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww : String
-  → String;
+axiom
+wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww : String → String;
 
 nesting : String;
 nesting :=

--- a/tests/positive/Axiom.juvix
+++ b/tests/positive/Axiom.juvix
@@ -1,3 +1,4 @@
 module Axiom;
 
-axiom Action : Type;
+axiom
+Action : Type;

--- a/tests/positive/BuiltinsBool.juvix
+++ b/tests/positive/BuiltinsBool.juvix
@@ -1,9 +1,11 @@
 module BuiltinsBool;
 
-builtin bool type Bool :=
+builtin bool
+type Bool :=
   | true : Bool
   | false : Bool;
 
-builtin bool-if if : {A : Type} → Bool → A → A → A;
+builtin bool-if
+if : {A : Type} → Bool → A → A → A;
 if true t _ := t;
 if false _ e := e;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -13,7 +13,8 @@ go n s :=
 
 module M;
   infixr 4 ,;
-  axiom , : String → String → String;
+  axiom
+  , : String → String → String;
 end;
 
 -- qualified commas
@@ -47,19 +48,24 @@ t3 :=
     , "1234";
 
 infixl 7 +l7;
-axiom +l7 : String → String → String;
+axiom
++l7 : String → String → String;
 
 infixr 3 +r3;
-axiom +r3 : String → String → String;
+axiom
++r3 : String → String → String;
 
 infixl 1 +l1;
-axiom +l1 : String → String → String;
+axiom
++l1 : String → String → String;
 
 infixl 6 +l6;
-axiom +l6 : String → String → String;
+axiom
++l6 : String → String → String;
 
 infixr 6 +r6;
-axiom +r6 : String → String → String;
+axiom
++r6 : String → String → String;
 
 -- nesting of chains
 t : String;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -120,6 +120,10 @@ exampleFunction2 :
       + 100
       + 100;
 
+positive
+type T0 (A : Type) :=
+  | c0 : (A -> T0 A) -> T0 A;
+
 module Patterns;
   infixr 4 ,;
   type Pair :=

--- a/tests/positive/Imports/A.juvix
+++ b/tests/positive/Imports/A.juvix
@@ -8,7 +8,8 @@ module M;
   end;
 
   infixr 2 +;
-  axiom + : Type → Type → Type;
+  axiom
+  + : Type → Type → Type;
 end;
 
 import M;

--- a/tests/positive/Literals.juvix
+++ b/tests/positive/Literals.juvix
@@ -1,8 +1,11 @@
 module Literals;
 
-axiom Int : Type;
-axiom String : Type;
-axiom + : Int → Int → Int;
+axiom
+Int : Type;
+axiom
+String : Type;
+axiom
++ : Int → Int → Int;
 
 a : Int;
 a := 12313;

--- a/tests/positive/Operators.juvix
+++ b/tests/positive/Operators.juvix
@@ -1,7 +1,8 @@
 module Operators;
 
 infixl 5 +;
-axiom + : Type → Type → Type;
+axiom
++ : Type → Type → Type;
 
 plus : Type → Type → Type;
 plus := (+);

--- a/tests/positive/QualifiedConstructor/M.juvix
+++ b/tests/positive/QualifiedConstructor/M.juvix
@@ -1,7 +1,8 @@
 module M;
 
 module O;
-  axiom A : Type;
+  axiom
+  A : Type;
 end;
 
 open O;

--- a/tests/positive/QualifiedSymbol/M.juvix
+++ b/tests/positive/QualifiedSymbol/M.juvix
@@ -2,7 +2,8 @@ module M;
 
 module N;
   module O;
-    axiom A : Type;
+    axiom
+    A : Type;
   end;
 end;
 
@@ -12,4 +13,5 @@ module O;
   
 end;
 
-axiom B : O.A;
+axiom
+B : O.A;

--- a/tests/positive/QualifiedSymbol2/N.juvix
+++ b/tests/positive/QualifiedSymbol2/N.juvix
@@ -3,7 +3,9 @@ module N;
 import M;
 
 module M;
-  axiom A : Type;
+  axiom
+  A : Type;
 end;
 
-axiom B : M.A;
+axiom
+B : M.A;

--- a/tests/positive/ShadowPublicOpen.juvix
+++ b/tests/positive/ShadowPublicOpen.juvix
@@ -2,7 +2,8 @@ module ShadowPublicOpen;
 
 module M;
   module N;
-    axiom A : Type;
+    axiom
+    A : Type;
   end;
 
   open N public;
@@ -10,4 +11,5 @@ end;
 
 open M;
 
-axiom A : Type;
+axiom
+A : Type;

--- a/tests/positive/Symbols.juvix
+++ b/tests/positive/Symbols.juvix
@@ -29,7 +29,8 @@ infixl 7 ·;
 主功能 : Nat;
 主功能 := （0）;
 
-axiom = : Type;
+axiom
+= : Type;
 
 K : Nat → Nat → Nat;
 K =a@zero (=) := =a · =;


### PR DESCRIPTION
As the title says.

- I found this bug while formatting the examples found in the tests folder. 

- In addition to printing the missing positive' keyword for data types, the code also prints certain keyword annotations onto separate lines, the ones that act as attributes to their term. While this is a matter of personal preference, I find that it makes it easier to comment and uncomment individual annotations.