### PR TITLE
Simplify formatting of lambdas with a single clause

### DIFF
--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -513,8 +513,10 @@ instance (SingI s) => PrettyCode (Case s) where
 
 instance (SingI s) => PrettyCode (Lambda s) where
   ppCode Lambda {..} = do
-    lambdaClauses' <- bracesIndent <$> ppPipeBlock _lambdaClauses
     lambdaKw' <- ppCode _lambdaKw
+    lambdaClauses' <- case _lambdaClauses of
+      s :| [] -> braces <$> ppCode s
+      _ -> bracesIndent <$> ppPipeBlock _lambdaClauses
     return $ lambdaKw' <+> lambdaClauses'
 
 instance (SingI s) => PrettyCode (FunctionClause s) where

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -151,7 +151,7 @@ module Patterns;
   infixr 4 ,;
   type × (A : Type) (B : Type) :=
     | , : A → B → A × B;
-
+  
   f : Nat × Nat × Nat × Nat -> Nat;
   f (a, b, c, d) := a;
 end;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -114,26 +114,28 @@ exampleFunction2 :
     -> List A
     -> List A
     -> Nat :=
-    λ {
-      | _ _ _ _ _ _ _ :=
-        undefined
-          + undefined
-          + undefined
-          + undefined
-          + undefined
-          + undefined
-          + undefined
-          + undefined
-          + undefined
-          + undefined
-          + undefined
-    };
+    λ {_ _ _ _ _ _ _ :=
+      undefined
+        + undefined
+        + undefined
+        + undefined
+        + undefined
+        + undefined
+        + undefined
+        + undefined
+        + undefined
+        + undefined
+        + undefined};
 
 positive
 type T0 (A : Type) :=
   | c0 : (A -> T0 A) -> T0 A;
 
--- Lambda clause
+-- Single Lambda clause
+idLambda : {A : Type} -> A -> A;
+idLambda := λ {x := x};
+
+-- Lambda clauses
 f : Nat -> Nat;
 f :=
   \ {
@@ -149,7 +151,7 @@ module Patterns;
   infixr 4 ,;
   type × (A : Type) (B : Type) :=
     | , : A → B → A × B;
-  
+
   f : Nat × Nat × Nat × Nat -> Nat;
   f (a, b, c, d) := a;
 end;

--- a/tests/positive/StdlibList/Data/List.juvix
+++ b/tests/positive/StdlibList/Data/List.juvix
@@ -71,9 +71,7 @@ splitAt a (suc zero) (:: x xs) := , (:: x nil) xs;
 splitAt a (suc (suc m)) (:: x xs) :=
   match
     (splitAt a m xs)
-    λ {
-      | (, xs' xs'') := , (:: x xs') xs''
-    };
+    λ {(, xs' xs'') := , (:: x xs') xs''};
 
 terminating
 merge :


### PR DESCRIPTION
After this pr, lambdas with a single clause will be printed in one line, without a preceding `|`. I.e. `\ {x := x}`.