### PR TITLE
Add syntax for Judoc blocks

### DIFF
--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -360,7 +360,8 @@ goJudoc (Judoc bs) = mconcatMapM goBlock bs
   where
     goBlock :: JudocBlock 'Scoped -> Sem r Html
     goBlock = \case
-      JudocParagraph ls -> Html.p . concatWith (\l r -> l <> " " <> r) <$> mapM goLine (toList ls)
+      JudocParagraphLines ls -> Html.p . concatWith (\l r -> l <> " " <> r) <$> mapM goLine (toList ls)
+      JudocParagraphBlock {} -> undefined
       JudocExample e -> goExample e
 
     goLine :: JudocParagraphLine 'Scoped -> Sem r Html

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -356,12 +356,19 @@ goJudocMay :: (Members '[Reader HtmlOptions, Reader NormalizedTable] r) => Maybe
 goJudocMay = maybe (return mempty) goJudoc
 
 goJudoc :: forall r. (Members '[Reader HtmlOptions, Reader NormalizedTable] r) => Judoc 'Scoped -> Sem r Html
-goJudoc (Judoc bs) = mconcatMapM goBlock bs
+goJudoc (Judoc bs) = mconcatMapM goGroup bs
   where
+    goGroup :: JudocGroup 'Scoped -> Sem r Html
+    goGroup = \case
+      JudocGroupLines l -> mconcatMapM goBlock l
+      JudocGroupBlock l -> goGroupBlock l
+
+    goGroupBlock :: JudocBlockParagraph 'Scoped -> Sem r Html
+    goGroupBlock = mconcatMap goBlock . (^. judocBlockParagraphBlocks)
+
     goBlock :: JudocBlock 'Scoped -> Sem r Html
     goBlock = \case
       JudocParagraphLines ls -> Html.p . concatWith (\l r -> l <> " " <> r) <$> mapM goLine (toList ls)
-      JudocParagraphBlock {} -> undefined
       JudocExample e -> goExample e
 
     goLine :: JudocParagraphLine 'Scoped -> Sem r Html

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/PrettyJudoc.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/PrettyJudoc.hs
@@ -54,7 +54,8 @@ ppJudoc (Judoc bs) = do
 
     ppBlock :: JudocBlock 'Scoped -> Sem r (Doc CodeAnn)
     ppBlock = \case
-      JudocParagraph ls -> hsep <$> mapM ppLine (toList ls)
+      JudocParagraphLines ls -> hsep <$> mapM ppLine (toList ls)
+      JudocParagraphBlock ls -> undefined
       JudocExample {} -> return mempty
 
     ppLine :: JudocParagraphLine 'Scoped -> Sem r (Doc CodeAnn)

--- a/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
@@ -31,10 +31,10 @@ registerKeyword r =
           _parsedTag = ann
         }
   where
-  ann = case r ^. keywordRefKeyword . keywordType of
-    KeywordTypeKeyword -> ParsedTagKeyword
-    KeywordTypeJudoc -> ParsedTagJudoc
-    KeywordTypeDelimiter -> ParsedTagDelimiter
+    ann = case r ^. keywordRefKeyword . keywordType of
+      KeywordTypeKeyword -> ParsedTagKeyword
+      KeywordTypeJudoc -> ParsedTagJudoc
+      KeywordTypeDelimiter -> ParsedTagDelimiter
 
 registerDelimiter :: Member InfoTableBuilder r => Interval -> Sem r ()
 registerDelimiter i =

--- a/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ParsedInfoTableBuilder.hs
@@ -28,8 +28,13 @@ registerKeyword r =
     <$ registerItem
       ParsedItem
         { _parsedLoc = getLoc r,
-          _parsedTag = ParsedTagKeyword
+          _parsedTag = ann
         }
+  where
+  ann = case r ^. keywordRefKeyword . keywordType of
+    KeywordTypeKeyword -> ParsedTagKeyword
+    KeywordTypeJudoc -> ParsedTagJudoc
+    KeywordTypeDelimiter -> ParsedTagDelimiter
 
 registerDelimiter :: Member InfoTableBuilder r => Interval -> Sem r ()
 registerDelimiter i =

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -7,10 +7,10 @@ where
 
 import Juvix.Data.Keyword
 import Juvix.Data.Keyword.All
-  (
-    -- delimiters
-    delimJudocBlockStart,
+  ( -- delimiters
+
     delimJudocBlockEnd,
+    delimJudocBlockStart,
     delimJudocStart,
     -- keywords
     kwAs,

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -7,9 +7,12 @@ where
 
 import Juvix.Data.Keyword
 import Juvix.Data.Keyword.All
-  ( -- reserved
-
-    -- extra
+  (
+    -- delimiters
+    delimJudocBlockStart,
+    delimJudocBlockEnd,
+    delimJudocStart,
+    -- keywords
     kwAs,
     kwAssign,
     kwAt,

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -917,10 +917,10 @@ deriving stock instance (Eq (ExpressionType s)) => Eq (Example s)
 
 deriving stock instance (Ord (ExpressionType s)) => Ord (Example s)
 
-data JudocBlockParagraph (s :: Stage) = JudocBlockParagraph {
-  _judocBlockParagraphStart :: KeywordRef,
-  _judocBlockParagraphBlocks :: [JudocBlock s],
-  _judocBlockParagraphEnd :: KeywordRef
+data JudocBlockParagraph (s :: Stage) = JudocBlockParagraph
+  { _judocBlockParagraphStart :: KeywordRef,
+    _judocBlockParagraphBlocks :: [JudocBlock s],
+    _judocBlockParagraphEnd :: KeywordRef
   }
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocBlockParagraph s)

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -895,7 +895,7 @@ data ExpressionAtoms (s :: Stage) = ExpressionAtoms
   }
 
 newtype Judoc (s :: Stage) = Judoc
-  { _block :: NonEmpty (JudocBlock s)
+  { _judocGroups :: NonEmpty (JudocGroup s)
   }
   deriving newtype (Semigroup)
 
@@ -918,9 +918,9 @@ deriving stock instance (Eq (ExpressionType s)) => Eq (Example s)
 deriving stock instance (Ord (ExpressionType s)) => Ord (Example s)
 
 data JudocBlockParagraph (s :: Stage) = JudocBlockParagraph {
-  _judocBlockParagraphStart :: Interval,
-  _judocBlockParagraphLines :: [JudocParagraphLine s],
-  _judocBlockParagraphEnd :: Interval
+  _judocBlockParagraphStart :: KeywordRef,
+  _judocBlockParagraphBlocks :: [JudocBlock s],
+  _judocBlockParagraphEnd :: KeywordRef
   }
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocBlockParagraph s)
@@ -929,9 +929,18 @@ deriving stock instance (Eq (ExpressionType s), Eq (SymbolType s)) => Eq (JudocB
 
 deriving stock instance (Ord (ExpressionType s), Ord (SymbolType s)) => Ord (JudocBlockParagraph s)
 
+data JudocGroup (s :: Stage)
+  = JudocGroupBlock (JudocBlockParagraph s)
+  | JudocGroupLines (NonEmpty (JudocBlock s))
+
+deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocGroup s)
+
+deriving stock instance (Eq (ExpressionType s), Eq (SymbolType s)) => Eq (JudocGroup s)
+
+deriving stock instance (Ord (ExpressionType s), Ord (SymbolType s)) => Ord (JudocGroup s)
+
 data JudocBlock (s :: Stage)
   = JudocParagraphLines (NonEmpty (JudocParagraphLine s))
-  | JudocParagraphBlock (JudocBlockParagraph s)
   | JudocExample (Example s)
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocBlock s)
@@ -1207,12 +1216,16 @@ instance HasLoc (Judoc s) where
   getLoc (Judoc j) = getLocSpan j
 
 instance HasLoc (JudocBlockParagraph s) where
-  getLoc p = p ^. judocBlockParagraphStart <> p ^. judocBlockParagraphEnd
+  getLoc p = getLoc (p ^. judocBlockParagraphStart) <> getLoc (p ^. judocBlockParagraphEnd)
+
+instance HasLoc (JudocGroup s) where
+  getLoc = \case
+    JudocGroupBlock l -> getLoc l
+    JudocGroupLines l -> getLocSpan l
 
 instance HasLoc (JudocBlock s) where
   getLoc = \case
     JudocParagraphLines ls -> getLocSpan ls
-    JudocParagraphBlock p -> getLoc p
     JudocExample e -> getLoc e
 
 instance HasLoc (JudocParagraphLine s) where
@@ -1529,10 +1542,18 @@ entryIsExpression = \case
   EntryModule {} -> False
 
 judocExamples :: Judoc s -> [Example s]
-judocExamples (Judoc bs) = concatMap go bs
+judocExamples (Judoc bs) = concatMap goGroup bs
   where
-    go :: JudocBlock s -> [Example s]
-    go = \case
+    goGroup :: JudocGroup s -> [Example s]
+    goGroup = \case
+      JudocGroupBlock p -> goParagraph p
+      JudocGroupLines l -> concatMap goBlock l
+
+    goParagraph :: JudocBlockParagraph s -> [Example s]
+    goParagraph l = concatMap goBlock (l ^. judocBlockParagraphBlocks)
+
+    goBlock :: JudocBlock s -> [Example s]
+    goBlock = \case
       JudocExample e -> [e]
       _ -> mempty
 

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -917,8 +917,21 @@ deriving stock instance (Eq (ExpressionType s)) => Eq (Example s)
 
 deriving stock instance (Ord (ExpressionType s)) => Ord (Example s)
 
+data JudocBlockParagraph (s :: Stage) = JudocBlockParagraph {
+  _judocBlockParagraphStart :: Interval,
+  _judocBlockParagraphLines :: [JudocParagraphLine s],
+  _judocBlockParagraphEnd :: Interval
+  }
+
+deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocBlockParagraph s)
+
+deriving stock instance (Eq (ExpressionType s), Eq (SymbolType s)) => Eq (JudocBlockParagraph s)
+
+deriving stock instance (Ord (ExpressionType s), Ord (SymbolType s)) => Ord (JudocBlockParagraph s)
+
 data JudocBlock (s :: Stage)
-  = JudocParagraph (NonEmpty (JudocParagraphLine s))
+  = JudocParagraphLines (NonEmpty (JudocParagraphLine s))
+  | JudocParagraphBlock (JudocBlockParagraph s)
   | JudocExample (Example s)
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (JudocBlock s)
@@ -951,6 +964,7 @@ makeLenses ''Example
 makeLenses ''Lambda
 makeLenses ''LambdaClause
 makeLenses ''Judoc
+makeLenses ''JudocBlockParagraph
 makeLenses ''Function
 makeLenses ''InductiveDef
 makeLenses ''PostfixApplication
@@ -1192,9 +1206,13 @@ instance HasLoc (Example s) where
 instance HasLoc (Judoc s) where
   getLoc (Judoc j) = getLocSpan j
 
+instance HasLoc (JudocBlockParagraph s) where
+  getLoc p = p ^. judocBlockParagraphStart <> p ^. judocBlockParagraphEnd
+
 instance HasLoc (JudocBlock s) where
   getLoc = \case
-    JudocParagraph ls -> getLocSpan ls
+    JudocParagraphLines ls -> getLocSpan ls
+    JudocParagraphBlock p -> getLoc p
     JudocExample e -> getLoc e
 
 instance HasLoc (JudocParagraphLine s) where

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -296,15 +296,10 @@ instance PrettyCode S.NameId where
   ppCode (S.NameId k) = return (pretty k)
 
 instance PrettyCode KeywordRef where
-  ppCode = ppCode . (^. keywordRefKeyword)
+  ppCode p = return . annotate (kwTypeAnn (p ^. keywordRefKeyword . keywordType)) . pretty $ p
 
 instance PrettyCode Keyword where
-  ppCode p = return . annotate ann . pretty $ p
-    where
-      ann = case p ^. keywordType of
-        KeywordTypeDelimiter -> AnnDelimiter
-        KeywordTypeKeyword -> AnnKeyword
-        KeywordTypeJudoc -> AnnJudoc
+  ppCode p = return . annotate (kwTypeAnn (p ^. keywordType)) . pretty $ p
 
 annDef :: forall s. SingI s => SymbolType s -> Doc Ann -> Doc Ann
 annDef nm = case sing :: SStage s of

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -399,7 +399,8 @@ instance (SingI s) => PrettyCode (Example s) where
 
 instance (SingI s) => PrettyCode (JudocBlock s) where
   ppCode = \case
-    JudocParagraph l -> vsep <$> mapM ppCode l
+    JudocParagraphLines l -> vsep <$> mapM ppCode l
+    JudocParagraphBlock {} -> undefined
     JudocExample e -> ppCode e
 
 instance (SingI s) => PrettyCode (JudocParagraphLine s) where

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -9,6 +9,7 @@ import Data.List.NonEmpty.Extra qualified as NonEmpty
 import Juvix.Compiler.Concrete.Data.ScopedName (AbsModulePath, IsConcrete (..))
 import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
 import Juvix.Compiler.Concrete.Extra (unfoldApplication)
+import Juvix.Compiler.Concrete.Keywords (delimJudocStart)
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Pretty.Options
 import Juvix.Data.Ape
@@ -16,7 +17,6 @@ import Juvix.Data.CodeAnn
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
 import Juvix.Prelude.Pretty qualified as PP
-import Juvix.Compiler.Concrete.Keywords (delimJudocStart)
 
 doc :: (PrettyCode c) => Options -> c -> Doc Ann
 doc opts =
@@ -301,10 +301,10 @@ instance PrettyCode KeywordRef where
 instance PrettyCode Keyword where
   ppCode p = return . annotate ann . pretty $ p
     where
-    ann = case p ^. keywordType of
-      KeywordTypeDelimiter -> AnnDelimiter
-      KeywordTypeKeyword -> AnnKeyword
-      KeywordTypeJudoc -> AnnJudoc
+      ann = case p ^. keywordType of
+        KeywordTypeDelimiter -> AnnDelimiter
+        KeywordTypeKeyword -> AnnKeyword
+        KeywordTypeJudoc -> AnnJudoc
 
 annDef :: forall s. SingI s => SymbolType s -> Doc Ann -> Doc Ann
 annDef nm = case sing :: SStage s of
@@ -396,8 +396,8 @@ ppJudocStart :: Members '[Reader Options] r => Sem r (Maybe (Doc Ann))
 ppJudocStart = do
   i <- asks (^. optInJudocBlock)
   if
-    | i -> Just <$> ppCode delimJudocStart
-    | otherwise -> return Nothing
+      | i -> Just <$> ppCode delimJudocStart
+      | otherwise -> return Nothing
 
 ppJudocExampleStart :: Doc Ann
 ppJudocExampleStart = pretty (Str.judocExample :: Text)
@@ -420,11 +420,11 @@ instance SingI s => PrettyCode (JudocBlock s) where
     JudocParagraphLines l -> vsep <$> mapM ppStandaloneLine l
     JudocExample e -> ppCode e
     where
-    ppStandaloneLine :: (Members '[Reader Options] r) => JudocParagraphLine s -> Sem r (Doc Ann)
-    ppStandaloneLine l = do
-      atoms' <- ppCode l
-      prefix <- ppJudocStart
-      return (prefix <?+> atoms')
+      ppStandaloneLine :: (Members '[Reader Options] r) => JudocParagraphLine s -> Sem r (Doc Ann)
+      ppStandaloneLine l = do
+        atoms' <- ppCode l
+        prefix <- ppJudocStart
+        return (prefix <?+> atoms')
 
 instance (SingI s) => PrettyCode (JudocParagraphLine s) where
   ppCode (JudocParagraphLine atoms) = mconcatMap ppCode atoms

--- a/src/Juvix/Compiler/Concrete/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Options.hs
@@ -4,14 +4,16 @@ import Juvix.Prelude
 
 data Options = Options
   { _optShowNameIds :: Bool,
-    _optNoApe :: Bool
+    _optNoApe :: Bool,
+    _optInJudocBlock :: Bool
   }
 
 defaultOptions :: Options
 defaultOptions =
   Options
     { _optShowNameIds = False,
-      _optNoApe = False
+      _optNoApe = False,
+      _optInJudocBlock = False
     }
 
 makeLenses ''Options
@@ -23,3 +25,6 @@ fromGenericOptions GenericOptions {..} =
       optNoApe
       _genericNoApe
       defaultOptions
+
+inJudocBlock :: Members '[Reader Options] r => Sem r a -> Sem r a
+inJudocBlock = local (set optInJudocBlock True)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -171,7 +171,8 @@ instance PrettyPrint (Judoc 'Scoped) where
 
 instance PrettyPrint (JudocBlock 'Scoped) where
   ppCode = \case
-    JudocParagraph l -> vsep (ppCode <$> l)
+    JudocParagraphLines l -> vsep (ppCode <$> l)
+    JudocParagraphBlock {} -> undefined
     JudocExample e -> ppCode e
 
 instance PrettyPrint (JudocAtom 'Scoped) where

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -156,8 +156,8 @@ ppJudocStart :: Members '[ExactPrint, Reader Options] r => Sem r (Maybe ())
 ppJudocStart = do
   inBlock <- asks (^. optInJudocBlock)
   if
-    | inBlock -> return Nothing
-    | otherwise -> ppCode delimJudocStart $> Just ()
+      | inBlock -> return Nothing
+      | otherwise -> ppCode delimJudocStart $> Just ()
 
 instance PrettyPrint (Example 'Scoped) where
   ppCode e =
@@ -188,10 +188,10 @@ instance PrettyPrint (JudocGroup 'Scoped) where
     JudocGroupLines l -> goLines l
     JudocGroupBlock l -> ppCode l
     where
-    goLines blocks = sequenceWith paragraphSep (fmap ppCode blocks) >> line
-     where
-      paragraphSep :: Sem r ()
-      paragraphSep = line >> ppJudocStart >> line
+      goLines blocks = sequenceWith paragraphSep (fmap ppCode blocks) >> line
+        where
+          paragraphSep :: Sem r ()
+          paragraphSep = line >> ppJudocStart >> line
 
 instance PrettyPrint (JudocBlock 'Scoped) where
   ppCode = \case

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1195,7 +1195,15 @@ checkJudoc ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>
   Judoc 'Parsed ->
   Sem r (Judoc 'Scoped)
-checkJudoc (Judoc atoms) = Judoc <$> mapM checkJudocBlock atoms
+checkJudoc (Judoc groups) = Judoc <$> mapM checkJudocGroup groups
+
+checkJudocGroup ::
+  (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>
+  JudocGroup 'Parsed ->
+  Sem r (JudocGroup 'Scoped)
+checkJudocGroup = \case
+  JudocGroupBlock b -> JudocGroupBlock <$> checkJudocBlockParagraph b
+  JudocGroupLines l -> JudocGroupLines <$> mapM checkJudocBlock l
 
 checkJudocBlock ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>
@@ -1203,14 +1211,13 @@ checkJudocBlock ::
   Sem r (JudocBlock 'Scoped)
 checkJudocBlock = \case
   JudocParagraphLines l -> JudocParagraphLines <$> mapM checkJudocLine l
-  JudocParagraphBlock b -> JudocParagraphBlock <$> checkJudocBlockParagraph b
   JudocExample e -> JudocExample <$> traverseOf exampleExpression checkParseExpressionAtoms e
 
 checkJudocBlockParagraph ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>
   JudocBlockParagraph 'Parsed ->
   Sem r (JudocBlockParagraph 'Scoped)
-checkJudocBlockParagraph = undefined
+checkJudocBlockParagraph = traverseOf judocBlockParagraphBlocks (mapM checkJudocBlock)
 
 checkJudocLine ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1202,7 +1202,8 @@ checkJudocBlock ::
   JudocBlock 'Parsed ->
   Sem r (JudocBlock 'Scoped)
 checkJudocBlock = \case
-  JudocParagraph l -> JudocParagraph <$> mapM checkJudocLine l
+  JudocParagraphLines l -> JudocParagraphLines <$> mapM checkJudocLine l
+  JudocParagraphBlock {} -> undefined
   JudocExample e -> JudocExample <$> traverseOf exampleExpression checkParseExpressionAtoms e
 
 checkJudocLine ::

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1203,8 +1203,14 @@ checkJudocBlock ::
   Sem r (JudocBlock 'Scoped)
 checkJudocBlock = \case
   JudocParagraphLines l -> JudocParagraphLines <$> mapM checkJudocLine l
-  JudocParagraphBlock {} -> undefined
+  JudocParagraphBlock b -> JudocParagraphBlock <$> checkJudocBlockParagraph b
   JudocExample e -> JudocExample <$> traverseOf exampleExpression checkParseExpressionAtoms e
+
+checkJudocBlockParagraph ::
+  (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>
+  JudocBlockParagraph 'Parsed ->
+  Sem r (JudocBlockParagraph 'Scoped)
+checkJudocBlockParagraph = undefined
 
 checkJudocLine ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -291,13 +291,14 @@ stashJudoc = do
     judocGroup :: ParsecS r (JudocGroup 'Parsed)
     judocGroup =
       JudocGroupBlock <$> judocParagraphBlock
-      <|> JudocGroupLines <$> some1 (judocBlock False)
+        <|> JudocGroupLines <$> some1 (judocBlock False)
 
     judocEmptyLine :: Bool -> ParsecS r ()
-    judocEmptyLine inBlock = lexeme . void $
-      if
-        | inBlock -> P.newline
-        | otherwise -> P.try (judocStart >> P.newline)
+    judocEmptyLine inBlock =
+      lexeme . void $
+        if
+            | inBlock -> P.newline
+            | otherwise -> P.try (judocStart >> P.newline)
 
     judocBlock :: Bool -> ParsecS r (JudocBlock 'Parsed)
     judocBlock inBlock = do
@@ -327,8 +328,8 @@ stashJudoc = do
     judocExample :: Bool -> ParsecS r (JudocBlock 'Parsed)
     judocExample inBlock = do
       if
-        | inBlock -> judocExampleStart
-        | otherwise -> P.try (judocStart >> judocExampleStart)
+          | inBlock -> judocExampleStart
+          | otherwise -> P.try (judocStart >> judocExampleStart)
       _exampleId <- P.lift freshNameId
       (_exampleExpression, _exampleLoc) <- interval parseExpressionAtoms
       semicolon
@@ -338,12 +339,12 @@ stashJudoc = do
     paragraphLine :: Bool -> ParsecS r (JudocParagraphLine 'Parsed)
     paragraphLine inBlock = do
       if
-        | inBlock -> return ()
-        | otherwise -> P.try (judocStart >> P.notFollowedBy (P.choice [judocExampleStart, void P.newline]))
+          | inBlock -> return ()
+          | otherwise -> P.try (judocStart >> P.notFollowedBy (P.choice [judocExampleStart, void P.newline]))
       l <- JudocParagraphLine <$> some1 (withLoc judocAtom)
       if
-        | inBlock -> optional_ P.newline
-        | otherwise -> void P.newline
+          | inBlock -> optional_ P.newline
+          | otherwise -> void P.newline
       return l
 
 judocAtom :: forall r. (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (JudocAtom 'Parsed)

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -9,6 +9,7 @@ where
 import Data.ByteString.UTF8 qualified as BS
 import Data.List.NonEmpty.Extra qualified as NonEmpty
 import Data.Singletons
+import Data.Text qualified as Text
 import Data.Yaml
 import Juvix.Compiler.Concrete.Data.Highlight.Input (HighlightBuilder, ignoreHighlightBuilder)
 import Juvix.Compiler.Concrete.Data.ParsedInfoTable
@@ -30,7 +31,6 @@ import Juvix.Prelude.Pretty
   ( Pretty,
     prettyText,
   )
-import Data.Text qualified as Text
 
 type JudocStash = State (Maybe (Judoc 'Parsed))
 
@@ -343,11 +343,11 @@ stashJudoc = do
       where
         trimLast :: NonEmpty (WithLoc (JudocAtom 'Parsed)) -> NonEmpty (WithLoc (JudocAtom 'Parsed))
         trimLast = over (_last1 . withLocParam) tr
-         where
-         tr :: JudocAtom 'Parsed -> JudocAtom 'Parsed
-         tr a = case a of
-           JudocExpression {} -> a
-           JudocText txt -> JudocText (Text.stripEnd txt)
+          where
+            tr :: JudocAtom 'Parsed -> JudocAtom 'Parsed
+            tr a = case a of
+              JudocExpression {} -> a
+              JudocText txt -> JudocText (Text.stripEnd txt)
 
 judocAtom ::
   forall r.

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -292,13 +292,26 @@ stashJudoc = do
     judocBlock = do
       p <-
         judocExample
-          <|> judocParagraph
-
+          <|> judocParagraphLines
+          <|> judocParagraphBlock
       void (many judocEmptyLine)
       return p
 
-    judocParagraph :: ParsecS r (JudocBlock 'Parsed)
-    judocParagraph = JudocParagraph <$> some1 judocLine
+    judocParagraphBlock :: ParsecS r (JudocBlock 'Parsed)
+    judocParagraphBlock = JudocParagraphBlock <$> blockPar
+      where
+        blockPar :: ParsecS r (JudocBlockParagraph 'Parsed)
+        blockPar = do
+          _judocBlockParagraphStart <- judocBlockStart
+          _judocBlockParagraphEnd <- judocBlockEnd
+          return
+            JudocBlockParagraph
+              { _judocBlockParagraphLines = [],
+                ..
+              }
+
+    judocParagraphLines :: ParsecS r (JudocBlock 'Parsed)
+    judocParagraphLines = JudocParagraphLines <$> some1 judocLine
 
     judocExample :: ParsecS r (JudocBlock 'Parsed)
     judocExample = do

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -84,9 +84,6 @@ judocBlockStart = kw delimJudocBlockStart
 judocStart :: Members '[InfoTableBuilder] r => ParsecS r ()
 judocStart = judocText_ (P.chunk Str.judocStart) >> hspace_
 
-judocEmptyLine :: (Members '[InfoTableBuilder] r) => ParsecS r ()
-judocEmptyLine = lexeme (void (P.try (judocStart >> P.newline)))
-
 kw :: Member InfoTableBuilder r => Keyword -> ParsecS r KeywordRef
 kw k = lexeme $ kw' k >>= P.lift . registerKeyword
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -78,7 +78,6 @@ judocBlockEnd :: Members '[InfoTableBuilder] r => ParsecS r KeywordRef
 judocBlockEnd = kw delimJudocBlockEnd
 
 judocBlockStart :: Members '[InfoTableBuilder] r => ParsecS r KeywordRef
--- judocBlockStart = lexeme . judocText . onlyInterval . P.chunk $ Str.judocBlockStart
 judocBlockStart = kw delimJudocBlockStart
 
 judocStart :: Members '[InfoTableBuilder] r => ParsecS r ()

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -74,6 +74,12 @@ string = lexemeInterval string'
 judocExampleStart :: ParsecS r ()
 judocExampleStart = P.chunk Str.judocExample >> hspace_
 
+judocBlockEnd :: Members '[InfoTableBuilder] r => ParsecS r Interval
+judocBlockEnd = lexeme . judocText . onlyInterval . P.chunk $ Str.judocBlockEnd
+
+judocBlockStart :: Members '[InfoTableBuilder] r => ParsecS r Interval
+judocBlockStart = lexeme . judocText . onlyInterval . P.chunk $ Str.judocBlockStart
+
 judocStart :: Members '[InfoTableBuilder] r => ParsecS r ()
 judocStart = judocText_ (P.chunk Str.judocStart) >> hspace_
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -78,13 +78,17 @@ judocBlockEnd :: Members '[InfoTableBuilder] r => ParsecS r KeywordRef
 judocBlockEnd = kw delimJudocBlockEnd
 
 judocBlockStart :: Members '[InfoTableBuilder] r => ParsecS r KeywordRef
-judocBlockStart = kw delimJudocBlockStart
+judocBlockStart = kwBare delimJudocBlockStart
 
 judocStart :: Members '[InfoTableBuilder] r => ParsecS r ()
 judocStart = judocText_ (P.chunk Str.judocStart) >> hspace_
 
+-- | Does not consume space after it
+kwBare :: Member InfoTableBuilder r => Keyword -> ParsecS r KeywordRef
+kwBare k = kw' k >>= P.lift . registerKeyword
+
 kw :: Member InfoTableBuilder r => Keyword -> ParsecS r KeywordRef
-kw k = lexeme $ kw' k >>= P.lift . registerKeyword
+kw = lexeme . kwBare
 
 -- | Same as @identifier@ but does not consume space after it.
 bareIdentifier :: ParsecS r (Text, Interval)

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -74,11 +74,12 @@ string = lexemeInterval string'
 judocExampleStart :: ParsecS r ()
 judocExampleStart = P.chunk Str.judocExample >> hspace_
 
-judocBlockEnd :: Members '[InfoTableBuilder] r => ParsecS r Interval
-judocBlockEnd = lexeme . judocText . onlyInterval . P.chunk $ Str.judocBlockEnd
+judocBlockEnd :: Members '[InfoTableBuilder] r => ParsecS r KeywordRef
+judocBlockEnd = kw delimJudocBlockEnd
 
-judocBlockStart :: Members '[InfoTableBuilder] r => ParsecS r Interval
-judocBlockStart = lexeme . judocText . onlyInterval . P.chunk $ Str.judocBlockStart
+judocBlockStart :: Members '[InfoTableBuilder] r => ParsecS r KeywordRef
+-- judocBlockStart = lexeme . judocText . onlyInterval . P.chunk $ Str.judocBlockStart
+judocBlockStart = kw delimJudocBlockStart
 
 judocStart :: Members '[InfoTableBuilder] r => ParsecS r ()
 judocStart = judocText_ (P.chunk Str.judocStart) >> hspace_

--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -5,6 +5,7 @@ module Juvix.Data.CodeAnn
 where
 
 import Juvix.Compiler.Concrete.Data.Name
+import Juvix.Data.Keyword
 import Juvix.Data.NameKind
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
@@ -51,6 +52,12 @@ class PrettyCodeAnn a where
 instance HasAnsiBackend (Doc CodeAnn) where
   toAnsiDoc = fmap stylize
   toAnsiStream = fmap stylize . layoutPretty defaultLayoutOptions
+
+kwTypeAnn :: KeywordType -> CodeAnn
+kwTypeAnn = \case
+  KeywordTypeDelimiter -> AnnDelimiter
+  KeywordTypeKeyword -> AnnKeyword
+  KeywordTypeJudoc -> AnnJudoc
 
 -- | for builtin stuff
 primitive :: Text -> Doc Ann

--- a/src/Juvix/Data/Effect/ExactPrint.hs
+++ b/src/Juvix/Data/Effect/ExactPrint.hs
@@ -22,6 +22,15 @@ infixr 7 ?<>
 (?<>) :: Maybe (Sem r ()) -> Sem r () -> Sem r ()
 (?<>) = maybe id (<>)
 
+infixr 7 <??+>
+
+(<??+>) :: Members '[ExactPrint] r => Sem r (Maybe ()) -> Sem r () -> Sem r ()
+(<??+>) ma b = do
+  r <- ma
+  case r of
+    Nothing -> b
+    Just () -> (space <> b)
+
 infixr 7 <?+>
 
 (<?+>) :: Members '[ExactPrint] r => Maybe (Sem r ()) -> Sem r () -> Sem r ()

--- a/src/Juvix/Data/Keyword.hs
+++ b/src/Juvix/Data/Keyword.hs
@@ -10,11 +10,18 @@ data IsUnicode
   | Ascii
   deriving stock (Eq, Show, Ord, Data)
 
+data KeywordType
+  = KeywordTypeKeyword
+  | KeywordTypeDelimiter
+  | KeywordTypeJudoc
+  deriving stock (Eq, Show, Ord, Data)
+
 data Keyword = Keyword
   { _keywordAscii :: Text,
     _keywordUnicode :: Maybe Text,
     -- | true if _keywordAscii has a reserved character (the unicode is assumed to not have any)
-    _keywordHasReserved :: Bool
+    _keywordHasReserved :: Bool,
+    _keywordType :: KeywordType
   }
   deriving stock (Eq, Show, Ord, Data)
 
@@ -66,7 +73,26 @@ mkKw :: Text -> Maybe Text -> Keyword
 mkKw _keywordAscii _keywordUnicode =
   Keyword
     { _keywordHasReserved = hasReservedChar _keywordAscii,
+      _keywordType = KeywordTypeKeyword,
       ..
+    }
+
+mkJudocDelim :: Text -> Keyword
+mkJudocDelim ascii =
+  Keyword
+    { _keywordType = KeywordTypeJudoc,
+      _keywordAscii = ascii,
+      _keywordUnicode = Nothing,
+      _keywordHasReserved = hasReservedChar ascii
+    }
+
+mkDelim :: Text -> Keyword
+mkDelim ascii =
+  Keyword
+    { _keywordType = KeywordTypeDelimiter,
+      _keywordAscii = ascii,
+      _keywordUnicode = Nothing,
+      _keywordHasReserved = hasReservedChar ascii
     }
 
 asciiKw :: Text -> Keyword

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -219,3 +219,12 @@ kwDollar = asciiKw Str.dollar
 
 kwMutual :: Keyword
 kwMutual = asciiKw Str.mutual
+
+delimJudocStart :: Keyword
+delimJudocStart = mkJudocDelim Str.judocStart
+
+delimJudocBlockStart :: Keyword
+delimJudocBlockStart = mkJudocDelim Str.judocBlockStart
+
+delimJudocBlockEnd :: Keyword
+delimJudocBlockEnd = mkJudocDelim Str.judocBlockEnd

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -8,6 +8,12 @@ module_ = "module"
 axiom :: (IsString s) => s
 axiom = "axiom"
 
+judocBlockStart :: (IsString s) => s
+judocBlockStart = "{--"
+
+judocBlockEnd :: (IsString s) => s
+judocBlockEnd = "--}"
+
 judocStart :: (IsString s) => s
 judocStart = "---"
 

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -78,7 +78,11 @@ space' special =
           let _commentType = CommentOneLine
           when
             special
-            (notFollowedBy (P.chunk Str.judocStart))
+            ( notFollowedBy
+                ( P.chunk Str.judocStart
+                    <|> P.chunk Str.judocBlockEnd
+                )
+            )
           (_commentText, _commentInterval) <- interval $ do
             void (P.chunk "--")
             P.takeWhileP Nothing (/= '\n')
@@ -89,7 +93,11 @@ space' special =
           let _commentType = CommentBlock
           when
             special
-            (notFollowedBy (P.chunk Str.pragmasStart))
+            ( notFollowedBy
+                ( P.chunk Str.pragmasStart
+                    <|> P.chunk Str.judocBlockStart
+                )
+            )
           (_commentText, _commentInterval) <- interval $ do
             void start
             go 1 ""

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -415,6 +415,9 @@ fromRightIO' pp = do
 fromRightIO :: (e -> Text) -> IO (Either e r) -> IO r
 fromRightIO pp = fromRightIO' (putStrLn . pp)
 
+optional_ :: Alternative m => m a -> m ()
+optional_ = void . optional
+
 --------------------------------------------------------------------------------
 -- Misc
 --------------------------------------------------------------------------------

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -511,5 +511,5 @@ popFirstJust f = \case
     Nothing -> (h :) <$> popFirstJust f hs
     Just x -> (Just x, hs)
 
-uncurryF :: Functor f => (a -> b -> c) -> f (a , b) -> f c
+uncurryF :: Functor f => (a -> b -> c) -> f (a, b) -> f c
 uncurryF g input = uncurry g <$> input

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -510,3 +510,6 @@ popFirstJust f = \case
   (h : hs) -> case f h of
     Nothing -> (h :) <$> popFirstJust f hs
     Just x -> (Just x, hs)
+
+uncurryF :: Functor f => (a -> b -> c) -> f (a , b) -> f c
+uncurryF g input = uncurry g <$> input

--- a/src/Juvix/Prelude/Lens.hs
+++ b/src/Juvix/Prelude/Lens.hs
@@ -2,9 +2,19 @@ module Juvix.Prelude.Lens where
 
 import Juvix.Prelude.Base
 
--- | points to the first element of a non-empty list.
+-- | Points to the first element of a non-empty list.
 _head1 :: Lens' (NonEmpty a) a
 _head1 = singular each
+
+-- | View a non-empty list as the init part plus the last element.
+_unsnoc1 :: Lens (NonEmpty a) (NonEmpty b) ([a], a) ([b], b)
+_unsnoc1 afb la = uncurryF (|:) (afb (maybe [] toList minit, lasta))
+    where
+    (minit, lasta) = nonEmptyUnsnoc la
+
+-- | Points to the last element of a non-empty list.
+_last1 :: Lens' (NonEmpty a) a
+_last1 = _unsnoc1 . _2
 
 overM :: Applicative m => Lens' a b -> (b -> m b) -> a -> m a
 overM l f a = do

--- a/src/Juvix/Prelude/Lens.hs
+++ b/src/Juvix/Prelude/Lens.hs
@@ -9,7 +9,7 @@ _head1 = singular each
 -- | View a non-empty list as the init part plus the last element.
 _unsnoc1 :: Lens (NonEmpty a) (NonEmpty b) ([a], a) ([b], b)
 _unsnoc1 afb la = uncurryF (|:) (afb (maybe [] toList minit, lasta))
-    where
+  where
     (minit, lasta) = nonEmptyUnsnoc la
 
 -- | Points to the last element of a non-empty list.

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -224,6 +224,10 @@ tests =
       $(mkRelDir "ImportShadow")
       $(mkRelFile "Main.juvix"),
     PosTest
+      "Judoc"
+      $(mkRelDir ".")
+      $(mkRelFile "Judoc.juvix"),
+    PosTest
       "Pragmas"
       $(mkRelDir ".")
       $(mkRelFile "Pragmas.juvix"),

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -19,7 +19,8 @@ id a := a;
 
 --- hellowww
 {-- judoc block --}
-{-- judoc block --}
+{-- judoc
+block --}
 {--  --}
 id2 : {A : Type} → A → A;
 id2 a := a;

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -4,8 +4,10 @@ axiom A : Type;
 
 axiom b : Type;
 
+--- document type
 type T :=
-  | t : T;
+  | --- document constructor
+  t : T;
 
 --- he ;id A; and ;A A id T A id; this is another ;id
   id

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -21,5 +21,14 @@ id a := a;
 id2 : {A : Type} → A → A;
 id2 a := a;
 
-{-- --}
+{-- hi --}
+id2 a := a;
+
+
+-- }
+--- testing double minus --
+--- testing triple --- minus
+--- testing closing --}.
+axiom B : {A : Type} → A → A;
+
 axiom M : Type

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -18,3 +18,8 @@ id a := a;
 --- hellowww
 id2 : {A : Type} → A → A;
 id2 a := a;
+
+{--
+
+--}
+axiom M : Type

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -21,7 +21,10 @@ id a := a;
 {-- judoc block --}
 {-- judoc
 block --}
+{-- -- --}
 {--  --}
+{-- f
+z --}
 id2 : {A : Type} → A → A;
 id2 a := a;
 id2 a := a;

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -19,7 +19,5 @@ id a := a;
 id2 : {A : Type} → A → A;
 id2 a := a;
 
-{--
-
---}
+{-- --}
 axiom M : Type

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -7,9 +7,9 @@ axiom b : Type;
 --- document type
 type T :=
   | --- document constructor
-  t : T;
+    t : T;
 
---- he ;id A; and ;A A id T A id; this is another ;id
+--- blah ;id A; and ;A A id T A id; this is another ;id
   id
   id; example
 --- hahahah
@@ -18,17 +18,23 @@ id : {A : Type} → A → A;
 id a := a;
 
 --- hellowww
+{-- judoc block --}
+{-- judoc block --}
+{--  --}
 id2 : {A : Type} → A → A;
 id2 a := a;
-
-{-- hi --}
 id2 a := a;
-
 
 -- }
 --- testing double minus --
 --- testing triple --- minus
 --- testing closing --}.
+---
+--- second paragraph
 axiom B : {A : Type} → A → A;
 
-axiom M : Type
+{-- Hi
+
+Bye
+end --}
+axiom M : Type;

--- a/tests/positive/Judoc.juvix
+++ b/tests/positive/Judoc.juvix
@@ -24,7 +24,7 @@ block --}
 {-- -- --}
 {--  --}
 {-- f
-z --}
+z ;Type; --}
 id2 : {A : Type} → A → A;
 id2 a := a;
 id2 a := a;


### PR DESCRIPTION
- Closes #2050 

This pr adds the possibility to give judoc documentation in blocks delimited by `{--` and `--}`. 
- Inside these blocks, normal comments are disabled.
- It is allowed to have multiple blocks associated with the same identifier, e.g.
```
{-- an axiom --}
{-- of type ;Type; --}
axiom a : Type;
```
- Nested blocks are *not* allowed.
- Blocks can be empty: `{-- --}`.
- The formatter respects line breaks inside blocks.
- The formatter normalizes whitespace at both ends of the block to a single whitespace.