### PR TITLE
Qualified imports

### DIFF
--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -88,6 +88,9 @@ topModulePathToDottedPath :: IsString s => TopModulePath -> s
 topModulePathToDottedPath (TopModulePath l r) =
   fromText $ mconcat $ intersperse "." $ map (^. symbolText) $ l ++ [r]
 
+moduleSymbolToTopModulePath :: Symbol -> TopModulePath
+moduleSymbolToTopModulePath = moduleNameToTopModulePath . NameUnqualified
+
 moduleNameToTopModulePath :: Name -> TopModulePath
 moduleNameToTopModulePath = \case
   NameUnqualified s -> TopModulePath [] s

--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -86,10 +86,7 @@ topModulePathToName (TopModulePath ms m) = case nonEmpty ms of
 
 topModulePathToDottedPath :: IsString s => TopModulePath -> s
 topModulePathToDottedPath (TopModulePath l r) =
-  fromText $ mconcat $ intersperse "." $ map (^. symbolText) $ l ++ [r]
-
-moduleSymbolToTopModulePath :: Symbol -> TopModulePath
-moduleSymbolToTopModulePath = moduleNameToTopModulePath . NameUnqualified
+  fromText . mconcat . intersperse "." . map (^. symbolText) $ l ++ [r]
 
 moduleNameToTopModulePath :: Name -> TopModulePath
 moduleNameToTopModulePath = \case

--- a/src/Juvix/Compiler/Concrete/Data/Scope.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope.hs
@@ -31,7 +31,11 @@ data BindingStrategy
 data Scope = Scope
   { _scopePath :: S.AbsModulePath,
     _scopeSymbols :: HashMap Symbol SymbolInfo,
-    _scopeTopModules :: HashMap TopModulePath (ModuleRef'' 'S.NotConcrete 'ModuleTop),
+    -- | The map from S.NameId to Modules is needed because we support merging
+    -- several imports under the same name. E.g.
+    -- import A as X;
+    -- import B as X;
+    _scopeTopModules :: HashMap TopModulePath (HashMap S.NameId (ModuleRef'' 'S.NotConcrete 'ModuleTop)),
     -- | Symbols that have been defined in the current scope level. Every symbol
     -- should map to itself. This is needed because we may query it with a
     -- symbol with a different location but we may want the location of the

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -79,7 +79,8 @@ allKeywords =
     kwWildcard
   ]
 
