### PR TITLE
Add format stdin smoke tests

### DIFF
--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -128,3 +128,44 @@ tests:
     stderr:
       contains: "error"
     exit-status: 1
+
+  - name: format-stdin
+    command:
+      - juvix
+      - --stdin
+      - format
+      - positive/Format.juvix
+    stdin: "module Format; open import Stdlib.Prelude; main : Nat; main := 5; "
+    stdout:
+      contains: |
+        module Format;
+
+        open import Stdlib.Prelude;
+
+        main : Nat;
+        main := 5;
+    exit-status: 1
+
+  - name: format-stdin-file-does-not-exist
+    command:
+      - juvix
+      - --stdin
+      - format
+      - positive/NonExistingFormat.juvix
+    stdin: "module Format; open import Stdlib.Prelude; main : Nat; main := 5; "
+    stderr:
+      contains: |
+        positive/NonExistingFormat.juvix: openFile: does not exist (No such file or directory)
+    exit-status: 1
+
+  - name: format-stdin-module-name-not-file-name
+    command:
+      - juvix
+      - --stdin
+      - format
+      - positive/Format.juvix
+    stdin: "module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; "
+    stderr:
+      contains: |-
+          The top module
+    exit-status: 1

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -165,7 +165,12 @@ tests:
       - format
       - positive/Format.juvix
     stdin: "module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; "
-    stderr:
-      contains: |-
-          The top module
+    stdout:
+      contains: |
+        module OtherFormat;
+
+        open import Stdlib.Prelude;
+
+        main : Nat;
+        main := 5;
     exit-status: 1


### PR DESCRIPTION
 * Exploration of #2008 

As I were trying to fix the behaviour of `format` command with the `--stdin` global option, I noticed that actually it is already behaves the same was as `dev scope` command (which was the desire at least at this point).

So, no actual behaviour of the command is channged, only a few tests added to showcase some edge cases of the command with the `--stdin` option together.

Here are the highlights:

* The filename is **not** optional for both `dev scope` and `format` even if with `stdin` the content of the file comes from the input.
* `format` command expects the stdin input to be a proper module
* the name of the stdin module should be aligned with the provided filename even though its sources are not used

I think that some of the above behaviours we can consider to change. Let me know what do you think about any of that.

Otherwise, the `dev scope` command can be replaced with `format`. 