### PR TITLE
 Fix a bug in the positivity checker (#1943)

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
@@ -133,18 +133,17 @@ checkStrictlyPositiveOccurrences ty ctorName name recLimit ref =
         helperApp tyApp = do
           let (hdExpr, args) = unfoldApplication tyApp
           case hdExpr of
-            ExpressionIden (IdenInductive ty') ->
-              do
-                when (inside && name == ty') (strictlyPositivityError expr)
-                InductiveInfo indType' <- lookupInductive ty'
+            ExpressionIden (IdenInductive ty') -> do
+              when (inside && name == ty') (strictlyPositivityError expr)
+              InductiveInfo indType' <- lookupInductive ty'
 
-                -- We now need to know whether `name` negatively occurs at `indTy'`
-                -- or not. The way to know is by checking that the type ty'
-                -- preserves the positivity condition, i.e., its type parameters
-                -- are no negative.
+              -- We now need to know whether `name` negatively occurs at `indTy'`
+              -- or not. The way to know is by checking that the type ty'
+              -- preserves the positivity condition, i.e., its type parameters
+              -- are no negative.
 
-                let paramsTy' = indType' ^. inductiveParameters
-                helperInductiveApp indType' (zip paramsTy' (toList args))
+              let paramsTy' = indType' ^. inductiveParameters
+              helperInductiveApp indType' (zip paramsTy' (toList args))
             _ -> return ()
 
         helperInductiveApp :: InductiveDef -> [(InductiveParameter, Expression)] -> Sem r ()

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
@@ -14,18 +14,23 @@ type NegativeTypeParameters = HashSet VarName
 
 type ErrorReference = Maybe Expression
 
+type TypeOfConstructor = Expression
+
 type RecursionLimit = Int
 
+type CheckPositivityEffects r =
+  Members
+    '[ Reader E.EntryPoint,
+       Reader InfoTable,
+       Error TypeCheckerError,
+       Inference,
+       State NegativeTypeParameters
+     ]
+    r
+
 checkPositivity ::
-  ( Members
-      '[ Reader E.EntryPoint,
-         Reader InfoTable,
-         Error TypeCheckerError,
-         Inference,
-         State NegativeTypeParameters
-       ]
-      r
-  ) =>
+  forall r.
+  CheckPositivityEffects r =>
   InductiveDef ->
   Sem r ()
 checkPositivity ty = do
@@ -41,13 +46,13 @@ checkPositivity ty = do
 
 checkStrictlyPositiveOccurrences ::
   forall r.
-  (Members '[Reader InfoTable, Error TypeCheckerError, State NegativeTypeParameters, Inference] r) =>
+  CheckPositivityEffects r =>
   InductiveDef ->
   ConstrName ->
   Name ->
   RecursionLimit ->
   ErrorReference ->
-  Expression ->
+  TypeOfConstructor ->
   Sem r ()
 checkStrictlyPositiveOccurrences ty ctorName name recLimit ref =
   strongNormalize >=> helper False
@@ -62,16 +67,16 @@ checkStrictlyPositiveOccurrences ty ctorName name recLimit ref =
 
     helper :: Bool -> Expression -> Sem r ()
     helper inside expr = case expr of
-      ExpressionIden i -> helperIden i
-      ExpressionFunction (Function l r) -> helper True (l ^. paramType) >> helper inside r
       ExpressionApplication tyApp -> helperApp tyApp
-      ExpressionLiteral {} -> return ()
+      ExpressionCase l -> helperCase l
+      ExpressionFunction (Function l r) -> helper True (l ^. paramType) >> helper inside r
       ExpressionHole {} -> return ()
-      ExpressionUniverse {} -> return ()
-      ExpressionSimpleLambda l -> helperSimpleLambda l
+      ExpressionIden i -> helperIden i
       ExpressionLambda l -> helperLambda l
       ExpressionLet l -> helperLet l
-      ExpressionCase l -> helperCase l
+      ExpressionLiteral {} -> return ()
+      ExpressionSimpleLambda l -> helperSimpleLambda l
+      ExpressionUniverse {} -> return ()
       where
         helperCase :: Case -> Sem r ()
         helperCase l = do
@@ -115,7 +120,8 @@ checkStrictlyPositiveOccurrences ty ctorName name recLimit ref =
 
         helperIden :: Iden -> Sem r ()
         helperIden = \case
-          IdenInductive ty' -> when (inside && name == ty') (strictlyPositivityError expr)
+          IdenInductive ty' ->
+            when (inside && name == ty') (strictlyPositivityError expr)
           IdenVar name'
             | not inside -> return ()
             | name == name' -> strictlyPositivityError expr
@@ -127,38 +133,40 @@ checkStrictlyPositiveOccurrences ty ctorName name recLimit ref =
         helperApp tyApp = do
           let (hdExpr, args) = unfoldApplication tyApp
           case hdExpr of
-            ExpressionIden (IdenInductive ty') -> do
-              when (inside && name == ty') (strictlyPositivityError expr)
-              InductiveInfo indTy' <- lookupInductive ty'
+            ExpressionIden (IdenInductive ty') ->
+              do
+                when (inside && name == ty') (strictlyPositivityError expr)
+                InductiveInfo indType' <- lookupInductive ty'
 
-              -- We now need to know whether `name` negatively occurs at `indTy'`
-              -- or not. The way to know is by checking that the type ty'
-              -- preserves the positivity condition, i.e., its type parameters
-              -- are no negative.
+                -- We now need to know whether `name` negatively occurs at `indTy'`
+                -- or not. The way to know is by checking that the type ty'
+                -- preserves the positivity condition, i.e., its type parameters
+                -- are no negative.
 
-              let paramsTy' = indTy' ^. inductiveParameters
-              helperInductiveApp indTy' (zip paramsTy' (toList args))
+                let paramsTy' = indType' ^. inductiveParameters
+                helperInductiveApp indType' (zip paramsTy' (toList args))
             _ -> return ()
 
         helperInductiveApp :: InductiveDef -> [(InductiveParameter, Expression)] -> Sem r ()
-        helperInductiveApp typ = \case
-          ((InductiveParameter pName, arg) : ps) -> do
+        helperInductiveApp indType' = \case
+          ((InductiveParameter pName', tyArg) : ps) -> do
             negParms :: NegativeTypeParameters <- get
-            when (varOrInductiveInExpression name arg) $ do
-              when (HashSet.member pName negParms) (strictlyPositivityError arg)
+            when (varOrInductiveInExpression name tyArg) $ do
+              when (HashSet.member pName' negParms) (strictlyPositivityError tyArg)
               when (recLimit > 0) $
-                forM_ (typ ^. inductiveConstructors) $ \ctor' ->
+                forM_ (indType' ^. inductiveConstructors) $ \ctor' -> do
+                  let ctorName' = ctor' ^. inductiveConstructorName
+                  let errorRef = fromMaybe tyArg ref
                   mapM_
                     ( checkStrictlyPositiveOccurrences
-                        ty
-                        ctorName
-                        pName
+                        indType'
+                        ctorName'
+                        pName'
                         (recLimit - 1)
-                        (Just (fromMaybe arg ref))
+                        (Just errorRef)
                     )
                     (ctor' ^. inductiveConstructorParameters)
-                    >> modify (HashSet.insert pName)
-            helperInductiveApp ty ps
+            helperInductiveApp indType' ps
           [] -> return ()
 
     strictlyPositivityError :: Expression -> Sem r ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
 ghc-options:
   "$locals": -optP-Wno-nonportable-include-path
-resolver: lts-20.12
+resolver: lts-20.19

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
 ghc-options:
   "$locals": -optP-Wno-nonportable-include-path
-resolver: lts-20.19
+resolver: lts-20.12

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -69,7 +69,6 @@ testPositivityKeyword =
       $(mkRelFile "E5.juvix")
   ]
 
-
 positivityTestGroup :: TestTree
 positivityTestGroup =
   testGroup
@@ -80,7 +79,7 @@ positivityTestGroup =
       testGroup
         "Usages of the positive keyword"
         (map (mkTest . testDescr) testPositivityKeyword),
-        testGroup
+      testGroup
         "Well-defined inductive definitions"
         (map (mkTest . testDescr) testWellDefinedInductiveDefs)
     ]

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -53,6 +53,14 @@ testNoPositivityFlag N.NegTest {..} =
 negPositivityTests :: [N.NegTest]
 negPositivityTests = N.negPositivityTests
 
+testWellDefinedInductiveDefs :: [PosTest]
+testWellDefinedInductiveDefs =
+  [ posTest
+      "Rose tree definition is well-defined"
+      $(mkRelDir "Internal/Positivity")
+      $(mkRelFile "RoseTree.juvix")
+  ]
+
 testPositivityKeyword :: [PosTest]
 testPositivityKeyword =
   [ posTest
@@ -60,6 +68,7 @@ testPositivityKeyword =
       $(mkRelDir "Internal/Positivity")
       $(mkRelFile "E5.juvix")
   ]
+
 
 positivityTestGroup :: TestTree
 positivityTestGroup =
@@ -70,7 +79,10 @@ positivityTestGroup =
         (map (mkTest . testNoPositivityFlag) negPositivityTests),
       testGroup
         "Usages of the positive keyword"
-        (map (mkTest . testDescr) testPositivityKeyword)
+        (map (mkTest . testDescr) testPositivityKeyword),
+        testGroup
+        "Well-defined inductive definitions"
+        (map (mkTest . testDescr) testWellDefinedInductiveDefs)
     ]
 
 --------------------------------------------------------------------------------

--- a/tests/positive/Internal/Positivity/RoseTree.juvix
+++ b/tests/positive/Internal/Positivity/RoseTree.juvix
@@ -1,0 +1,8 @@
+module RoseTree;
+
+type List (A : Type) : Type :=
+  | nil : List A
+  | cons : A -> List A -> List A;
+
+type RoseTree (A : Type) : Type :=
+  | node : A -> List (RoseTree A) -> RoseTree A;


### PR DESCRIPTION
# Description

This PR fixes #1943. The primary issue stemmed from an incorrect insertion in the set designated for storing negative type parameters. Additionally, there was a call site intended to use the variable `typ`, but I mistakenly used `ty` (which was for something else). To prevent such silly typos better to adopt more meaningful names.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works:
  - [ ] Negative tests
  - [x] Positive tests
  - [ ] Shell tests
