### PR TITLE
Add `main` field to `juvix.yaml`

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -6,11 +6,11 @@ import GlobalOptions
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
 import Juvix.Compiler.Pipeline
 import Juvix.Data.Error qualified as Error
+import Juvix.Extra.Paths.Base
 import Juvix.Prelude.Pretty hiding
   ( Doc,
   )
 import System.Console.ANSI qualified as Ansi
-import Juvix.Extra.Paths.Base
 
 data App m a where
   ExitMsg :: ExitCode -> Text -> App m a

--- a/app/App.hs
+++ b/app/App.hs
@@ -86,10 +86,9 @@ runAppIO args@RunAppIOArgs {..} =
     exitMsg' :: ExitCode -> Text -> Sem r x
     exitMsg' exitCode t = embed (putStrLn t >> hFlush stdout >> exitWith exitCode)
     getMainFile' :: Maybe (AppPath File) -> Sem r (Path Abs File)
-    getMainFile' m = case m of
+    getMainFile' = \case
       Just p -> embed (prepathToAbsFile invDir (p ^. pathPath))
       Nothing -> case pkg ^. packageMain of
-        -- TODO do something special if it is the global package?
         Just p -> embed (prepathToAbsFile invDir p)
         Nothing -> missingMainErr
     missingMainErr :: Sem r x

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -11,8 +11,8 @@ import Juvix.Compiler.Core.Transformation.DisambiguateNames qualified as Core
 
 runCommand :: (Members '[Embed IO, App] r) => CompileOptions -> Sem r ()
 runCommand opts@CompileOptions {..} = do
-  inputFile <- fromAppPathFile _compileInputFile
-  Core.CoreResult {..} <- runPipeline _compileInputFile upToCore
+  inputFile <- getMainFile _compileInputFile
+  Core.CoreResult {..} <- runPipeline (AppPath (preFileFromAbs inputFile) True) upToCore
   let arg =
         Compile.PipelineArg
           { _pipelineArgFile = inputFile,

--- a/app/Commands/Dev/Asm/Compile.hs
+++ b/app/Commands/Dev/Asm/Compile.hs
@@ -30,10 +30,10 @@ runCommand opts = do
           ensureDir buildDir
           cFile <- inputCFile file
           embed $ TIO.writeFile (toFilePath cFile) _resultCCode
-          Compile.runCommand opts {_compileInputFile = AppPath (preFileFromAbs cFile) False}
+          Compile.runCommand opts {_compileInputFile = Just (AppPath (preFileFromAbs cFile) False)}
   where
     getFile :: Sem r (Path Abs File)
-    getFile = fromAppPathFile (opts ^. compileInputFile)
+    getFile = getMainFile (opts ^. compileInputFile)
 
     getTarget :: CompileTarget -> Sem r Backend.Target
     getTarget = \case

--- a/app/Commands/Dev/Core/Compile.hs
+++ b/app/Commands/Dev/Core/Compile.hs
@@ -21,4 +21,4 @@ runCommand opts = do
     TargetAsm -> runAsmPipeline arg
   where
     getFile :: Sem r (Path Abs File)
-    getFile = fromAppPathFile (opts ^. compileInputFile)
+    getFile = getMainFile (opts ^. compileInputFile)

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -56,7 +56,7 @@ runCPipeline pa@PipelineArg {..} = do
   outfile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   Compile.runCommand
     _pipelineArgOptions
-      { _compileInputFile = AppPath (preFileFromAbs cFile) False,
+      { _compileInputFile = Just (AppPath (preFileFromAbs cFile) False),
         _compileOutputFile = Just (AppPath (preFileFromAbs outfile) False)
       }
   where

--- a/app/Commands/Extra/Compile.hs
+++ b/app/Commands/Extra/Compile.hs
@@ -10,7 +10,7 @@ import System.Process qualified as P
 
 runCommand :: forall r. (Members '[Embed IO, App] r) => CompileOptions -> Sem r ()
 runCommand opts = do
-  inputFile <- fromAppPathFile (opts ^. compileInputFile)
+  inputFile <- getMainFile (opts ^. compileInputFile)
   result <- runCompile inputFile opts
   case result of
     Left err -> printFailureExit err

--- a/app/Commands/Extra/Compile/Options.hs
+++ b/app/Commands/Extra/Compile/Options.hs
@@ -30,7 +30,7 @@ data CompileOptions = CompileOptions
     _compileTerm :: Bool,
     _compileOutputFile :: Maybe (AppPath File),
     _compileTarget :: CompileTarget,
-    _compileInputFile :: AppPath File,
+    _compileInputFile :: Maybe (AppPath File),
     _compileOptimizationLevel :: Maybe Int,
     _compileInliningDepth :: Int
   }
@@ -100,7 +100,7 @@ parseCompileOptions supportedTargets parseInputFile = do
       )
   _compileTarget <- optCompileTarget supportedTargets
   _compileOutputFile <- optional parseGenericOutputFile
-  _compileInputFile <- parseInputFile
+  _compileInputFile <- optional parseInputFile
   pure CompileOptions {..}
 
 optCompileTarget :: SupportedTargets -> Parser CompileTarget

--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -49,6 +49,7 @@ getPackage = do
       { _packageName = tproj,
         _packageVersion = tversion,
         _packageBuildDir = Nothing,
+        _packageMain = Nothing,
         _packageDependencies = [defaultStdlibDep]
       }
 

--- a/examples/milestone/Collatz/juvix.yaml
+++ b/examples/milestone/Collatz/juvix.yaml
@@ -1,2 +1,3 @@
 name: Collatz
+main: Collatz.juvix
 version: 0.1.0

--- a/examples/milestone/Fibonacci/juvix.yaml
+++ b/examples/milestone/Fibonacci/juvix.yaml
@@ -1,2 +1,3 @@
 name: Fibonacci
+main: Fibonacci.juvix
 version: 0.1.0

--- a/examples/milestone/Hanoi/juvix.yaml
+++ b/examples/milestone/Hanoi/juvix.yaml
@@ -1,2 +1,3 @@
 name: Hanoi
+main: Hanoi.juvix
 version: 0.1.0

--- a/examples/milestone/HelloWorld/juvix.yaml
+++ b/examples/milestone/HelloWorld/juvix.yaml
@@ -1,2 +1,3 @@
 name: HelloWorld
+main: HelloWorld.juvix
 version: 0.1.0

--- a/examples/milestone/PascalsTriangle/juvix.yaml
+++ b/examples/milestone/PascalsTriangle/juvix.yaml
@@ -1,2 +1,3 @@
 name: PascalsTriangle
+main: PascalsTriangle.juvix
 version: 0.1.0

--- a/examples/milestone/TicTacToe/juvix.yaml
+++ b/examples/milestone/TicTacToe/juvix.yaml
@@ -1,2 +1,3 @@
 name: TicTacToe
+main: TicTacToe.juvix
 version: 0.1.0

--- a/examples/milestone/TicTacToe/juvix.yaml
+++ b/examples/milestone/TicTacToe/juvix.yaml
@@ -1,3 +1,3 @@
 name: TicTacToe
-main: TicTacToe.juvix
+main: CLI/TicTacToe.juvix
 version: 0.1.0

--- a/src/Juvix/Prelude/Prepath.hs
+++ b/src/Juvix/Prelude/Prepath.hs
@@ -20,7 +20,9 @@ import System.Directory qualified as System
 import System.Environment
 
 -- | A file/directory path that may contain environmental variables
-newtype Prepath d = Prepath {_prepath :: String}
+newtype Prepath d = Prepath
+  { _prepath :: String
+  }
   deriving stock (Show, Eq, Data, Generic)
 
 makeLenses ''Prepath

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -23,6 +23,22 @@ tests:
     stdout: |
       hello world!
 
+  - name: hello-world-no-arg-error
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        cd ./examples/milestone/
+        cp -r HelloWorld "$temp"
+        cd "$temp/HelloWorld"
+        sed -i '/^main:/d' juvix.yaml
+        juvix compile
+    exit-status: 1
+    stdout: |
+     A path to the main file must be given in the CLI or specified in the `main` field of the juvix.yaml file
+
   - name: hello-world
     command:
       shell:

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -11,6 +11,18 @@ tests:
         JUVIX_FILE
     exit-status: 0
 
+  - name: hello-world-no-arg
+    command:
+      shell:
+        - bash
+      script: |
+        cd ./examples/milestone/HelloWorld
+        juvix compile
+        ./HelloWorld
+    exit-status: 0
+    stdout: |
+      hello world!
+
   - name: hello-world
     command:
       shell:

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -33,7 +33,13 @@ tests:
         cd ./examples/milestone/
         cp -r HelloWorld "$temp"
         cd "$temp/HelloWorld"
-        sed -i '/^main:/d' juvix.yaml
+        if command -v gsed >/dev/null 2>&1; then
+          # gsed is available
+          sed_cmd="gsed"
+        else
+          sed_cmd="sed"
+        fi
+        $sed_cmd -i '/^main:/d' juvix.yaml
         juvix compile
     exit-status: 1
     stdout: |

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -33,13 +33,7 @@ tests:
         cd ./examples/milestone/
         cp -r HelloWorld "$temp"
         cd "$temp/HelloWorld"
-        if command -v gsed >/dev/null 2>&1; then
-          # gsed is available
-          sed_cmd="gsed"
-        else
-          sed_cmd="sed"
-        fi
-        $sed_cmd -i '/^main:/d' juvix.yaml
+        sed -i '/^main:/d' juvix.yaml
         juvix compile
     exit-status: 1
     stdout: |


### PR DESCRIPTION
- Closes #2067

This pr adds the field `main` to `juvix.yaml`. This field is optional and should contain a path to a juvix file that is meant to be used for the `compile` (and `dev compile`) command when no file is given as an argument in the CLI. This makes it possible to simply run `juvix compile` if the `main` is specified in the `jvuix.yaml`.

I have updated the `juvix.yaml` of the milestone examples.