### PR TITLE
Add VampIR to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,22 @@ jobs:
         with:
           working-directory: smoke
 
-      - name: Install Smoke
-        shell: bash
-        run: |
-          cd smoke
-          stack install --stack-root ${{ steps.stack.outputs.stack-root }}
+      # - name: Install Smoke
+      #   shell: bash
+      #   run: |
+      #     cd smoke
+      #     stack install --stack-root ${{ steps.stack.outputs.stack-root }}
+
+      - name: Install Smoke for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: jonaprieto/smoke
+          platform: linux
+          tag: v2.3.2
+          chmod: 0755
+          rename-to: smoke
+          extension-matching: disable
+          cache: enable
 
       - name: Smoke testing
         id: smoke-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,100 +50,100 @@ jobs:
   build-and-test-linux:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout our repository
-        uses: actions/checkout@v3
-        with:
-          path: main
-          submodules: true
+      # - name: Checkout our repository
+      #   uses: actions/checkout@v3
+      #   with:
+      #     path: main
+      #     submodules: true
 
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@v3
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: "${{ runner.os }}-llvm-13"
+      # - name: Cache LLVM and Clang
+      #   id: cache-llvm
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       C:/Program Files/LLVM
+      #       ./llvm
+      #     key: "${{ runner.os }}-llvm-13"
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "13.0"
-          cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
+      # - name: Install LLVM and Clang
+      #   uses: KyleMayes/install-llvm-action@v1
+      #   with:
+      #     version: "13.0"
+      #     cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
 
-      - name: Download and extract wasi-sysroot
-        run: >
-          curl
-          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-          -OL
+      # - name: Download and extract wasi-sysroot
+      #   run: >
+      #     curl
+      #     https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+      #     -OL
 
-          tar xfv wasi-sysroot-15.0.tar.gz
+      #     tar xfv wasi-sysroot-15.0.tar.gz
 
-      - name: Set WASI_SYSROOT_PATH
-        run: |
-          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+      # - name: Set WASI_SYSROOT_PATH
+      #   run: |
+      #     echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      # - name: Add ~/.local/bin to PATH
+      #   run: |
+      #     echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v2
+      # - name: Setup Wasmer
+      #   uses: wasmerio/setup-wasmer@v2
 
-      - name: Install libncurses5
-        run: sudo apt install -y libncurses5
+      - name: Install libs
+        run: sudo apt install -y libncurses5 libicu70
 
-      - name: Install VampIR for testing
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: anoma/vamp-ir
-          platform: linux
-          tag: v0.1.2
-          chmod: 0755
-          rename-to: vamp-ir
-          extension-matching: disable
-          cache: enable
+      # - name: Install VampIR for testing
+      #   uses: jaxxstorm/action-install-gh-release@v1.10.0
+      #   with:
+      #     repo: anoma/vamp-ir
+      #     platform: linux
+      #     tag: v0.1.2
+      #     chmod: 0755
+      #     rename-to: vamp-ir
+      #     extension-matching: disable
+      #     cache: enable
 
-      - name: Test VampIR
-        shell: bash
-        run: |
-          vamp-ir --version
+      # - name: Test VampIR
+      #   shell: bash
+      #   run: |
+      #     vamp-ir --version
 
-      - name: Make runtime
-        run: |
-          cd main
-          make runtime
+      # - name: Make runtime
+      #   run: |
+      #     cd main
+      #     make runtime
 
-      - name: Stack setup
-        id: stack
-        uses: freckle/stack-action@v4
-        with:
-          working-directory: main
-          test: false
+      # - name: Stack setup
+      #   id: stack
+      #   uses: freckle/stack-action@v4
+      #   with:
+      #     working-directory: main
+      #     test: false
 
-      - name: Install and test Juvix
-        id: test
-        if: ${{ success() }}
-        run: |
-          cd main
-          make install
-          make test
+      # - name: Install and test Juvix
+      #   id: test
+      #   if: ${{ success() }}
+      #   run: |
+      #     cd main
+      #     make install
+      #     make test
 
-      - name: Typecheck and format Juvix examples
-        if: ${{ success() }}
-        shell: bash
-        run: |
-          cd main
-          make check-format-juvix-files && make typecheck-juvix-examples
+      # - name: Typecheck and format Juvix examples
+      #   if: ${{ success() }}
+      #   shell: bash
+      #   run: |
+      #     cd main
+      #     make check-format-juvix-files && make typecheck-juvix-examples
 
