### PR TITLE
Arity check types and functions (->)

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -705,7 +705,16 @@ inferExpression' hint e = case e of
           case l'ty of
             ExpressionFunction (Function (FunctionParameter paraName ifun funL) funR) -> do
               r' <- checkExpression funL r
-              unless (iapp == ifun) (error "implicitness mismatch")
+              unless
+                (iapp == ifun)
+                ( error
+                    ( "Impossible: implicitness mismatch"
+                        <> show ifun
+                        <> show iapp
+                        <> "\n"
+                        <> ppTrace (Application l r iapp)
+                    )
+                )
               return
                 TypedExpression
                   { _typedExpression =

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -214,6 +214,10 @@ tests =
       $(mkRelDir ".")
       $(mkRelFile "MutualLet.juvix"),
     posTest
+      "id application in type"
+      $(mkRelDir ".")
+      $(mkRelFile "IdInType.juvix"),
+    posTest
       "Nested pattern match with type variables"
       $(mkRelDir ".")
       $(mkRelFile "NestedPatterns.juvix")

--- a/tests/positive/IdInType.juvix
+++ b/tests/positive/IdInType.juvix
@@ -1,0 +1,10 @@
+module IdInType;
+
+type Unit :=
+  | unit : Unit;
+
+id : {a : Type} -> a -> a;
+id a := a;
+
+f : id Unit -> Unit;
+f _ := unit;


### PR DESCRIPTION
This pr fixes the following:

This example causes the compiler to crash with "implicitness mismatch".
```
f : id Bool -> Bool;
f _ := false;
```
The reason is that `id` expects an implicit argument but finds `Bool`, which is explicit. The arity checker was not inserting any hole because it was ignoring the whole type. Moreover the aritychecker was never checking `->` types as we never expected to 
have to insert holes in `->` types (since the only fragment of defined functions that we accept in types are those which do not have implicit arguments).

We now properly arity check all types and process the function type `->` correctly.