### PR TITLE
Fix devcontainer juvix install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,7 @@ RUN sudo bash -c 'curl -s https://api.github.com/repos/anoma/juvix/releases/late
       | tr -d \" \
       | wget --output-document juvix.zip -qi - \
       && unzip juvix.zip \
-      && mv juvix-linux* /home/vscode/.local/bin/juvix'
+      && mv juvix /home/vscode/.local/bin/juvix'
 
 RUN sudo bash -c 'mkdir -p /home/vscode/.local/wasi-sysroot'
 RUN sudo bash -c 'curl -s https://api.github.com/repos/WebAssembly/wasi-sdk/releases/tags/wasi-sdk-16 \


### PR DESCRIPTION
The binary inside the Juvix release archive is now named `juvix` so this PR updates the script that unzips and adds the juvix binary to the devcontainer PATH to expect this.

Also see: https://github.com/anoma/juvix-docs/pull/8
