### PR TITLE
Add gnu-sed to the macOS build in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Install Sed
         run: |
-          brew install --default-names gnu-sed
+          brew install --with-default-names gnu-sed
 
       - name: Download and extract wasi-sysroot
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Install Sed
         run: |
           brew install gnu-sed
-          echo "PATH=$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH" >> $GITHUB_ENV
+          echo "export PATH=$(brew --prefix coreutils)/libexec/gnubin:\$PATH" >> $GITHUB_ENV
           echo "$PATH"
           sed --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
         run: |
           brew install gnu-sed
           echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+          sed --version
 
       - name: Download and extract wasi-sysroot
         run: >
@@ -186,7 +187,7 @@ jobs:
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
       - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v2
+        uses: wasmerio/setup-wasmer@v3
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,8 @@ jobs:
       - name: Install Sed
         run: |
           brew install gnu-sed
-          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+          echo "PATH=$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH" >> $GITHUB_ENV
+          echo "$PATH"
           sed --version
 
       - name: Download and extract wasi-sysroot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,133 +26,133 @@ env:
   SKIP: ormolu,format-juvix-files,typecheck-juvix-examples
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - uses: pre-commit/action@v3.0.0
+  # pre-commit:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.11"
+  #     - uses: pre-commit/action@v3.0.0
 
-  ormolu:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mrkkrp/ormolu-action@v11
-        with:
-          version: 0.5.2.0
-          extra-args: >-
-            --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
-            --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
-            --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
+  # ormolu:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: mrkkrp/ormolu-action@v11
+  #       with:
+  #         version: 0.5.2.0
+  #         extra-args: >-
+  #           --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
+  #           --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
+  #           --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
 
-  build-and-test-linux:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout our repository
-        uses: actions/checkout@v3
-        with:
-          path: main
-          submodules: true
+  # build-and-test-linux:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Checkout our repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         path: main
+  #         submodules: true
 
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@v3
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: "${{ runner.os }}-llvm-13"
+  #     - name: Cache LLVM and Clang
+  #       id: cache-llvm
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           C:/Program Files/LLVM
+  #           ./llvm
+  #         key: "${{ runner.os }}-llvm-13"
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "13.0"
-          cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
+  #     - name: Install LLVM and Clang
+  #       uses: KyleMayes/install-llvm-action@v1
+  #       with:
+  #         version: "13.0"
+  #         cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
 
-      - name: Download and extract wasi-sysroot
-        run: >
-          curl
-          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-          -OL
+  #     - name: Download and extract wasi-sysroot
+  #       run: >
+  #         curl
+  #         https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+  #         -OL
 
-          tar xfv wasi-sysroot-15.0.tar.gz
+  #         tar xfv wasi-sysroot-15.0.tar.gz
 
-      - name: Set WASI_SYSROOT_PATH
-        run: |
-          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+  #     - name: Set WASI_SYSROOT_PATH
+  #       run: |
+  #         echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+  #     - name: Add ~/.local/bin to PATH
+  #       run: |
+  #         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v2
+  #     - name: Setup Wasmer
+  #       uses: wasmerio/setup-wasmer@v2
 
-      - name: Install libs
-        run: sudo apt install -y libncurses5
+  #     - name: Install libs
+  #       run: sudo apt install -y libncurses5
 
-      - name: Install VampIR for testing
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: anoma/vamp-ir
-          platform: linux
-          tag: v0.1.2
-          chmod: 0755
-          rename-to: vamp-ir
-          extension-matching: disable
-          cache: enable
+  #     - name: Install VampIR for testing
+  #       uses: jaxxstorm/action-install-gh-release@v1.10.0
+  #       with:
+  #         repo: anoma/vamp-ir
+  #         platform: linux
+  #         tag: v0.1.2
+  #         chmod: 0755
+  #         rename-to: vamp-ir
+  #         extension-matching: disable
+  #         cache: enable
 
