### PR TITLE
Add `:def` command to the repl

### DIFF
--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -8,7 +8,6 @@ import Commands.Base hiding
 import Commands.Repl.Base
 import Commands.Repl.Options
 import Control.Exception (throwIO)
-import Juvix.Data.NameKind
 import Control.Monad.Except qualified as Except
 import Control.Monad.Reader qualified as Reader
 import Control.Monad.State.Strict qualified as State
@@ -34,6 +33,7 @@ import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Pipeline.Repl
 import Juvix.Compiler.Pipeline.Setup (entrySetup)
 import Juvix.Data.Error.GenericError qualified as Error
+import Juvix.Data.NameKind
 import Juvix.Extra.Paths
 import Juvix.Extra.Stdlib
 import Juvix.Extra.Version
@@ -231,8 +231,8 @@ printDefinition input = do
 
     printIdentifiers :: NonEmpty Concrete.ScopedIden -> Repl ()
     printIdentifiers (d :| ds) = do
-        printIdentifier d
-        whenJust (nonEmpty ds) $ \ds' -> replNewline >> printIdentifiers ds'
+      printIdentifier d
+      whenJust (nonEmpty ds) $ \ds' -> replNewline >> printIdentifiers ds'
       where
         getInfoTable :: Repl Scoped.InfoTable
         getInfoTable = (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
@@ -246,39 +246,39 @@ printDefinition input = do
             Concrete.ScopedFunction f -> printFunction (f ^. Concrete.functionRefName . Scoped.nameId)
             Concrete.ScopedConstructor c -> printConstructor (c ^. Concrete.constructorRefName . Scoped.nameId)
           where
-          printLocation :: HasLoc s => s -> Repl ()
-          printLocation def = do
-            s' <- ppConcrete s
-            let txt :: Text = " is " <> prettyText (nameKindWithArticle (getNameKind s)) <> " defined at " <> prettyText (getLoc def)
-            renderOut s'
-            renderOutLn (AnsiText txt)
+            printLocation :: HasLoc s => s -> Repl ()
+            printLocation def = do
+              s' <- ppConcrete s
+              let txt :: Text = " is " <> prettyText (nameKindWithArticle (getNameKind s)) <> " defined at " <> prettyText (getLoc def)
+              renderOut s'
+              renderOutLn (AnsiText txt)
 
-          printFunction :: Scoped.NameId -> Repl ()
-          printFunction fun = do
-            tbl :: Scoped.InfoTable <- getInfoTable
-            let def :: Scoped.FunctionInfo = tbl ^?! Scoped.infoFunctions . at fun . _Just
-            printLocation def
-            printConcrete def
+            printFunction :: Scoped.NameId -> Repl ()
+            printFunction fun = do
+              tbl :: Scoped.InfoTable <- getInfoTable
+              let def :: Scoped.FunctionInfo = tbl ^?! Scoped.infoFunctions . at fun . _Just
+              printLocation def
+              printConcrete def
 
-          printInductive :: Scoped.NameId -> Repl ()
-          printInductive ind = do
-            tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
-            let def :: Concrete.InductiveDef 'Concrete.Scoped = tbl ^?! Scoped.infoInductives . at ind . _Just . Scoped.inductiveInfoDef
-            printLocation def
-            printConcrete def
+            printInductive :: Scoped.NameId -> Repl ()
+            printInductive ind = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let def :: Concrete.InductiveDef 'Concrete.Scoped = tbl ^?! Scoped.infoInductives . at ind . _Just . Scoped.inductiveInfoDef
+              printLocation def
+              printConcrete def
 
-          printAxiom :: Scoped.NameId -> Repl ()
-          printAxiom ax = do
-            tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
-            let def :: Concrete.AxiomDef 'Concrete.Scoped = tbl ^?! Scoped.infoAxioms . at ax . _Just . Scoped.axiomInfoDef
-            printLocation def
-            printConcrete def
+            printAxiom :: Scoped.NameId -> Repl ()
+            printAxiom ax = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let def :: Concrete.AxiomDef 'Concrete.Scoped = tbl ^?! Scoped.infoAxioms . at ax . _Just . Scoped.axiomInfoDef
+              printLocation def
+              printConcrete def
 
-          printConstructor :: Scoped.NameId -> Repl ()
-          printConstructor c = do
-            tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
-            let ind :: Scoped.Symbol = tbl ^?! Scoped.infoConstructors . at c . _Just . Scoped.constructorInfoTypeName
-            printInductive (ind ^. Scoped.nameId)
+            printConstructor :: Scoped.NameId -> Repl ()
+            printConstructor c = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let ind :: Scoped.Symbol = tbl ^?! Scoped.infoConstructors . at c . _Just . Scoped.constructorInfoTypeName
+              printInductive (ind ^. Scoped.nameId)
 
 inferType :: String -> Repl ()
 inferType input = do

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -327,9 +327,9 @@ replBanner = \case
               . scopePath
               . absTopModulePath
         )
-    case mmodulePath of
-      Just path -> return [i|#{unpack (P.prettyText path)}> |]
-      Nothing -> return "juvix> "
+    return $ case mmodulePath of
+      Just path -> [i|#{unpack (P.prettyText path)}> |]
+      Nothing -> "juvix> "
 
 replPrefix :: Maybe Char
 replPrefix = Just ':'

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -7,7 +7,10 @@ import Commands.Base hiding
   )
 import Commands.Repl.Options
 import Control.Exception (throwIO)
+import Control.Monad.Except qualified as Except
+import Control.Monad.Reader qualified as Reader
 import Control.Monad.State.Strict qualified as State
+import Control.Monad.Trans.Class (lift)
 import Data.String.Interpolate (i, __i)
 import Evaluator
 import Juvix.Compiler.Concrete.Data.Scope (scopePath)
@@ -29,19 +32,25 @@ import Juvix.Data.Error.GenericError qualified as Error
 import Juvix.Extra.Paths
 import Juvix.Extra.Stdlib
 import Juvix.Extra.Version
+import Juvix.Prelude.Pretty
 import Juvix.Prelude.Pretty qualified as P
 import System.Console.ANSI qualified as Ansi
 import System.Console.Haskeline
 import System.Console.Repline
 import System.Console.Repline qualified as Repline
 
-type ReplS = State.StateT ReplState IO
+type ReplS = Reader.ReaderT ReplEnv (State.StateT ReplState (Except.ExceptT JuvixError IO))
 
 type Repl a = HaskelineT ReplS a
 
 data ReplContext = ReplContext
   { _replContextArtifacts :: Artifacts,
     _replContextEntryPoint :: EntryPoint
+  }
+
+data ReplEnv = ReplEnv
+  { _replRoots :: Roots,
+    _replOptions :: ReplOptions
   }
 
 data ReplState = ReplState
@@ -52,6 +61,7 @@ data ReplState = ReplState
 
 makeLenses ''ReplState
 makeLenses ''ReplContext
+makeLenses ''ReplEnv
 
 helpTxt :: MonadIO m => m ()
 helpTxt =
@@ -72,305 +82,301 @@ helpTxt =
   |]
     )
 
-noFileLoadedMsg :: (MonadIO m) => m ()
-noFileLoadedMsg = liftIO (putStrLn "No file loaded. Load a file using the `:load FILE` command.")
+replDefaultLoc :: Interval
+replDefaultLoc = singletonInterval (mkInitialLoc replPath)
 