--- | Keywords that do not need to be reserved
+-- | Keywords that do not need to be reserved. Currently only for documentation
+-- purposes
 nonKeywords :: [Keyword]
 nonKeywords =
   [ kwAs

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -10,6 +10,7 @@ import Juvix.Data.Keyword.All
   ( -- reserved
 
     -- extra
+    kwAs,
     kwAssign,
     kwAt,
     kwAxiom,
@@ -49,7 +50,8 @@ allKeywordStrings = keywordsStrings allKeywords
 
 allKeywords :: [Keyword]
 allKeywords =
-  [ kwAssign,
+  [ kwAs,
+    kwAssign,
     kwAt,
     kwAxiom,
     kwCase,

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -50,8 +50,7 @@ allKeywordStrings = keywordsStrings allKeywords
 
 allKeywords :: [Keyword]
 allKeywords =
-  [ kwAs,
-    kwAssign,
+  [ kwAssign,
     kwAt,
     kwAxiom,
     kwCase,
@@ -78,4 +77,10 @@ allKeywords =
     kwUsing,
     kwWhere,
     kwWildcard
+  ]
+
+-- | Keywords that do not need to be reserved
+nonKeywords :: [Keyword]
+nonKeywords =
+  [ kwAs
   ]

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -160,14 +160,15 @@ deriving stock instance
 
 data Import (s :: Stage) = Import
   { _importKw :: KeywordRef,
-    _importModule :: ImportType s
+    _importModule :: ImportType s,
+    _importQualified :: Maybe (SymbolType s)
   }
 
-deriving stock instance (Show (ImportType s)) => Show (Import s)
+deriving stock instance (Show (SymbolType s), Show (ImportType s)) => Show (Import s)
 
-deriving stock instance (Eq (ImportType s)) => Eq (Import s)
+deriving stock instance (Eq (SymbolType s), Eq (ImportType s)) => Eq (Import s)
 
-deriving stock instance (Ord (ImportType s)) => Ord (Import s)
+deriving stock instance (Ord (SymbolType s), Ord (ImportType s)) => Ord (Import s)
 
 --------------------------------------------------------------------------------
 -- Operator syntax declaration

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -124,6 +124,7 @@ data Statement (s :: Stage)
 deriving stock instance
   ( Show (ImportType s),
     Show (ModulePathType s 'ModuleLocal),
+    Show (ModulePathType s 'ModuleTop),
     Show (PatternType s),
     Show (SymbolType s),
     Show (IdentifierType s),
@@ -136,6 +137,7 @@ deriving stock instance
   ( Eq (ImportType s),
     Eq (PatternType s),
     Eq (ModulePathType s 'ModuleLocal),
+    Eq (ModulePathType s 'ModuleTop),
     Eq (SymbolType s),
     Eq (IdentifierType s),
     Eq (ModuleRefType s),
@@ -147,6 +149,7 @@ deriving stock instance
   ( Ord (ImportType s),
     Ord (PatternType s),
     Ord (ModulePathType s 'ModuleLocal),
+    Ord (ModulePathType s 'ModuleTop),
     Ord (SymbolType s),
     Ord (IdentifierType s),
     Ord (ModuleRefType s),
@@ -161,14 +164,14 @@ deriving stock instance
 data Import (s :: Stage) = Import
   { _importKw :: KeywordRef,
     _importModule :: ImportType s,
-    _importQualified :: Maybe (SymbolType s)
+    _importAsName :: Maybe (ModulePathType s 'ModuleTop)
   }
 
-deriving stock instance (Show (SymbolType s), Show (ImportType s)) => Show (Import s)
+deriving stock instance (Show (ModulePathType s 'ModuleTop), Show (ImportType s)) => Show (Import s)
 
-deriving stock instance (Eq (SymbolType s), Eq (ImportType s)) => Eq (Import s)
+deriving stock instance (Eq (ModulePathType s 'ModuleTop), Eq (ImportType s)) => Eq (Import s)
 
-deriving stock instance (Ord (SymbolType s), Ord (ImportType s)) => Ord (Import s)
+deriving stock instance (Ord (ModulePathType s 'ModuleTop), Ord (ImportType s)) => Ord (Import s)
 
 --------------------------------------------------------------------------------
 -- Operator syntax declaration
@@ -409,6 +412,7 @@ data Module (s :: Stage) (t :: ModuleIsTop) = Module
 deriving stock instance
   ( Show (ModulePathType s t),
     Show (ModulePathType s 'ModuleLocal),
+    Show (ModulePathType s 'ModuleTop),
     Show (ImportType s),
     Show (PatternType s),
     Show (IdentifierType s),
@@ -422,6 +426,7 @@ deriving stock instance
 deriving stock instance
   ( Eq (ModulePathType s t),
     Eq (ModulePathType s 'ModuleLocal),
+    Eq (ModulePathType s 'ModuleTop),
     Eq (ImportType s),
     Eq (PatternType s),
     Eq (IdentifierType s),
@@ -435,6 +440,7 @@ deriving stock instance
 deriving stock instance
   ( Ord (ModulePathType s t),
     Ord (ModulePathType s 'ModuleLocal),
+    Ord (ModulePathType s 'ModuleTop),
     Ord (ImportType s),
     Ord (PatternType s),
     Ord (IdentifierType s),

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -512,8 +512,15 @@ instance SingI s => PrettyCode (Import s) where
   ppCode :: forall r. Members '[Reader Options] r => Import s -> Sem r (Doc Ann)
   ppCode i = do
     modulePath' <- ppModulePath
-    return $ kwImport <+> modulePath'
+    qual' <- ppQual
+    return $ kwImport <+> modulePath' <+?> qual'
     where
+      ppQual :: Sem r (Maybe (Doc Ann))
+      ppQual = case i ^. importQualified of
+        Nothing -> return Nothing
+        Just as -> do
+          syn <- ppSymbol as
+          return . Just $ kwAs <+> syn
       ppModulePath = case sing :: SStage s of
         SParsed -> ppCode (i ^. importModule)
         SScoped -> ppCode (i ^. importModule)

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -516,10 +516,10 @@ instance SingI s => PrettyCode (Import s) where
     return $ kwImport <+> modulePath' <+?> qual'
     where
       ppQual :: Sem r (Maybe (Doc Ann))
-      ppQual = case i ^. importQualified of
+      ppQual = case i ^. importAsName of
         Nothing -> return Nothing
         Just as -> do
-          syn <- ppSymbol as
+          syn <- ppTopModulePath as
           return . Just $ kwAs <+> syn
       ppModulePath = case sing :: SStage s of
         SParsed -> ppCode (i ^. importModule)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -119,10 +119,16 @@ instance PrettyPrint (ModuleRef'' 'S.Concrete 'ModuleTop) where
   ppCode m = ppCode (m ^. moduleRefName)
 
 instance PrettyPrint (Import 'Scoped) where
-  ppCode :: Members '[ExactPrint, Reader Options] r => Import 'Scoped -> Sem r ()
+  ppCode :: forall r. Members '[ExactPrint, Reader Options] r => Import 'Scoped -> Sem r ()
   ppCode i = do
     ppCode (i ^. importKw)
       <+> ppCode (i ^. importModule)
+      <+?> ppQual
+    where
+      ppQual :: Maybe (Sem r ())
+      ppQual = case i ^. importQualified of
+        Nothing -> Nothing
+        Just as -> Just (noLoc P.kwAs <+> ppMorpheme as)
 
 instance PrettyPrint OperatorSyntaxDef where
   ppCode OperatorSyntaxDef {..} = do

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -126,7 +126,7 @@ instance PrettyPrint (Import 'Scoped) where
       <+?> ppQual
     where
       ppQual :: Maybe (Sem r ())
-      ppQual = case i ^. importQualified of
+      ppQual = case i ^. importAsName of
         Nothing -> Nothing
         Just as -> Just (noLoc P.kwAs <+> ppMorpheme as)
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -231,8 +231,8 @@ checkImport import_@(Import kw path qual) = do
       importName :: S.TopModulePath = set S.nameConcrete path sname
       synonymName :: Maybe S.TopModulePath = do
         synonym <- qual
-        return (set S.nameConcrete (moduleSymbolToTopModulePath synonym) sname)
-      qual' :: Maybe S.Symbol
+        return (set S.nameConcrete synonym sname)
+      qual' :: Maybe S.TopModulePath
       qual' = do
         asName <- qual
         return (set S.nameConcrete asName sname')
@@ -245,7 +245,7 @@ checkImport import_@(Import kw path qual) = do
   where
     addModuleToScope :: ModuleRef'' 'S.NotConcrete 'ModuleTop -> Sem r ()
     addModuleToScope moduleRef = do
-      let mpath :: TopModulePath = maybe path moduleSymbolToTopModulePath qual
+      let mpath :: TopModulePath = fromMaybe path qual
       modify (over scopeTopModules (HashMap.insert mpath moduleRef))
     checkCycle :: Sem r ()
     checkCycle = do

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -229,12 +229,16 @@ checkImport import_@(Import kw path qual) = do
       moduleId = sname ^. S.nameId
       cmoduleRef :: ModuleRef'' 'S.Concrete 'ModuleTop = set moduleRefName sname' moduleRef
       importName :: S.TopModulePath = set S.nameConcrete path sname
+      synonymName :: Maybe S.TopModulePath = do
+        synonym <- qual
+        return (set S.nameConcrete (moduleSymbolToTopModulePath synonym) sname)
       qual' :: Maybe S.Symbol
       qual' = do
         asName <- qual
         return (set S.nameConcrete asName sname')
   addModuleToScope moduleRef
   registerName importName
+  whenJust synonymName registerName
   let moduleRef' = mkModuleRef' moduleRef
   modify (over scoperModules (HashMap.insert moduleId moduleRef'))
   return (Import kw cmoduleRef qual')

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -233,14 +233,14 @@ checkImport import_@(Import kw path qual) = do
       qual' = do
         asName <- qual
         return (set S.nameConcrete asName sname')
-  addModuleToScope qual' moduleRef
+  addModuleToScope moduleRef
   registerName importName
   let moduleRef' = mkModuleRef' moduleRef
   modify (over scoperModules (HashMap.insert moduleId moduleRef'))
   return (Import kw cmoduleRef qual')
   where
-    addModuleToScope :: Maybe S.Symbol -> ModuleRef'' 'S.NotConcrete 'ModuleTop -> Sem r ()
-    addModuleToScope altName moduleRef = do
+    addModuleToScope :: ModuleRef'' 'S.NotConcrete 'ModuleTop -> Sem r ()
+    addModuleToScope moduleRef = do
       let mpath :: TopModulePath = maybe path moduleSymbolToTopModulePath qual
       modify (over scopeTopModules (HashMap.insert mpath moduleRef))
     checkCycle :: Sem r ()
@@ -538,7 +538,8 @@ localBindings = runReader BindingLocal
 freshTopModulePath ::
   forall s.
   (Members '[State ScoperState, NameIdGen] s) =>
-  TopModulePath -> Sem s S.TopModulePath
+  TopModulePath ->
+  Sem s S.TopModulePath
 freshTopModulePath _modulePath = do
   _nameId <- freshNameId
   let _nameDefinedIn = S.topModulePathToAbsPath _modulePath

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -297,8 +297,8 @@ import_ = do
   _importQualified <- optional qualified
   return Import {..}
   where
-  qualified :: ParsecS r Symbol
-  qualified = void (kw kwAs) >> symbol
+    qualified :: ParsecS r Symbol
+    qualified = void (kw kwAs) >> symbol
 
 withPath' ::
   forall r a.

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -289,12 +289,16 @@ operatorSyntaxDef = do
 -- Import statement
 --------------------------------------------------------------------------------
 
-import_ :: Members '[Files, PathResolver, InfoTableBuilder, JudocStash, NameIdGen, Error ParserError] r => ParsecS r (Import 'Parsed)
+import_ :: forall r. Members '[Files, PathResolver, InfoTableBuilder, JudocStash, NameIdGen, Error ParserError] r => ParsecS r (Import 'Parsed)
 import_ = do
   _importKw <- kw kwImport
   _importModule <- topModulePath
   P.lift (importedModule _importModule)
+  _importQualified <- optional qualified
   return Import {..}
+  where
+  qualified :: ParsecS r Symbol
+  qualified = void (kw kwAs) >> symbol
 
 withPath' ::
   forall r a.

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -294,11 +294,11 @@ import_ = do
   _importKw <- kw kwImport
   _importModule <- topModulePath
   P.lift (importedModule _importModule)
-  _importQualified <- optional qualified
+  _importAsName <- optional pasName
   return Import {..}
   where
-    qualified :: ParsecS r Symbol
-    qualified = void (kw kwAs) >> symbol
+    pasName :: ParsecS r TopModulePath
+    pasName = void (kw kwAs) >> topModulePath
 
 withPath' ::
   forall r a.

--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -152,6 +152,9 @@ kwUsing = keyword Str.using
 kwHiding :: Doc Ann
 kwHiding = keyword Str.hiding
 
+kwAs :: Doc Ann
+kwAs = keyword Str.as
+
 kwImport :: Doc Ann
 kwImport = keyword Str.import_
 

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -7,6 +7,9 @@ where
 import Juvix.Data.Keyword
 import Juvix.Extra.Strings qualified as Str
 
+kwAs :: Keyword
+kwAs = asciiKw Str.as
+
 kwBuiltin :: Keyword
 kwBuiltin = asciiKw Str.builtin
 

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -209,6 +209,9 @@ intLt = "int-lt"
 intPrint :: (IsString s) => s
 intPrint = "int-print"
 
+as :: IsString s => s
+as = "as"
+
 builtin :: IsString s => s
 builtin = "builtin"
 

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -218,6 +218,10 @@ tests =
       $(mkRelDir "Internal")
       $(mkRelFile "Case.juvix"),
     PosTest
+      "Qualified imports"
+      $(mkRelDir "QualifiedImports")
+      $(mkRelFile "Main.juvix"),
+    PosTest
       "Short syntax for multiple parameters"
       $(mkRelDir ".")
       $(mkRelFile "MultiParams.juvix"),

--- a/tests/positive/QualifiedImports/Main.juvix
+++ b/tests/positive/QualifiedImports/Main.juvix
@@ -1,0 +1,6 @@
+module Main;
+
+import Stdlib.Prelude as Prelude;
+
+main : Prelude.Nat;
+main := 123;

--- a/tests/positive/QualifiedImports/Main.juvix
+++ b/tests/positive/QualifiedImports/Main.juvix
@@ -1,9 +1,12 @@
 module Main;
 
 import Stdlib.Prelude as Prelude;
+import Stdlib.Prelude as Longer.For.No.Reason;
 open Prelude;
 
 axiom a : Nat;
+
+axiom b : Longer.For.No.Reason.Nat;
 
 main : Prelude.Nat;
 main := 123;

--- a/tests/positive/QualifiedImports/Main.juvix
+++ b/tests/positive/QualifiedImports/Main.juvix
@@ -1,6 +1,9 @@
 module Main;
 
 import Stdlib.Prelude as Prelude;
+open Prelude;
+
+axiom a : Nat;
 
 main : Prelude.Nat;
 main := 123;

--- a/tests/positive/QualifiedImports/Main.juvix
+++ b/tests/positive/QualifiedImports/Main.juvix
@@ -1,7 +1,8 @@
 module Main;
 
-import Stdlib.Prelude as Prelude;
+import Stdlib.Data.Nat as Prelude;
 import Stdlib.Prelude as Longer.For.No.Reason;
+
 open Prelude;
 
 axiom a : Nat;
@@ -10,3 +11,11 @@ axiom b : Longer.For.No.Reason.Nat;
 
 main : Prelude.Nat;
 main := 123;
+
+-- Merging imports
+import Stdlib.Data.Nat as X;
+import Stdlib.Data.Int as X;
+
+axiom c : X.Nat;
+
+axiom d : X.Int;

--- a/tests/positive/QualifiedImports/juvix.yaml
+++ b/tests/positive/QualifiedImports/juvix.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- .juvix-build/stdlib/
+name: qualifiedimports
+version: 0.0.0


### PR DESCRIPTION
This pr extends the `import` statement to support optional renaming. The syntax is as follows:
```
import Stdlib.Data.Nat as Nat;
import Stdlib.Data.Nat as Qual.Nat;
```

It is allowed to give the same name to multiple modules:
```
import Stdlib.Data.Nat as X;
import Stdlib.Data.Int as X;

axiom a : X.Nat;
axiom b : X.Int;

open X; -- This will cause an ambiguous name error
```