-      - name: Test VampIR
-        shell: bash
-        run: |
-          vamp-ir --version
+  #     - name: Test VampIR
+  #       shell: bash
+  #       run: |
+  #         vamp-ir --version
 
-      - name: Make runtime
-        run: |
-          cd main
-          make runtime
+  #     - name: Make runtime
+  #       run: |
+  #         cd main
+  #         make runtime
 
-      - name: Stack setup
-        id: stack
-        uses: freckle/stack-action@v4
-        with:
-          working-directory: main
-          test: false
+  #     - name: Stack setup
+  #       id: stack
+  #       uses: freckle/stack-action@v4
+  #       with:
+  #         working-directory: main
+  #         test: false
 
-      - name: Install and test Juvix
-        id: test
-        if: ${{ success() }}
-        run: |
-          cd main
-          make install
-          make test
+  #     - name: Install and test Juvix
+  #       id: test
+  #       if: ${{ success() }}
+  #       run: |
+  #         cd main
+  #         make install
+  #         make test
 
-      - name: Typecheck and format Juvix examples
-        if: ${{ success() }}
-        shell: bash
-        run: |
-          cd main
-          make check-format-juvix-files && make typecheck-juvix-examples
+  #     - name: Typecheck and format Juvix examples
+  #       if: ${{ success() }}
+  #       shell: bash
+  #       run: |
+  #         cd main
+  #         make check-format-juvix-files && make typecheck-juvix-examples
 
-      - name: Install Smoke for testing
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: jonaprieto/smoke
-          platform: linux
-          tag: v2.3.2
-          chmod: 0755
-          rename-to: smoke
-          extension-matching: disable
-          cache: enable
+  #     - name: Install Smoke for testing
+  #       uses: jaxxstorm/action-install-gh-release@v1.10.0
+  #       with:
+  #         repo: jonaprieto/smoke
+  #         platform: linux
+  #         tag: v2.3.2
+  #         chmod: 0755
+  #         rename-to: smoke
+  #         extension-matching: disable
+  #         cache: enable
 
-      - name: Smoke testing
-        id: smoke-linux
-        if: ${{ success() }}
-        run: |
-          cd main
-          make smoke-only
+  #     - name: Smoke testing
+  #       id: smoke-linux
+  #       if: ${{ success() }}
+  #       run: |
+  #         cd main
+  #         make smoke-only
 
   build-and-test-macos:
     runs-on: macos-12
@@ -163,103 +163,103 @@ jobs:
           path: main
           submodules: true
 
-      - name: Install ICU4C
-        run: |
-          brew install icu4c
-          brew link icu4c --force
+      # - name: Install ICU4C
+      #   run: |
+      #     brew install icu4c
+      #     brew link icu4c --force
 
       - name: Install Sed
         run: |
           brew install gnu-sed
-          echo "export PATH=$(brew --prefix coreutils)/libexec/gnubin:\$PATH" >> $GITHUB_ENV
+          echo "PATH=$(brew --prefix coreutils)/libexec/gnubin:\$PATH" >> $GITHUB_ENV
 
       - name: Test Sed
         run: |
           sed --version
 
-      - name: Download and extract wasi-sysroot
-        run: >
-          curl
-          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-          -OL
+      # - name: Download and extract wasi-sysroot
+      #   run: >
+      #     curl
+      #     https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+      #     -OL
 
-          tar xfv wasi-sysroot-15.0.tar.gz
+      #     tar xfv wasi-sysroot-15.0.tar.gz
 
-      - name: Set WASI_SYSROOT_PATH
-        run: |
-          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+      # - name: Set WASI_SYSROOT_PATH
+      #   run: |
+      #     echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v3
+      # - name: Setup Wasmer
+      #   uses: wasmerio/setup-wasmer@v3
 
-      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-        run: |
-          echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
-          echo "LIBTOOL=$(brew --prefix llvm@15)/bin/llvm-ar" >> $GITHUB_ENV
+      # - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+      #   run: |
+      #     echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
+      #     echo "LIBTOOL=$(brew --prefix llvm@15)/bin/llvm-ar" >> $GITHUB_ENV
 
