### PR TITLE
Add delimiter face

### DIFF
--- a/src/Juvix/Compiler/Concrete/Data/Highlight.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight.hs
@@ -69,6 +69,7 @@ goFaceParsedItem i = WithLoc (i ^. parsedLoc) (PropertyFace f)
       ParsedTagLiteralInt -> FaceNumber
       ParsedTagLiteralString -> FaceString
       ParsedTagComment -> FaceComment
+      ParsedTagDelimiter -> FaceDelimiter
 
 goFaceName :: AName -> Maybe (WithLoc PropertyFace)
 goFaceName n = do

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/Properties.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/Properties.hs
@@ -27,6 +27,7 @@ data Face
   | FaceFunction
   | FaceModule
   | FaceAxiom
+  | FaceDelimiter
   | FaceKeyword
   | FaceString
   | FaceNumber
@@ -40,6 +41,7 @@ faceSymbolStr = \case
   FaceConstructor -> Str.constructor
   FaceModule -> Str.module_
   FaceKeyword -> Str.keyword
+  FaceDelimiter -> Str.delimiter
   FaceFunction -> Str.function
   FaceNumber -> Str.number
   FaceComment -> Str.comment

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/RenderEmacs.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/RenderEmacs.hs
@@ -23,7 +23,7 @@ fromCodeAnn = \case
     f <- nameKindFace k
     return (EPropertyFace (PropertyFace f))
   AnnKeyword -> Just (EPropertyFace (PropertyFace FaceKeyword))
-  AnnDelimiter -> Just (EPropertyFace (PropertyFace FaceKeyword))
+  AnnDelimiter -> Just (EPropertyFace (PropertyFace FaceDelimiter))
   AnnComment -> Just (EPropertyFace (PropertyFace FaceComment))
   AnnLiteralString -> Just (EPropertyFace (PropertyFace FaceString))
   AnnLiteralInteger -> Just (EPropertyFace (PropertyFace FaceNumber))

--- a/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
@@ -1,6 +1,7 @@
 module Juvix.Compiler.Concrete.Data.ParsedInfoTableBuilder
   ( InfoTableBuilder,
     registerLiteral,
+    registerDelimiter,
     registerKeyword,
     registerJudocText,
     registerComment,
@@ -37,6 +38,14 @@ registerKeyword r =
         { _parsedLoc = getLoc r,
           _parsedTag = ParsedTagKeyword
         }
+
+registerDelimiter :: Member InfoTableBuilder r => Interval -> Sem r ()
+registerDelimiter i =
+  registerItem
+    ParsedItem
+      { _parsedLoc = i,
+        _parsedTag = ParsedTagDelimiter
+      }
 
 registerJudocText :: Member InfoTableBuilder r => Interval -> Sem r ()
 registerJudocText i =

--- a/src/Juvix/Compiler/Concrete/Data/ParsedItem.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedItem.hs
@@ -13,6 +13,7 @@ data ParsedItemTag
   | ParsedTagLiteralInt
   | ParsedTagLiteralString
   | ParsedTagComment
+  | ParsedTagDelimiter
   deriving stock (Eq, Show, Generic)
 
 makeLenses ''ParsedItem

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -93,20 +93,30 @@ dot = P.char '.'
 dottedIdentifier :: (Members '[InfoTableBuilder] r) => ParsecS r (NonEmpty (Text, Interval))
 dottedIdentifier = lexeme $ P.sepBy1 bareIdentifier dot
 
+delim :: (Members '[InfoTableBuilder] r) => Text -> ParsecS r ()
+delim sym = lexeme $ delim' sym >>= P.lift . registerDelimiter
+
 lbrace :: (Members '[InfoTableBuilder] r) => ParsecS r ()
-lbrace = symbol "{"
+lbrace = delim "{"
 
 rbrace :: (Members '[InfoTableBuilder] r) => ParsecS r ()
-rbrace = symbol "}"
+rbrace = delim "}"
 
 lparen :: (Members '[InfoTableBuilder] r) => ParsecS r ()
-lparen = symbol "("
+lparen = delim "("
 
 rparen :: (Members '[InfoTableBuilder] r) => ParsecS r ()
-rparen = symbol ")"
+rparen = delim ")"
+
+-- TODO Consider using this instead of kw kwPipe
+pipe :: (Members '[InfoTableBuilder] r) => ParsecS r ()
+pipe = delim "|"
+
+semicolon :: (Members '[InfoTableBuilder] r) => ParsecS r ()
+semicolon = delim ";"
 
 parens :: (Members '[InfoTableBuilder] r) => ParsecS r a -> ParsecS r a
 parens = between lparen rparen
 
 braces :: (Members '[InfoTableBuilder] r) => ParsecS r a -> ParsecS r a
-braces = between (symbol "{") (symbol "}")
+braces = between lbrace rbrace

--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -94,7 +94,7 @@ kwColonColon :: Doc Ann
 kwColonColon = keyword (Str.colon <> Str.colon)
 
 kwPipe :: Doc Ann
-kwPipe = keyword Str.pipe
+kwPipe = delimiter Str.pipe
 
 kwHole :: Doc Ann
 kwHole = keyword Str.underscore

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -227,6 +227,9 @@ any = "Any"
 questionMark :: (IsString s) => s
 questionMark = "?"
 
+delimiter :: (IsString s) => s
+delimiter = "delimiter"
+
 keyword :: (IsString s) => s
 keyword = "keyword"
 

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -75,6 +75,10 @@ string' :: ParsecS r Text
 string' = pack <$> (char '"' >> manyTill L.charLiteral (char '"'))
 
 -- | The caller is responsible of consuming space after it.
+delim' :: Text -> ParsecS r Interval
+delim' d = P.label (unpack d) . fmap snd . interval $ chunk d
+
+-- | The caller is responsible of consuming space after it.
 kw' :: Keyword -> ParsecS r KeywordRef
 kw' k@Keyword {..} = P.label (unpack _keywordAscii) (reserved <|> normal)
   where


### PR DESCRIPTION
Adds a delimiter face for coloring semicolons, parentheses and braces. 
I think pipes should also fall in this category, but some extra work is still needed to include those, so they are left out for now