### PR TITLE
Allow symbol renaming inside `using {..}`

### DIFF
--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1599,6 +1599,9 @@ instance HasLoc SymbolEntry where
 overModuleRef'' :: forall s s'. (forall t. ModuleRef'' s t -> ModuleRef'' s' t) -> ModuleRef' s -> ModuleRef' s'
 overModuleRef'' f = over unModuleRef' (\(t :&: m'') -> t :&: f m'')
 
+symbolEntryNameId :: SymbolEntry -> NameId
+symbolEntryNameId = (^. S.nameId) . symbolEntryToSName
+
 symbolEntryToSName :: SymbolEntry -> S.Name' ()
 symbolEntryToSName = \case
   EntryAxiom a -> a ^. axiomRefName

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -467,8 +467,9 @@ deriving stock instance
   ) =>
   Ord (Module s t)
 
-newtype UsingItem (s :: Stage) = UsingItem
-  { _usingSymbol :: SymbolType s
+data UsingItem (s :: Stage) = UsingItem
+  { _usingSymbol :: SymbolType s,
+    _usingAs :: Maybe (SymbolType s)
   }
 
 deriving stock instance

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -384,10 +384,15 @@ instance SingI s => PrettyCode (UsingHiding s) where
         Hiding {} -> kwHiding
       ppItems :: Sem r (NonEmpty (Doc Ann))
       ppItems = case uh of
-        Using s -> mapM ppUsingItem s
+        Using s -> mapM ppCode s
         Hiding s -> mapM ppSymbol s
-      ppUsingItem :: UsingItem s -> Sem r (Doc Ann)
-      ppUsingItem ui = ppSymbol (ui ^. usingSymbol)
+
+instance SingI s => PrettyCode (UsingItem s) where
+  ppCode ui = do
+    kwAs' <- ppCode kwAs
+    as' <- fmap (kwAs' <+>) <$> mapM ppSymbol (ui ^. usingAs)
+    sym' <- ppSymbol (ui ^. usingSymbol)
+    return (sym' <+?> as')
 
 instance PrettyCode (WithSource Pragmas) where
   ppCode pragma =

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -321,6 +321,14 @@ instance PrettyPrint (UsingHiding 'Scoped) where
       ppUsingItem :: UsingItem 'Scoped -> Sem r ()
       ppUsingItem ui = ppCode (ui ^. usingSymbol)
 
+instance PrettyPrint (UsingItem 'Scoped) where
+  ppCode :: forall r. Members '[ExactPrint, Reader Options] r => UsingItem 'Scoped -> Sem r ()
+  ppCode ui = do
+    let kwAs' :: Sem r () = ppCode kwAs
+        as' = (kwAs' <+>) . ppCode <$> ui ^. usingAs
+        sym' = ppCode (ui ^. usingSymbol)
+    sym' <+?> as'
+
 instance PrettyPrint ModuleRef where
   ppCode (ModuleRef' (_ :&: ModuleRef'' {..})) = ppCode _moduleRefName
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -868,23 +868,22 @@ checkOpenModuleNoImport OpenModule {..}
           NoPublic -> VisPrivate
 
         filterScope :: ExportInfo -> ExportInfo
-        filterScope ei = case openModif of
-          Just (Using l) -> over exportSymbols (HashMap.fromList . mapMaybe inUsing . HashMap.toList) ei
+        filterScope = case openModif of
+          Just (Using l) -> over exportSymbols (HashMap.fromList . mapMaybe inUsing . HashMap.toList)
             where
               inUsing :: (Symbol, SymbolEntry) -> Maybe (Symbol, SymbolEntry)
               inUsing (sym, e) = do
                 mayAs' <- u ^. at (symbolEntryNameId e)
                 return (fromMaybe sym mayAs', e)
-
               u :: HashMap NameId (Maybe Symbol)
               u = HashMap.fromList [(i ^. usingSymbol . S.nameId, i ^? usingAs . _Just . S.nameConcrete) | i <- toList l]
-          Just (Hiding l) -> over exportSymbols (HashMap.filter (not . inHiding)) ei
+          Just (Hiding l) -> over exportSymbols (HashMap.filter (not . inHiding))
             where
               inHiding :: SymbolEntry -> Bool
               inHiding e = HashSet.member (symbolEntryNameId e) u
               u :: HashSet NameId
               u = HashSet.fromList (map (^. S.nameId) (toList l))
-          Nothing -> ei
+          Nothing -> id
 
 checkOpenModule ::
   forall r.

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -793,7 +793,6 @@ checkOpenModuleNoImport OpenModule {..}
   | otherwise = do
       openModuleName'@(ModuleRef' (_ :&: moduleRef'')) <- lookupModuleSymbol _openModuleName
       let exportInfo@(ExportInfo tbl) = moduleRef'' ^. moduleExportInfo
-      mergeScope (alterScope exportInfo)
       registerName (moduleRef'' ^. moduleRefName)
 
       let checkUsingHiding :: UsingHiding 'Parsed -> Sem r (UsingHiding 'Scoped)
@@ -822,13 +821,18 @@ checkOpenModuleNoImport OpenModule {..}
               checkUsingItem :: UsingItem 'Parsed -> Sem r (UsingItem 'Scoped)
               checkUsingItem i = do
                 scopedSym <- scopeSymbol (i ^. usingSymbol)
