### PR TITLE
Fix dependencies suggestion in missing module error

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -55,7 +55,16 @@ instance PrettyCodeAnn MissingModule where
       suggestion =
         "It should be in"
           <+> pcode (_missingInfo ^. packageRoot <//> topModulePathToRelativePath' _missingModule)
-            <> line
-            <> "or in one of the dependencies:"
-            <> line
-            <> itemize (map pcode (_missingInfo ^.. packagePackage . packageDependencies . each))
+            <> dependenciesSuggestion
+
+      dependenciesSuggestion :: Doc Ann
+      dependenciesSuggestion
+        | null deps = mempty
+        | otherwise =
+            line
+              <> "or in one of the dependencies:"
+              <> line
+              <> itemize (map pcode deps)
+        where
+          deps :: [Dependency]
+          deps = _missingInfo ^. packagePackage . packageDependencies

--- a/test/Parsing/Negative.hs
+++ b/test/Parsing/Negative.hs
@@ -78,5 +78,13 @@ filesErrorTests =
       $(mkRelFile "WrongModuleName.juvix")
       $ \case
         ErrWrongTopModuleName {} -> Nothing
+        _ -> wrongError,
+    negTest
+      "Import a module that doesn't exist"
+      $(mkRelDir "NoDependencies")
+      $(mkRelFile "InvalidImport.juvix")
+      $ \case
+        ErrTopModulePath
+          TopModulePathError {_topModulePathError = ErrMissingModule {}} -> Nothing
         _ -> wrongError
   ]

--- a/tests/negative/Dependencies/InvalidImport.juvix
+++ b/tests/negative/Dependencies/InvalidImport.juvix
@@ -1,0 +1,3 @@
+module InvalidImport;
+
+import Foo;

--- a/tests/negative/NoDependencies/InvalidImport.juvix
+++ b/tests/negative/NoDependencies/InvalidImport.juvix
@@ -1,0 +1,3 @@
+module InvalidImport;
+
+import Foo;

--- a/tests/negative/NoDependencies/juvix.yaml
+++ b/tests/negative/NoDependencies/juvix.yaml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/smoke/Commands/dev/parse.smoke.yaml
+++ b/tests/smoke/Commands/dev/parse.smoke.yaml
@@ -24,3 +24,29 @@ tests:
       matches: |
         Module \{.*
     exit-status: 0
+
+  - name: missing-module-no-dependencies-suggestion-with-no-dependencies
+    command:
+      - juvix
+      - dev
+      - parse
+    args:
+      - negative/NoDependencies/InvalidImport.juvix
+    stderr:
+      matches:
+        regex: |-
+          ^((?!dependencies).)*$
+        options:
+          - dot-all
+    exit-status: 1
+
+  - name: missing-module-dependencies-suggestion-with-dependencies
+    command:
+      - juvix
+      - dev
+      - parse
+    args:
+      - negative/Dependencies/InvalidImport.juvix
+    stderr:
+      contains: dependencies
+    exit-status: 1


### PR DESCRIPTION
If an import statement to a missing module occurs when parsing in a project with no dependencies the error message has the following form:

```
The module Foo does not exist.
It should be in /Users/paul/heliax/juvix-2023/tests/negative/NoDependencies/Foo.juvix
or in one of the dependencies:
```

This PR changes this error message to the `or in one of the dependencies:` line is omitted from the error message when there are no dependencies in the project.

This commit also adds a negative parse error test for missing module.