### PR TITLE
Fix extra whitespace in text rendering of indented empty lines

### DIFF
--- a/app/Commands/Dev/Geb/Repl/Format.hs
+++ b/app/Commands/Dev/Geb/Repl/Format.hs
@@ -23,7 +23,7 @@ instance HasAnsiBackend ReplMessageDoc where
 
 instance HasTextBackend ReplMessageDoc where
   toTextDoc (ReplMessageDoc o) = unAnnotate o
-  toTextStream (ReplMessageDoc o) = unAnnotateS (layoutPretty defaultLayoutOptions o)
+  toTextStream (ReplMessageDoc o) = layoutPretty defaultLayoutOptions (unAnnotate o)
 
 stylize :: ReplStyle -> AnsiStyle
 stylize = \case

--- a/src/Juvix/Data/PPOutput.hs
+++ b/src/Juvix/Data/PPOutput.hs
@@ -15,7 +15,7 @@ instance HasAnsiBackend PPOutput where
 
 instance HasTextBackend PPOutput where
   toTextDoc (PPOutput o) = unAnnotate o
-  toTextStream (PPOutput o) = unAnnotateS (layoutPretty defaultLayoutOptions o)
+  toTextStream (PPOutput o) = layoutPretty defaultLayoutOptions (unAnnotate o)
 
 ppOutput :: Doc Ann -> AnsiText
 ppOutput = AnsiText . PPOutput

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -58,7 +58,7 @@ instance HasAnsiBackend AnsiText where
 
 instance HasTextBackend (Doc a) where
   toTextDoc = unAnnotate
-  toTextStream = unAnnotateS . layoutPretty defaultLayoutOptions
+  toTextStream = layoutPretty defaultLayoutOptions . unAnnotate
 
 instance HasAnsiBackend (Doc Ansi.AnsiStyle) where
   toAnsiDoc = id

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -149,7 +149,7 @@ module Patterns;
   infixr 4 ,;
   type × (A : Type) (B : Type) :=
     | , : A → B → A × B;
-  
+
   f : Nat × Nat × Nat × Nat -> Nat;
   f (a, b, c, d) := a;
 end;


### PR DESCRIPTION
The prettyprinter library takes care avoid adding whitespace to empty lines when it is rendering indented text.

See:

https://github.com/quchen/prettyprinter/blob/7e32c010ecfaa510c0cbf6ffea04bc7db95d4fcb/prettyprinter/src/Prettyprinter/Internal.hs#L1999

However it only does this for unannotated text.

In our code we were stripping annotations from renderings within `toTextStream` but we must remove the annotations before calling `layoutPretty` to get the proper handling of whitespace with indentations. That's what this PR does.