### PR TITLE
Pass through compile optimization flag to C compiler and disable optimization for --debug

### DIFF
--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -25,10 +25,7 @@ getEntry PipelineArg {..} = do
     ep
       { _entryPointTarget = getTarget (_pipelineArgOptions ^. compileTarget),
         _entryPointDebug = _pipelineArgOptions ^. compileDebug,
-        _entryPointOptimizationLevel =
-          if
-              | _pipelineArgOptions ^. compileDebug -> 0
-              | otherwise -> _pipelineArgOptions ^. compileOptimizationLevel,
+        _entryPointOptimizationLevel = fromMaybe defaultOptLevel (_pipelineArgOptions ^. compileOptimizationLevel),
         _entryPointInliningDepth = _pipelineArgOptions ^. compileInliningDepth
       }
   where
@@ -40,6 +37,11 @@ getEntry PipelineArg {..} = do
       TargetVampIR -> Backend.TargetVampIR
       TargetCore -> Backend.TargetCore
       TargetAsm -> Backend.TargetAsm
+
+    defaultOptLevel :: Int
+    defaultOptLevel
+      | _pipelineArgOptions ^. compileDebug = 0
+      | otherwise = defaultOptimizationLevel
 
 runCPipeline ::
   forall r.

--- a/app/Commands/Extra/Compile.hs
+++ b/app/Commands/Extra/Compile.hs
@@ -176,7 +176,7 @@ native64Args buildDir o outfile inputFile =
     <> [ "-DARCH_NATIVE64",
          "-DAPI_LIBC",
          "-m64",
-         "-O" <> show optValue,
+         "-O" <> show (maybe defaultOptLevel (max 1) (o ^. compileOptimizationLevel)),
          toFilePath inputFile
        ]
     <> ( if
@@ -185,10 +185,10 @@ native64Args buildDir o outfile inputFile =
              | otherwise -> []
        )
   where
-    optValue :: Int
-    optValue
-      | o ^. compileDebug = 1
-      | otherwise = max 1 (o ^. compileOptimizationLevel)
+    defaultOptLevel :: Int
+    defaultOptLevel
+      | o ^. compileDebug = debugClangOptimizationLevel
+      | otherwise = defaultClangOptimizationLevel
 
 wasiArgs :: Path Abs Dir -> CompileOptions -> Path Abs File -> Path Abs File -> Path Abs Dir -> [String]
 wasiArgs buildDir o outfile inputFile sysrootPath =
@@ -217,3 +217,9 @@ runClang args = do
   case exitCode of
     ExitSuccess -> return ()
     _ -> throw (pack err)
+
+debugClangOptimizationLevel :: Int
+debugClangOptimizationLevel = 1
+
+defaultClangOptimizationLevel :: Int
+defaultClangOptimizationLevel = 1

--- a/app/Commands/Extra/Compile/Options.hs
+++ b/app/Commands/Extra/Compile/Options.hs
@@ -31,7 +31,7 @@ data CompileOptions = CompileOptions
     _compileOutputFile :: Maybe (AppPath File),
     _compileTarget :: CompileTarget,
     _compileInputFile :: AppPath File,
-    _compileOptimizationLevel :: Int,
+    _compileOptimizationLevel :: Maybe Int,
     _compileInliningDepth :: Int
   }
   deriving stock (Data)
@@ -83,12 +83,13 @@ parseCompileOptions supportedTargets parseInputFile = do
         | otherwise ->
             pure False
   _compileOptimizationLevel <-
-    option
-      (fromIntegral <$> naturalNumberOpt)
-      ( short 'O'
-          <> long "optimize"
-          <> value defaultOptimizationLevel
-          <> help ("Optimization level (default: " <> show defaultOptimizationLevel <> ")")
+    optional
+      ( option
+          (fromIntegral <$> naturalNumberOpt)
+          ( short 'O'
+              <> long "optimize"
+              <> help ("Optimization level (default: " <> show defaultOptimizationLevel <> ")")
+          )
       )
   _compileInliningDepth <-
     option


### PR DESCRIPTION
In this PR we pass through the `juvix compile` optimization flag to the C compiler in the native compilation.

NB: Clang supports -On for any positive n. -O4 and higher is equivalent to -O3

Also we disable optimizations when the `-g` / `--debug` option is specified.

* Closes https://github.com/anoma/juvix/issues/2104