### PR TITLE
Support new `import ... open` syntax in REPL

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -204,9 +204,10 @@ topModuleDef = do
 replInput :: forall r. Members '[Files, PathResolver, InfoTableBuilder, JudocStash, NameIdGen, Error ParserError, State (Maybe ParsedPragmas)] r => ParsecS r ReplInput
 replInput =
   P.label "<repl input>" $
-    (ReplExpression <$> parseExpressionAtoms)
-      <|> (ReplImport <$> import_)
-      <|> (ReplOpenImport <$> openModule)
+    ReplExpression <$> parseExpressionAtoms
+      <|> P.try (ReplOpenImport <$> newOpenSyntax)
+      <|> ReplImport <$> import_
+      <|> ReplOpenImport <$> openModule
 
 --------------------------------------------------------------------------------
 -- Symbols and names

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -449,6 +449,15 @@ tests:
       contains: "true"
     exit-status: 0
 
+  - name: open-import-from-stdlib-new-syntax
+    command:
+      - juvix
+      - repl
+    stdin: "import Stdlib.Data.Int.Ord open\n1 == 1"
+    stdout:
+      contains: "true"
+    exit-status: 0
+
   - name: infix-constructors
     command:
       - juvix


### PR DESCRIPTION
Similar to https://github.com/anoma/juvix/pull/2098 which introduced the new `import ... open` syntax the old syntax is still supported.

The `try` must be removed when the old `open import ...` syntax is removed.

* Closes https://github.com/anoma/juvix/issues/2155
