### PR TITLE
Fix fromSource behaviour when both stdin and filename

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -49,7 +49,11 @@ fromSource e = mapError (JuvixError @ParserError) $ do
       Sem r (NonEmpty (Module 'Parsed 'ModuleTop))
     getParsedModuleTops = case (e ^. entryPointStdin, e ^. entryPointModulePaths) of
       (Nothing, []) -> throw $ ErrStdinOrFile StdinOrFileError
-      (Just txt, _) ->
+      (Just txt, x : _) ->
+        runModuleParser x txt >>= \case
+          Left err -> throw err
+          Right r -> return (r :| [])
+      (Just txt, []) ->
         runModuleStdinParser txt >>= \case
           Left err -> throw err
           Right r -> return (r :| [])

--- a/tests/smoke/Commands/dev/highlight.smoke.yaml
+++ b/tests/smoke/Commands/dev/highlight.smoke.yaml
@@ -11,7 +11,7 @@ tests:
 
     stdout:
       contains: |
-          add-text-properties
+        add-text-properties
     exit-status: 0
 
   - name: highlight-vscode
@@ -26,5 +26,26 @@ tests:
 
     stdout:
       matches: |-
-          ^\{\"face\".*$
+        ^\{\"face\".*$
+    exit-status: 0
+
+  - name: highlight-stdin
+    command:
+      - juvix
+      - dev
+      - highlight
+      - --format
+      - json
+    args:
+      - Compilation/positive/test001.juvix
+      - --stdin
+    stdin: |
+      module OtherFormat;
+
+      open import Stdlib.Prelude;
+
+      main : Nat;
+      main := 5;
+    stdout:
+      contains: 'function'
     exit-status: 0

--- a/tests/smoke/Commands/typecheck.smoke.yaml
+++ b/tests/smoke/Commands/typecheck.smoke.yaml
@@ -1,13 +1,12 @@
 working-directory: ./../../../tests/
 tests:
   - name: flag-help-shows-juvix-file-for-autocompletion
-    command: 
-      - juvix 
+    command:
+      - juvix
       - typecheck
       - --help
     stdout:
-      contains:
-        "Usage: juvix typecheck JUVIX_FILE"
+      contains: 'Usage: juvix typecheck JUVIX_FILE'
     exit-status: 0
 
   - name: check-simple-file
@@ -16,7 +15,7 @@ tests:
       - typecheck
     args:
       - positive/Internal/Simple.juvix
-    stdout: 
+    stdout:
       equals: "Well done! It type checks\n"
     exit-status: 0
 
@@ -27,7 +26,7 @@ tests:
       - typecheck
     args:
       - positive/Internal/Simple.juvix
-    stdout: ""
+    stdout: ''
     exit-status: 0
 
   - name: get-typechecking-error
@@ -37,8 +36,8 @@ tests:
       - typecheck
     args:
       - negative/Internal/MultiWrongType.juvix
-    stdout: ""
-    stderr: 
+    stdout: ''
+    stderr:
       matches: |-
         (.+)\/([^\/]+)\.juvix\:[0-9]*\:[0-9]*\-[0-9]*\: error
     exit-status: 1
@@ -52,3 +51,15 @@ tests:
     stdout:
       equals: "Well done! It type checks\n"
     exit-status: 0
+
+  - name: typecheck-stdin
+    command:
+      - juvix
+      - --stdin
+      - typecheck
+    args:
+      - positive/Internal/Simple.juvix
+    stdin: 'module OtherModule; open import Stdlib.Prelude; main : Nat; main := 5;'
+    stderr:
+      contains: 'positive/Internal/Simple.juvix'
+    exit-status: 1


### PR DESCRIPTION
# Description

While working on highlight command, I noticed that after `format` command changes the behaviour of the `highlight` command when both `--stdin` option specified and FILENAME is provided is changed.
Instead on returning the result for the `stdin` input, it started to return empty result.

This PR fixes that behaviour, it will now act exactly as before introducing the changes that came with the `format` command fixes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works:
  - [x] smoke test