-      - uses: actions/checkout@v3
-        with:
-          repository: jonaprieto/smoke
-          path: smoke
+      # - uses: actions/checkout@v3
+      #   with:
+      #     repository: jonaprieto/smoke
+      #     path: smoke
 
-      - uses: freckle/stack-cache-action@v2
-        with:
-          working-directory: smoke
+      # - uses: freckle/stack-cache-action@v2
+      #   with:
+      #     working-directory: smoke
 
       # - name: Install Smoke
       #   shell: bash
@@ -167,7 +167,7 @@ jobs:
         if: ${{ success() }}
         run: |
           cd main
-          make smoke
+          make smoke-only
 
   build-and-test-macos:
     runs-on: macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,11 @@ jobs:
       - name: Set WASI_SYSROOT_PATH
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-
+          
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          
       - name: Install the latest Wasmer version
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -90,14 +94,11 @@ jobs:
           tag: v3.2.1
           binaries-location: bin
           rename-to: wasmer
+          chmod: 0755
           cache: enable
 
       - name: Install libicu for testing
         run: sudo apt install -y libicu66
-
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install VampIR for testing
         uses: jaxxstorm/action-install-gh-release@v1.10.0
@@ -196,6 +197,7 @@ jobs:
           repo: wasmerio/wasmer
           tag: v3.2.1
           binaries-location: bin
+          chmod: 0755
           rename-to: wasmer
           cache: enable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,21 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Install VampIR for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: anoma/vamp-ir
+          platform: linux
+          tag: latest
+          chmod: 0755
+          rename-to: vamp-ir
+          cache: true
+
+      - name: Test VampIR
+        shell: bash
+        run: |
+          vamp-ir --version
+
       - uses: actions/checkout@v3
         with:
           repository: jonaprieto/smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,6 @@ jobs:
           cd main
           make check-format-juvix-files && make typecheck-juvix-examples
 
-
-
       - uses: actions/checkout@v3
         with:
           repository: jonaprieto/smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v2
 
-      # - name: Install libicu for testing
-      #   run: sudo apt install -y libicu66
+      - name: Install libncurses5
+        run: sudo apt install -y libncurses5
 
       - name: Install VampIR for testing
         uses: jaxxstorm/action-install-gh-release@v1.10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,30 @@ jobs:
           repo: wasmerio/wasmer
           tag: v3.2.1
           binaries-location: bin
-          cache: true
+          cache: enable
 
       - name: Install libicu for testing
         run: sudo apt install -y libicu66
+
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install VampIR for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: anoma/vamp-ir
+          platform: linux
+          tag: latest
+          chmod: 0755
+          rename-to: vamp-ir
+          extension-matching: disable
+          cache: enable
+
+      - name: Test VampIR
+        shell: bash
+        run: |
+          vamp-ir --version
 
       - name: Make runtime
         run: |
@@ -121,25 +141,7 @@ jobs:
           cd main
           make check-format-juvix-files && make typecheck-juvix-examples
 
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Install VampIR for testing
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: anoma/vamp-ir
-          platform: linux
-          tag: latest
-          chmod: 0755
-          rename-to: vamp-ir
-          extension-matching: disable
-          cache: true
-
-      - name: Test VampIR
-        shell: bash
-        run: |
-          vamp-ir --version
 
       - uses: actions/checkout@v3
         with:
@@ -195,7 +197,7 @@ jobs:
           repo: wasmerio/wasmer
           tag: v3.2.1
           binaries-location: bin
-          cache: true
+          cache: enable
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |
@@ -217,6 +219,22 @@ jobs:
       - name: Add homebrew clang to the PATH (macOS)
         run: |
           echo "$(brew --prefix llvm@15)/bin" >> $GITHUB_PATH
+
+      - name: Install VampIR for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: anoma/vamp-ir
+          platform: linux
+          tag: latest
+          chmod: 0755
+          rename-to: vamp-ir
+          extension-matching: disable
+          cache: enable
+
+      - name: Test VampIR
+        shell: bash
+        run: |
+          vamp-ir --version
 
       - name: Install and test Juvix
         if: ${{ success() }}
@@ -244,6 +262,7 @@ jobs:
           extension-matching: disable
           rename-to: smoke
           chmod: 0755
+          cache: enable
 
       - name: Smoke testing (macOS)
         id: smoke-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,20 +82,13 @@ jobs:
       - name: Set WASI_SYSROOT_PATH
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-          
+
       - name: Add ~/.local/bin to PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          