-      - name: Make runtime
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL runtime
+      # - name: Make runtime
+      #   run: |
+      #     cd main
+      #     make CC=$CC LIBTOOL=$LIBTOOL runtime
 
-      - name: Stack setup
-        id: stack
-        uses: freckle/stack-action@v4
-        with:
-          working-directory: main
-          test: false
+      # - name: Stack setup
+      #   id: stack
+      #   uses: freckle/stack-action@v4
+      #   with:
+      #     working-directory: main
+      #     test: false
 
-      - name: Add homebrew clang to the PATH (macOS)
-        run: |
-          echo "$(brew --prefix llvm@15)/bin" >> $GITHUB_PATH
+      # - name: Add homebrew clang to the PATH (macOS)
+      #   run: |
+      #     echo "$(brew --prefix llvm@15)/bin" >> $GITHUB_PATH
 
-      - name: Install VampIR for testing
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: anoma/vamp-ir
-          platform: darwin
-          tag: v0.1.2
-          chmod: 0755
-          rename-to: vamp-ir
-          extension-matching: disable
-          cache: enable
+      # - name: Install VampIR for testing
+      #   uses: jaxxstorm/action-install-gh-release@v1.10.0
+      #   with:
+      #     repo: anoma/vamp-ir
+      #     platform: darwin
+      #     tag: v0.1.2
+      #     chmod: 0755
+      #     rename-to: vamp-ir
+      #     extension-matching: disable
+      #     cache: enable
 
-      - name: Test VampIR
-        shell: bash
-        run: |
-          vamp-ir --version
+      # - name: Test VampIR
+      #   shell: bash
+      #   run: |
+      #     vamp-ir --version
 
-      - name: Install and test Juvix
-        if: ${{ success() }}
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL install
-          make CC=$CC LIBTOOL=$LIBTOOL test
+      # - name: Install and test Juvix
+      #   if: ${{ success() }}
+      #   run: |
+      #     cd main
+      #     make CC=$CC LIBTOOL=$LIBTOOL install
+      #     make CC=$CC LIBTOOL=$LIBTOOL test
 
-      - name: Add ~/.local/bin to PATH
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      # - name: Add ~/.local/bin to PATH
+      #   run: |
+      #     echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Typecheck and format Juvix examples
-        if: ${{ success() }}
-        shell: bash
-        run: |
-          cd main
-          make check-format-juvix-files && make typecheck-juvix-examples
+      # - name: Typecheck and format Juvix examples
+      #   if: ${{ success() }}
+      #   shell: bash
+      #   run: |
+      #     cd main
+      #     make check-format-juvix-files && make typecheck-juvix-examples
 
-      - name: Install Smoke
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: jonaprieto/smoke
-          tag: latest
-          extension-matching: disable
-          rename-to: smoke
-          chmod: 0755
-          cache: enable
+      # - name: Install Smoke
+      #   uses: jaxxstorm/action-install-gh-release@v1.10.0
+      #   with:
+      #     repo: jonaprieto/smoke
+      #     tag: latest
+      #     extension-matching: disable
+      #     rename-to: smoke
+      #     chmod: 0755
+      #     cache: enable
 
-      - name: Smoke testing (macOS)
-        id: smoke-macos
-        if: ${{ success() }}
-        run: |
-          cd main
-          make CC=$CC LIBTOOL=$LIBTOOL smoke
+      # - name: Smoke testing (macOS)
+      #   id: smoke-macos
+      #   if: ${{ success() }}
+      #   run: |
+      #     cd main
+      #     make CC=$CC LIBTOOL=$LIBTOOL smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,8 @@ jobs:
 
       - name: Install Sed
         run: |
-          brew install --with-default-names gnu-sed
+          brew install gnu-sed
+          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
 
       - name: Download and extract wasi-sysroot
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           key: "${{ runner.os }}-llvm-13"
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-ection@v1
+        uses: KyleMayes/install-llvm-action@v1
         with:
           version: "13.0"
           cached: "${{ steps.cache-llvm.outputs.cache-hit }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,20 +163,19 @@ jobs:
           path: main
           submodules: true
 
