### PR TITLE
Add `:doc` command to the repl

### DIFF
--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -243,20 +243,21 @@ printDocumentation = replParseIdentifiers >=> printIdentifiers
 
         printIdentifier :: Concrete.ScopedIden -> Repl ()
         printIdentifier s = do
-          d <- case s of
+          mdoc <- case s of
             Concrete.ScopedAxiom a -> getDocAxiom (a ^. Concrete.axiomRefName . Scoped.nameId)
             Concrete.ScopedInductive a -> getDocInductive (a ^. Concrete.inductiveRefName . Scoped.nameId)
             Concrete.ScopedVar {} -> return Nothing
             Concrete.ScopedFunction f -> getDocFunction (f ^. Concrete.functionRefName . Scoped.nameId)
             Concrete.ScopedConstructor c -> getDocConstructor (c ^. Concrete.constructorRefName . Scoped.nameId)
-          printDoc d
+          printDoc mdoc
           where
             printDoc :: Maybe (Concrete.Judoc 'Concrete.Scoped) -> Repl ()
             printDoc = \case
               Nothing -> do
-                s <- ppConcrete
+                s' <- ppConcrete s
                 renderOut (AnsiText @Text "No documentation available for ")
-                renderOutLn s
+                renderOutLn s'
+              Just ju -> printConcrete ju
 
             getDocFunction :: Scoped.NameId -> Repl (Maybe (Concrete.Judoc 'Concrete.Scoped))
             getDocFunction fun = do

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -5,13 +5,21 @@ module Commands.Repl where
 import Commands.Base hiding
   ( command,
   )
+import Commands.Repl.Base
 import Commands.Repl.Options
 import Control.Exception (throwIO)
+import Control.Monad.Except qualified as Except
+import Control.Monad.Reader qualified as Reader
 import Control.Monad.State.Strict qualified as State
+import Control.Monad.Trans.Class (lift)
 import Data.String.Interpolate (i, __i)
 import Evaluator
+import Juvix.Compiler.Concrete.Data.InfoTable qualified as Scoped
 import Juvix.Compiler.Concrete.Data.Scope (scopePath)
 import Juvix.Compiler.Concrete.Data.ScopedName (absTopModulePath)
+import Juvix.Compiler.Concrete.Data.ScopedName qualified as Scoped
+import Juvix.Compiler.Concrete.Language qualified as Concrete
+import Juvix.Compiler.Concrete.Pretty qualified as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver (runPathResolver)
 import Juvix.Compiler.Core qualified as Core
 import Juvix.Compiler.Core.Extra.Value
@@ -25,32 +33,16 @@ import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Pipeline.Repl
 import Juvix.Compiler.Pipeline.Setup (entrySetup)
 import Juvix.Data.Error.GenericError qualified as Error
+import Juvix.Data.NameKind
 import Juvix.Extra.Paths
 import Juvix.Extra.Stdlib
 import Juvix.Extra.Version
+import Juvix.Prelude.Pretty
 import Juvix.Prelude.Pretty qualified as P
 import System.Console.ANSI qualified as Ansi
 import System.Console.Haskeline
 import System.Console.Repline
 import System.Console.Repline qualified as Repline
-
-type ReplS = State.StateT ReplState IO
-
-type Repl a = HaskelineT ReplS a
-
-data ReplContext = ReplContext
-  { _replContextArtifacts :: Artifacts,
-    _replContextEntryPoint :: EntryPoint
-  }
-
-data ReplState = ReplState
-  { _replStateRoots :: Roots,
-    _replStateContext :: Maybe ReplContext,
-    _replStateGlobalOptions :: GlobalOptions
-  }
-
-makeLenses ''ReplState
-makeLenses ''ReplContext
 
 helpTxt :: MonadIO m => m ()
 helpTxt =
@@ -62,6 +54,8 @@ helpTxt =
   :load       FILE          Load a file into the REPL
   :reload                   Reload the currently loaded file
   :type       EXPRESSION    Infer the type of an expression
+  :def        IDENTIFIER    Print the definition of the identifier
+  :doc        IDENTIFIER    Print the documentation of the identifier
   :core       EXPRESSION    Translate the expression to JuvixCore
   :multiline                Start a multi-line input. Submit with <Ctrl-D>
   :root                     Print the current project root
@@ -70,254 +64,408 @@ helpTxt =
   |]
     )
 
-noFileLoadedMsg :: (MonadIO m) => m ()
-noFileLoadedMsg = liftIO (putStrLn "No file loaded. Load a file using the `:load FILE` command.")
+replDefaultLoc :: Interval
+replDefaultLoc = singletonInterval (mkInitialLoc replPath)
 
-welcomeMsg :: (MonadIO m) => m ()
+replFromJust :: Repl a -> Maybe a -> Repl a
+replFromJust err = maybe err return
+
+replFromEither :: Either JuvixError a -> Repl a
+replFromEither = either (lift . Except.throwError) return
+
+replGetContext :: Repl ReplContext
+replGetContext = State.gets (^. replStateContext) >>= replFromJust noFileLoadedErr
+
+replError :: AnsiText -> Repl a
+replError msg =
+  lift
+    . Except.throwError
+    . JuvixError
+    $ GenericError
+      { _genericErrorLoc = replDefaultLoc,
+        _genericErrorMessage = msg,
+        _genericErrorIntervals = [replDefaultLoc]
+      }
+
+noFileLoadedErr :: Repl a
+noFileLoadedErr = replError (AnsiText @Text "No file loaded. Load a file using the `:load FILE` command.")
+
+welcomeMsg :: MonadIO m => m ()
 welcomeMsg = liftIO (putStrLn [i|Juvix REPL version #{versionTag}: https://juvix.org. Run :help for help|])
 
-runCommand :: Members '[Embed IO, App] r => ReplOptions -> Sem r ()
-runCommand opts = do
-  roots <- askRoots
-  let getReplEntryPoint :: Prepath File -> Repl EntryPoint
-      getReplEntryPoint inputFile = do
-        gopts <- State.gets (^. replStateGlobalOptions)
-        liftIO (entryPointFromGlobalOptionsPre roots inputFile gopts)
+printHelpTxt :: String -> Repl ()
+printHelpTxt _ = helpTxt
 
-      printHelpTxt :: String -> Repl ()
-      printHelpTxt _ = helpTxt
+multilineCmd :: String
+multilineCmd = "multiline"
 
-      multilineCmd :: String
-      multilineCmd = "multiline"
+quit :: String -> Repl ()
+quit _ = liftIO (throwIO Interrupt)
 
-      quit :: String -> Repl ()
-      quit _ = liftIO (throwIO Interrupt)
+loadEntryPoint :: EntryPoint -> Repl ()
+loadEntryPoint ep = do
+  artif <- liftIO (corePipelineIO' ep)
+  let newCtx =
+        ReplContext
+          { _replContextArtifacts = artif,
+            _replContextEntryPoint = ep
+          }
+  State.modify (set replStateContext (Just newCtx))
+  let epPath :: Maybe (Path Abs File) = ep ^? entryPointModulePaths . _head
+  whenJust epPath $ \path -> liftIO (putStrLn [i|OK loaded: #{toFilePath path}|])
 
-      loadEntryPoint :: EntryPoint -> Repl ()
-      loadEntryPoint ep = do
-        artif <- liftIO (corePipelineIO' ep)
-        State.modify
-          ( set
-              replStateContext
-              ( Just
-                  ( ReplContext
-                      { _replContextArtifacts = artif,
-                        _replContextEntryPoint = ep
-                      }
-                  )
-              )
-          )
-        let epPath :: Maybe (Path Abs File) = ep ^? entryPointModulePaths . _head
-        whenJust epPath $ \path -> liftIO (putStrLn [i|OK loaded: #{toFilePath path}|])
+reloadFile :: String -> Repl ()
+reloadFile _ = replGetContext >>= loadEntryPoint . (^. replContextEntryPoint)
 
-      reloadFile :: String -> Repl ()
-      reloadFile _ = do
-        mentryPoint <- State.gets (fmap (^. replContextEntryPoint) . (^. replStateContext))
-        case mentryPoint of
-          Just entryPoint -> do
-            loadEntryPoint entryPoint
-          Nothing -> noFileLoadedMsg
+pSomeFile :: String -> Prepath File
+pSomeFile = mkPrepath
 
-      pSomeFile :: String -> Prepath File
-      pSomeFile = mkPrepath
+loadFile :: Prepath File -> Repl ()
+loadFile f = do
+  entryPoint <- getReplEntryPoint f
+  loadEntryPoint entryPoint
 
-      loadFile :: Prepath File -> Repl ()
-      loadFile f = do
-        entryPoint <- getReplEntryPoint f
-        loadEntryPoint entryPoint
+loadDefaultPrelude :: Repl ()
+loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
+  root <- Reader.asks (^. replRoots . rootsRootDir)
+  -- The following is needed to ensure that the default location of the
+  -- standard library exists
+  void
+    . liftIO
+    . runM
+    . runFilesIO
+    . runError @Text
+    . runReader e
+    . runPathResolver root
+    $ entrySetup
+  loadEntryPoint e
 
-      loadDefaultPrelude :: Repl ()
-      loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
-        let root = roots ^. rootsRootDir
-        -- The following is needed to ensure that the default location of the
-        -- standard library exists
-        void
-          . liftIO
-          . runM
-          . runFilesIO
-          . runError @Text
-          . runReader e
-          . runPathResolver root
-          $ entrySetup
-        loadEntryPoint e
+getReplEntryPoint :: Prepath File -> Repl EntryPoint
+getReplEntryPoint inputFile = do
+  roots <- Reader.asks (^. replRoots)
+  gopts <- State.gets (^. replStateGlobalOptions)
+  liftIO (entryPointFromGlobalOptionsPre roots inputFile gopts)
 
-      printRoot :: String -> Repl ()
-      printRoot _ = do
-        r <- State.gets (^. replStateRoots . rootsRootDir)
-        liftIO $ putStrLn (pack (toFilePath r))
+displayVersion :: String -> Repl ()
+displayVersion _ = liftIO (putStrLn versionTag)
 
-      displayVersion :: String -> Repl ()
-      displayVersion _ = liftIO (putStrLn versionTag)
+replCommand :: ReplOptions -> String -> Repl ()
+replCommand opts input = catchAll $ do
+  ctx <- replGetContext
+  let tab = ctx ^. replContextArtifacts . artifactCoreTable
+  evalRes <- compileThenEval ctx input
+  whenJust evalRes $ \n ->
+    if
+        | Info.member Info.kNoDisplayInfo (Core.getInfo n) -> return ()
+        | opts ^. replPrintValues ->
+            renderOutLn (Core.ppOut opts (toValue tab n))
+        | otherwise -> renderOutLn (Core.ppOut opts n)
+  where
+    compileThenEval :: ReplContext -> String -> Repl (Maybe Core.Node)
+    compileThenEval ctx s = compileString >>= mapM eval
+      where
+        artif :: Artifacts
+        artif = ctx ^. replContextArtifacts
 
-      command :: String -> Repl ()
-      command input = Repline.dontCrash $ do
-        ctx <- State.gets (^. replStateContext)
-        case ctx of
-          Just ctx' -> do
-            let tab = ctx' ^. replContextArtifacts . artifactCoreTable
-            evalRes <- compileThenEval ctx' input
-            case evalRes of
-              Left err -> printError err
-              Right (Just n)
-                | Info.member Info.kNoDisplayInfo (Core.getInfo n) -> return ()
-              Right (Just n)
-                | opts ^. replPrintValues ->
-                    renderOut (Core.ppOut opts (toValue tab n))
-                | otherwise ->
-                    renderOut (Core.ppOut opts n)
-              Right Nothing -> return ()
-          Nothing -> noFileLoadedMsg
-        where
-          defaultLoc :: Interval
-          defaultLoc = singletonInterval (mkInitialLoc replPath)
-
-          compileThenEval :: ReplContext -> String -> Repl (Either JuvixError (Maybe Core.Node))
-          compileThenEval ctx s = do
-            mn <- compileString
-            case mn of
-              Left err -> return (Left err)
-              Right Nothing -> return (Right Nothing)
-              Right (Just n) -> fmap Just <$> eval n
-            where
-              artif :: Artifacts
-              artif = ctx ^. replContextArtifacts
-
-              shouldDisambiguate :: Bool
+        eval :: Core.Node -> Repl Core.Node
+        eval n = do
+          ep <- getReplEntryPoint (mkPrepath (toFilePath replPath))
+          let shouldDisambiguate :: Bool
               shouldDisambiguate = not (opts ^. replNoDisambiguate)
+          (artif', n') <-
+            replFromEither
+              . run
+              . runReader ep
+              . runError @JuvixError
+              . runState artif
+              . runTransformations shouldDisambiguate (opts ^. replTransformations)
+              $ n
+          liftIO (doEvalIO' artif' n') >>= replFromEither
 
-              eval :: Core.Node -> Repl (Either JuvixError Core.Node)
-              eval n = do
-                ep <- getReplEntryPoint (mkPrepath (toFilePath replPath))
-                case run
-                  . runReader ep
-                  . runError @JuvixError
-                  . runState artif
-                  . runTransformations shouldDisambiguate (opts ^. replTransformations)
-                  $ n of
-                  Left err -> return $ Left err
-                  Right (artif', n') -> liftIO (doEvalIO' artif' n')
+        doEvalIO' :: Artifacts -> Core.Node -> IO (Either JuvixError Core.Node)
+        doEvalIO' artif' n =
+          mapLeft (JuvixError @Core.CoreError)
+            <$> doEvalIO False replDefaultLoc (artif' ^. artifactCoreTable) n
 
-              doEvalIO' :: Artifacts -> Core.Node -> IO (Either JuvixError Core.Node)
-              doEvalIO' artif' n =
-                mapLeft (JuvixError @Core.CoreError)
-                  <$> doEvalIO False defaultLoc (artif' ^. artifactCoreTable) n
+        compileString :: Repl (Maybe Core.Node)
+        compileString = do
+          (artifacts, res) <- liftIO $ compileReplInputIO' ctx (strip (pack s))
+          res' <- replFromEither res
+          State.modify (over (replStateContext . _Just) (set replContextArtifacts artifacts))
+          return res'
 
-              compileString :: Repl (Either JuvixError (Maybe Core.Node))
-              compileString = do
-                (artifacts, res) <- liftIO $ compileReplInputIO' ctx (strip (pack s))
-                State.modify (over (replStateContext . _Just) (set replContextArtifacts artifacts))
-                return res
+core :: String -> Repl ()
+core input = do
+  ctx <- replGetContext
+  opts <- Reader.asks (^. replOptions)
+  compileRes <- liftIO (compileReplInputIO' ctx (strip (pack input))) >>= replFromEither . snd
+  whenJust compileRes (renderOutLn . Core.ppOut opts)
 
-      core :: String -> Repl ()
-      core input = Repline.dontCrash $ do
-        ctx <- State.gets (^. replStateContext)
-        case ctx of
-          Just ctx' -> do
-            compileRes <- snd <$> liftIO (compileReplInputIO' ctx' (strip (pack input)))
-            case compileRes of
-              Left err -> printError err
-              Right (Just n) -> renderOut (Core.ppOut opts n)
-              Right Nothing -> return ()
-          Nothing -> noFileLoadedMsg
+ppConcrete :: Concrete.PrettyCode a => a -> Repl AnsiText
+ppConcrete a = do
+  gopts <- State.gets (^. replStateGlobalOptions)
+  let popts :: GenericOptions = project' gopts
+  return (Concrete.ppOut popts a)
 
-      inferType :: String -> Repl ()
-      inferType input = Repline.dontCrash $ do
-        ctx <- State.gets (^. replStateContext)
-        gopts <- State.gets (^. replStateGlobalOptions)
-        case ctx of
-          Just ctx' -> do
-            compileRes <- liftIO (inferExpressionIO' ctx' (strip (pack input)))
-            case compileRes of
-              Left err -> printError err
-              Right n -> renderOut (Internal.ppOut (project' @GenericOptions gopts) n)
-          Nothing -> noFileLoadedMsg
+printConcrete :: Concrete.PrettyCode a => a -> Repl ()
+printConcrete = ppConcrete >=> renderOutLn
 
-      options :: [(String, String -> Repl ())]
-      options =
-        [ ("help", Repline.dontCrash . printHelpTxt),
+replParseIdentifiers :: String -> Repl (NonEmpty Concrete.ScopedIden)
+replParseIdentifiers input =
+  replExpressionUpToScopedAtoms (strip (pack input))
+  >>= getIdentifiers
+  where
+    getIdentifiers :: Concrete.ExpressionAtoms 'Concrete.Scoped -> Repl (NonEmpty Concrete.ScopedIden)
+    getIdentifiers as = mapM getIdentifier (as ^. Concrete.expressionAtoms)
+      where
+        getIdentifier :: Concrete.ExpressionAtom 'Concrete.Scoped -> Repl (Concrete.ScopedIden)
+        getIdentifier = \case
+          Concrete.AtomIdentifier a -> return a
+          Concrete.AtomParens p
+            | Concrete.ExpressionIdentifier a <- p -> return a
+            | Concrete.ExpressionParensIdentifier a <- p -> return a
+          _ -> err
+          where
+            err :: Repl a
+            err = replError (AnsiText @Text ":def expects one or more identifiers")
+
+
+printDocumentation :: String -> Repl ()
+printDocumentation = replParseIdentifiers >=> printIdentifiers
+  where
+    printIdentifiers :: NonEmpty Concrete.ScopedIden -> Repl ()
+    printIdentifiers (d :| ds) = do
+      printIdentifier d
+      whenJust (nonEmpty ds) $ \ds' -> replNewline >> printIdentifiers ds'
+      where
+        getInfoTable :: Repl Scoped.InfoTable
+        getInfoTable = (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+
+        printIdentifier :: Concrete.ScopedIden -> Repl ()
+        printIdentifier s = do
+          d <- case s of
+            Concrete.ScopedAxiom a -> getDocAxiom (a ^. Concrete.axiomRefName . Scoped.nameId)
+            Concrete.ScopedInductive a -> getDocInductive (a ^. Concrete.inductiveRefName . Scoped.nameId)
+            Concrete.ScopedVar {} -> return Nothing
+            Concrete.ScopedFunction f -> getDocFunction (f ^. Concrete.functionRefName . Scoped.nameId)
+            Concrete.ScopedConstructor c -> getDocConstructor (c ^. Concrete.constructorRefName . Scoped.nameId)
+          printDoc d
+          where
+            printDoc :: Maybe (Concrete.Judoc 'Concrete.Scoped) -> Repl ()
+            printDoc = \case
+              Nothing -> do
+                s <- ppConcrete
+                renderOut (AnsiText @Text "No documentation available for ")
+                renderOutLn s
+
+            getDocFunction :: Scoped.NameId -> Repl (Maybe (Concrete.Judoc 'Concrete.Scoped))
+            getDocFunction fun = do
+              tbl :: Scoped.InfoTable <- getInfoTable
+              let def :: Scoped.FunctionInfo = tbl ^?! Scoped.infoFunctions . at fun . _Just
+              return (def ^. Scoped.functionInfoType . Concrete.sigDoc)
+
+            getDocInductive :: Scoped.NameId -> Repl (Maybe (Concrete.Judoc 'Concrete.Scoped))
+            getDocInductive ind = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let def :: Concrete.InductiveDef 'Concrete.Scoped = tbl ^?! Scoped.infoInductives . at ind . _Just . Scoped.inductiveInfoDef
+              return (def ^. Concrete.inductiveDoc)
+
+            getDocAxiom :: Scoped.NameId -> Repl (Maybe (Concrete.Judoc 'Concrete.Scoped))
+            getDocAxiom ax = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let def :: Concrete.AxiomDef 'Concrete.Scoped = tbl ^?! Scoped.infoAxioms . at ax . _Just . Scoped.axiomInfoDef
+              return (def ^. Concrete.axiomDoc)
+
+            getDocConstructor :: Scoped.NameId -> Repl (Maybe (Concrete.Judoc 'Concrete.Scoped))
+            getDocConstructor c = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let def :: Scoped.ConstructorInfo = tbl ^?! Scoped.infoConstructors . at c . _Just
+              return (def ^. Scoped.constructorInfoDef . Concrete.constructorDoc)
+
+printDefinition :: String -> Repl ()
+printDefinition = replParseIdentifiers >=> printIdentifiers
+  where
+    printIdentifiers :: NonEmpty Concrete.ScopedIden -> Repl ()
+    printIdentifiers (d :| ds) = do
+      printIdentifier d
+      whenJust (nonEmpty ds) $ \ds' -> replNewline >> printIdentifiers ds'
+      where
+        getInfoTable :: Repl Scoped.InfoTable
+        getInfoTable = (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+
+        printIdentifier :: Concrete.ScopedIden -> Repl ()
+        printIdentifier s = do
+          case s of
+            Concrete.ScopedAxiom a -> printAxiom (a ^. Concrete.axiomRefName . Scoped.nameId)
+            Concrete.ScopedInductive a -> printInductive (a ^. Concrete.inductiveRefName . Scoped.nameId)
+            Concrete.ScopedVar {} -> return ()
+            Concrete.ScopedFunction f -> printFunction (f ^. Concrete.functionRefName . Scoped.nameId)
+            Concrete.ScopedConstructor c -> printConstructor (c ^. Concrete.constructorRefName . Scoped.nameId)
+          where
+            printLocation :: HasLoc s => s -> Repl ()
+            printLocation def = do
+              s' <- ppConcrete s
+              let txt :: Text = " is " <> prettyText (nameKindWithArticle (getNameKind s)) <> " defined at " <> prettyText (getLoc def)
+              renderOut s'
+              renderOutLn (AnsiText txt)
+
+            printFunction :: Scoped.NameId -> Repl ()
+            printFunction fun = do
+              tbl :: Scoped.InfoTable <- getInfoTable
+              let def :: Scoped.FunctionInfo = tbl ^?! Scoped.infoFunctions . at fun . _Just
+              printLocation def
+              printConcrete def
+
+            printInductive :: Scoped.NameId -> Repl ()
+            printInductive ind = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let def :: Concrete.InductiveDef 'Concrete.Scoped = tbl ^?! Scoped.infoInductives . at ind . _Just . Scoped.inductiveInfoDef
+              printLocation def
+              printConcrete def
+
+            printAxiom :: Scoped.NameId -> Repl ()
+            printAxiom ax = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let def :: Concrete.AxiomDef 'Concrete.Scoped = tbl ^?! Scoped.infoAxioms . at ax . _Just . Scoped.axiomInfoDef
+              printLocation def
+              printConcrete def
+
+            printConstructor :: Scoped.NameId -> Repl ()
+            printConstructor c = do
+              tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
+              let ind :: Scoped.Symbol = tbl ^?! Scoped.infoConstructors . at c . _Just . Scoped.constructorInfoTypeName
+              printInductive (ind ^. Scoped.nameId)
+
+inferType :: String -> Repl ()
+inferType input = do
+  gopts <- State.gets (^. replStateGlobalOptions)
+  n <- replExpressionUpToTyped (strip (pack input))
+  renderOutLn (Internal.ppOut (project' @GenericOptions gopts) (n ^. Internal.typedType))
+
+replCommands :: [(String, String -> Repl ())]
+replCommands = catchable ++ nonCatchable
+  where
+    nonCatchable :: [(String, String -> Repl ())]
+    nonCatchable =
+      [ ("quit", quit)
+      ]
+    catchable :: [(String, String -> Repl ())]
+    catchable =
+      map
+        (second (catchAll .))
+        [ ("help", printHelpTxt),
           -- `multiline` is included here for auto-completion purposes only.
           -- `repline`'s `multilineCommand` logic overrides this no-op.
-          (multilineCmd, Repline.dontCrash . \_ -> return ()),
-          ("quit", quit),
-          ("load", Repline.dontCrash . loadFile . pSomeFile),
-          ("reload", Repline.dontCrash . reloadFile),
+          (multilineCmd, const (return ())),
+          ("load", loadFile . pSomeFile),
+          ("reload", reloadFile),
           ("root", printRoot),
+          ("def", printDefinition),
+          ("doc", printDocumentation),
           ("type", inferType),
           ("version", displayVersion),
           ("core", core)
         ]
 
-      defaultMatcher :: [(String, CompletionFunc ReplS)]
-      defaultMatcher = [(":load", fileCompleter)]
+catchAll :: Repl () -> Repl ()
+catchAll = Repline.dontCrash . catchJuvixError
+  where
+    catchJuvixError :: Repl () -> Repl ()
+    catchJuvixError (HaskelineT m) = HaskelineT (mapInputT_ catchErrorS m)
+      where
+        catchErrorS :: ReplS () -> ReplS ()
+        catchErrorS = (`Except.catchError` printErrorS)
 
-      optsCompleter :: WordCompleter ReplS
-      optsCompleter n = do
-        let names = (":" <>) . fst <$> options
-        return (filter (isPrefixOf n) names)
+defaultMatcher :: [(String, CompletionFunc ReplS)]
+defaultMatcher = [(":load", fileCompleter)]
 
-      banner :: MultiLine -> Repl String
-      banner = \case
-        MultiLine -> return "... "
-        SingleLine -> do
-          mmodulePath <-
-            State.gets
-              ( ^?
-                  replStateContext
-                    . _Just
-                    . replContextArtifacts
-                    . artifactMainModuleScope
-                    . _Just
-                    . scopePath
-                    . absTopModulePath
-              )
-          case mmodulePath of
-            Just path -> return [i|#{unpack (P.prettyText path)}> |]
-            Nothing -> return "juvix> "
+optsCompleter :: WordCompleter ReplS
+optsCompleter n = do
+  let names = (":" <>) . fst <$> replCommands
+  return (filter (isPrefixOf n) names)
 
-      prefix :: Maybe Char
-      prefix = Just ':'
+replBanner :: MultiLine -> Repl String
+replBanner = \case
+  MultiLine -> return "... "
+  SingleLine -> do
+    mmodulePath <-
+      State.gets
+        ( ^?
+            replStateContext
+              . _Just
+              . replContextArtifacts
+              . artifactMainModuleScope
+              . _Just
+              . scopePath
+              . absTopModulePath
+        )
+    return $ case mmodulePath of
+      Just path -> [i|#{unpack (P.prettyText path)}> |]
+      Nothing -> "juvix> "
 
-      multilineCommand :: Maybe String
-      multilineCommand = Just multilineCmd
+replPrefix :: Maybe Char
+replPrefix = Just ':'
 
-      initialiser :: Repl ()
-      initialiser = do
-        gopts <- State.gets (^. replStateGlobalOptions)
-        welcomeMsg
-        unless
-          (opts ^. replNoPrelude || gopts ^. globalNoStdlib)
-          (maybe loadDefaultPrelude (loadFile . (^. pathPath)) (opts ^. replInputFile))
+replMultilineCommand :: Maybe String
+replMultilineCommand = Just multilineCmd
 
-      finaliser :: Repl ExitDecision
-      finaliser = return Exit
+replInitialiser :: Repl ()
+replInitialiser = do
+  gopts <- State.gets (^. replStateGlobalOptions)
+  opts <- Reader.asks (^. replOptions)
+  welcomeMsg
+  unless
+    (opts ^. replNoPrelude || gopts ^. globalNoStdlib)
+    (maybe loadDefaultPrelude (loadFile . (^. pathPath)) (opts ^. replInputFile))
 
-      tabComplete :: CompleterStyle ReplS
-      tabComplete = Prefix (wordCompleter optsCompleter) defaultMatcher
+replFinaliser :: Repl ExitDecision
+replFinaliser = return Exit
 
-      replAction :: ReplS ()
+replTabComplete :: CompleterStyle ReplS
+replTabComplete = Prefix (wordCompleter optsCompleter) defaultMatcher
+
+printRoot :: String -> Repl ()
+printRoot _ = do
+  r <- State.gets (^. replStateRoots . rootsRootDir)
+  liftIO $ putStrLn (pack (toFilePath r))
+
+runCommand :: Members '[Embed IO, App] r => ReplOptions -> Sem r ()
+runCommand opts = do
+  roots <- askRoots
+  let replAction :: ReplS ()
       replAction = do
         evalReplOpts
           ReplOpts
-            { prefix,
-              multilineCommand,
-              initialiser,
-              finaliser,
-              tabComplete,
-              command,
-              options,
-              banner
+            { prefix = replPrefix,
+              multilineCommand = replMultilineCommand,
+              initialiser = replInitialiser,
+              finaliser = replFinaliser,
+              tabComplete = replTabComplete,
+              command = replCommand opts,
+              options = replCommands,
+              banner = replBanner
             }
   globalOptions <- askGlobalOptions
-  embed
-    ( State.evalStateT
-        replAction
-        ( ReplState
-            { _replStateRoots = roots,
-              _replStateContext = Nothing,
-              _replStateGlobalOptions = globalOptions
-            }
-        )
-    )
+  let env =
+        ReplEnv
+          { _replRoots = roots,
+            _replOptions = opts
+          }
+      iniState =
+        ReplState
+          { _replStateRoots = roots,
+            _replStateContext = Nothing,
+            _replStateGlobalOptions = globalOptions
+          }
+  e <-
+    embed
+      . Except.runExceptT
+      . (`State.evalStateT` iniState)
+      . (`Reader.runReaderT` env)
+      $ replAction
+  case e of
+    Left {} -> error "impossible: uncaught exception"
+    Right () -> return ()
 
 -- | If the package contains the stdlib as a dependency, loads the Prelude
 defaultPreludeEntryPoint :: Repl (Maybe EntryPoint)
@@ -341,12 +489,29 @@ replMakeAbsolute = \case
     invokeDir <- State.gets (^. replStateRoots . rootsInvokeDir)
     return (invokeDir <//> r)
 
-inferExpressionIO' :: ReplContext -> Text -> IO (Either JuvixError Internal.Expression)
-inferExpressionIO' ctx txt =
-  runM
-    . evalState (ctx ^. replContextArtifacts)
-    . runReader (ctx ^. replContextEntryPoint)
-    $ inferExpressionIO replPath txt
+replExpressionUpToScopedAtoms :: Text -> Repl (Concrete.ExpressionAtoms 'Concrete.Scoped)
+replExpressionUpToScopedAtoms txt = do
+  ctx <- replGetContext
+  x <-
+    liftIO
+      . runM
+      . runError
+      . evalState (ctx ^. replContextArtifacts)
+      . runReader (ctx ^. replContextEntryPoint)
+      $ expressionUpToAtomsScoped replPath txt
+  replFromEither x
+
+replExpressionUpToTyped :: Text -> Repl Internal.TypedExpression
+replExpressionUpToTyped txt = do
+  ctx <- replGetContext
+  x <-
+    liftIO
+      . runM
+      . runError
+      . evalState (ctx ^. replContextArtifacts)
+      . runReader (ctx ^. replContextEntryPoint)
+      $ expressionUpToTyped replPath txt
+  replFromEither x
 
 compileReplInputIO' :: ReplContext -> Text -> IO (Artifacts, (Either JuvixError (Maybe Core.Node)))
 compileReplInputIO' ctx txt =
@@ -369,11 +534,17 @@ render' t = do
   hasAnsi <- liftIO (Ansi.hSupportsANSIColor stdout)
   liftIO (P.renderIO (not (opts ^. globalNoColors) && hasAnsi) t)
 
-renderOut :: (P.HasAnsiBackend a, P.HasTextBackend a) => a -> Repl ()
-renderOut t = render' t >> liftIO (putStrLn "")
+replNewline :: Repl ()
+replNewline = liftIO (putStrLn "")
 
-printError :: JuvixError -> Repl ()
-printError e = do
+renderOut :: (P.HasAnsiBackend a, P.HasTextBackend a) => a -> Repl ()
+renderOut = render'
+
+renderOutLn :: (P.HasAnsiBackend a, P.HasTextBackend a) => a -> Repl ()
+renderOutLn t = renderOut t >> replNewline
+
+printErrorS :: JuvixError -> ReplS ()
+printErrorS e = do
   opts <- State.gets (^. replStateGlobalOptions)
   hasAnsi <- liftIO (Ansi.hSupportsANSIColor stderr)
   liftIO $ hPutStrLn stderr $ run (runReader (project' @GenericOptions opts) (Error.render (not (opts ^. globalNoColors) && hasAnsi) False e))

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -208,12 +208,15 @@ ppConcrete a = do
   return (Concrete.ppOut popts a)
 
 printConcrete :: Concrete.PrettyCode a => a -> Repl ()
-printConcrete = ppConcrete >=> renderOutLn
+printConcrete = ppConcrete >=> renderOut
+
+printConcreteLn :: Concrete.PrettyCode a => a -> Repl ()
+printConcreteLn = ppConcrete >=> renderOutLn
 
 replParseIdentifiers :: String -> Repl (NonEmpty Concrete.ScopedIden)
 replParseIdentifiers input =
   replExpressionUpToScopedAtoms (strip (pack input))
-  >>= getIdentifiers
+    >>= getIdentifiers
   where
     getIdentifiers :: Concrete.ExpressionAtoms 'Concrete.Scoped -> Repl (NonEmpty Concrete.ScopedIden)
     getIdentifiers as = mapM getIdentifier (as ^. Concrete.expressionAtoms)
@@ -228,7 +231,6 @@ replParseIdentifiers input =
           where
             err :: Repl a
             err = replError (AnsiText @Text ":def expects one or more identifiers")
-
 
 printDocumentation :: String -> Repl ()
 printDocumentation = replParseIdentifiers >=> printIdentifiers
@@ -315,21 +317,21 @@ printDefinition = replParseIdentifiers >=> printIdentifiers
               tbl :: Scoped.InfoTable <- getInfoTable
               let def :: Scoped.FunctionInfo = tbl ^?! Scoped.infoFunctions . at fun . _Just
               printLocation def
-              printConcrete def
+              printConcreteLn def
 
             printInductive :: Scoped.NameId -> Repl ()
             printInductive ind = do
               tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
               let def :: Concrete.InductiveDef 'Concrete.Scoped = tbl ^?! Scoped.infoInductives . at ind . _Just . Scoped.inductiveInfoDef
               printLocation def
-              printConcrete def
+              printConcreteLn def
 
             printAxiom :: Scoped.NameId -> Repl ()
             printAxiom ax = do
               tbl :: Scoped.InfoTable <- (^. replContextArtifacts . artifactScopeTable) <$> replGetContext
               let def :: Concrete.AxiomDef 'Concrete.Scoped = tbl ^?! Scoped.infoAxioms . at ax . _Just . Scoped.axiomInfoDef
               printLocation def
-              printConcrete def
+              printConcreteLn def
 
             printConstructor :: Scoped.NameId -> Repl ()
             printConstructor c = do

--- a/app/Commands/Repl/Base.hs
+++ b/app/Commands/Repl/Base.hs
@@ -1,0 +1,34 @@
+module Commands.Repl.Base where
+
+import Commands.Base hiding
+  ( command,
+  )
+import Commands.Repl.Options
+import Control.Monad.Except qualified as Except
+import Control.Monad.Reader qualified as Reader
+import Control.Monad.State.Strict qualified as State
+import System.Console.Repline
+
+type ReplS = Reader.ReaderT ReplEnv (State.StateT ReplState (Except.ExceptT JuvixError IO))
+
+type Repl a = HaskelineT ReplS a
+
+data ReplContext = ReplContext
+  { _replContextArtifacts :: Artifacts,
+    _replContextEntryPoint :: EntryPoint
+  }
+
+data ReplEnv = ReplEnv
+  { _replRoots :: Roots,
+    _replOptions :: ReplOptions
+  }
+
+data ReplState = ReplState
+  { _replStateRoots :: Roots,
+    _replStateContext :: Maybe ReplContext,
+    _replStateGlobalOptions :: GlobalOptions
+  }
+
+makeLenses ''ReplState
+makeLenses ''ReplContext
+makeLenses ''ReplEnv

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -10,9 +10,9 @@ import Juvix.Prelude
 
 data InfoTableBuilder m a where
   RegisterAxiom :: AxiomDef 'Scoped -> InfoTableBuilder m ()
-  RegisterConstructor :: InductiveConstructorDef 'Scoped -> InfoTableBuilder m ()
+  RegisterConstructor :: S.Symbol -> InductiveConstructorDef 'Scoped -> InfoTableBuilder m ()
   RegisterInductive :: InductiveDef 'Scoped -> InfoTableBuilder m ()
-  RegisterFunction :: TypeSignature 'Scoped -> InfoTableBuilder m ()
+  RegisterTypeSignature :: TypeSignature 'Scoped -> InfoTableBuilder m ()
   RegisterFunctionClause :: FunctionClause 'Scoped -> InfoTableBuilder m ()
   RegisterName :: (HasLoc c) => S.Name' c -> InfoTableBuilder m ()
   RegisterModule :: Module 'Scoped 'ModuleTop -> InfoTableBuilder m ()
@@ -25,37 +25,41 @@ registerDoc k md = modify (set (highlightDoc . at k) md)
 toState :: Members '[HighlightBuilder] r => Sem (InfoTableBuilder ': r) a -> Sem (State InfoTable ': r) a
 toState = reinterpret $ \case
   RegisterAxiom d ->
-    let ref = AxiomRef' (S.unqualifiedSymbol (d ^. axiomName))
-        info = AxiomInfo {_axiomInfoType = d ^. axiomType}
+    let ref = d ^. axiomName . S.nameId
+        info = AxiomInfo d
         j = d ^. axiomDoc
      in do
           modify (over infoAxioms (HashMap.insert ref info))
           registerDoc (d ^. axiomName . nameId) j
-  RegisterConstructor c ->
-    let ref = ConstructorRef' (S.unqualifiedSymbol (c ^. constructorName))
-        info = ConstructorInfo {_constructorInfoType = c ^. constructorType}
+  RegisterConstructor ind c ->
+    let ref = c ^. constructorName . S.nameId
+        info = ConstructorInfo c ind
         j = c ^. constructorDoc
      in do
           modify (over infoConstructors (HashMap.insert ref info))
           registerDoc (c ^. constructorName . nameId) j
   RegisterInductive ity ->
-    let ref = InductiveRef' (S.unqualifiedSymbol (ity ^. inductiveName))
+    let ref = ity ^. inductiveName . S.nameId
         info = InductiveInfo {_inductiveInfoDef = ity}
         j = ity ^. inductiveDoc
      in do
           modify (over infoInductives (HashMap.insert ref info))
           registerDoc (ity ^. inductiveName . nameId) j
-  RegisterFunction f ->
-    let ref = FunctionRef' (S.unqualifiedSymbol (f ^. sigName))
-        info = FunctionInfo {_functionInfoType = f ^. sigType}
+  RegisterTypeSignature f ->
+    let ref = f ^. sigName . S.nameId
+        info =
+          FunctionInfo
+            { _functionInfoType = f,
+              _functionInfoClauses = []
+            }
         j = f ^. sigDoc
      in do
-          modify (over infoFunctions (HashMap.insert ref info))
+          modify (set (infoFunctions . at ref) (Just info))
           registerDoc (f ^. sigName . nameId) j
   RegisterFunctionClause c ->
-    let key = c ^. clauseOwnerFunction
-        value = c
-     in do modify (over infoFunctionClauses (HashMap.insert key value))
+    -- assumes the signature has already been registered
+    let key = c ^. clauseOwnerFunction . S.nameId
+     in modify (over (infoFunctions . at key . _Just . functionInfoClauses) (`snoc` c))
   RegisterName n -> modify (over highlightNames (cons (S.AName n)))
   RegisterModule m -> do
     let j = m ^. moduleDoc

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1624,5 +1624,13 @@ symbolEntryToSName = \case
   EntryModule m -> getModuleRefNameType m
   EntryVariable m -> m
 
+instance HasNameKind ScopedIden where
+  getNameKind = \case
+    ScopedAxiom {} -> KNameAxiom
+    ScopedInductive {} -> KNameInductive
+    ScopedConstructor {} -> KNameConstructor
+    ScopedVar {} -> KNameLocal
+    ScopedFunction {} -> KNameFunction
+
 instance HasNameKind SymbolEntry where
   getNameKind = getNameKind . entryName

--- a/src/Juvix/Compiler/Concrete/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Base.hs
@@ -6,6 +6,7 @@ module Juvix.Compiler.Concrete.Pretty.Base
 where
 
 import Data.List.NonEmpty.Extra qualified as NonEmpty
+import Juvix.Compiler.Concrete.Data.InfoTable
 import Juvix.Compiler.Concrete.Data.ScopedName
   ( AbsModulePath,
     IsConcrete (..),
@@ -118,6 +119,12 @@ groupStatements = \case
                   _inductiveName
                     ^. S.nameConcrete
                     : map (^. constructorName . S.nameConcrete) constructors
+
+instance PrettyCode FunctionInfo where
+  ppCode f = do
+    let ty = StatementTypeSignature (f ^. functionInfoType)
+        cs = map StatementFunctionClause (f ^. functionInfoClauses)
+    ppCode (ty : cs)
 
 instance (SingI s) => PrettyCode [Statement s] where
   ppCode ss = vsep2 <$> mapM (fmap vsep . mapM (fmap endSemicolon . ppCode)) (groupStatements ss)

--- a/src/Juvix/Compiler/Concrete/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Concrete/Pretty/Options.hs
@@ -22,3 +22,6 @@ fromGenericOptions GenericOptions {..} =
 
 inJudocBlock :: Members '[Reader Options] r => Sem r a -> Sem r a
 inJudocBlock = local (set optInJudocBlock True)
+
+instance CanonicalProjection GenericOptions Options where
+  project = fromGenericOptions

--- a/src/Juvix/Compiler/Internal/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Internal/Data/InfoTable.hs
@@ -16,9 +16,8 @@ newtype FunctionInfo = FunctionInfo
   { _functionInfoDef :: FunctionDef
   }
 
-data AxiomInfo = AxiomInfo
-  { _axiomInfoType :: Expression,
-    _axiomInfoBuiltin :: Maybe BuiltinAxiom
+newtype AxiomInfo = AxiomInfo
+  { _axiomInfoDef :: AxiomDef
   }
 
 newtype InductiveInfo = InductiveInfo
@@ -157,21 +156,13 @@ buildTable1' m = do
     _infoAxioms :: HashMap Name AxiomInfo
     _infoAxioms =
       HashMap.fromList
-        [ (d ^. axiomName, AxiomInfo (d ^. axiomType) (d ^. axiomBuiltin))
+        [ (d ^. axiomName, AxiomInfo d)
           | StatementAxiom d <- ss
         ]
 
     ss :: [Statement]
     ss = m ^. moduleBody . moduleStatements
 
--- | Returns all statements in a module, including those in local modules
--- flattenModule :: Module -> [Statement]
--- flattenModule m = concatMap go (m ^. moduleBody . moduleStatements)
---   where
---     go :: Statement -> [Statement]
---     go = \case
---       StatementModule l -> flattenModule l
---       s -> [s]
 lookupConstructor :: (Member (Reader InfoTable) r) => Name -> Sem r ConstructorInfo
 lookupConstructor f = HashMap.lookupDefault impossible f <$> asks (^. infoConstructors)
 
@@ -239,7 +230,7 @@ getAxiomBuiltinInfo :: Member (Reader InfoTable) r => Name -> Sem r (Maybe Built
 getAxiomBuiltinInfo n = do
   maybeAxiomInfo <- HashMap.lookup n <$> asks (^. infoAxioms)
   return $ case maybeAxiomInfo of
-    Just axiomInfo -> axiomInfo ^. axiomInfoBuiltin
+    Just axiomInfo -> axiomInfo ^. axiomInfoDef . axiomBuiltin
     Nothing -> Nothing
 
 getFunctionBuiltinInfo :: Member (Reader InfoTable) r => Name -> Sem r (Maybe BuiltinFunction)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -3,8 +3,8 @@ module Juvix.Compiler.Internal.Translation.FromInternal
     arityChecking,
     typeChecking,
     typeCheckExpression,
+    typeCheckExpressionType,
     arityCheckExpression,
-    inferExpressionType,
     arityCheckInclude,
     typeCheckInclude,
   )
@@ -103,12 +103,6 @@ typeCheckInclude i = do
       . runReader table
       . withEmptyVars
     $ checkInclude i
-
-inferExpressionType ::
-  (Members '[Error JuvixError, State Artifacts] r) =>
-  Expression ->
-  Sem r Expression
-inferExpressionType exp = (^. typedType) <$> typeCheckExpressionType exp
 
 typeChecking ::
   Members '[HighlightBuilder, Error JuvixError, Builtins, NameIdGen] r =>

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -450,7 +450,7 @@ idenArity = \case
   IdenInductive i -> typeArity <$> inductiveType i
   IdenFunction f -> typeArity . (^. functionInfoDef . funDefType) <$> lookupFunction f
   IdenConstructor c -> typeArity <$> constructorType c
-  IdenAxiom a -> typeArity . (^. axiomInfoType) <$> lookupAxiom a
+  IdenAxiom a -> typeArity . (^. axiomInfoDef . axiomType) <$> lookupAxiom a
 
 -- | let x be some expression of type T. The argument of this function is T and it returns
 -- the arity of x. In other words, given (T : Type), it returns the arity of the elements of T.

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -699,7 +699,7 @@ inferExpression' hint e = case e of
         return (TypedExpression ty (ExpressionIden i))
       IdenAxiom v -> do
         info <- lookupAxiom v
-        return (TypedExpression (info ^. axiomInfoType) (ExpressionIden i))
+        return (TypedExpression (info ^. axiomInfoDef . axiomType) (ExpressionIden i))
       IdenInductive v -> do
         kind <- inductiveType v
         return (TypedExpression kind (ExpressionIden i))

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -28,6 +28,41 @@ arityCheckExpression p = do
       >>= Internal.fromAbstractExpression
       >>= Internal.arityCheckExpression
 
+expressionUpToAtomsParsed ::
+  Members '[State Artifacts, Error JuvixError] r =>
+  Path Abs File ->
+  Text ->
+  Sem r (ExpressionAtoms 'Parsed)
+expressionUpToAtomsParsed fp txt =
+  runNameIdGenArtifacts
+    . runBuiltinsArtifacts
+    $ Parser.expressionFromTextSource fp txt
+
+expressionUpToAtomsScoped ::
+  Members '[State Artifacts, Error JuvixError] r =>
+  Path Abs File ->
+  Text ->
+  Sem r (ExpressionAtoms 'Scoped)
+expressionUpToAtomsScoped fp txt = do
+  scopeTable <- gets (^. artifactScopeTable)
+  runNameIdGenArtifacts
+    . runBuiltinsArtifacts
+    . runScoperScopeArtifacts
+    $ Parser.expressionFromTextSource fp txt
+      >>= Scoper.scopeCheckExpressionAtoms scopeTable
+
+scopeCheckExpression ::
+  Members '[Error JuvixError, State Artifacts] r =>
+  ExpressionAtoms 'Parsed ->
+  Sem r Expression
+scopeCheckExpression p = do
+  scopeTable <- gets (^. artifactScopeTable)
+  runNameIdGenArtifacts
+    . runBuiltinsArtifacts
+    . runScoperScopeArtifacts
+    . Scoper.scopeCheckExpression scopeTable
+    $ p
+
 openImportToInternal ::
   Members '[Reader EntryPoint, Error JuvixError, State Artifacts] r =>
   OpenModule 'Parsed ->
@@ -80,17 +115,6 @@ importToInternal' ::
   Sem r Internal.Include
 importToInternal' = Internal.arityCheckInclude >=> Internal.typeCheckInclude
 
-parseExpression ::
-  Members '[State Artifacts, Error JuvixError] r =>
-  Path Abs File ->
-  Text ->
-  Sem r (ExpressionAtoms 'Parsed)
-parseExpression fp txt =
-  ( runNameIdGenArtifacts
-      . runBuiltinsArtifacts
-  )
-    $ Parser.expressionFromTextSource fp txt
-
 parseReplInput ::
   Members '[PathResolver, Files, State Artifacts, Error JuvixError] r =>
   Path Abs File ->
@@ -103,15 +127,15 @@ parseReplInput fp txt =
   )
     $ Parser.replInputFromTextSource fp txt
 
-inferExpression ::
+expressionUpToTyped ::
   Members '[Error JuvixError, State Artifacts] r =>
   Path Abs File ->
   Text ->
-  Sem r Internal.Expression
-inferExpression fp txt = do
-  p <- parseExpression fp txt
+  Sem r Internal.TypedExpression
+expressionUpToTyped fp txt = do
+  p <- expressionUpToAtomsParsed fp txt
   arityCheckExpression p
-    >>= Internal.inferExpressionType
+    >>= Internal.typeCheckExpressionType
 
 compileExpression ::
   Members '[Error JuvixError, State Artifacts] r =>
@@ -179,10 +203,9 @@ compileReplInputIO fp txt =
         Parser.ReplImport i -> registerImport i $> ReplPipelineResultImport (i ^. importModule)
         Parser.ReplOpenImport i -> registerOpenImport i $> ReplPipelineResultOpenImport (i ^. openModuleName)
 
-inferExpressionIO ::
+expressionUpToTypedIO ::
   Members '[State Artifacts, Embed IO] r =>
   Path Abs File ->
   Text ->
-  Sem r (Either JuvixError Internal.Expression)
-inferExpressionIO fp txt =
-  runError (inferExpression fp txt)
+  Sem r (Either JuvixError Internal.TypedExpression)
+expressionUpToTypedIO fp txt = runError (expressionUpToTyped fp txt)

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -16,7 +16,7 @@ data GenericError = GenericError
     _genericErrorIntervals :: [Interval]
   }
 
-data GenericOptions = GenericOptions
+newtype GenericOptions = GenericOptions
   { _showNameIds :: Bool
   }
   deriving stock (Eq, Show)
@@ -47,6 +47,9 @@ genericErrorHeader g =
 
 class ToGenericError a where
   genericError :: (Member (Reader GenericOptions) r) => a -> Sem r GenericError
+
+instance ToGenericError GenericError where
+  genericError = return
 
 errorIntervals :: (ToGenericError e, Member (Reader GenericOptions) r) => e -> Sem r [Interval]
 errorIntervals e = do

--- a/src/Juvix/Data/NameKind.hs
+++ b/src/Juvix/Data/NameKind.hs
@@ -31,14 +31,20 @@ instance HasNameKind NameKind where
   getNameKind = id
 
 instance Pretty NameKind where
-  pretty = \case
-    KNameConstructor -> "constructor"
-    KNameInductive -> "inductive type"
-    KNameFunction -> "function"
-    KNameLocal -> "variable"
-    KNameAxiom -> "axiom"
-    KNameLocalModule -> "local module"
-    KNameTopModule -> "module"
+  pretty = pretty . nameKindText
+
+nameKindWithArticle :: NameKind -> Text
+nameKindWithArticle = withArticle . nameKindText
+
+nameKindText :: NameKind -> Text
+nameKindText = \case
+  KNameConstructor -> "constructor"
+  KNameInductive -> "inductive type"
+  KNameFunction -> "function"
+  KNameLocal -> "variable"
+  KNameAxiom -> "axiom"
+  KNameLocalModule -> "local module"
+  KNameTopModule -> "module"
 
 isLocallyBounded :: (HasNameKind a) => a -> Bool
 isLocallyBounded k = case getNameKind k of

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -6,6 +6,7 @@ module Juvix.Prelude.Pretty
   )
 where
 
+import Data.Text qualified as Text
 import Juvix.Prelude.Base
 import Prettyprinter hiding (concatWith, defaultLayoutOptions, hsep, sep, vsep)
 import Prettyprinter qualified as PP
@@ -147,6 +148,18 @@ ordinal = \case
   11 -> "eleventh"
   12 -> "twelfth"
   n -> pretty n <> "th"
+
+isVowel :: Char -> Bool
+isVowel = (`elem` ("aeiouAEIOU" :: [Char]))
+
+withArticle :: Text -> Text
+withArticle n = articleFor n <> " " <> n
+
+articleFor :: Text -> Text
+articleFor n
+  | Text.null n = ""
+  | isVowel (Text.head n) = "an"
+  | otherwise = "a"
 
 itemize :: (Functor f, Foldable f) => f (Doc ann) -> Doc ann
 itemize = vsep . fmap ("• " <>)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,8 @@
 ghc-options:
   "$locals": -optP-Wno-nonportable-include-path
 resolver: lts-20.21
+extra-deps:
+  - git: https://github.com/janmasrovira/repline.git
+    commit: a735ab1459db408adda080eb5ea21b96fb4a6011
+  - git: https://github.com/janmasrovira/haskeline.git
+    commit: 81e393e156508a20fcc197acc945b0f44aa4f82b

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -1,6 +1,62 @@
 working-directory: ./../../../tests/
 
 tests:
+  - name: repl-def
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def suc"
+    stdout:
+      contains: |
+        --- Inductive natural numbers. I.e. whole non-negative numbers.
+        builtin nat type Nat :=
+          | zero : Nat
+          | suc : Nat → Nat
+    exit-status: 0
+
+  - name: repl-def-error
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def 1 Nat"
+    stdout:
+      matches: |
+        .*
+    stderr:
+      contains: |
+        :def expects one or more identifiers
+    exit-status: 0
+
+  - name: repl-def-multiple
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def + (+) (((+)))"
+    stdout:
+      contains: |
+        --- Addition for ;Nat;s.
+        builtin nat-plus + : Nat → Nat → Nat;
+        + zero b := b;
+        + (suc a) b := suc (a + b);
+    exit-status: 0
+
+  - name: repl-def-infix
+    command:
+      - juvix
+      - repl
+      - ../examples/milestone/HelloWorld/HelloWorld.juvix
+    stdin: ":def +"
+    stdout:
+      contains: |
+        --- Addition for ;Nat;s.
+        builtin nat-plus + : Nat → Nat → Nat;
+        + zero b := b;
+        + (suc a) b := suc (a + b);
+    exit-status: 0
+
   - name: open
     command:
       - juvix


### PR DESCRIPTION
This pr adds the `:doc` command to the repl. This command expects an identifier in scope and then prints its associated judoc documentation