-      - name: Install the latest Wasmer version
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: wasmerio/wasmer
-          tag: v3.2.1
-          binaries-location: bin
-          rename-to: wasmer
-          chmod: 0755
-          cache: enable
+
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v2
 
       - name: Install libicu for testing
         run: sudo apt install -y libicu66
@@ -191,15 +184,8 @@ jobs:
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      - name: Install the latest Wasmer version
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: wasmerio/wasmer
-          tag: v3.2.1
-          binaries-location: bin
-          chmod: 0755
-          rename-to: wasmer
-          cache: enable
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v2
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,100 +56,85 @@ jobs:
           path: main
           submodules: true
 
-      # - name: Cache LLVM and Clang
-      #   id: cache-llvm
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       C:/Program Files/LLVM
-      #       ./llvm
-      #     key: "${{ runner.os }}-llvm-13"
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v3
+        with:
+          path: |
+            C:/Program Files/LLVM
+            ./llvm
+          key: "${{ runner.os }}-llvm-13"
 
-      # - name: Install LLVM and Clang
-      #   uses: KyleMayes/install-llvm-action@v1
-      #   with:
-      #     version: "13.0"
-      #     cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "13.0"
+          cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
 
-      # - name: Download and extract wasi-sysroot
-      #   run: >
-      #     curl
-      #     https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-      #     -OL
+      - name: Download and extract wasi-sysroot
+        run: >
+          curl
+          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+          -OL
 
-      #     tar xfv wasi-sysroot-15.0.tar.gz
+          tar xfv wasi-sysroot-15.0.tar.gz
 
-      # - name: Set WASI_SYSROOT_PATH
-      #   run: |
-      #     echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+      - name: Set WASI_SYSROOT_PATH
+        run: |
+          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      # - name: Add ~/.local/bin to PATH
-      #   run: |
-      #     echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      # - name: Setup Wasmer
-      #   uses: wasmerio/setup-wasmer@v2
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v2
 
       - name: Install libs
-        run: sudo apt install -y libncurses5 glibc libicu-dev libncurses5 libtinfo5
+        run: sudo apt install -y libncurses5
 
-      # - name: Install VampIR for testing
-      #   uses: jaxxstorm/action-install-gh-release@v1.10.0
-      #   with:
-      #     repo: anoma/vamp-ir
-      #     platform: linux
-      #     tag: v0.1.2
-      #     chmod: 0755
-      #     rename-to: vamp-ir
-      #     extension-matching: disable
-      #     cache: enable
+      - name: Install VampIR for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: anoma/vamp-ir
+          platform: linux
+          tag: v0.1.2
+          chmod: 0755
+          rename-to: vamp-ir
+          extension-matching: disable
+          cache: enable
 
-      # - name: Test VampIR
-      #   shell: bash
-      #   run: |
-      #     vamp-ir --version
+      - name: Test VampIR
+        shell: bash
+        run: |
+          vamp-ir --version
 
-      # - name: Make runtime
-      #   run: |
-      #     cd main
-      #     make runtime
+      - name: Make runtime
+        run: |
+          cd main
+          make runtime
 
-      # - name: Stack setup
-      #   id: stack
-      #   uses: freckle/stack-action@v4
-      #   with:
-      #     working-directory: main
-      #     test: false
+      - name: Stack setup
+        id: stack
+        uses: freckle/stack-action@v4
+        with:
+          working-directory: main
+          test: false
 
-      # - name: Install and test Juvix
-      #   id: test
-      #   if: ${{ success() }}
-      #   run: |
-      #     cd main
-      #     make install
-      #     make test
+      - name: Install and test Juvix
+        id: test
+        if: ${{ success() }}
+        run: |
+          cd main
+          make install
+          make test
 
-      # - name: Typecheck and format Juvix examples
-      #   if: ${{ success() }}
-      #   shell: bash
-      #   run: |
-      #     cd main
-      #     make check-format-juvix-files && make typecheck-juvix-examples
-
-      # - uses: actions/checkout@v3
-      #   with:
-      #     repository: jonaprieto/smoke
-      #     path: smoke
-
-      # - uses: freckle/stack-cache-action@v2
-      #   with:
-      #     working-directory: smoke
-
-      # - name: Install Smoke
-      #   shell: bash
-      #   run: |
-      #     cd smoke
-      #     stack install --stack-root ${{ steps.stack.outputs.stack-root }}
+      - name: Typecheck and format Juvix examples
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          cd main
+          make check-format-juvix-files && make typecheck-juvix-examples
 
       - name: Install Smoke for testing
         uses: jaxxstorm/action-install-gh-release@v1.10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       #   uses: wasmerio/setup-wasmer@v2
 
       - name: Install libs