-      # - name: Install ICU4C
-      #   run: |
-      #     brew install icu4c
-      #     brew link icu4c --force
-
       - name: Install Sed
         run: |
           brew install gnu-sed
-          echo "PATH=$(brew --prefix coreutils)/libexec/gnubin:\$PATH" >> $GITHUB_ENV
+          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
 
       - name: Test Sed
         run: |
           sed --version
 
+      # - name: Install ICU4C
+      #   run: |
+      #     brew install icu4c
+      #     brew link icu4c --force
       # - name: Download and extract wasi-sysroot
       #   run: >
       #     curl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           key: "${{ runner.os }}-llvm-13"
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
+        uses: KyleMayes/install-llvm-ection@v1
         with:
           version: "13.0"
           cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
@@ -167,6 +167,10 @@ jobs:
         run: |
           brew install icu4c
           brew link icu4c --force
+
+      - name: Install Sed
+        run: |
+          brew install --default-names gnu-sed
 
       - name: Download and extract wasi-sysroot
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,133 +26,133 @@ env:
   SKIP: ormolu,format-juvix-files,typecheck-juvix-examples
 
 jobs:
-  # pre-commit:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.11"
-  #     - uses: pre-commit/action@v3.0.0
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: pre-commit/action@v3.0.0
 
-  # ormolu:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: mrkkrp/ormolu-action@v11
-  #       with:
-  #         version: 0.5.2.0
-  #         extra-args: >-
-  #           --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
-  #           --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
-  #           --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
+  ormolu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mrkkrp/ormolu-action@v11
+        with:
+          version: 0.5.2.0
+          extra-args: >-
+            --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
+            --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
+            --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
 
-  # build-and-test-linux:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Checkout our repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         path: main
-  #         submodules: true
+  build-and-test-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout our repository
+        uses: actions/checkout@v3
+        with:
+          path: main
+          submodules: true
 
-  #     - name: Cache LLVM and Clang
-  #       id: cache-llvm
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           C:/Program Files/LLVM
-  #           ./llvm
-  #         key: "${{ runner.os }}-llvm-13"
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v3
+        with:
+          path: |
+            C:/Program Files/LLVM
+            ./llvm
+          key: "${{ runner.os }}-llvm-13"
 
-  #     - name: Install LLVM and Clang
-  #       uses: KyleMayes/install-llvm-action@v1
-  #       with:
-  #         version: "13.0"
-  #         cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "13.0"
+          cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
 
-  #     - name: Download and extract wasi-sysroot
-  #       run: >
-  #         curl
-  #         https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-  #         -OL
+      - name: Download and extract wasi-sysroot
+        run: >
+          curl
+          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+          -OL
 
-  #         tar xfv wasi-sysroot-15.0.tar.gz
+          tar xfv wasi-sysroot-15.0.tar.gz
 
-  #     - name: Set WASI_SYSROOT_PATH
-  #       run: |
-  #         echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+      - name: Set WASI_SYSROOT_PATH
+        run: |
+          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-  #     - name: Add ~/.local/bin to PATH
-  #       run: |
-  #         echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-  #     - name: Setup Wasmer
-  #       uses: wasmerio/setup-wasmer@v2
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v2
 
-  #     - name: Install libs
-  #       run: sudo apt install -y libncurses5
+      - name: Install libs
+        run: sudo apt install -y libncurses5
 
-  #     - name: Install VampIR for testing
-  #       uses: jaxxstorm/action-install-gh-release@v1.10.0
-  #       with:
-  #         repo: anoma/vamp-ir
-  #         platform: linux
-  #         tag: v0.1.2
-  #         chmod: 0755
-  #         rename-to: vamp-ir
-  #         extension-matching: disable
-  #         cache: enable
+      - name: Install VampIR for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: anoma/vamp-ir
+          platform: linux
+          tag: v0.1.2
+          chmod: 0755
+          rename-to: vamp-ir
+          extension-matching: disable
+          cache: enable
 
