### PR TITLE
Fix pipeline setup in the repl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
           repo: wasmerio/wasmer
-          tag: latest
+          tag: v3.2.1
           binaries-location: bin
           cache: true
 
@@ -178,7 +178,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
           repo: wasmerio/wasmer
-          tag: latest
+          tag: v3.2.1
           binaries-location: bin
           cache: true
 

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -12,6 +12,7 @@ import Data.String.Interpolate (i, __i)
 import Evaluator
 import Juvix.Compiler.Concrete.Data.Scope (scopePath)
 import Juvix.Compiler.Concrete.Data.ScopedName (absTopModulePath)
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver (runPathResolver)
 import Juvix.Compiler.Core qualified as Core
 import Juvix.Compiler.Core.Extra.Value
 import Juvix.Compiler.Core.Info qualified as Info
@@ -21,6 +22,7 @@ import Juvix.Compiler.Core.Transformation qualified as Core
 import Juvix.Compiler.Core.Transformation.DisambiguateNames (disambiguateNames)
 import Juvix.Compiler.Internal.Language qualified as Internal
 import Juvix.Compiler.Internal.Pretty qualified as Internal
+import Juvix.Compiler.Pipeline.Setup (entrySetup)
 import Juvix.Data.Error.GenericError qualified as Error
 import Juvix.Extra.Paths
 import Juvix.Extra.Stdlib
@@ -123,11 +125,18 @@ runCommand opts = do
         entryPoint <- getReplEntryPoint f
         loadEntryPoint entryPoint
 
-      loadPrelude :: Repl ()
-      loadPrelude = loadDefaultPrelude
-
       loadDefaultPrelude :: Repl ()
-      loadDefaultPrelude = whenJustM defaultPreludeEntryPoint loadEntryPoint
+      loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
+        let root = roots ^. rootsRootDir
+        void
+          . liftIO
+          . runM
+          . runFilesIO
+          . runError @Text
+          . runReader e
+          . runPathResolver root
+          $ entrySetup
+        loadEntryPoint e
 
       printRoot :: String -> Repl ()
       printRoot _ = do
@@ -267,7 +276,7 @@ runCommand opts = do
         welcomeMsg
         unless
           (opts ^. replNoPrelude || gopts ^. globalNoStdlib)
-          (maybe loadPrelude (loadFile . (^. pathPath)) (opts ^. replInputFile))
+          (maybe loadDefaultPrelude (loadFile . (^. pathPath)) (opts ^. replInputFile))
 
       finaliser :: Repl ExitDecision
       finaliser = return Exit

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -128,6 +128,8 @@ runCommand opts = do
       loadDefaultPrelude :: Repl ()
       loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
         let root = roots ^. rootsRootDir
+        -- The following is needed to ensure that the default location of the
+        -- standard library exists
         void
           . liftIO
           . runM

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -7,6 +7,7 @@ module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
     withPath,
     withPathFile,
     expectedModulePath,
+    runPathResolver,
     runPathResolverPipe,
     runPathResolverPipe',
     ResolverState,


### PR DESCRIPTION
This pr fixes a bug where the repl would crash if it had the implicit stdlib dependency and the .juvix-build/stdlib directory did not yet exist. This bug was not exposed in the smoke tests because the .juvix-build was never cleared.