### PR TITLE
format long lambda clause body on a new line

### DIFF
--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -467,7 +467,7 @@ instance (SingI s) => PrettyCode (LambdaClause s) where
   ppCode LambdaClause {..} = do
     lambdaParameters' <- hsep <$> mapM ppPatternAtom _lambdaParameters
     lambdaBody' <- ppExpression _lambdaBody
-    return $ lambdaParameters' <+> kwAssign <+> lambdaBody'
+    return $ lambdaParameters' <+> kwAssign <> oneLineOrNext lambdaBody'
 
 instance (SingI s) => PrettyCode (CaseBranch s) where
   ppCode CaseBranch {..} = do

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -128,6 +128,17 @@ positive
 type T0 (A : Type) :=
   | c0 : (A -> T0 A) -> T0 A;
 
+-- Lambda clause
+f : Nat -> Nat;
+f :=
+  \ {
+    | zero :=
+      let
+        foo : Nat := 1;
+      in foo
+    | _ := 1
+  };
+
 module Patterns;
   infixr 4 ,;
   type Pair :=


### PR DESCRIPTION
This PR modifies the pretty printer for lambda clauses so that the body will start on a new line if it is too long to fit on a single line. This is exactly how we handle function clause bodies.

* Closes https://github.com/anoma/juvix/issues/2014