### PR TITLE
Use PrettyCode instance instead of obsolete ppUsingItem in Print.Base

### DIFF
--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -320,10 +320,8 @@ instance PrettyPrint (UsingHiding 'Scoped) where
         Hiding {} -> ppCode kwHiding
       ppItems :: NonEmpty (Sem r ())
       ppItems = case uh of
-        Using s -> fmap ppUsingItem s
+        Using s -> fmap ppCode s
         Hiding s -> fmap ppCode s
-      ppUsingItem :: UsingItem 'Scoped -> Sem r ()
-      ppUsingItem ui = ppCode (ui ^. usingSymbol)
 
 instance PrettyPrint (UsingItem 'Scoped) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => UsingItem 'Scoped -> Sem r ()

--- a/tests/negative/Termination/Data/Nat.juvix
+++ b/tests/negative/Termination/Data/Nat.juvix
@@ -1,8 +1,8 @@
 module Data.Nat;
 
 type ℕ :=
-  zero : ℕ
-| suc : ℕ → ℕ;
+  | zero : ℕ
+  | suc : ℕ → ℕ;
 
 syntax infixl 6 +;
 + : ℕ → ℕ → ℕ;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -156,6 +156,8 @@ module Patterns;
   f (a, b, c, d) := a;
 end;
 
+import Stdlib.Prelude open using {Nat as Natural};
+
 module Comments;
   axiom a1 : Type;
   -- attached to a1


### PR DESCRIPTION
- Closes #2114 