### PR TITLE
Fix: add supported targets as option for compile commands

### DIFF
--- a/app/Commands/Compile/Options.hs
+++ b/app/Commands/Compile/Options.hs
@@ -11,8 +11,8 @@ import Data.List.NonEmpty qualified as NonEmpty
 supportedTargets :: NonEmpty CompileTarget
 supportedTargets = NonEmpty.fromList allTargets
 
-parseUserCompileOptions :: Parser CompileOptions
-parseUserCompileOptions =
+parseMainCompileOptions :: Parser CompileOptions
+parseMainCompileOptions =
   parseCompileOptions
     supportedTargets
-    parseInputJuvixAsmFile
+    parseInputJuvixFile

--- a/app/Commands/Compile/Options.hs
+++ b/app/Commands/Compile/Options.hs
@@ -1,6 +1,18 @@
 module Commands.Compile.Options
-  ( module Commands.Extra.Compile.Options,
+  ( module Commands.Compile.Options,
+    module Commands.Extra.Compile.Options,
   )
 where
 
 import Commands.Extra.Compile.Options
+import CommonOptions
+import Data.List.NonEmpty qualified as NonEmpty
+
+supportedTargets :: NonEmpty CompileTarget
+supportedTargets = NonEmpty.fromList allTargets
+
+parseUserCompileOptions :: Parser CompileOptions
+parseUserCompileOptions =
+  parseCompileOptions
+    supportedTargets
+    parseInputJuvixAsmFile

--- a/app/Commands/Dev/Asm/Compile/Options.hs
+++ b/app/Commands/Dev/Asm/Compile/Options.hs
@@ -6,8 +6,21 @@ where
 
 import Commands.Extra.Compile.Options
 import CommonOptions
+import Data.List.NonEmpty qualified as NonEmpty
 
 type AsmCompileOptions = CompileOptions
 
+asmSupportedTargets :: NonEmpty CompileTarget
+asmSupportedTargets =
+  NonEmpty.fromList
+    ( [ TargetWasm32Wasi,
+        TargetNative64,
+        TargetAsm
+      ]
+    )
+
 parseAsmCompileOptions :: Parser AsmCompileOptions
-parseAsmCompileOptions = parseCompileOptions parseInputJuvixAsmFile
+parseAsmCompileOptions =
+  parseCompileOptions
+    asmSupportedTargets
+    parseInputJuvixAsmFile

--- a/app/Commands/Dev/Asm/Compile/Options.hs
+++ b/app/Commands/Dev/Asm/Compile/Options.hs
@@ -13,11 +13,10 @@ type AsmCompileOptions = CompileOptions
 asmSupportedTargets :: NonEmpty CompileTarget
 asmSupportedTargets =
   NonEmpty.fromList
-    ( [ TargetWasm32Wasi,
-        TargetNative64,
-        TargetAsm
-      ]
-    )
+    [ TargetWasm32Wasi,
+      TargetNative64
+    ]
+
 
 parseAsmCompileOptions :: Parser AsmCompileOptions
 parseAsmCompileOptions =

--- a/app/Commands/Dev/Asm/Compile/Options.hs
+++ b/app/Commands/Dev/Asm/Compile/Options.hs
@@ -17,7 +17,6 @@ asmSupportedTargets =
       TargetNative64
     ]
 
-
 parseAsmCompileOptions :: Parser AsmCompileOptions
 parseAsmCompileOptions =
   parseCompileOptions

--- a/app/Commands/Dev/Core/Asm.hs
+++ b/app/Commands/Dev/Core/Asm.hs
@@ -3,11 +3,8 @@ module Commands.Dev.Core.Asm where
 import AsmInterpreter
 import Commands.Base
 import Commands.Dev.Core.Asm.Options