-  #     - name: Test VampIR
-  #       shell: bash
-  #       run: |
-  #         vamp-ir --version
+      - name: Test VampIR
+        shell: bash
+        run: |
+          vamp-ir --version
 
-  #     - name: Make runtime
-  #       run: |
-  #         cd main
-  #         make runtime
+      - name: Make runtime
+        run: |
+          cd main
+          make runtime
 
-  #     - name: Stack setup
-  #       id: stack
-  #       uses: freckle/stack-action@v4
-  #       with:
-  #         working-directory: main
-  #         test: false
+      - name: Stack setup
+        id: stack
+        uses: freckle/stack-action@v4
+        with:
+          working-directory: main
+          test: false
 
-  #     - name: Install and test Juvix
-  #       id: test
-  #       if: ${{ success() }}
-  #       run: |
-  #         cd main
-  #         make install
-  #         make test
+      - name: Install and test Juvix
+        id: test
+        if: ${{ success() }}
+        run: |
+          cd main
+          make install
+          make test
 
-  #     - name: Typecheck and format Juvix examples
-  #       if: ${{ success() }}
-  #       shell: bash
-  #       run: |
-  #         cd main
-  #         make check-format-juvix-files && make typecheck-juvix-examples
+      - name: Typecheck and format Juvix examples
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          cd main
+          make check-format-juvix-files && make typecheck-juvix-examples
 
-  #     - name: Install Smoke for testing
-  #       uses: jaxxstorm/action-install-gh-release@v1.10.0
-  #       with:
-  #         repo: jonaprieto/smoke
-  #         platform: linux
-  #         tag: v2.3.2
-  #         chmod: 0755
-  #         rename-to: smoke
-  #         extension-matching: disable
-  #         cache: enable
+      - name: Install Smoke for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: jonaprieto/smoke
+          platform: linux
+          tag: v2.3.2
+          chmod: 0755
+          rename-to: smoke
+          extension-matching: disable
+          cache: enable
 
-  #     - name: Smoke testing
-  #       id: smoke-linux
-  #       if: ${{ success() }}
-  #       run: |
-  #         cd main
-  #         make smoke-only
+      - name: Smoke testing
+        id: smoke-linux
+        if: ${{ success() }}
+        run: |
+          cd main
+          make smoke-only
 
   build-and-test-macos:
     runs-on: macos-12
@@ -172,93 +172,93 @@ jobs:
         run: |
           sed --version
 
-      # - name: Install ICU4C
-      #   run: |
-      #     brew install icu4c
-      #     brew link icu4c --force
-      # - name: Download and extract wasi-sysroot
-      #   run: >
-      #     curl
-      #     https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
-      #     -OL
+      - name: Install ICU4C
+        run: |
+          brew install icu4c
+          brew link icu4c --force
+      - name: Download and extract wasi-sysroot
+        run: >
+          curl
+          https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz
+          -OL
 
-      #     tar xfv wasi-sysroot-15.0.tar.gz
+          tar xfv wasi-sysroot-15.0.tar.gz
 
-      # - name: Set WASI_SYSROOT_PATH
-      #   run: |
-      #     echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
+      - name: Set WASI_SYSROOT_PATH
+        run: |
+          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      # - name: Setup Wasmer
-      #   uses: wasmerio/setup-wasmer@v3
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v3
 
-      # - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
-      #   run: |
-      #     echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
-      #     echo "LIBTOOL=$(brew --prefix llvm@15)/bin/llvm-ar" >> $GITHUB_ENV
+      - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
+        run: |
+          echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
+          echo "LIBTOOL=$(brew --prefix llvm@15)/bin/llvm-ar" >> $GITHUB_ENV
 
