### PR TITLE
Enable self-application test

### DIFF
--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -203,5 +203,5 @@ tests =
       $(mkRelDir ".")
       $(mkRelFile "MutualLet.juvix")
   ]
-    <> [ compilationTest t | t <- Compilation.tests, t ^. Compilation.name /= "Self-application"
+    <> [ compilationTest t | t <- Compilation.tests
        ]


### PR DESCRIPTION
This test was disabled in the past when it used to loop. It is now ok to enable it again.