### PR TITLE
Improve error message when input path doesn't exist

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Main (main) where
 
 import App
 import CommonOptions
+import Data.String.Interpolate (i)
 import GlobalOptions
 import Juvix.Compiler.Pipeline.Root
 import TopCommand
@@ -13,10 +16,19 @@ main = do
   invokeDir <- getCurrentDir
   (_runAppIOArgsGlobalOptions, cli) <- customExecParser parserPreferences descr
   mbuildDir <- mapM (prepathToAbsDir invokeDir) (_runAppIOArgsGlobalOptions ^? globalBuildDir . _Just . pathPath)
-  mainFileDir <- topCommandInputFile cli
-  _runAppIOArgsRoots <- findRootAndChangeDir mainFileDir mbuildDir invokeDir
+  mainFile <- topCommandInputPath cli
+  mapM_ checkMainFile mainFile
+  _runAppIOArgsRoots <- findRootAndChangeDir (containingDir <$> mainFile) mbuildDir invokeDir
   runFinal
     . resourceToIOFinal
     . embedToFinal @IO
     . runAppIO RunAppIOArgs {..}
     $ runTopCommand cli
+  where
+    checkMainFile :: SomePath b -> IO ()
+    checkMainFile p = unlessM (doesSomePathExist p) err
+      where
+        err :: IO ()
+        err = do
+          hPutStrLn stderr [i|The input path #{p} does not exist|]
+          exitFailure

--- a/src/Juvix/Prelude/Path.hs
+++ b/src/Juvix/Prelude/Path.hs
@@ -2,12 +2,14 @@ module Juvix.Prelude.Path
   ( module Juvix.Prelude.Path,
     module Path,
     module Path.IO,
+    module Juvix.Prelude.Path.SomePath,
   )
 where
 
 import Data.List.NonEmpty qualified as NonEmpty
 import Juvix.Prelude.Base
 import Juvix.Prelude.Path.OrphanInstances ()
+import Juvix.Prelude.Path.SomePath
 import Path hiding ((<.>), (</>))
 import Path qualified
 import Path.IO hiding (listDirRel, walkDirRel)

--- a/src/Juvix/Prelude/Path/SomePath.hs
+++ b/src/Juvix/Prelude/Path/SomePath.hs
@@ -1,0 +1,27 @@
+module Juvix.Prelude.Path.SomePath where
+
+import Juvix.Prelude.Base
+import Path
+import Path.IO
+import Prelude qualified
+
+data SomePath b
+  = File (Path b File)
+  | Dir (Path b Dir)
+
+-- | Return the directory containing a path. i.e the path itself if it is a
+-- directory or its parent if it is a file.
+containingDir :: SomePath b -> Path b Dir
+containingDir = \case
+  File f -> parent f
+  Dir d -> d
+
+doesSomePathExist :: SomePath b -> IO Bool
+doesSomePathExist = \case
+  File p -> doesPathExist p
+  Dir p -> doesPathExist p
+
+instance Show (SomePath b) where
+  show = \case
+    File p -> show p
+    Dir p -> show p

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -94,3 +94,13 @@ tests:
         [ -f test001.lisp ]
     stdout: ""
     exit-status: 0
+
+  - name: input-file-does-not-exist
+    command:
+      - juvix
+      - compile
+      - positive/NonExistingCompileFile.juvix
+    stderr:
+      contains: |
+        positive/NonExistingCompileFile.juvix" does not exist
+    exit-status: 1

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -179,7 +179,7 @@ tests:
     stdin: 'module Format; open import Stdlib.Prelude; main : Nat; main := 5; '
     stderr:
       contains: |
-        positive/NonExistingFormat.juvix: openFile: does not exist (No such file or directory)
+        positive/NonExistingFormat.juvix" does not exist
     exit-status: 1
 
   - name: format-stdin-module-name-not-file-name


### PR DESCRIPTION
Previously if you call Juvix on a file that doesn't exist you get the error:

```
$ juvix compile /i/don't/exist.juvix
juvix: /i/dont: changeWorkingDirectory: does not exist (No such file or directory)
```

After this change you will see:

```
$ juvix compile /i/don't/exist.juvix
The input path "/i/dont/exist.juvix" does not exist
```
