### PR TITLE
Remove --no-format option

### DIFF
--- a/app/Commands/Dev/Scope/Options.hs
+++ b/app/Commands/Dev/Scope/Options.hs
@@ -31,6 +31,5 @@ parseScope = do
 instance CanonicalProjection (GlobalOptions, ScopeOptions) Scoper.Options where
   project (g, _) =
     Scoper.defaultOptions
-      { Scoper._optShowNameIds = g ^. globalShowNameIds,
-        Scoper._optNoApe = g ^. globalNoApe
+      { Scoper._optShowNameIds = g ^. globalShowNameIds
       }

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -15,7 +15,6 @@ data GlobalOptions = GlobalOptions
     _globalShowNameIds :: Bool,
     _globalBuildDir :: Maybe (AppPath Dir),
     _globalOnlyErrors :: Bool,
-    _globalNoApe :: Bool,
     _globalStdin :: Bool,
     _globalNoTermination :: Bool,
     _globalNoPositivity :: Bool,
@@ -42,8 +41,7 @@ instance CanonicalProjection GlobalOptions Abstract.Options where
 instance CanonicalProjection GlobalOptions E.GenericOptions where
   project GlobalOptions {..} =
     E.GenericOptions
-      { E._showNameIds = _globalShowNameIds,
-        E._genericNoApe = _globalNoApe
+      { E._showNameIds = _globalShowNameIds
       }
 
 instance CanonicalProjection GlobalOptions Core.CoreOptions where
@@ -61,7 +59,6 @@ defaultGlobalOptions =
     { _globalNoColors = False,
       _globalShowNameIds = False,
       _globalOnlyErrors = False,
-      _globalNoApe = False,
       _globalNoTermination = False,
       _globalBuildDir = Nothing,
       _globalStdin = False,
@@ -91,11 +88,6 @@ parseGlobalFlags = do
           ( long "internal-build-dir"
               <> help "Directory for compiler internal output"
           )
-      )
-  _globalNoApe <-
-    switch
-      ( long "no-format"
-          <> help "Disable the new pretty printing algorithm"
       )
   _globalStdin <-
     switch

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -6,7 +6,10 @@ module Juvix.Compiler.Concrete.Pretty.Base
 where
 
 import Data.List.NonEmpty.Extra qualified as NonEmpty
-import Juvix.Compiler.Concrete.Data.ScopedName (AbsModulePath, IsConcrete (..))
+import Juvix.Compiler.Concrete.Data.ScopedName
+  ( AbsModulePath,
+    IsConcrete (..),
+  )
 import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
 import Juvix.Compiler.Concrete.Extra (unfoldApplication)
 import Juvix.Compiler.Concrete.Keywords (delimJudocStart)
@@ -495,7 +498,7 @@ instance (SingI s) => PrettyCode (TypeSignature s) where
 instance (SingI s) => PrettyCode (Function s) where
   ppCode a = case sing :: SStage s of
     SParsed -> ppCode' a
-    SScoped -> apeHelper a (ppCode' a)
+    SScoped -> apeHelper a
     where
       ppCode' :: forall r. (Members '[Reader Options] r) => Function s -> Sem r (Doc Ann)
       ppCode' Function {..} = do
@@ -629,10 +632,7 @@ instance PrettyCode PatternArg where
     return $ (n' <&> (<> kwAt)) ?<> delimIf i (isJust n && not (isAtomic p)) p'
 
 instance PrettyCode PatternApp where
-  ppCode p@(PatternApp l r) = apeHelper p $ do
-    l' <- ppLeftExpression appFixity l
-    r' <- ppRightExpression appFixity r
-    return $ l' <+> r'
+  ppCode = apeHelper
 
 ppPatternParensType :: forall s r. (SingI s, Member (Reader Options) r) => PatternParensType s -> Sem r (Doc Ann)
 ppPatternParensType p = case sing :: SStage s of
@@ -678,27 +678,13 @@ instance PrettyCode Text where
   ppCode = return . pretty
 
 instance PrettyCode InfixApplication where
-  ppCode i@InfixApplication {..} =
-    apeHelper i $ do
-      infixAppLeft' <- ppLeftExpression (getFixity i) _infixAppLeft
-      infixAppOperator' <- ppCode _infixAppOperator
-      infixAppRight' <- ppRightExpression (getFixity i) _infixAppRight
-      return $ infixAppLeft' <+> infixAppOperator' <+> infixAppRight'
+  ppCode = apeHelper
 
 instance PrettyCode PostfixApplication where
-  ppCode i@PostfixApplication {..} =
-    apeHelper i $ do
-      postfixAppParameter' <- ppPostExpression (getFixity i) _postfixAppParameter
-      postfixAppOperator' <- ppCode _postfixAppOperator
-      return $ postfixAppParameter' <+> postfixAppOperator'
+  ppCode = apeHelper
 
 instance PrettyCode Application where
-  ppCode a =
-    apeHelper a $ do
-      let (f, args) = unfoldApplication a
-      f' <- ppCode f
-      args' <- mapM ppCodeAtom args
-      return $ PP.group (f' <+> nest' (vsep args'))
+  ppCode = apeHelper
 
 instance PrettyCode ApeLeaf where
   ppCode = \case
@@ -708,16 +694,12 @@ instance PrettyCode ApeLeaf where
     ApeLeafPattern r -> ppCode r
     ApeLeafPatternArg r -> ppCode r
 
-apeHelper :: (IsApe a ApeLeaf, Members '[Reader Options] r) => a -> Sem r (Doc CodeAnn) -> Sem r (Doc CodeAnn)
-apeHelper a alt = do
+apeHelper :: (IsApe a ApeLeaf, Members '[Reader Options] r) => a -> Sem r (Doc CodeAnn)
+apeHelper a = do
   opts <- ask @Options
-  if
-      | not (opts ^. optNoApe) ->
-          return $
-            let params :: ApeParams ApeLeaf
-                params = ApeParams (run . runReader opts . ppCode)
-             in runApe params a
-      | otherwise -> alt
+  let params :: ApeParams ApeLeaf
+      params = ApeParams (run . runReader opts . ppCode)
+  return $ runApe params a
 
 instance PrettyCode Literal where
   ppCode = \case
@@ -774,21 +756,8 @@ instance PrettyCode Pattern where
     PatternWildcard {} -> return kwWildcard
     PatternEmpty {} -> return $ parens mempty
     PatternConstructor constr -> ppCode constr
-    PatternInfixApplication i -> ppPatternInfixApp i
-    PatternPostfixApplication i -> ppPatternPostfixApp i
-    where
-      ppPatternInfixApp :: PatternInfixApp -> Sem r (Doc Ann)
-      ppPatternInfixApp p@PatternInfixApp {..} = apeHelper p $ do
-        patInfixConstructor' <- ppCode _patInfixConstructor
-        patInfixLeft' <- ppLeftExpression (getFixity p) _patInfixLeft
-        patInfixRight' <- ppRightExpression (getFixity p) _patInfixRight
-        return $ patInfixLeft' <+> patInfixConstructor' <+> patInfixRight'
-
-      ppPatternPostfixApp :: PatternPostfixApp -> Sem r (Doc Ann)
-      ppPatternPostfixApp p@PatternPostfixApp {..} = apeHelper p $ do
-        patPostfixConstructor' <- ppCode _patPostfixConstructor
-        patPostfixParameter' <- ppLeftExpression (getFixity p) _patPostfixParameter
-        return $ patPostfixParameter' <+> patPostfixConstructor'
+    PatternInfixApplication i -> apeHelper i
+    PatternPostfixApplication i -> apeHelper i
 
 ppPostExpression ::
   (PrettyCode a, HasAtomicity a, Member (Reader Options) r) =>

--- a/src/Juvix/Compiler/Concrete/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Options.hs
@@ -4,7 +4,6 @@ import Juvix.Prelude
 
 data Options = Options
   { _optShowNameIds :: Bool,
-    _optNoApe :: Bool,
     _optInJudocBlock :: Bool
   }
 
@@ -12,7 +11,6 @@ defaultOptions :: Options
 defaultOptions =
   Options
     { _optShowNameIds = False,
-      _optNoApe = False,
       _optInJudocBlock = False
     }
 
@@ -20,11 +18,7 @@ makeLenses ''Options
 
 fromGenericOptions :: GenericOptions -> Options
 fromGenericOptions GenericOptions {..} =
-  set optShowNameIds _showNameIds $
-    set
-      optNoApe
-      _genericNoApe
-      defaultOptions
+  set optShowNameIds _showNameIds defaultOptions
 
 inJudocBlock :: Members '[Reader Options] r => Sem r a -> Sem r a
 inJudocBlock = local (set optInJudocBlock True)

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -17,8 +17,7 @@ data GenericError = GenericError
   }
 
 data GenericOptions = GenericOptions
-  { _showNameIds :: Bool,
-    _genericNoApe :: Bool
+  { _showNameIds :: Bool
   }
   deriving stock (Eq, Show)
 
@@ -28,8 +27,7 @@ makeLenses ''GenericOptions
 defaultGenericOptions :: GenericOptions
 defaultGenericOptions =
   GenericOptions
-    { _showNameIds = False,
-      _genericNoApe = False
+    { _showNameIds = False
     }
 
 instance Pretty GenericError where

--- a/tests/smoke/Commands/dev/geb.smoke.yaml
+++ b/tests/smoke/Commands/dev/geb.smoke.yaml
@@ -5,23 +5,23 @@ tests:
     command:
       - juvix
       - --no-colors
-      - dev 
+      - dev
       - geb
       - repl
     stdout:
-      contains: "Welcome to the Juvix Geb REPL!"
+      contains: 'Welcome to the Juvix Geb REPL!'
     exit-status: 0
-    
+
   - name: geb-quit
     command:
       - juvix
       - --no-colors
-      - dev 
+      - dev
       - geb
       - repl
-    stdout: 
-      contains: "geb>"
-    stdin: ":quit"
+    stdout:
+      contains: 'geb>'
+    stdin: ':quit'
     exit-status: 0
 
   - name: geb-infer-type-unit
@@ -31,59 +31,58 @@ tests:
       - dev
       - geb
       - repl
-    stdin: ":type unit"
+    stdin: ':type unit'
     stdout:
-      contains: "so1"
+      contains: 'so1'
     exit-status: 0
 
   - name: geb-infer-type-object
     command:
       - juvix
-      - --no-colors      
+      - --no-colors
       - dev
       - geb
       - repl
-    stdin: ":type so1"
-    stdout: 
-      contains: "Inference only works on Geb morphisms"
+    stdin: ':type so1'
+    stdout:
+      contains: 'Inference only works on Geb morphisms'
     exit-status: 0
 
   - name: geb-infer-type-integer
     command:
       - juvix
-      - --no-colors        
+      - --no-colors
       - dev
       - geb
       - repl
-    stdin: ":t (mul 2 3)"
-    stdout: 
-      contains: "int"
-    exit-status: 0    
+    stdin: ':t (mul 2 3)'
+    stdout:
+      contains: 'int'
+    exit-status: 0
 
   # - name: geb-check-int
   #   command:
   #     - juvix
-  #     - --no-colors      
+  #     - --no-colors
   #     - dev
   #     - geb
   #     - repl
   #   stdin: ":check (typed (add 1 2) so1)"
-  #   stderr: 
+  #   stderr:
   #     contains: "so1 is not a valid object for (add 1 2)"
   #   exit-status: 1
 
   - name: geb-eval-and-operations
     command:
       - juvix
-      - --no-format
       - dev
       - geb
       - repl
-    stdin: "(add 2 (mul 3 4))"
-    stdout: 
+    stdin: '(add 2 (mul 3 4))'
+    stdout:
       contains: |
         14
-    exit-status: 0    
+    exit-status: 0
 
   - name: geb-eval-with-spaces
     command:
@@ -91,11 +90,10 @@ tests:
       - dev
       - geb
       - repl
-    stdin: "  unit"
-    stdout: 
-      contains:
-        "unit"
-    exit-status:    
+    stdin: '  unit'
+    stdout:
+      contains: 'unit'
+    exit-status:
 
   - name: geb-load-and-eval-gebext
     command:
@@ -103,8 +101,8 @@ tests:
         - bash
       script: |
         cd ./Geb/positive/ && juvix dev geb repl
-    stdin: ":load    basic-app.geb"
-    stdout: 
+    stdin: ':load    basic-app.geb'
+    stdout:
       contains: |
         3000
     exit-status: 0
@@ -116,13 +114,13 @@ tests:
       - dev
       - geb
       - repl
-    stdin: ":root"
-    stdout: 
+    stdin: ':root'
+    stdout:
       matches: |
         Welcome .*
         Juvix .*
         Type .*
-        
+
         geb> .*/tests/
     exit-status: 0
 


### PR DESCRIPTION
Instead, always act as `--no-format` option is set to `False` as previous default.

The change seem to not affect any current formatting, so I assume it passes the checks on testing.

Fixes #2084 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
