### PR TITLE
Fix format on projects that contain subprojects

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -90,7 +90,7 @@ mkPackageInfo mpackageEntry _packageRoot = do
   return PackageInfo {..}
   where
     juvixAccum :: Path Abs Dir -> [Path Rel Dir] -> [Path Rel File] -> [Path Abs File] -> Sem r ([Path Abs File], Recurse Rel)
-    juvixAccum cd _ files acc = return (newJuvixFiles <> acc, RecurseFilter (\hasJuvixYaml d -> not hasJuvixYaml || not (isHiddenDirectory d)))
+    juvixAccum cd _ files acc = return (newJuvixFiles <> acc, RecurseFilter (\hasJuvixYaml d -> not hasJuvixYaml && not (isHiddenDirectory d)))
       where
         newJuvixFiles :: [Path Abs File]
         newJuvixFiles = [cd <//> f | f <- files, isJuvixFile f]

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -88,7 +88,7 @@ formatProject p = do
     handler cd _ files _ = do
       let juvixFiles = [cd <//> f | f <- files, isJuvixFile f]
       res <- combineResults <$> mapM format juvixFiles
-      return (res, RecurseFilter (\hasJuvixYaml d -> not (hasJuvixYaml && isHiddenDirectory d)))
+      return (res, RecurseFilter (\hasJuvixYaml d -> not hasJuvixYaml && not (isHiddenDirectory d)))
 
 formatPath :: Member ScopeEff r => Path Abs File -> Sem r (NonEmpty AnsiText)
 formatPath p = do

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -95,6 +95,22 @@ tests:
       contains: 'Foo.juvix'
     exit-status: 1
 
+  - name: format-ignore-subproject
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        touch $temp/juvix.yaml
+        cp positive/Format.juvix $temp
+        mkdir $temp/sub
+        touch $temp/sub/juvix.yaml
+        cp positive/Format.juvix $temp/sub
+        juvix format $temp
+    stdout: ''
+    exit-status: 0
+
   - name: format-dir-containing-unformatted-check-no-stdout
     command:
       shell:


### PR DESCRIPTION
This PR fixes the behaviour of the `format` command when run on a project that contains subprojects. Files in subprojects must not be processed by the formatter.

The format issue was caused by a bug in the `walkDirRel` function that is used to traverse a file system tree:

https://github.com/anoma/juvix/blob/9a64184253eb9129d2ac36d538d0c5f55cc46d35/src/Juvix/Data/Effect/Files.hs#L36

In this function, the passed handler can return a function that determines if a candidate subdirectory should be traversed. The first argument of this function indicates if the candidate subdirectory contains a juvix.yaml file. In the formatter and the path resolver we use this argument to exclude such subdirectories from the traversal.

Previously the first argument was calculated from the files in the current directory instead of the candidate subdirectory - which was the source of the bug.

The callers of walkDirRel are also fixed to match the updated behaviour.

* Closes https://github.com/anoma/juvix/issues/2077
