### PR TITLE
Fix topCommandInputFile for Format command

### DIFF
--- a/examples/milestone/Bank/Bank.juvix
+++ b/examples/milestone/Bank/Bank.juvix
@@ -66,7 +66,7 @@ module Balances;
       (eqField f b)
       ((b, sub bn n) :: bs)
       ((b, bn) :: decrement f n bs);
-  
+
   emtpyBalances : Balances;
   emtpyBalances := nil;
 

--- a/examples/milestone/Bank/Bank.juvix
+++ b/examples/milestone/Bank/Bank.juvix
@@ -66,7 +66,7 @@ module Balances;
       (eqField f b)
       ((b, sub bn n) :: bs)
       ((b, bn) :: decrement f n bs);
-
+  
   emtpyBalances : Balances;
   emtpyBalances := nil;
 

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -62,7 +62,7 @@ tests:
         - bash
       script: |
         cd ..
-        juvix format examples/milestone/TicTacToe/CLI/TicTacToe.juvix
+        juvix format --in-place examples/milestone/TicTacToe/CLI/TicTacToe.juvix
     exit-status: 0
     stdout: ''
 

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -56,6 +56,16 @@ tests:
     exit-status: 0
     stdout: ''
 
+  - name: format-formatted-file-from-upper-folder
+    command:
+      shell:
+        - bash
+      script: |
+        cd ..
+        juvix format examples/milestone/TicTacToe/CLI/TicTacToe.juvix
+    exit-status: 0
+    stdout: ''
+
   - name: format-dir-with-all-formatted
     command:
       shell:

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -7,8 +7,7 @@ tests:
       - format
       - --help
     stdout:
-      contains:
-        JUVIX_FILE
+      contains: JUVIX_FILE
     exit-status: 0
 
   - name: format-formatted-file
@@ -17,7 +16,7 @@ tests:
       - format
       - positive/Format.juvix
     exit-status: 0
-    stdout: ""
+    stdout: ''
 
   - name: format-unformatted-file
     command:
@@ -45,7 +44,7 @@ tests:
         touch juvix.yaml
         echo "module Foo ;" >> Foo.juvix
         juvix format --check Foo.juvix
-    stdout: ""
+    stdout: ''
     exit-status: 1
 
   - name: format-formatted-file-check-no-stdout
@@ -55,7 +54,7 @@ tests:
       - --check
       - positive/Format.juvix
     exit-status: 0
-    stdout: ""
+    stdout: ''
 
   - name: format-dir-with-all-formatted
     command:
@@ -67,7 +66,7 @@ tests:
         touch $temp/juvix.yaml
         cp positive/Format.juvix $temp
         juvix format $temp
-    stdout: ""
+    stdout: ''
     exit-status: 0
 
   - name: format-dir-containing-unformatted
@@ -83,8 +82,7 @@ tests:
         echo "module Foo ;" >> Foo.juvix
         juvix format $temp
     stdout:
-      contains:
-        "Foo.juvix"
+      contains: 'Foo.juvix'
     exit-status: 1
 
   - name: format-dir-containing-unformatted-check-no-stdout
@@ -99,7 +97,7 @@ tests:
         cd $temp
         echo "module Foo ;" >> Foo.juvix
         juvix format --check $temp
-    stdout: ""
+    stdout: ''
     exit-status: 1
 
   - name: format-dir-with-all-formatted-check-no-stdout
@@ -112,7 +110,7 @@ tests:
         touch $temp/juvix.yaml
         cp positive/Format.juvix $temp
         juvix format --check $temp
-    stdout: ""
+    stdout: ''
     exit-status: 0
 
   - name: format-file-with-scope-error
@@ -126,7 +124,7 @@ tests:
         echo "modul Bar;" > Foo.juvix
         juvix format Foo.juvix
     stderr:
-      contains: "error"
+      contains: 'error'
     exit-status: 1
 
   - name: format-stdin
@@ -135,7 +133,7 @@ tests:
       - --stdin
       - format
       - positive/Format.juvix
-    stdin: "module Format; open import Stdlib.Prelude; main : Nat; main := 5; "
+    stdin: 'module Format; open import Stdlib.Prelude; main : Nat; main := 5; '
     stdout:
       contains: |
         module Format;
@@ -152,7 +150,7 @@ tests:
       - --stdin
       - format
       - positive/NonExistingFormat.juvix
-    stdin: "module Format; open import Stdlib.Prelude; main : Nat; main := 5; "
+    stdin: 'module Format; open import Stdlib.Prelude; main : Nat; main := 5; '
     stderr:
       contains: |
         positive/NonExistingFormat.juvix: openFile: does not exist (No such file or directory)
@@ -164,15 +162,9 @@ tests:
       - --stdin
       - format
       - positive/Format.juvix
-    stdin: "module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; "
-    stdout:
-      contains: |
-        module OtherFormat;
-
-        open import Stdlib.Prelude;
-
-        main : Nat;
-        main := 5;
+    stdin: 'module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; '
+    stderr:
+      contains: 'is defined in the file'
     exit-status: 1
 
   - name: format-stdin-no-file-name
@@ -180,7 +172,7 @@ tests:
       - juvix
       - --stdin
       - format
-    stdin: "module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; "
+    stdin: 'module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; '
     stdout:
       contains: |
         module OtherFormat;
@@ -195,7 +187,7 @@ tests:
     command:
       - juvix
       - format
-    stdin: "module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5;; "
+    stdin: 'module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5;; '
     stdout:
       contains: juvix format error
     exit-status: 1


### PR DESCRIPTION
Thanks to @paulcadman , we figured out that the behaviour of the `format` command described in issue #2058 was due to the way the `uniplates` library was handling the `FormatOptions`. As `FormatOption` doesn't have the `AppPath FileOrDir`, it was not set up to anything, therefore, the directory was not properly set.

This change, instead of changing the `FormatOptions` data type to have some `AppPath *`, it just adds the special case on how to handle this specific command to figure out its input directory.

For the future, we might think of either refactoring the whole uniplates logic, or handling each command the way that I am handling the `format` command at the moment, so it is more explicit and consistent.

Let me know what you think!

- Fixes #2058 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works:
  - [ ] Negative tests
  - [ ] Positive tests
  - [ ] Shell tests