-import Juvix.Compiler.Asm.Pretty qualified as Asm
-import Juvix.Compiler.Asm.Translation.FromCore qualified as Asm
-import Juvix.Compiler.Core.Options qualified as Core
-import Juvix.Compiler.Core.Pipeline qualified as Core
-import Juvix.Compiler.Core.Translation.FromSource qualified as Core
+import Juvix.Compiler.Asm qualified as Asm
+import Juvix.Compiler.Core qualified as Core
 import Juvix.Compiler.Core.Translation.Stripped.FromCore qualified as Stripped
 
 runCommand :: forall r a. (Members '[Embed IO, App] r, CanonicalProjection a CoreAsmOptions) => a -> Sem r ()

--- a/app/Commands/Dev/Core/Compile/Options.hs
+++ b/app/Commands/Dev/Core/Compile/Options.hs
@@ -11,7 +11,12 @@ import Data.List.NonEmpty qualified as NonEmpty
 type CoreCompileOptions = CompileOptions
 
 coreSupportedTargets :: NonEmpty CompileTarget
-coreSupportedTargets = NonEmpty.fromList allTargets
+coreSupportedTargets = NonEmpty.fromList
+  [ TargetWasm32Wasi
+  , TargetNative64
+  , TargetGeb
+  , TargetAsm
+  ]
 
 parseCoreCompileOptions :: Parser CoreCompileOptions
 parseCoreCompileOptions =

--- a/app/Commands/Dev/Core/Compile/Options.hs
+++ b/app/Commands/Dev/Core/Compile/Options.hs
@@ -1,6 +1,20 @@
 module Commands.Dev.Core.Compile.Options
-  ( module Commands.Extra.Compile.Options,
+  ( module Commands.Dev.Core.Compile.Options,
+    module Commands.Extra.Compile.Options,
   )
 where
 
 import Commands.Extra.Compile.Options
+import CommonOptions
+import Data.List.NonEmpty qualified as NonEmpty
+
+type CoreCompileOptions = CompileOptions
+
+coreSupportedTargets :: NonEmpty CompileTarget
+coreSupportedTargets = NonEmpty.fromList allTargets
+
+parseCoreCompileOptions :: Parser CoreCompileOptions
+parseCoreCompileOptions =
+  parseCompileOptions
+    coreSupportedTargets
+    parseInputJuvixAsmFile

--- a/app/Commands/Dev/Core/Compile/Options.hs
+++ b/app/Commands/Dev/Core/Compile/Options.hs
@@ -11,12 +11,13 @@ import Data.List.NonEmpty qualified as NonEmpty
 type CoreCompileOptions = CompileOptions
 
 coreSupportedTargets :: NonEmpty CompileTarget
-coreSupportedTargets = NonEmpty.fromList
-  [ TargetWasm32Wasi
-  , TargetNative64
-  , TargetGeb
-  , TargetAsm
-  ]
+coreSupportedTargets =
+  NonEmpty.fromList
+    [ TargetWasm32Wasi,
+      TargetNative64,
+      TargetGeb,
+      TargetAsm
+    ]
 
 parseCoreCompileOptions :: Parser CoreCompileOptions
 parseCoreCompileOptions =

--- a/app/Commands/Dev/Core/Options.hs
+++ b/app/Commands/Dev/Core/Options.hs
@@ -92,5 +92,5 @@ parseCoreCommand =
     compileInfo :: ParserInfo CoreCommand
     compileInfo =
       info
-        (CoreCompile <$> parseCompileOptions parseInputJuvixCoreFile)
+        (CoreCompile <$> parseCoreCompileOptions)
         (progDesc "Compile a JuvixCore file to native code, WebAssembly or GEB")

--- a/app/Commands/Dev/Runtime/Options.hs
+++ b/app/Commands/Dev/Runtime/Options.hs
@@ -21,7 +21,6 @@ parseRuntimeOptions =
     runtimeSupportedTargets
     parseInputJuvixFile
 
-
 parseRuntimeCommand :: Parser RuntimeCommand
 parseRuntimeCommand =
   hsubparser $

--- a/app/Commands/Dev/Runtime/Options.hs
+++ b/app/Commands/Dev/Runtime/Options.hs
@@ -2,10 +2,25 @@ module Commands.Dev.Runtime.Options where
 
 import Commands.Dev.Runtime.Compile.Options
 import CommonOptions
+import Data.List.NonEmpty qualified as NonEmpty
 
 newtype RuntimeCommand
   = Compile CompileOptions
   deriving stock (Data)
+
+runtimeSupportedTargets :: NonEmpty CompileTarget
+runtimeSupportedTargets =
+  NonEmpty.fromList
+    [ TargetWasm32Wasi,
+      TargetNative64
+    ]
+
+parseRuntimeOptions :: Parser CompileOptions
+parseRuntimeOptions =
+  parseCompileOptions
+    runtimeSupportedTargets
+    parseInputJuvixFile
+
 
 parseRuntimeCommand :: Parser RuntimeCommand
 parseRuntimeCommand =
@@ -20,5 +35,5 @@ parseRuntimeCommand =
     compileInfo :: ParserInfo RuntimeCommand
     compileInfo =
       info
-        (Compile <$> parseCompileOptions parseInputCFile)
+        (Compile <$> parseRuntimeOptions)
         (progDesc "Compile a C file with Juvix runtime included")

--- a/app/Commands/Extra/Compile/Options.hs
+++ b/app/Commands/Extra/Compile/Options.hs
@@ -87,15 +87,18 @@ optCompileTarget supportedTargets =
         <> metavar "TARGET"
         <> value TargetNative64
         <> showDefault
-        <> help ("select a target: " <> show supportedTargets)
-        <> completeWith (map show (toList supportedTargets))
+        <> help ("select a target: " <> show listTargets)
+        <> completeWith (map show listTargets)
     )
   where
+    listTargets :: [CompileTarget]
+    listTargets = toList supportedTargets
+
     parseTarget :: String -> Either String CompileTarget
     parseTarget txt =
       maybe err return $
         lookup
           (map toLower txt)
-          [(Prelude.show t, t) | t <- toList supportedTargets]
+          [(Prelude.show t, t) | t <- listTargets]
       where
         err = Left $ "unrecognised target: " <> txt

--- a/app/Commands/Extra/Compile/Options.hs
+++ b/app/Commands/Extra/Compile/Options.hs
@@ -33,8 +33,16 @@ data CompileOptions = CompileOptions
 
 makeLenses ''CompileOptions
 
-parseCompileOptions :: Parser (AppPath File) -> Parser CompileOptions
-parseCompileOptions parseInputFile = do
+type SupportedTargets = NonEmpty CompileTarget
+
+allTargets :: [CompileTarget]
+allTargets = allElements
+
+parseCompileOptions ::
+  SupportedTargets ->
+  Parser (AppPath File) ->
+  Parser CompileOptions
+parseCompileOptions supportedTargets parseInputFile = do
   _compileDebug <-
     switch
       ( short 'g'
@@ -65,13 +73,13 @@ parseCompileOptions parseInputFile = do
           <> long "only-term"
           <> help "Produce term output only (for targets: geb)"
       )
-  _compileTarget <- optCompileTarget
+  _compileTarget <- optCompileTarget supportedTargets
   _compileOutputFile <- optional parseGenericOutputFile
   _compileInputFile <- parseInputFile
   pure CompileOptions {..}
 
-optCompileTarget :: Parser CompileTarget
-optCompileTarget =
+optCompileTarget :: SupportedTargets -> Parser CompileTarget
+optCompileTarget supportedTargets =
   option
     (eitherReader parseTarget)
     ( long "target"
@@ -79,13 +87,15 @@ optCompileTarget =
         <> metavar "TARGET"
         <> value TargetNative64
         <> showDefault
-        <> help ("select a target: " <> show allTargets)
-        <> completeWith (map show allTargets)
+        <> help ("select a target: " <> show supportedTargets)
+        <> completeWith (map show (toList supportedTargets))
     )
   where
-    allTargets :: [CompileTarget]
-    allTargets = allElements
     parseTarget :: String -> Either String CompileTarget
-    parseTarget txt = maybe err return (lookup (map toLower txt) [(Prelude.show t, t) | t <- allElements])
+    parseTarget txt =
+      maybe err return $
+        lookup
+          (map toLower txt)
+          [(Prelude.show t, t) | t <- toList supportedTargets]
       where
         err = Left $ "unrecognised target: " <> txt

--- a/app/TopCommand/Options.hs
+++ b/app/TopCommand/Options.hs
@@ -144,7 +144,7 @@ commandCompile :: Mod CommandFields TopCommand
 commandCompile =
   command "compile" $
     info
-      (Compile <$> parseUserCompileOptions)
+      (Compile <$> parseMainCompileOptions)
       (progDesc "Compile a Juvix file")
 
 commandEval :: Mod CommandFields TopCommand

--- a/app/TopCommand/Options.hs
+++ b/app/TopCommand/Options.hs
@@ -144,7 +144,7 @@ commandCompile :: Mod CommandFields TopCommand
 commandCompile =
   command "compile" $
     info
-      (Compile <$> parseCompileOptions parseInputJuvixFile)
+      (Compile <$> parseUserCompileOptions)
       (progDesc "Compile a Juvix file")
 
 commandEval :: Mod CommandFields TopCommand

--- a/docs/reference/language/modules.md
+++ b/docs/reference/language/modules.md
@@ -130,7 +130,7 @@ We simplify it by the expression:
 open import Prelude;
 ```
 
-The `hiding` keyword can be used within a `open-import` statement.
+The `hiding` keyword can be used within an `open-import` statement.
 
 ```juvix
 -- B.juvix

--- a/docs/reference/language/modules.md
+++ b/docs/reference/language/modules.md
@@ -15,7 +15,7 @@ end;
 A <u>Juvix project</u> is a collection of Juvix modules inside one main
 project folder containing a metadata file named `juvix.yaml`. Each Juvix
 file has to define a <u>module</u> of the same name. The name of the
-module must coincide with the path of the its file relative to its
+module must coincide with the path of its file relative to its
 project's root directory. For example, if the file is
 `root/Data/List.juvix` then the module must be called `Data.List`,
 assuming `root` is the project's folder.
@@ -130,7 +130,7 @@ We simplify it by the expression:
 open import Prelude;
 ```
 
-The `hiding` keyword can be used within an `open-import` statement.
+The `hiding` keyword can be used within a `open-import` statement.
 
 ```juvix
 -- B.juvix

--- a/src/Juvix/Compiler/Asm.hs
+++ b/src/Juvix/Compiler/Asm.hs
@@ -1,0 +1,22 @@
+module Juvix.Compiler.Asm
+  ( module Juvix.Compiler.Asm.Error,
+    module Juvix.Compiler.Asm.Extra,
+    module Juvix.Compiler.Asm.Keywords,
+    module Juvix.Compiler.Asm.Language,
+    module Juvix.Compiler.Asm.Pretty,
+    module Juvix.Compiler.Asm.Options,
+    module Juvix.Compiler.Asm.Pipeline,
+    module Juvix.Compiler.Asm.Transformation,
+    module Juvix.Compiler.Asm.Translation,
+  )
+where
+
+import Juvix.Compiler.Asm.Error
+import Juvix.Compiler.Asm.Extra
+import Juvix.Compiler.Asm.Keywords
+import Juvix.Compiler.Asm.Language
+import Juvix.Compiler.Asm.Options
+import Juvix.Compiler.Asm.Pipeline
+import Juvix.Compiler.Asm.Pretty hiding (Options)
+import Juvix.Compiler.Asm.Transformation
+import Juvix.Compiler.Asm.Translation

--- a/src/Juvix/Compiler/Asm/Data.hs
+++ b/src/Juvix/Compiler/Asm/Data.hs
@@ -1,0 +1,10 @@
+module Juvix.Compiler.Asm.Data
+  ( module Juvix.Compiler.Asm.Data.InfoTable,
+    module Juvix.Compiler.Asm.Data.InfoTableBuilder,
+    module Juvix.Compiler.Asm.Data.Stack,
+  )
+where
+
+import Juvix.Compiler.Asm.Data.InfoTable
+import Juvix.Compiler.Asm.Data.InfoTableBuilder
+import Juvix.Compiler.Asm.Data.Stack

--- a/src/Juvix/Compiler/Asm/Translation.hs
+++ b/src/Juvix/Compiler/Asm/Translation.hs
@@ -1,0 +1,8 @@
+module Juvix.Compiler.Asm.Translation
+  ( module Juvix.Compiler.Asm.Translation.FromCore,
+    module Juvix.Compiler.Asm.Translation.FromSource,
+  )
+where
+
+import Juvix.Compiler.Asm.Translation.FromCore
+import Juvix.Compiler.Asm.Translation.FromSource

--- a/tests/positive/Dependencies/Input.juvix
+++ b/tests/positive/Dependencies/Input.juvix
@@ -5,5 +5,3 @@ open import Base;
 open import Stdlib.Prelude;
 
 axiom x : Extra;
-
-end;


### PR DESCRIPTION
- Closes #1882 