-welcomeMsg :: (MonadIO m) => m ()
+replFromJust :: JuvixError -> Maybe a -> Repl a
+replFromJust err = maybe (lift (Except.throwError err)) return
+
+replFromEither :: Either JuvixError a -> Repl a
+replFromEither = either (lift . Except.throwError) return
+
+replGetContext :: Repl ReplContext
+replGetContext = State.gets (^. replStateContext) >>= replFromJust noFileLoadedErr
+
+replError :: AnsiText -> JuvixError
+replError msg =
+  JuvixError $
+    GenericError
+      { _genericErrorLoc = replDefaultLoc,
+        _genericErrorMessage = msg,
+        _genericErrorIntervals = [replDefaultLoc]
+      }
+
+noFileLoadedErr :: JuvixError
+noFileLoadedErr = replError (AnsiText @Text "No file loaded. Load a file using the `:load FILE` command.")
+
+welcomeMsg :: MonadIO m => m ()
 welcomeMsg = liftIO (putStrLn [i|Juvix REPL version #{versionTag}: https://juvix.org. Run :help for help|])
+
+printHelpTxt :: String -> Repl ()
+printHelpTxt _ = helpTxt
+
+multilineCmd :: String
+multilineCmd = "multiline"
+
+quit :: String -> Repl ()
+quit _ = liftIO (throwIO Interrupt)
+
+loadEntryPoint :: EntryPoint -> Repl ()
+loadEntryPoint ep = do
+  artif <- liftIO (corePipelineIO' ep)
+  let newCtx =
+        ReplContext
+          { _replContextArtifacts = artif,
+            _replContextEntryPoint = ep
+          }
+  State.modify (set replStateContext (Just newCtx))
+  let epPath :: Maybe (Path Abs File) = ep ^? entryPointModulePaths . _head
+  whenJust epPath $ \path -> liftIO (putStrLn [i|OK loaded: #{toFilePath path}|])
+
+reloadFile :: String -> Repl ()
+reloadFile _ = replGetContext >>= loadEntryPoint . (^. replContextEntryPoint)
+
+pSomeFile :: String -> Prepath File
+pSomeFile = mkPrepath
+
+loadFile :: Prepath File -> Repl ()
+loadFile f = do
+  entryPoint <- getReplEntryPoint f
+  loadEntryPoint entryPoint
+
+loadDefaultPrelude :: Repl ()
+loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
+  root <- Reader.asks (^. replRoots . rootsRootDir)
+  -- The following is needed to ensure that the default location of the
+  -- standard library exists
+  void
+    . liftIO
+    . runM
+    . runFilesIO
+    . runError @Text
+    . runReader e
+    . runPathResolver root
+    $ entrySetup
+  loadEntryPoint e
+
+getReplEntryPoint :: Prepath File -> Repl EntryPoint
+getReplEntryPoint inputFile = do
+  roots <- Reader.asks (^. replRoots)
+  gopts <- State.gets (^. replStateGlobalOptions)
+  liftIO (entryPointFromGlobalOptionsPre roots inputFile gopts)
+
+displayVersion :: String -> Repl ()
+displayVersion _ = liftIO (putStrLn versionTag)
+
+replCommand :: ReplOptions -> String -> Repl ()
+replCommand opts input = Repline.dontCrash $ do
+  ctx <- replGetContext
+  let tab = ctx ^. replContextArtifacts . artifactCoreTable
+  evalRes <- compileThenEval ctx input
+  whenJust evalRes $ \n ->
+    if
+        | Info.member Info.kNoDisplayInfo (Core.getInfo n) -> return ()
+        | opts ^. replPrintValues ->
+            renderOut (Core.ppOut opts (toValue tab n))
+        | otherwise -> renderOut (Core.ppOut opts n)
+  where
+    compileThenEval :: ReplContext -> String -> Repl (Maybe Core.Node)
+    compileThenEval ctx s = compileString >>= mapM eval
+      where
+        artif :: Artifacts
+        artif = ctx ^. replContextArtifacts
+
+        eval :: Core.Node -> Repl Core.Node
+        eval n = do
+          ep <- getReplEntryPoint (mkPrepath (toFilePath replPath))
+          let shouldDisambiguate :: Bool
+              shouldDisambiguate = not (opts ^. replNoDisambiguate)
+          (artif', n') <-
+            replFromEither
+              . run
+              . runReader ep
+              . runError @JuvixError
+              . runState artif
+              . runTransformations shouldDisambiguate (opts ^. replTransformations)
+              $ n
+          liftIO (doEvalIO' artif' n') >>= replFromEither
+
+        doEvalIO' :: Artifacts -> Core.Node -> IO (Either JuvixError Core.Node)
+        doEvalIO' artif' n =
+          mapLeft (JuvixError @Core.CoreError)
+            <$> doEvalIO False replDefaultLoc (artif' ^. artifactCoreTable) n
+
+        compileString :: Repl (Maybe Core.Node)
+        compileString = do
+          (artifacts, res) <- liftIO $ compileReplInputIO' ctx (strip (pack s))
+          res' <- replFromEither res
+          State.modify (over (replStateContext . _Just) (set replContextArtifacts artifacts))
+          return res'
+
+core :: String -> Repl ()
+core input = Repline.dontCrash $ do
+  ctx <- replGetContext
+  opts <- Reader.asks (^. replOptions)
+  compileRes <- liftIO (compileReplInputIO' ctx (strip (pack input))) >>= replFromEither . snd
+  whenJust compileRes (renderOut . Core.ppOut opts)
+
+printDefinition :: String -> Repl ()
+printDefinition input = Repline.dontCrash $ do
+  ctx <- replGetContext
+  gopts <- State.gets (^. replStateGlobalOptions)
+  compileRes <- liftIO (inferExpressionIO' ctx (strip (pack input)))
+  let tbl :: Internal.InfoTable = ctx ^. replContextArtifacts . artifactInternalTypedTable
+
+      getIdentifier :: Internal.Expression -> Maybe Internal.Iden
+      getIdentifier = \case
+        Internal.ExpressionIden n -> return n
+        _ -> Nothing
+
+      printFunction :: Internal.FunctionName -> Repl ()
+      printFunction fun = do
+        let def :: Internal.FunctionDef = tbl ^?! Internal.infoFunctions . at fun . _Just . Internal.functionInfoDef
+        renderOut (Internal.ppOut (project' @GenericOptions gopts) def)
+
+      printInductive :: Internal.InductiveName -> Repl ()
+      printInductive ind = do
+        let def :: Internal.InductiveDef = tbl ^?! Internal.infoInductives . at ind . _Just . Internal.inductiveInfoDef
+        renderOut (Internal.ppOut (project' @GenericOptions gopts) def)
+
+      printAxiom :: Internal.AxiomName -> Repl ()
+      printAxiom ax = do
+        let def :: Internal.AxiomDef = tbl ^?! Internal.infoAxioms . at ax . _Just . Internal.axiomInfoDef
+        renderOut (Internal.ppOut (project' @GenericOptions gopts) def)
+
+      printConstructor :: Internal.ConstructorName -> Repl ()
+      printConstructor c = do
+        let ind :: Internal.InductiveName = tbl ^?! Internal.infoConstructors . at c . _Just . Internal.constructorInfoInductive
+        printInductive ind
+
+  case (^. Internal.typedExpression) <$> compileRes of
+    Left err -> printError err
+    Right expr -> do
+      let m = getIdentifier (expr)
+      case m of
+        Nothing -> do
+          liftIO (putStrLn ":def expects a single identifier, but got: ")
+          renderOut (Internal.ppOut (project' @GenericOptions gopts) expr)
+        Just iden -> case iden of
+          Internal.IdenAxiom a -> printAxiom a
+          Internal.IdenVar {} -> impossible
+          Internal.IdenInductive ind -> printInductive ind
+          Internal.IdenConstructor c -> printConstructor c
+          Internal.IdenFunction fun -> printFunction fun
+
+inferType :: String -> Repl ()
+inferType input = Repline.dontCrash $ do
+  ctx <- replGetContext
+  gopts <- State.gets (^. replStateGlobalOptions)
+  n <- liftIO (inferExpressionIO' ctx (strip (pack input))) >>= replFromEither
+  renderOut (Internal.ppOut (project' @GenericOptions gopts) (n ^. Internal.typedType))
+
+replCommands :: [(String, String -> Repl ())]
+replCommands =
+  [ ("help", Repline.dontCrash . printHelpTxt),
+    -- `multiline` is included here for auto-completion purposes only.
+    -- `repline`'s `multilineCommand` logic overrides this no-op.
+    (multilineCmd, Repline.dontCrash . \_ -> return ()),
+    ("quit", quit),
+    ("load", Repline.dontCrash . loadFile . pSomeFile),
+    ("reload", Repline.dontCrash . reloadFile),
+    ("root", printRoot),
+    ("def", printDefinition),
+    ("type", inferType),
+    ("version", displayVersion),
+    ("core", core)
+  ]
+
+defaultMatcher :: [(String, CompletionFunc ReplS)]
+defaultMatcher = [(":load", fileCompleter)]
+
+optsCompleter :: WordCompleter ReplS
+optsCompleter n = do
+  let names = (":" <>) . fst <$> replCommands
+  return (filter (isPrefixOf n) names)
+
+replBanner :: MultiLine -> Repl String
+replBanner = \case
+  MultiLine -> return "... "
+  SingleLine -> do
+    mmodulePath <-
+      State.gets
+        ( ^?
+            replStateContext
+              . _Just
+              . replContextArtifacts
+              . artifactMainModuleScope
+              . _Just
+              . scopePath
+              . absTopModulePath
+        )
+    case mmodulePath of
+      Just path -> return [i|#{unpack (P.prettyText path)}> |]
+      Nothing -> return "juvix> "
+
+replPrefix :: Maybe Char
+replPrefix = Just ':'
+
+replMultilineCommand :: Maybe String
+replMultilineCommand = Just multilineCmd
+
+replInitialiser :: Repl ()
+replInitialiser = do
+  gopts <- State.gets (^. replStateGlobalOptions)
+  opts <- Reader.asks (^. replOptions)
+  welcomeMsg
+  unless
+    (opts ^. replNoPrelude || gopts ^. globalNoStdlib)
+    (maybe loadDefaultPrelude (loadFile . (^. pathPath)) (opts ^. replInputFile))
+
+replFinaliser :: Repl ExitDecision
+replFinaliser = return Exit
+
+replTabComplete :: CompleterStyle ReplS
+replTabComplete = Prefix (wordCompleter optsCompleter) defaultMatcher
+
+printRoot :: String -> Repl ()
+printRoot _ = do
+  r <- State.gets (^. replStateRoots . rootsRootDir)
+  liftIO $ putStrLn (pack (toFilePath r))
 
 runCommand :: Members '[Embed IO, App] r => ReplOptions -> Sem r ()
 runCommand opts = do
   roots <- askRoots
-  let getReplEntryPoint :: Prepath File -> Repl EntryPoint
-      getReplEntryPoint inputFile = do
-        gopts <- State.gets (^. replStateGlobalOptions)
-        liftIO (entryPointFromGlobalOptionsPre roots inputFile gopts)
-
-      printHelpTxt :: String -> Repl ()
-      printHelpTxt _ = helpTxt
-
-      multilineCmd :: String
-      multilineCmd = "multiline"
-
-      quit :: String -> Repl ()
-      quit _ = liftIO (throwIO Interrupt)
-
-      loadEntryPoint :: EntryPoint -> Repl ()
-      loadEntryPoint ep = do
-        artif <- liftIO (corePipelineIO' ep)
-        State.modify
-          ( set
-              replStateContext
-              ( Just
-                  ( ReplContext
-                      { _replContextArtifacts = artif,
-                        _replContextEntryPoint = ep
-                      }
-                  )
-              )
-          )
-        let epPath :: Maybe (Path Abs File) = ep ^? entryPointModulePaths . _head
-        whenJust epPath $ \path -> liftIO (putStrLn [i|OK loaded: #{toFilePath path}|])
-
-      reloadFile :: String -> Repl ()
-      reloadFile _ = do
-        mentryPoint <- State.gets (fmap (^. replContextEntryPoint) . (^. replStateContext))
-        case mentryPoint of
-          Just entryPoint -> do
-            loadEntryPoint entryPoint
-          Nothing -> noFileLoadedMsg
-
-      pSomeFile :: String -> Prepath File
-      pSomeFile = mkPrepath
-
-      loadFile :: Prepath File -> Repl ()
-      loadFile f = do
-        entryPoint <- getReplEntryPoint f
-        loadEntryPoint entryPoint
-
-      loadDefaultPrelude :: Repl ()
-      loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
-        let root = roots ^. rootsRootDir
-        -- The following is needed to ensure that the default location of the
-        -- standard library exists
-        void
-          . liftIO
-          . runM
-          . runFilesIO
-          . runError @Text
-          . runReader e
-          . runPathResolver root
-          $ entrySetup
-        loadEntryPoint e
-
-      printRoot :: String -> Repl ()
-      printRoot _ = do
-        r <- State.gets (^. replStateRoots . rootsRootDir)
-        liftIO $ putStrLn (pack (toFilePath r))
-
-      displayVersion :: String -> Repl ()
-      displayVersion _ = liftIO (putStrLn versionTag)
-
-      command :: String -> Repl ()
-      command input = Repline.dontCrash $ do
-        ctx <- State.gets (^. replStateContext)
-        case ctx of
-          Just ctx' -> do
-            let tab = ctx' ^. replContextArtifacts . artifactCoreTable
-            evalRes <- compileThenEval ctx' input
-            case evalRes of
-              Left err -> printError err
-              Right (Just n)
-                | Info.member Info.kNoDisplayInfo (Core.getInfo n) -> return ()
-              Right (Just n)
-                | opts ^. replPrintValues ->
-                    renderOut (Core.ppOut opts (toValue tab n))
-                | otherwise ->
-                    renderOut (Core.ppOut opts n)
-              Right Nothing -> return ()
-          Nothing -> noFileLoadedMsg
-        where
-          defaultLoc :: Interval
-          defaultLoc = singletonInterval (mkInitialLoc replPath)
-
-          compileThenEval :: ReplContext -> String -> Repl (Either JuvixError (Maybe Core.Node))
-          compileThenEval ctx s = do
-            mn <- compileString
-            case mn of
-              Left err -> return (Left err)
-              Right Nothing -> return (Right Nothing)
-              Right (Just n) -> fmap Just <$> eval n
-            where
-              artif :: Artifacts
-              artif = ctx ^. replContextArtifacts
-
-              shouldDisambiguate :: Bool
-              shouldDisambiguate = not (opts ^. replNoDisambiguate)
-
-              eval :: Core.Node -> Repl (Either JuvixError Core.Node)
-              eval n = do
-                ep <- getReplEntryPoint (mkPrepath (toFilePath replPath))
-                case run
-                  . runReader ep
-                  . runError @JuvixError
-                  . runState artif
-                  . runTransformations shouldDisambiguate (opts ^. replTransformations)
-                  $ n of
-                  Left err -> return $ Left err
-                  Right (artif', n') -> liftIO (doEvalIO' artif' n')
-
-              doEvalIO' :: Artifacts -> Core.Node -> IO (Either JuvixError Core.Node)
-              doEvalIO' artif' n =
-                mapLeft (JuvixError @Core.CoreError)
-                  <$> doEvalIO False defaultLoc (artif' ^. artifactCoreTable) n
-
-              compileString :: Repl (Either JuvixError (Maybe Core.Node))
-              compileString = do
-                (artifacts, res) <- liftIO $ compileReplInputIO' ctx (strip (pack s))
-                State.modify (over (replStateContext . _Just) (set replContextArtifacts artifacts))
-                return res
-
-      core :: String -> Repl ()
-      core input = Repline.dontCrash $ do
-        ctx <- State.gets (^. replStateContext)
-        case ctx of
-          Just ctx' -> do
-            compileRes <- snd <$> liftIO (compileReplInputIO' ctx' (strip (pack input)))
-            case compileRes of
-              Left err -> printError err
-              Right (Just n) -> renderOut (Core.ppOut opts n)
-              Right Nothing -> return ()
-          Nothing -> noFileLoadedMsg
-
-      printDefinition :: String -> Repl ()
-      printDefinition input = Repline.dontCrash $ do
-        ctx <- State.gets (^. replStateContext)
-        gopts <- State.gets (^. replStateGlobalOptions)
-        case ctx of
-          Nothing -> noFileLoadedMsg
-          Just ctx' -> do
-            compileRes <- liftIO (inferExpressionIO' ctx' (strip (pack input)))
-            let tbl :: Internal.InfoTable = ctx' ^. replContextArtifacts . artifactInternalTypedTable
-
-                getIdentifier :: Internal.Expression -> Maybe Internal.Iden
-                getIdentifier = \case
-                  Internal.ExpressionIden n -> return n
-                  _ -> Nothing
-
-                printFunction :: Internal.FunctionName -> Repl ()
-                printFunction fun = do
-                  let def :: Internal.FunctionDef = tbl ^?! Internal.infoFunctions . at fun . _Just . Internal.functionInfoDef
-                  renderOut (Internal.ppOut (project' @GenericOptions gopts) def)
-
-                printInductive :: Internal.InductiveName -> Repl ()
-                printInductive ind = do
-                  let def :: Internal.InductiveDef = tbl ^?! Internal.infoInductives . at ind . _Just . Internal.inductiveInfoDef
-                  renderOut (Internal.ppOut (project' @GenericOptions gopts) def)
-
-                printAxiom :: Internal.AxiomName -> Repl ()
-                printAxiom ax = do
-                  let def :: Internal.AxiomDef = tbl ^?! Internal.infoAxioms . at ax . _Just . Internal.axiomInfoDef
-                  renderOut (Internal.ppOut (project' @GenericOptions gopts) def)
-
-                printConstructor :: Internal.ConstructorName -> Repl ()
-                printConstructor c = do
-                  let ind :: Internal.InductiveName = tbl ^?! Internal.infoConstructors . at c . _Just . Internal.constructorInfoInductive
-                  printInductive ind
-
-            case (^. Internal.typedExpression) <$> compileRes of
-              Left err -> printError err
-              Right expr -> do
-                let m = getIdentifier (expr)
-                case m of
-                  Nothing -> do
-                    liftIO (putStrLn ":def expects a single identifier, but got: ")
-                    renderOut (Internal.ppOut (project' @GenericOptions gopts) expr)
-                  Just iden -> case iden of
-                    Internal.IdenAxiom a -> printAxiom a
-                    Internal.IdenVar {} -> impossible
-                    Internal.IdenInductive ind -> printInductive ind
-                    Internal.IdenConstructor c -> printConstructor c
-                    Internal.IdenFunction fun -> printFunction fun
-
-      inferType :: String -> Repl ()
-      inferType input = Repline.dontCrash $ do
-        ctx <- State.gets (^. replStateContext)
-        gopts <- State.gets (^. replStateGlobalOptions)
-        case ctx of
-          Just ctx' -> do
-            compileRes <- liftIO (inferExpressionIO' ctx' (strip (pack input)))
-            case compileRes of
-              Left err -> printError err
-              Right n -> renderOut (Internal.ppOut (project' @GenericOptions gopts) (n ^. Internal.typedType))
-          Nothing -> noFileLoadedMsg
-
-      options :: [(String, String -> Repl ())]
-      options =
-        [ ("help", Repline.dontCrash . printHelpTxt),
-          -- `multiline` is included here for auto-completion purposes only.
-          -- `repline`'s `multilineCommand` logic overrides this no-op.
-          (multilineCmd, Repline.dontCrash . \_ -> return ()),
-          ("quit", quit),
-          ("load", Repline.dontCrash . loadFile . pSomeFile),
-          ("reload", Repline.dontCrash . reloadFile),
-          ("root", printRoot),
-          ("def", printDefinition),
-          ("type", inferType),
-          ("version", displayVersion),
-          ("core", core)
-        ]
-
-      defaultMatcher :: [(String, CompletionFunc ReplS)]
-      defaultMatcher = [(":load", fileCompleter)]
-
-      optsCompleter :: WordCompleter ReplS
-      optsCompleter n = do
-        let names = (":" <>) . fst <$> options
-        return (filter (isPrefixOf n) names)
-
-      banner :: MultiLine -> Repl String
-      banner = \case
-        MultiLine -> return "... "
-        SingleLine -> do
-          mmodulePath <-
-            State.gets
-              ( ^?
-                  replStateContext
-                    . _Just
-                    . replContextArtifacts
-                    . artifactMainModuleScope
-                    . _Just
-                    . scopePath
-                    . absTopModulePath
-              )
-          case mmodulePath of
-            Just path -> return [i|#{unpack (P.prettyText path)}> |]
-            Nothing -> return "juvix> "
-
-      prefix :: Maybe Char
-      prefix = Just ':'
-
-      multilineCommand :: Maybe String
-      multilineCommand = Just multilineCmd
-
-      initialiser :: Repl ()
-      initialiser = do
-        gopts <- State.gets (^. replStateGlobalOptions)
-        welcomeMsg
-        unless
-          (opts ^. replNoPrelude || gopts ^. globalNoStdlib)
-          (maybe loadDefaultPrelude (loadFile . (^. pathPath)) (opts ^. replInputFile))
-
-      finaliser :: Repl ExitDecision
-      finaliser = return Exit
-
-      tabComplete :: CompleterStyle ReplS
-      tabComplete = Prefix (wordCompleter optsCompleter) defaultMatcher
-
-      replAction :: ReplS ()
+  let replAction :: ReplS ()
       replAction = do
         evalReplOpts
           ReplOpts
-            { prefix,
-              multilineCommand,
-              initialiser,
-              finaliser,
-              tabComplete,
-              command,
-              options,
-              banner
+            { prefix = replPrefix,
+              multilineCommand = replMultilineCommand,
+              initialiser = replInitialiser,
+              finaliser = replFinaliser,
+              tabComplete = replTabComplete,
+              command = replCommand opts,
+              options = replCommands,
+              banner = replBanner
             }
   globalOptions <- askGlobalOptions
-  embed
-    ( State.evalStateT
-        replAction
-        ( ReplState
-            { _replStateRoots = roots,
-              _replStateContext = Nothing,
-              _replStateGlobalOptions = globalOptions
-            }
-        )
-    )
+  let env =
+        ReplEnv
+          { _replRoots = roots,
+            _replOptions = opts
+          }
+      iniState =
+        ReplState
+          { _replStateRoots = roots,
+            _replStateContext = Nothing,
+            _replStateGlobalOptions = globalOptions
+          }
+  e <-
+    embed
+      . Except.runExceptT
+      . (`State.evalStateT` iniState)
+      . (`Reader.runReaderT` env)
+      $ replAction
+  case e of
+    Left {} -> error "impossible: uncaught exception"
+    Right () -> return ()
 
 -- | If the package contains the stdlib as a dependency, loads the Prelude
 defaultPreludeEntryPoint :: Repl (Maybe EntryPoint)

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -218,7 +218,7 @@ printDefinition input = do
             _ -> err
             where
               err :: Repl a
-              err = replError (AnsiText @Text ":def one or more identifiers")
+              err = replError (AnsiText @Text ":def expects one or more identifiers")
 
       printIdentifier :: Concrete.ScopedIden -> Repl ()
       printIdentifier = \case

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -227,9 +227,10 @@ runCommand opts = do
         ctx <- State.gets (^. replStateContext)
         gopts <- State.gets (^. replStateGlobalOptions)
         case ctx of
+          Nothing -> noFileLoadedMsg
           Just ctx' -> do
             compileRes <- liftIO (inferExpressionIO' ctx' (strip (pack input)))
-            let tbl :: Internal.InfoTable = ctx ^?! _Just . replContextArtifacts . artifactInternalTypedTable
+            let tbl :: Internal.InfoTable = ctx' ^. replContextArtifacts . artifactInternalTypedTable
 
                 printFunction :: Internal.FunctionName -> Repl ()
                 printFunction fun = do
@@ -260,7 +261,6 @@ runCommand opts = do
                   Internal.IdenInductive ind -> printInductive ind
                   Internal.IdenConstructor c -> printConstructor c
                   Internal.IdenFunction fun -> printFunction fun
-          Nothing -> noFileLoadedMsg
         where
           getIdentifier :: Internal.Expression -> Repl Internal.Iden
           getIdentifier = \case

--- a/app/Commands/Repl/Base.hs
+++ b/app/Commands/Repl/Base.hs
@@ -1,0 +1,34 @@
+module Commands.Repl.Base where
+
+import Commands.Base hiding
+  ( command,
+  )
+import Commands.Repl.Options
+import Control.Monad.Except qualified as Except
+import Control.Monad.Reader qualified as Reader
+import Control.Monad.State.Strict qualified as State
+import System.Console.Repline
+
+type ReplS = Reader.ReaderT ReplEnv (State.StateT ReplState (Except.ExceptT JuvixError IO))
+
+type Repl a = HaskelineT ReplS a
+
+data ReplContext = ReplContext
+  { _replContextArtifacts :: Artifacts,
+    _replContextEntryPoint :: EntryPoint
+  }
+
+data ReplEnv = ReplEnv
+  { _replRoots :: Roots,
+    _replOptions :: ReplOptions
+  }
+
+data ReplState = ReplState
+  { _replStateRoots :: Roots,
+    _replStateContext :: Maybe ReplContext,
+    _replStateGlobalOptions :: GlobalOptions
+  }
+
+makeLenses ''ReplState
+makeLenses ''ReplContext
+makeLenses ''ReplEnv

--- a/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
@@ -53,5 +53,6 @@ makeLenses ''AxiomInfo
 makeLenses ''FunctionInfo
 
 instance HasLoc FunctionInfo where
-  getLoc f = getLoc (f ^. functionInfoType) <>?
-    (getLocSpan <$> nonEmpty (f ^. functionInfoClauses))
+  getLoc f =
+    getLoc (f ^. functionInfoType)
+      <>? (getLocSpan <$> nonEmpty (f ^. functionInfoClauses))

--- a/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
@@ -10,13 +10,14 @@ data FunctionInfo = FunctionInfo
   }
   deriving stock (Eq, Show)
 
-newtype ConstructorInfo = ConstructorInfo
-  { _constructorDef :: InductiveConstructorDef 'Scoped
+data ConstructorInfo = ConstructorInfo
+  { _constructorInfoDef :: InductiveConstructorDef 'Scoped,
+    _constructorInfoTypeName :: S.Symbol
   }
   deriving stock (Eq, Show)
 
 newtype AxiomInfo = AxiomInfo
-  { _axiomDef :: AxiomDef 'Scoped
+  { _axiomInfoDef :: AxiomDef 'Scoped
   }
   deriving stock (Eq, Show)
 
@@ -50,3 +51,7 @@ makeLenses ''InductiveInfo
 makeLenses ''ConstructorInfo
 makeLenses ''AxiomInfo
 makeLenses ''FunctionInfo
+
+instance HasLoc FunctionInfo where
+  getLoc f = getLoc (f ^. functionInfoType) <>?
+    (getLocSpan <$> nonEmpty (f ^. functionInfoClauses))

--- a/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
@@ -4,18 +4,19 @@ import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
 import Juvix.Compiler.Concrete.Language
 import Juvix.Prelude
 
-newtype FunctionInfo = FunctionInfo
-  { _functionInfoType :: Expression
+data FunctionInfo = FunctionInfo
+  { _functionInfoType :: TypeSignature 'Scoped,
+    _functionInfoClauses :: [FunctionClause 'Scoped]
   }
   deriving stock (Eq, Show)
 
 newtype ConstructorInfo = ConstructorInfo
-  { _constructorInfoType :: Expression
+  { _constructorDef :: InductiveConstructorDef 'Scoped
   }
   deriving stock (Eq, Show)
 
 newtype AxiomInfo = AxiomInfo
-  { _axiomInfoType :: Expression
+  { _axiomDef :: AxiomDef 'Scoped
   }
   deriving stock (Eq, Show)
 
@@ -27,12 +28,11 @@ newtype InductiveInfo = InductiveInfo
 type DocTable = HashMap NameId (Judoc 'Scoped)
 
 data InfoTable = InfoTable
-  { _infoConstructors :: HashMap ConstructorRef ConstructorInfo,
+  { _infoConstructors :: HashMap S.NameId ConstructorInfo,
     _infoModules :: HashMap S.TopModulePath (Module 'Scoped 'ModuleTop),
-    _infoAxioms :: HashMap AxiomRef AxiomInfo,
-    _infoInductives :: HashMap InductiveRef InductiveInfo,
-    _infoFunctions :: HashMap FunctionRef FunctionInfo,
-    _infoFunctionClauses :: HashMap S.Symbol (FunctionClause 'Scoped)
+    _infoAxioms :: HashMap S.NameId AxiomInfo,
+    _infoInductives :: HashMap S.NameId InductiveInfo,
+    _infoFunctions :: HashMap S.NameId FunctionInfo
   }
 
 emptyInfoTable :: InfoTable
@@ -42,8 +42,7 @@ emptyInfoTable =
       _infoAxioms = mempty,
       _infoModules = mempty,
       _infoInductives = mempty,
-      _infoFunctions = mempty,
-      _infoFunctionClauses = mempty
+      _infoFunctions = mempty
     }
 
 makeLenses ''InfoTable

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -10,7 +10,7 @@ import Juvix.Prelude
 
 data InfoTableBuilder m a where
   RegisterAxiom :: AxiomDef 'Scoped -> InfoTableBuilder m ()
-  RegisterConstructor :: InductiveConstructorDef 'Scoped -> InfoTableBuilder m ()
+  RegisterConstructor :: S.Symbol -> InductiveConstructorDef 'Scoped -> InfoTableBuilder m ()
   RegisterInductive :: InductiveDef 'Scoped -> InfoTableBuilder m ()
   RegisterTypeSignature :: TypeSignature 'Scoped -> InfoTableBuilder m ()
   RegisterFunctionClause :: FunctionClause 'Scoped -> InfoTableBuilder m ()
@@ -31,9 +31,9 @@ toState = reinterpret $ \case
      in do
           modify (over infoAxioms (HashMap.insert ref info))
           registerDoc (d ^. axiomName . nameId) j
-  RegisterConstructor c ->
+  RegisterConstructor ind c ->
     let ref = c ^. constructorName . S.nameId
-        info = ConstructorInfo c
+        info = ConstructorInfo c ind
         j = c ^. constructorDoc
      in do
           modify (over infoConstructors (HashMap.insert ref info))

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1624,5 +1624,13 @@ symbolEntryToSName = \case
   EntryModule m -> getModuleRefNameType m
   EntryVariable m -> m
 
+instance HasNameKind ScopedIden where
+  getNameKind = \case
+    ScopedAxiom {} -> KNameAxiom
+    ScopedInductive {} -> KNameInductive
+    ScopedConstructor {} -> KNameConstructor
+    ScopedVar {} -> KNameLocal
+    ScopedFunction {} -> KNameFunction
+
 instance HasNameKind SymbolEntry where
   getNameKind = getNameKind . entryName

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -18,6 +18,7 @@ import Juvix.Data.Ape
 import Juvix.Data.CodeAnn
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
+import Juvix.Compiler.Concrete.Data.InfoTable
 
 doc :: (PrettyCode c) => Options -> c -> Doc Ann
 doc opts =
@@ -118,6 +119,12 @@ groupStatements = \case
                   _inductiveName
                     ^. S.nameConcrete
                     : map (^. constructorName . S.nameConcrete) constructors
+
+instance PrettyCode FunctionInfo where
+  ppCode f = do
+    let ty = StatementTypeSignature (f ^. functionInfoType)
+        cs = map StatementFunctionClause (f ^. functionInfoClauses)
+    ppCode (ty : cs)
 
 instance (SingI s) => PrettyCode [Statement s] where
   ppCode ss = vsep2 <$> mapM (fmap vsep . mapM (fmap endSemicolon . ppCode)) (groupStatements ss)

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -6,6 +6,7 @@ module Juvix.Compiler.Concrete.Pretty.Base
 where
 
 import Data.List.NonEmpty.Extra qualified as NonEmpty
+import Juvix.Compiler.Concrete.Data.InfoTable
 import Juvix.Compiler.Concrete.Data.ScopedName
   ( AbsModulePath,
     IsConcrete (..),
@@ -18,7 +19,6 @@ import Juvix.Data.Ape
 import Juvix.Data.CodeAnn
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
-import Juvix.Compiler.Concrete.Data.InfoTable
 
 doc :: (PrettyCode c) => Options -> c -> Doc Ann
 doc opts =

--- a/src/Juvix/Compiler/Concrete/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Options.hs
@@ -22,3 +22,6 @@ fromGenericOptions GenericOptions {..} =
 
 inJudocBlock :: Members '[Reader Options] r => Sem r a -> Sem r a
 inJudocBlock = local (set optInJudocBlock True)
+
+instance CanonicalProjection GenericOptions Options where
+  project = fromGenericOptions

--- a/src/Juvix/Compiler/Concrete/Print.hs
+++ b/src/Juvix/Compiler/Concrete/Print.hs
@@ -16,3 +16,6 @@ ppOutDefault cs = AnsiText . PPOutput . doc defaultOptions cs
 
 ppOut :: (CanonicalProjection a Options, PrettyPrint c, HasLoc c) => a -> Comments -> c -> AnsiText
 ppOut o cs = AnsiText . PPOutput . doc (project o) cs
+
+ppOutNoComments :: (CanonicalProjection a Options, PrettyPrint c, HasLoc c) => a -> c -> AnsiText
+ppOutNoComments o = AnsiText . PPOutput . doc (project o) emptyComments

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -15,7 +15,6 @@ import Juvix.Data.Effect.ExactPrint
 import Juvix.Data.Keyword.All
 import Juvix.Prelude hiding ((<+>), (<+?>), (<?+>), (?<>))
 import Juvix.Prelude.Pretty (annotate, pretty)
-import Juvix.Compiler.Concrete.Data.InfoTable
 
 class PrettyPrint a where
   ppCode :: Members '[ExactPrint, Reader Options] r => a -> Sem r ()
@@ -440,11 +439,6 @@ instance PrettyPrint (InductiveDef 'Scoped) where
     where
       ppConstructorBlock :: NonEmpty (InductiveConstructorDef 'Scoped) -> Sem r ()
       ppConstructorBlock cs = vsep (ppCode <$> cs)
-
-instance PrettyPrint FunctionInfo where
-  ppCode f = do
-    ppCode (StatementTypeSignature (f ^. functionInfoType))
-    ppCode (map StatementFunctionClause (f ^. functionInfoClauses))
 
 instance PrettyPrint (Statement 'Scoped) where
   ppCode = \case

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -15,6 +15,7 @@ import Juvix.Data.Effect.ExactPrint
 import Juvix.Data.Keyword.All
 import Juvix.Prelude hiding ((<+>), (<+?>), (<?+>), (?<>))
 import Juvix.Prelude.Pretty (annotate, pretty)
+import Juvix.Compiler.Concrete.Data.InfoTable
 
 class PrettyPrint a where
   ppCode :: Members '[ExactPrint, Reader Options] r => a -> Sem r ()
@@ -439,6 +440,11 @@ instance PrettyPrint (InductiveDef 'Scoped) where
     where
       ppConstructorBlock :: NonEmpty (InductiveConstructorDef 'Scoped) -> Sem r ()
       ppConstructorBlock cs = vsep (ppCode <$> cs)
+
+instance PrettyPrint FunctionInfo where
+  ppCode f = do
+    ppCode (StatementTypeSignature (f ^. functionInfoType))
+    ppCode (map StatementFunctionClause (f ^. functionInfoClauses))
 
 instance PrettyPrint (Statement 'Scoped) where
   ppCode = \case

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -469,7 +469,7 @@ checkTypeSignature TypeSignature {..} = do
   sigName' <- bindFunctionSymbol _sigName
   sigDoc' <- mapM checkJudoc _sigDoc
   sigBody' <- mapM checkParseExpressionAtoms _sigBody
-  registerFunction
+  registerTypeSignature
     @$> TypeSignature
       { _sigName = sigName',
         _sigType = sigType',

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -62,6 +62,29 @@ scopeCheck pr modules =
           _resultScoperState = scoperSt
         }
 
+-- TODO refactor to have less code duplication
+scopeCheckExpressionAtoms ::
+  forall r.
+  (Members '[Error JuvixError, NameIdGen, State Scope] r) =>
+  InfoTable ->
+  ExpressionAtoms 'Parsed ->
+  Sem r (ExpressionAtoms 'Scoped)
+scopeCheckExpressionAtoms tab as = mapError (JuvixError @ScoperError) $ do
+  fmap snd
+    . ignoreHighlightBuilder
+    . runInfoTableBuilder tab
+    . runReader iniScopeParameters
+    . evalState iniScoperState
+    . withLocalScope
+    $ checkExpressionAtoms as
+  where
+    iniScopeParameters :: ScopeParameters
+    iniScopeParameters =
+      ScopeParameters
+        { _scopeTopParents = mempty,
+          _scopeParsedModules = mempty
+        }
+
 scopeCheckExpression ::
   forall r.
   (Members '[Error JuvixError, NameIdGen, State Scope] r) =>
@@ -69,14 +92,13 @@ scopeCheckExpression ::
   ExpressionAtoms 'Parsed ->
   Sem r Expression
 scopeCheckExpression tab as = mapError (JuvixError @ScoperError) $ do
-  snd
-    <$> ( ignoreHighlightBuilder
-            . runInfoTableBuilder tab
-            . runReader iniScopeParameters
-            . evalState iniScoperState
-            . withLocalScope
-            $ checkParseExpressionAtoms as
-        )
+  fmap snd
+    . ignoreHighlightBuilder
+    . runInfoTableBuilder tab
+    . runReader iniScopeParameters
+    . evalState iniScoperState
+    . withLocalScope
+    $ checkParseExpressionAtoms as
   where
     iniScopeParameters :: ScopeParameters
     iniScopeParameters =
@@ -499,7 +521,7 @@ checkInductiveDef InductiveDef {..} = do
     inductiveParameters' <- mapM checkInductiveParameters _inductiveParameters
     inductiveType' <- mapM checkParseExpressionAtoms _inductiveType
     inductiveDoc' <- mapM checkJudoc _inductiveDoc
-    inductiveConstructors' <- mapM checkConstructorDef _inductiveConstructors
+    inductiveConstructors' <- mapM (checkConstructorDef inductiveName') _inductiveConstructors
     return (inductiveParameters', inductiveType', inductiveDoc', inductiveConstructors')
   forM_ inductiveConstructors' bindConstructor
   registerInductive
@@ -526,12 +548,12 @@ checkInductiveDef InductiveDef {..} = do
               )
           )
     -- note that the constructor name is not bound here
-    checkConstructorDef :: InductiveConstructorDef 'Parsed -> Sem r (InductiveConstructorDef 'Scoped)
-    checkConstructorDef InductiveConstructorDef {..} = do
+    checkConstructorDef :: S.Symbol -> InductiveConstructorDef 'Parsed -> Sem r (InductiveConstructorDef 'Scoped)
+    checkConstructorDef tyName InductiveConstructorDef {..} = do
       constructorType' <- checkParseExpressionAtoms _constructorType
       constructorName' <- reserveSymbolOf S.KNameConstructor _constructorName
       doc' <- mapM checkJudoc _constructorDoc
-      registerConstructor
+      registerConstructor tyName
         @$> InductiveConstructorDef
           { _constructorName = constructorName',
             _constructorType = constructorType',

--- a/src/Juvix/Compiler/Internal/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Internal/Data/InfoTable.hs
@@ -16,9 +16,8 @@ newtype FunctionInfo = FunctionInfo
   { _functionInfoDef :: FunctionDef
   }
 
-data AxiomInfo = AxiomInfo
-  { _axiomInfoType :: Expression,
-    _axiomInfoBuiltin :: Maybe BuiltinAxiom
+newtype AxiomInfo = AxiomInfo
+  { _axiomInfoDef :: AxiomDef
   }
 
 newtype InductiveInfo = InductiveInfo
@@ -157,21 +156,13 @@ buildTable1' m = do
     _infoAxioms :: HashMap Name AxiomInfo
     _infoAxioms =
       HashMap.fromList
-        [ (d ^. axiomName, AxiomInfo (d ^. axiomType) (d ^. axiomBuiltin))
+        [ (d ^. axiomName, AxiomInfo d)
           | StatementAxiom d <- ss
         ]
 
     ss :: [Statement]
     ss = m ^. moduleBody . moduleStatements
 
--- | Returns all statements in a module, including those in local modules
--- flattenModule :: Module -> [Statement]
--- flattenModule m = concatMap go (m ^. moduleBody . moduleStatements)
---   where
---     go :: Statement -> [Statement]
---     go = \case
---       StatementModule l -> flattenModule l
---       s -> [s]
 lookupConstructor :: (Member (Reader InfoTable) r) => Name -> Sem r ConstructorInfo
 lookupConstructor f = HashMap.lookupDefault impossible f <$> asks (^. infoConstructors)
 
@@ -239,7 +230,7 @@ getAxiomBuiltinInfo :: Member (Reader InfoTable) r => Name -> Sem r (Maybe Built
 getAxiomBuiltinInfo n = do
   maybeAxiomInfo <- HashMap.lookup n <$> asks (^. infoAxioms)
   return $ case maybeAxiomInfo of
-    Just axiomInfo -> axiomInfo ^. axiomInfoBuiltin
+    Just axiomInfo -> axiomInfo ^. axiomInfoDef . axiomBuiltin
     Nothing -> Nothing
 
 getFunctionBuiltinInfo :: Member (Reader InfoTable) r => Name -> Sem r (Maybe BuiltinFunction)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -3,8 +3,8 @@ module Juvix.Compiler.Internal.Translation.FromInternal
     arityChecking,
     typeChecking,
     typeCheckExpression,
+    typeCheckExpressionType,
     arityCheckExpression,
-    inferExpressionType,
     arityCheckInclude,
     typeCheckInclude,
   )
@@ -103,12 +103,6 @@ typeCheckInclude i = do
       . runReader table
       . withEmptyVars
     $ checkInclude i
-
-inferExpressionType ::
-  (Members '[Error JuvixError, State Artifacts] r) =>
-  Expression ->
-  Sem r Expression
-inferExpressionType exp = (^. typedType) <$> typeCheckExpressionType exp
 
 typeChecking ::
   Members '[HighlightBuilder, Error JuvixError, Builtins, NameIdGen] r =>

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -450,7 +450,7 @@ idenArity = \case
   IdenInductive i -> typeArity <$> inductiveType i
   IdenFunction f -> typeArity . (^. functionInfoDef . funDefType) <$> lookupFunction f
   IdenConstructor c -> typeArity <$> constructorType c
-  IdenAxiom a -> typeArity . (^. axiomInfoType) <$> lookupAxiom a
+  IdenAxiom a -> typeArity . (^. axiomInfoDef . axiomType) <$> lookupAxiom a
 
 -- | let x be some expression of type T. The argument of this function is T and it returns
 -- the arity of x. In other words, given (T : Type), it returns the arity of the elements of T.

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -699,7 +699,7 @@ inferExpression' hint e = case e of
         return (TypedExpression ty (ExpressionIden i))
       IdenAxiom v -> do
         info <- lookupAxiom v
-        return (TypedExpression (info ^. axiomInfoType) (ExpressionIden i))
+        return (TypedExpression (info ^. axiomInfoDef . axiomType) (ExpressionIden i))
       IdenInductive v -> do
         kind <- inductiveType v
         return (TypedExpression kind (ExpressionIden i))

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -107,11 +107,11 @@ inferExpression ::
   Members '[Error JuvixError, State Artifacts] r =>
   Path Abs File ->
   Text ->
-  Sem r Internal.Expression
+  Sem r Internal.TypedExpression
 inferExpression fp txt = do
   p <- parseExpression fp txt
   arityCheckExpression p
-    >>= Internal.inferExpressionType
+    >>= Internal.typeCheckExpressionType
 
 compileExpression ::
   Members '[Error JuvixError, State Artifacts] r =>
@@ -183,6 +183,6 @@ inferExpressionIO ::
   Members '[State Artifacts, Embed IO] r =>
   Path Abs File ->
   Text ->
-  Sem r (Either JuvixError Internal.Expression)
+  Sem r (Either JuvixError Internal.TypedExpression)
 inferExpressionIO fp txt =
   runError (inferExpression fp txt)

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -49,7 +49,7 @@ expressionUpToAtomsScoped fp txt = do
     . runBuiltinsArtifacts
     . runScoperScopeArtifacts
     $ Parser.expressionFromTextSource fp txt
-    >>= Scoper.scopeCheckExpressionAtoms scopeTable
+      >>= Scoper.scopeCheckExpressionAtoms scopeTable
 
 scopeCheckExpression ::
   Members '[Error JuvixError, State Artifacts] r =>

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -16,7 +16,7 @@ data GenericError = GenericError
     _genericErrorIntervals :: [Interval]
   }
 
-data GenericOptions = GenericOptions
+newtype GenericOptions = GenericOptions
   { _showNameIds :: Bool
   }
   deriving stock (Eq, Show)
@@ -47,6 +47,9 @@ genericErrorHeader g =
 
 class ToGenericError a where
   genericError :: (Member (Reader GenericOptions) r) => a -> Sem r GenericError
+
+instance ToGenericError GenericError where
+  genericError = return
 
 errorIntervals :: (ToGenericError e, Member (Reader GenericOptions) r) => e -> Sem r [Interval]
 errorIntervals e = do

--- a/src/Juvix/Data/NameKind.hs
+++ b/src/Juvix/Data/NameKind.hs
@@ -38,13 +38,13 @@ nameKindWithArticle = withArticle . nameKindText
 
 nameKindText :: NameKind -> Text
 nameKindText = \case
-    KNameConstructor -> "constructor"
-    KNameInductive -> "inductive type"
-    KNameFunction -> "function"
-    KNameLocal -> "variable"
-    KNameAxiom -> "axiom"
-    KNameLocalModule -> "local module"
-    KNameTopModule -> "module"
+  KNameConstructor -> "constructor"
+  KNameInductive -> "inductive type"
+  KNameFunction -> "function"
+  KNameLocal -> "variable"
+  KNameAxiom -> "axiom"
+  KNameLocalModule -> "local module"
+  KNameTopModule -> "module"
 
 isLocallyBounded :: (HasNameKind a) => a -> Bool
 isLocallyBounded k = case getNameKind k of

--- a/src/Juvix/Data/NameKind.hs
+++ b/src/Juvix/Data/NameKind.hs
@@ -31,7 +31,13 @@ instance HasNameKind NameKind where
   getNameKind = id
 
 instance Pretty NameKind where
-  pretty = \case
+  pretty = pretty . nameKindText
+
+nameKindWithArticle :: NameKind -> Text
+nameKindWithArticle = withArticle . nameKindText
+
+nameKindText :: NameKind -> Text
+nameKindText = \case
     KNameConstructor -> "constructor"
     KNameInductive -> "inductive type"
     KNameFunction -> "function"

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -6,13 +6,13 @@ module Juvix.Prelude.Pretty
   )
 where
 
+import Data.Text qualified as Text
 import Juvix.Prelude.Base
 import Prettyprinter hiding (concatWith, defaultLayoutOptions, hsep, sep, vsep)
 import Prettyprinter qualified as PP
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import Prettyprinter.Render.Terminal qualified as Ansi
 import Prettyprinter.Render.Text qualified as Text
-import Data.Text qualified as Text
 import Prettyprinter.Util (reflow)
 import Prelude
 

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -12,6 +12,7 @@ import Prettyprinter qualified as PP
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import Prettyprinter.Render.Terminal qualified as Ansi
 import Prettyprinter.Render.Text qualified as Text
+import Data.Text qualified as Text
 import Prettyprinter.Util (reflow)
 import Prelude
 
@@ -147,6 +148,18 @@ ordinal = \case
   11 -> "eleventh"
   12 -> "twelfth"
   n -> pretty n <> "th"
+
+isVowel :: Char -> Bool
+isVowel = (`elem` ("aeiouAEIOU" :: [Char]))
+
+withArticle :: Text -> Text
+withArticle n = articleFor n <> n
+
+articleFor :: Text -> Text
+articleFor n
+  | Text.null n = ""
+  | isVowel (Text.head n) = "an"
+  | otherwise = "a"
 
 itemize :: (Functor f, Foldable f) => f (Doc ann) -> Doc ann
 itemize = vsep . fmap ("• " <>)

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -153,7 +153,7 @@ isVowel :: Char -> Bool
 isVowel = (`elem` ("aeiouAEIOU" :: [Char]))
 
 withArticle :: Text -> Text
-withArticle n = articleFor n <> n
+withArticle n = articleFor n <> " " <> n
 
 articleFor :: Text -> Text
 articleFor n

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ ghc-options:
   "$locals": -optP-Wno-nonportable-include-path
 resolver: lts-20.21
 extra-deps:
-- git: https://github.com/janmasrovira/repline.git
-  commit: a735ab1459db408adda080eb5ea21b96fb4a6011
-- git: https://github.com/janmasrovira/haskeline.git
-  commit: 81e393e156508a20fcc197acc945b0f44aa4f82b
+  - git: https://github.com/janmasrovira/repline.git
+    commit: a735ab1459db408adda080eb5ea21b96fb4a6011
+  - git: https://github.com/janmasrovira/haskeline.git
+    commit: 81e393e156508a20fcc197acc945b0f44aa4f82b

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,8 @@
 ghc-options:
   "$locals": -optP-Wno-nonportable-include-path
 resolver: lts-20.21
+extra-deps:
+- git: https://github.com/janmasrovira/repline.git
+  commit: a735ab1459db408adda080eb5ea21b96fb4a6011
+- git: https://github.com/janmasrovira/haskeline.git
+  commit: 81e393e156508a20fcc197acc945b0f44aa4f82b

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -1,6 +1,26 @@
 working-directory: ./../../../tests/
 
 tests:
+  - name: repl-def
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def Nat"
+    stdout:
+      contains: "zero"
+    exit-status: 0
+
+  - name: repl-def-error
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def 1"
+    stdout:
+      contains: ":def expects a single identifier, but got:"
+    exit-status: 0
+
   - name: open
     command:
       - juvix

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -6,9 +6,13 @@ tests:
       - juvix
       - repl
       - ../examples/milestone/HelloWorld/HelloWorld.juvix
-    stdin: ":def Nat"
+    stdin: ":def suc"
     stdout:
-      contains: "zero"
+      contains: |
+        --- Inductive natural numbers. I.e. whole non-negative numbers.
+        builtin nat type Nat :=
+          | zero : Nat
+          | suc : Nat → Nat
     exit-status: 0
 
   - name: repl-def-error
@@ -16,9 +20,10 @@ tests:
       - juvix
       - repl
       - ../examples/milestone/HelloWorld/HelloWorld.juvix
-    stdin: ":def 1"
+    stdin: ":def 1 Nat"
     stdout:
-      contains: ":def expects a single identifier, but got:"
+      contains: |
+        :def expects one or more identifiers
     exit-status: 0
 
   - name: open

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -22,8 +22,40 @@ tests:
       - ../examples/milestone/HelloWorld/HelloWorld.juvix
     stdin: ":def 1 Nat"
     stdout:
+      matches: |
+        .*
+    stderr:
       contains: |
         :def expects one or more identifiers
+    exit-status: 0
+
+  - name: repl-def-infix
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def +"
+    stdout:
+      contains: |
+        --- Addition for ;Nat;s.
+        builtin nat-plus + : Nat → Nat → Nat;
+        + zero b := b;
+        + (suc a) b := suc (a + b);
+    exit-status: 0
+
+  - name: repl-def-multiple
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def + (+) (((+)))"
+    stdout:
+      contains: |
+        --- Addition for ;Nat;s.
+        builtin nat-plus + : Nat → Nat → Nat;
+        + zero b := b;
+        + (suc a) b := suc (a + b);
+        --- Addition for ;Nat;s.
     exit-status: 0
 
   - name: open

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -29,20 +29,6 @@ tests:
         :def expects one or more identifiers
     exit-status: 0
 
-  - name: repl-def-infix
-    command:
-      - juvix
-      - repl
-      - ../examples/milestone/HelloWorld/HelloWorld.juvix
-    stdin: ":def +"
-    stdout:
-      contains: |
-        --- Addition for ;Nat;s.
-        builtin nat-plus + : Nat → Nat → Nat;
-        + zero b := b;
-        + (suc a) b := suc (a + b);
-    exit-status: 0
-
   - name: repl-def-multiple
     command:
       - juvix
@@ -55,7 +41,20 @@ tests:
         builtin nat-plus + : Nat → Nat → Nat;
         + zero b := b;
         + (suc a) b := suc (a + b);
+    exit-status: 0
+
+  - name: repl-def-infix
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def +"
+    stdout:
+      contains: |
         --- Addition for ;Nat;s.
+        builtin nat-plus + : Nat → Nat → Nat;
+        + zero b := b;
+        + (suc a) b := suc (a + b);
     exit-status: 0
 
   - name: open


### PR DESCRIPTION
This pr adds a new command, `:def` to the repl. This command expects a single identifier that must be in scope and then prints its definition. For constructors, the whole type definition is printed.

It also applies some refactors to the code for repl command.
1. Before there was a mega `where` block of definitions. I have hoisted most of the definitions there to the top level. I feel like now it is easier to navigate and read.
2. Use `ExceptT` instead of local `case` expressions for errors.
3. Use forks of `haskeline` and `repline`. These forks are necessary because these libraries do not export the constructors `HaskelineT` and `InputT` respectively, thus, making it impossible to catch errors in their underlying monad.