### PR TITLE
Fix printing of infix constructor values

### DIFF
--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -558,7 +558,7 @@ instance (PrettyCode a) => PrettyCode [a] where
 
 goBinary :: Member (Reader Options) r => Fixity -> Doc Ann -> [Value] -> Sem r (Doc Ann)
 goBinary fixity name = \case
-  [] -> return name
+  [] -> return (parens name)
   [arg] -> do
     arg' <- ppRightExpression appFixity arg
     return $ parens name <+> arg'
@@ -571,7 +571,7 @@ goBinary fixity name = \case
 
 goUnary :: Member (Reader Options) r => Fixity -> Doc Ann -> [Value] -> Sem r (Doc Ann)
 goUnary fixity name = \case
-  [] -> return name
+  [] -> return (parens name)
   [arg] -> do
     arg' <- ppPostExpression fixity arg
     return $ arg' <+> name

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -426,3 +426,12 @@ tests:
     stdout:
       contains: "true"
     exit-status: 0
+
+  - name: infix-constructors
+    command:
+      - juvix
+      - repl
+    stdin: "(::) :: nil {Nat -> List Nat -> List Nat}"
+    stdout:
+      contains: "(::) :: nil"
+    exit-status: 0


### PR DESCRIPTION
To print e.g.
```agda
(::) :: nil
```
instead of
```agda
:: :: nil
```