-      # - name: Make runtime
-      #   run: |
-      #     cd main
-      #     make CC=$CC LIBTOOL=$LIBTOOL runtime
+      - name: Make runtime
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL runtime
 
-      # - name: Stack setup
-      #   id: stack
-      #   uses: freckle/stack-action@v4
-      #   with:
-      #     working-directory: main
-      #     test: false
+      - name: Stack setup
+        id: stack
+        uses: freckle/stack-action@v4
+        with:
+          working-directory: main
+          test: false
 
-      # - name: Add homebrew clang to the PATH (macOS)
-      #   run: |
-      #     echo "$(brew --prefix llvm@15)/bin" >> $GITHUB_PATH
+      - name: Add homebrew clang to the PATH (macOS)
+        run: |
+          echo "$(brew --prefix llvm@15)/bin" >> $GITHUB_PATH
 
-      # - name: Install VampIR for testing
-      #   uses: jaxxstorm/action-install-gh-release@v1.10.0
-      #   with:
-      #     repo: anoma/vamp-ir
-      #     platform: darwin
-      #     tag: v0.1.2
-      #     chmod: 0755
-      #     rename-to: vamp-ir
-      #     extension-matching: disable
-      #     cache: enable
+      - name: Install VampIR for testing
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: anoma/vamp-ir
+          platform: darwin
+          tag: v0.1.2
+          chmod: 0755
+          rename-to: vamp-ir
+          extension-matching: disable
+          cache: enable
 
-      # - name: Test VampIR
-      #   shell: bash
-      #   run: |
-      #     vamp-ir --version
+      - name: Test VampIR
+        shell: bash
+        run: |
+          vamp-ir --version
 
-      # - name: Install and test Juvix
-      #   if: ${{ success() }}
-      #   run: |
-      #     cd main
-      #     make CC=$CC LIBTOOL=$LIBTOOL install
-      #     make CC=$CC LIBTOOL=$LIBTOOL test
+      - name: Install and test Juvix
+        if: ${{ success() }}
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL install
+          make CC=$CC LIBTOOL=$LIBTOOL test
 
-      # - name: Add ~/.local/bin to PATH
-      #   run: |
-      #     echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Add ~/.local/bin to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      # - name: Typecheck and format Juvix examples
-      #   if: ${{ success() }}
-      #   shell: bash
-      #   run: |
-      #     cd main
-      #     make check-format-juvix-files && make typecheck-juvix-examples
+      - name: Typecheck and format Juvix examples
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          cd main
+          make check-format-juvix-files && make typecheck-juvix-examples
 
-      # - name: Install Smoke
-      #   uses: jaxxstorm/action-install-gh-release@v1.10.0
-      #   with:
-      #     repo: jonaprieto/smoke
-      #     tag: latest
-      #     extension-matching: disable
-      #     rename-to: smoke
-      #     chmod: 0755
-      #     cache: enable
+      - name: Install Smoke
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: jonaprieto/smoke
+          tag: latest
+          extension-matching: disable
+          rename-to: smoke
+          chmod: 0755
+          cache: enable
 
-      # - name: Smoke testing (macOS)
-      #   id: smoke-macos
-      #   if: ${{ success() }}
-      #   run: |
-      #     cd main
-      #     make CC=$CC LIBTOOL=$LIBTOOL smoke
+      - name: Smoke testing (macOS)
+        id: smoke-macos
+        if: ${{ success() }}
+        run: |
+          cd main
+          make CC=$CC LIBTOOL=$LIBTOOL smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,9 @@ jobs:
         run: |
           brew install gnu-sed
           echo "export PATH=$(brew --prefix coreutils)/libexec/gnubin:\$PATH" >> $GITHUB_ENV
-          echo "$PATH"
+
+      - name: Test Sed
+        run: |
           sed --version
 
       - name: Download and extract wasi-sysroot


### PR DESCRIPTION
This PR installs the `gnu-sed` for the macOS build.
It can be called with the name `sed`, no `gsed`.

NB: The environmental variables set in one step are only reflected in the subsequent steps. 

