### PR TITLE
Modify `open import` syntax

### DIFF
--- a/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
@@ -5,9 +5,9 @@
 --- The module Logic.Game contains the game logic.
 module CLI.TicTacToe;
 
-open import Stdlib.Data.Nat.Ord;
-open import Stdlib.Prelude;
-open import Logic.Game;
+import Stdlib.Data.Nat.Ord open;
+import Stdlib.Prelude open;
+import Logic.Game open;
 
 --- A ;String; that prompts the user for their input
 prompt : GameState → String;

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -540,6 +540,7 @@ data OpenModule (s :: Stage) = OpenModule
   { _openModuleKw :: KeywordRef,
     _openModuleName :: ModuleRefType s,
     _openModuleImportKw :: Maybe KeywordRef,
+    _openImportAsName :: Maybe (ModulePathType s 'ModuleTop),
     _openUsingHiding :: Maybe UsingHiding,
     _openPublic :: PublicAnn
   }
@@ -548,6 +549,7 @@ deriving stock instance
   ( Eq (IdentifierType s),
     Eq (SymbolType s),
     Eq (ModuleRefType s),
+    Eq (ModulePathType s 'ModuleTop),
     Eq (PatternType s),
     Eq (ExpressionType s)
   ) =>
@@ -557,6 +559,7 @@ deriving stock instance
   ( Ord (IdentifierType s),
     Ord (SymbolType s),
     Ord (PatternType s),
+    Ord (ModulePathType s 'ModuleTop),
     Ord (ModuleRefType s),
     Ord (ExpressionType s)
   ) =>
@@ -565,6 +568,7 @@ deriving stock instance
 deriving stock instance
   ( Show (IdentifierType s),
     Show (ModuleRefType s),
+    Show (ModulePathType s 'ModuleTop),
     Show (ExpressionType s)
   ) =>
   Show (OpenModule s)

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -530,6 +530,9 @@ data SymbolEntry
   | EntryVariable (S.Name' ())
   deriving stock (Show)
 
+instance SingI t => CanonicalProjection (ModuleRef'' c t) (ModuleRef' c) where
+  project r = ModuleRef' (sing :&: r)
+
 -- | Symbols that a module exports
 newtype ExportInfo = ExportInfo
   { _exportSymbols :: HashMap Symbol SymbolEntry

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -351,6 +351,7 @@ instance (SingI s) => PrettyCode (OpenModule s) where
     openUsingHiding' <- mapM ppUsingHiding _openUsingHiding
     importkw' <- mapM ppCode _openModuleImportKw
     let openPublic' = ppPublic
+    alias' <- fmap (kwAs <+>) <$> mapM ppModulePathType _openImportAsName
     return $ case importkw' of
       Nothing ->
         kwOpen
@@ -360,6 +361,7 @@ instance (SingI s) => PrettyCode (OpenModule s) where
       Just importkw ->
         importkw
           <+> openModuleName'
+          <+?> alias'
           <+> kwOpen
           <+?> openUsingHiding'
           <+?> openPublic'

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -351,7 +351,18 @@ instance (SingI s) => PrettyCode (OpenModule s) where
     openUsingHiding' <- mapM ppUsingHiding _openUsingHiding
     importkw' <- mapM ppCode _openModuleImportKw
     let openPublic' = ppPublic
-    return $ kwOpen <+?> importkw' <+> openModuleName' <+?> openUsingHiding' <+?> openPublic'
+    return $ case importkw' of
+      Nothing ->
+        kwOpen
+          <+> openModuleName'
+          <+?> openUsingHiding'
+          <+?> openPublic'
+      Just importkw ->
+        importkw
+          <+> openModuleName'
+          <+> kwOpen
+          <+?> openUsingHiding'
+          <+?> openPublic'
     where
       ppUsingHiding :: UsingHiding -> Sem r (Doc Ann)
       ppUsingHiding uh = do

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -284,6 +284,7 @@ instance PrettyPrint (OpenModule 'Scoped) where
         usingHiding' = ppCode <$> _openUsingHiding
         importkw' = ppCode <$> _openModuleImportKw
         openkw = ppCode _openModuleKw
+        alias' = (noLoc P.kwAs <+>) . ppCode <$> _openImportAsName
         public' = case _openPublic of
           Public -> Just (noLoc P.kwPublic)
           NoPublic -> Nothing
@@ -291,11 +292,13 @@ instance PrettyPrint (OpenModule 'Scoped) where
       Nothing -> do
         openkw
           <+> name'
+          <+?> alias'
           <+?> usingHiding'
           <+?> public'
       Just importkw ->
         importkw
           <+> name'
+          <+?> alias'
           <+> openkw
           <+?> usingHiding'
           <+?> public'

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -283,14 +283,22 @@ instance PrettyPrint (OpenModule 'Scoped) where
     let name' = ppCode _openModuleName
         usingHiding' = ppCode <$> _openUsingHiding
         importkw' = ppCode <$> _openModuleImportKw
+        openkw = ppCode _openModuleKw
         public' = case _openPublic of
           Public -> Just (noLoc P.kwPublic)
           NoPublic -> Nothing
-    ppCode _openModuleKw
-      <+?> importkw'
-      <+> name'
-      <+?> usingHiding'
-      <+?> public'
+    case importkw' of
+      Nothing -> do
+        openkw
+          <+> name'
+          <+?> usingHiding'
+          <+?> public'
+      Just importkw ->
+        importkw
+          <+> name'
+          <+> openkw
+          <+?> usingHiding'
+          <+?> public'
 
 instance PrettyPrint (FunctionClause 'Scoped) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => FunctionClause 'Scoped -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -292,7 +292,6 @@ instance PrettyPrint (OpenModule 'Scoped) where
       Nothing -> do
         openkw
           <+> name'
-          <+?> alias'
           <+?> usingHiding'
           <+?> public'
       Just importkw ->

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -756,7 +756,12 @@ checkOpenImportModule ::
 checkOpenImportModule op
   | Just k <- op ^. openModuleImportKw =
       let import_ :: Import 'Parsed
-          import_ = Import k (moduleNameToTopModulePath (op ^. openModuleName)) Nothing
+          import_ =
+            Import
+              { _importKw = k,
+                _importModule = moduleNameToTopModulePath (op ^. openModuleName),
+                _importAsName = op ^. openImportAsName
+              }
        in do
             void (checkImport import_)
             scopedOpen <- checkOpenModule (set openModuleImportKw Nothing op)
@@ -773,6 +778,7 @@ checkOpenModuleNoImport OpenModule {..}
   | otherwise = do
       openModuleName'@(ModuleRef' (_ :&: moduleRef'')) <- lookupModuleSymbol _openModuleName
       mergeScope (alterScope (moduleRef'' ^. moduleExportInfo))
+      let _openImportAsName :: Maybe S.TopModulePath = Nothing
       registerName (moduleRef'' ^. moduleRefName)
       return
         OpenModule

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -764,7 +764,10 @@ checkOpenImportModule op
               }
        in do
             void (checkImport import_)
-            scopedOpen <- checkOpenModule (set openModuleImportKw Nothing op)
+            let changeOpenName = case op ^. openImportAsName of
+                  Nothing -> id
+                  Just o -> set openModuleName (topModulePathToName o)
+            scopedOpen <- checkOpenModule (set openModuleImportKw Nothing (changeOpenName op))
             return (set openModuleImportKw (Just k) scopedOpen)
   | otherwise = impossible
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -769,8 +769,11 @@ openModule = do
   _openParameters <- many atomicExpression
   _openUsingHiding <- optional usingOrHiding
   _openPublic <- maybe NoPublic (const Public) <$> optional (kw kwPublic)
-  let _openImportAsName = Nothing
-  return OpenModule {..}
+  return
+    OpenModule
+      { _openImportAsName = Nothing,
+        ..
+      }
 
 usingOrHiding :: (Members '[Error ParserError, InfoTableBuilder, JudocStash, NameIdGen, PragmasStash] r) => ParsecS r UsingHiding
 usingOrHiding =

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -226,5 +226,9 @@ tests =
     PosTest
       "Pragmas"
       $(mkRelDir ".")
-      $(mkRelFile "Pragmas.juvix")
+      $(mkRelFile "Pragmas.juvix"),
+    PosTest
+      "Import as open"
+      $(mkRelDir "ImportAsOpen")
+      $(mkRelFile "Main.juvix")
   ]

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -1,7 +1,7 @@
 module Format;
 
-open import Stdlib.Prelude hiding {,};
-open import Stdlib.Data.Nat.Ord;
+import Stdlib.Prelude open hiding {,};
+import Stdlib.Data.Nat.Ord open;
 
 terminating
 go : Nat → Nat → Nat;
@@ -149,7 +149,7 @@ module Patterns;
   infixr 4 ,;
   type × (A : Type) (B : Type) :=
     | , : A → B → A × B;
-  
+
   f : Nat × Nat × Nat × Nat -> Nat;
   f (a, b, c, d) := a;
 end;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -149,7 +149,7 @@ module Patterns;
   infixr 4 ,;
   type × (A : Type) (B : Type) :=
     | , : A → B → A × B;
-
+  
   f : Nat × Nat × Nat × Nat -> Nat;
   f (a, b, c, d) := a;
 end;

--- a/tests/positive/ImportAsOpen/Main.juvix
+++ b/tests/positive/ImportAsOpen/Main.juvix
@@ -1,0 +1,9 @@
+module Main;
+
+import Other as O open;
+
+B : Type;
+B := A;
+
+B' : Type;
+B' := O.A;

--- a/tests/positive/ImportAsOpen/Other.juvix
+++ b/tests/positive/ImportAsOpen/Other.juvix
@@ -1,0 +1,3 @@
+module Other;
+
+axiom A : Type;

--- a/tests/positive/ImportShadow/Main.juvix
+++ b/tests/positive/ImportShadow/Main.juvix
@@ -1,6 +1,6 @@
 module Main;
 
-open import Nat;
+import Nat open;
 
 type Unit :=
   | unit : Unit;
@@ -13,7 +13,9 @@ f :=
 f2 : Nat;
 f2 :=
   case suc zero
-    | suc is-zero := zero;
+    | suc is-zero := zero
+    | _ := zero;
 
 f3 : Nat → Nat;
 f3 (suc is-zero) := is-zero;
+f3 zero := zero;

--- a/tests/positive/Internal/Case.juvix
+++ b/tests/positive/Internal/Case.juvix
@@ -1,6 +1,6 @@
 module Case;
 
-open import Stdlib.Prelude;
+import Stdlib.Prelude open;
 
 isZero : Nat → Bool;
 isZero n :=

--- a/tests/positive/Pragmas.juvix
+++ b/tests/positive/Pragmas.juvix
@@ -1,7 +1,7 @@
 {-# unknownPragma: 300 #-}
 module Pragmas;
 
-open import Stdlib.Prelude;
+import Stdlib.Prelude open;
 
 {-# unknownPragma: 0 #-}
 axiom a : Nat;

--- a/tests/positive/SignatureWithBody.juvix
+++ b/tests/positive/SignatureWithBody.juvix
@@ -1,6 +1,6 @@
 module SignatureWithBody;
 
-open import Stdlib.Prelude;
+import Stdlib.Prelude open;
 
 isNull :
   {A : Type} → List A → Bool :=

--- a/tests/positive/Symbols.juvix
+++ b/tests/positive/Symbols.juvix
@@ -1,6 +1,6 @@
 module Symbols;
 
-open import Stdlib.Data.Nat;
+import Stdlib.Data.Nat open;
 
 ╘⑽╛ : Nat;
 ╘⑽╛ := suc 9;

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -159,7 +159,7 @@ tests:
       - --stdin
       - format
       - positive/Format.juvix
-    stdin: 'module Format; open import Stdlib.Prelude; main : Nat; main := 5; '
+    stdin: 'module Format; import Stdlib.Prelude open; main : Nat; main := 5; '
     stdout:
       contains: |
         module Format;
@@ -176,7 +176,7 @@ tests:
       - --stdin
       - format
       - positive/NonExistingFormat.juvix
-    stdin: 'module Format; open import Stdlib.Prelude; main : Nat; main := 5; '
+    stdin: 'module Format; import Stdlib.Prelude open; main : Nat; main := 5; '
     stderr:
       contains: |
         positive/NonExistingFormat.juvix" does not exist
@@ -188,7 +188,7 @@ tests:
       - --stdin
       - format
       - positive/Format.juvix
-    stdin: 'module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; '
+    stdin: 'module OtherFormat; import Stdlib.Prelude open; main : Nat; main := 5; '
     stderr:
       contains: 'is defined in the file'
     exit-status: 1
@@ -203,7 +203,7 @@ tests:
       contains: |
         module OtherFormat;
 
-        open import Stdlib.Prelude;
+        import Stdlib.Prelude open;
 
         main : Nat;
         main := 5;
@@ -213,7 +213,7 @@ tests:
     command:
       - juvix
       - format
-    stdin: 'module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5;; '
+    stdin: 'module OtherFormat; import Stdlib.Prelude open; main : Nat; main := 5module OtherFormat; import Stdlib.Prelude open; main : Nat; main := 5;; '
     stdout:
       contains: juvix format error
     exit-status: 1

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -164,7 +164,7 @@ tests:
       contains: |
         module Format;
 
-        open import Stdlib.Prelude;
+        import Stdlib.Prelude open;
 
         main : Nat;
         main := 5;
@@ -198,7 +198,7 @@ tests:
       - juvix
       - --stdin
       - format
-    stdin: 'module OtherFormat; open import Stdlib.Prelude; main : Nat; main := 5; '
+    stdin: 'module OtherFormat; import Stdlib.Prelude open; main : Nat; main := 5; '
     stdout:
       contains: |
         module OtherFormat;


### PR DESCRIPTION
- Closes #2088 
- Closes #2013 

This pr implements the syntax changes proposed in #2088.
It also makes it possible to combine `import as` and `open` in the same statement. Note that this was unsupported until now. E.g. 
```
import Stdlib.List as List open;
```
Which is equivalent to:
```
import Stdlib.List as List;
open List;
```

The old syntax is still supported by the parser, but the formatter will always print code in the new syntax.
Since this leaves the parser in a temporary state, I didn't think it was worth to put a lot of effort on it, so I have left a temporary `P.try (StatementOpenModule <$> newOpenSyntax)` which tries to parse the new syntax. This `try` will need to be removed when we remove the old syntax. Also, we will need to update the `HasLoc` instance for `open` statements to reflect the syntax changes.

I have formatted only the formatting tests. The rest of the juvix files should be formatted in an isolated pr.