### PR TITLE
Use the`JUVIX_LLVM_DIST_PATH` environment variable to search for the clang executable

### DIFF
--- a/app/Commands/Doctor/Options.hs
+++ b/app/Commands/Doctor/Options.hs
@@ -2,8 +2,9 @@ module Commands.Doctor.Options where
 
 import CommonOptions
 
-newtype DoctorOptions = DoctorOptions
-  { _doctorOffline :: Bool
+data DoctorOptions = DoctorOptions
+  { _doctorOffline :: Bool,
+    _doctorVerbose :: Bool
   }
   deriving stock (Data)
 
@@ -13,5 +14,11 @@ parseDoctorOptions = do
     switch
       ( long "offline"
           <> help "Run the doctor offline"
+      )
+  _doctorVerbose <-
+    switch
+      ( long "verbose"
+          <> short 'v'
+          <> help "Print verbose output"
       )
   pure DoctorOptions {..}

--- a/src/Juvix/Prelude/Path.hs
+++ b/src/Juvix/Prelude/Path.hs
@@ -127,3 +127,7 @@ parents = go [] . parent
 
 withTempDir' :: (MonadIO m, MonadMask m) => (Path Abs Dir -> m a) -> m a
 withTempDir' = withSystemTempDir "tmp"
+
+-- | 'pure True' if the file exists and is executable, 'pure False' otherwise
+isExecutable :: MonadIO m => Path b File -> m Bool
+isExecutable f = doesFileExist f &&^ (executable <$> getPermissions f)

--- a/tests/smoke/Commands/version-help-doctor.smoke.yaml
+++ b/tests/smoke/Commands/version-help-doctor.smoke.yaml
@@ -44,4 +44,41 @@ tests:
       > Checking that WASI_SYSROOT_PATH is set...
       > Checking for wasmer...
 
+  - name: cli-cmd-doctor-verbose-system
+    command:
+      - juvix
+      - doctor
+      - --verbose
+      - --offline
+    exit-status: 0
+    stdout:
+      matches:
+        regex: |-
+          Found clang(.*?)using system PATH
 
+  - name: cli-cmd-doctor-verbose-envvar
+    command:
+      shell:
+        - bash
+      script: |
+        CLANG_PATH=`which clang`
+        export JUVIX_LLVM_DIST_PATH=${CLANG_PATH%$'/bin/clang'}
+        juvix doctor --verbose --offline
+    exit-status: 0
+    stdout:
+      matches:
+        regex: |-
+          Found clang(.*?)using JUVIX_LLVM_DIST_PATH
+
+  - name: cli-cmd-doctor-verbose-envvar-system-fallback
+    command:
+      shell:
+        - bash
+      script: |
+        export JUVIX_LLVM_DIST_PATH=/tmp
+        juvix doctor --verbose --offline
+    exit-status: 0
+    stdout:
+      matches:
+        regex: |-
+          Found clang(.*?)using system PATH


### PR DESCRIPTION
If set, `JUVIX_LLVM_DIST_PATH` should point to the root of a LLVM installation, i.e clang should be present in`$JUVIX_LLVM_DIST_PATH`/bin/clang.

If `JUVIX_LLVM_DIST_PATH` is not set, or `clang` is not available there then the system PATH is used instead, (this is the current behaviour).

The `juvix doctor` clang checks use the same logic as `juvix compile` to find and check the `clang` executable.

To help with debugging the clang location, this PR also adds `juvix doctor --verbose` which prints the location of the `clang` executable and whether it was found using the system PATH or the JUVIX_LLVM_DIST_PATH environment variable:

```
juvix doctor --verbose
> Checking for clang...
  | Found clang at "/Users/paul/.local/share/juvix/llvmbox/bin/clang" using JUVIX_LLVM_DIST_PATH environment variable
```

or

```
juvix doctor --verbose
> Checking for clang...
  | Found clang at "/Users/paul/.local/bin/clang" using system PATH
```

* Closes https://github.com/anoma/juvix/issues/2133