### PR TITLE
Return endLine info in highlighting command

### DIFF
--- a/src/Juvix/Compiler/Concrete/Data/Highlight/Properties.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/Properties.hs
@@ -92,8 +92,8 @@ data RawProperties = RawProperties
     _rawPropertiesDoc :: [RawWithLoc RawType]
   }
 
--- | (File, Row, Col, Length)
-type RawInterval = (Path Abs File, Int, Int, Int)
+-- | (File, Start Row, Start Col, Length, End Row, End Col)
+type RawInterval = (Path Abs File, Int, Int, Int, Int, Int)
 
 type RawWithLoc a = (RawInterval, a)
 
@@ -126,7 +126,9 @@ rawProperties LocProperties {..} =
       ( i ^. intervalFile,
         fromIntegral (i ^. intervalStart . locLine),
         fromIntegral (i ^. intervalStart . locCol),
-        intervalLength i
+        intervalLength i,
+        fromIntegral (i ^. intervalEnd . locLine),
+        fromIntegral (i ^. intervalEnd . locCol)
       )
 
     rawWithLoc :: (a -> b) -> WithLoc a -> RawWithLoc b


### PR DESCRIPTION
# Description

This change is needed for my work on https://github.com/anoma/vscode-juvix/issues/24 .

Now I return the information about end line and end symbol, so in `vscode-juvix` I can handle multiline tokens properly (as VSCode can only deal with single line tokens).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works:
  - [ ] Negative tests
  - [ ] Positive tests
  - [ ] Shell tests