+                let scopedAs = do
+                      c <- i ^. usingAs
+                      return (set S.nameConcrete c scopedSym)
+                mapM_ (registerName . S.unqualifiedSymbol) scopedAs
                 return
-                  ( UsingItem
-                      { _usingSymbol = scopedSym
-                      }
-                  )
+                  UsingItem
+                    { _usingSymbol = scopedSym,
+                      _usingAs = scopedAs
+                    }
 
       usingHiding' <- mapM checkUsingHiding _openUsingHiding
+      mergeScope (alterScope usingHiding' exportInfo)
       return
         OpenModule
           { _openModuleName = openModuleName',
@@ -846,14 +850,8 @@ checkOpenModuleNoImport OpenModule {..}
           modify
             (over scopeSymbols (HashMap.insertWith (<>) s (symbolInfoSingle entry)))
 
-    setsUsingHiding :: Maybe (Either (HashSet Symbol) (HashSet Symbol))
-    setsUsingHiding = case _openUsingHiding of
-      Just (Using l) -> Just (Left (HashSet.fromList (map (^. usingSymbol) $ toList l)))
-      Just (Hiding l) -> Just (Right (HashSet.fromList (toList l)))
-      Nothing -> Nothing
-
-    alterScope :: ExportInfo -> ExportInfo
-    alterScope = alterEntries . filterScope
+    alterScope :: Maybe (UsingHiding 'Scoped) -> ExportInfo -> ExportInfo
+    alterScope openModif = alterEntries . filterScope
       where
         alterEntry :: SymbolEntry -> SymbolEntry
         alterEntry =
@@ -870,16 +868,23 @@ checkOpenModuleNoImport OpenModule {..}
           NoPublic -> VisPrivate
 
         filterScope :: ExportInfo -> ExportInfo
-        filterScope = over exportSymbols filterTable
-          where
-            filterTable :: HashMap Symbol a -> HashMap Symbol a
-            filterTable = HashMap.filterWithKey (const . shouldOpen)
+        filterScope ei = case openModif of
+          Just (Using l) -> over exportSymbols (HashMap.fromList . mapMaybe inUsing . HashMap.toList) ei
+            where
+              inUsing :: (Symbol, SymbolEntry) -> Maybe (Symbol, SymbolEntry)
+              inUsing (sym, e) = do
+                mayAs' <- u ^. at (symbolEntryNameId e)
+                return (fromMaybe sym mayAs', e)
 
-            shouldOpen :: Symbol -> Bool
-            shouldOpen s = case setsUsingHiding of
-              Nothing -> True
-              Just (Left using) -> HashSet.member s using
-              Just (Right hiding) -> not (HashSet.member s hiding)
+              u :: HashMap NameId (Maybe Symbol)
+              u = HashMap.fromList [(i ^. usingSymbol . S.nameId, i ^? usingAs . _Just . S.nameConcrete) | i <- toList l]
+          Just (Hiding l) -> over exportSymbols (HashMap.filter (not . inHiding)) ei
+            where
+              inHiding :: SymbolEntry -> Bool
+              inHiding e = HashSet.member (symbolEntryNameId e) u
+              u :: HashSet NameId
+              u = HashSet.fromList (map (^. S.nameId) (toList l))
+          Nothing -> ei
 
 checkOpenModule ::
   forall r.

--- a/tests/positive/UsingHiding/Main.juvix
+++ b/tests/positive/UsingHiding/Main.juvix
@@ -9,5 +9,8 @@ module M;
   axiom B : Type;
 end;
 
-open M using {A; id};
+open M using {A; id as myId};
 open M hiding {B};
+
+t : {X : Type} -> X -> X;
+t := myId;


### PR DESCRIPTION
- Closes #2090 
- Depends on #2108 