-        run: sudo apt install -y libncurses5 libicu70
+        run: sudo apt install -y libncurses5 libicu71
 
       # - name: Install VampIR for testing
       #   uses: jaxxstorm/action-install-gh-release@v1.10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       #   uses: wasmerio/setup-wasmer@v2
 
       - name: Install libs
-        run: sudo apt install -y libncurses5 libicu71
+        run: sudo apt install -y libncurses5 libicu-dev 
 
       # - name: Install VampIR for testing
       #   uses: jaxxstorm/action-install-gh-release@v1.10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
 
   build-and-test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout our repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           repo: wasmerio/wasmer
           tag: v3.2.1
           binaries-location: bin
+          rename-to: wasmer
           cache: enable
 
       - name: Install libicu for testing
@@ -195,6 +196,7 @@ jobs:
           repo: wasmerio/wasmer
           tag: v3.2.1
           binaries-location: bin
+          rename-to: wasmer
           cache: enable
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
           tag: latest
           chmod: 0755
           rename-to: vamp-ir
+          extension-matching: disable
           cache: true
 
       - name: Test VampIR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       #   uses: wasmerio/setup-wasmer@v2
 
       - name: Install libs
-        run: sudo apt install -y libncurses5 libicu-dev 
+        run: sudo apt install -y libncurses5 glibc libicu-dev libncurses5 libtinfo5
 
       # - name: Install VampIR for testing
       #   uses: jaxxstorm/action-install-gh-release@v1.10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
           repo: anoma/vamp-ir
-          platform: linux
+          platform: darwin
           tag: latest
           chmod: 0755
           rename-to: vamp-ir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,11 @@ jobs:
   build-and-test-linux:
     runs-on: ubuntu-22.04
     steps:
-      # - name: Checkout our repository
-      #   uses: actions/checkout@v3
-      #   with:
-      #     path: main
-      #     submodules: true
+      - name: Checkout our repository
+        uses: actions/checkout@v3
+        with:
+          path: main
+          submodules: true
 
       # - name: Cache LLVM and Clang
       #   id: cache-llvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           repo: anoma/vamp-ir
           platform: linux
-          tag: latest
+          tag: v0.1.2
           chmod: 0755
           rename-to: vamp-ir
           extension-matching: disable
@@ -223,7 +223,7 @@ jobs:
         with:
           repo: anoma/vamp-ir
           platform: darwin
-          tag: latest
+          tag: v0.1.2
           chmod: 0755
           rename-to: vamp-ir
           extension-matching: disable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v2
 
-      - name: Install libicu for testing
-        run: sudo apt install -y libicu66
+      # - name: Install libicu for testing
+      #   run: sudo apt install -y libicu66
 
       - name: Install VampIR for testing
         uses: jaxxstorm/action-install-gh-release@v1.10.0

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -320,10 +320,8 @@ instance PrettyPrint (UsingHiding 'Scoped) where
         Hiding {} -> ppCode kwHiding
       ppItems :: NonEmpty (Sem r ())
       ppItems = case uh of
-        Using s -> fmap ppUsingItem s
+        Using s -> fmap ppCode s
         Hiding s -> fmap ppCode s
-      ppUsingItem :: UsingItem 'Scoped -> Sem r ()
-      ppUsingItem ui = ppCode (ui ^. usingSymbol)
 
 instance PrettyPrint (UsingItem 'Scoped) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => UsingItem 'Scoped -> Sem r ()

--- a/tests/negative/Termination/Data/Nat.juvix
+++ b/tests/negative/Termination/Data/Nat.juvix
@@ -1,8 +1,8 @@
 module Data.Nat;
 
 type ℕ :=
-  zero : ℕ
-| suc : ℕ → ℕ;
+  | zero : ℕ
+  | suc : ℕ → ℕ;
 
 syntax infixl 6 +;
 + : ℕ → ℕ → ℕ;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -156,6 +156,8 @@ module Patterns;
   f (a, b, c, d) := a;
 end;
 
+import Stdlib.Prelude open using {Nat as Natural};
+
 module Comments;
   axiom a1 : Type;
   -- attached to a1


### PR DESCRIPTION
This PR:

- Makes `vamp-ir` available in the CI (pre-release 0.1.2)
- [Use a setup-wasmer action to install `wasmer`](https://github.com/marketplace/actions/setup-wasmer)
- Fixes cache option value for `jaxxstorm/action-install-gh-release`'s usages

Adds support for:

- #2103 


Related: 

- https://github.com/anoma/vamp-ir/issues/90