### PR TITLE
Fix baseUrl for juvix docs in Doctor command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ All pull requests will be reviewed by at least one member of the development tea
 
 Thank you for contributing to Juvix!
 
-[installation]: https://docs.juvix.org/howto/installing.html
+[installation]: https://docs.juvix.org/dev/howto/installing/
 [juvix-codespace]: https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=102404734&machine=standardLinux32gb&location=WestEurope
 [stack]: https://docs.haskellstack.org/en/stable/README/
 [pre-commit]: https://pre-commit.com/

--- a/app/Commands/Doctor.hs
+++ b/app/Commands/Doctor.hs
@@ -56,7 +56,7 @@ documentedMessage w = uncurry DocumentedMessage (first (baseUrl <>) warningInfo)
       NoWasmer -> ("could-not-find-the-wasmer-command", "Could not find the wasmer command")
 
     baseUrl :: Text
-    baseUrl = "https://docs.juvix.org/tooling/doctor.html#"
+    baseUrl = "https://docs.juvix.org/dev/reference/tooling/doctor/#"
 
 heading :: (Member Log r) => Text -> Sem r ()
 heading = log . ("> " <>)


### PR DESCRIPTION
Currently generated links for fixing errors in the `juvix doctor` command are broken.
Fixing that by updating the base Url link.

Also fixed the link to the installation of juvix in the contributing guide.