### PR TITLE
Properly scan imports inside local modules

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -182,15 +182,25 @@ goDefinition = \case
   Abstract.StatementAxiom a -> pure . PreAxiomDef <$> goAxiomDef a
   Abstract.StatementImport {} -> return []
 
+scanImports :: Abstract.ModuleBody -> [Abstract.TopModule]
+scanImports (Abstract.ModuleBody stmts) = mconcatMap go stmts where
+  go :: Abstract.Statement -> [Abstract.TopModule]
+  go = \case
+    Abstract.StatementLocalModule m -> scanImports (m ^. Abstract.moduleBody)
+    Abstract.StatementImport t -> [t]
+    Abstract.StatementInductive {} -> []
+    Abstract.StatementFunction {} -> []
+    Abstract.StatementAxiom {} -> []
+
 goModuleBody ::
   forall r.
   Members '[Reader ExportsTable, Reader NameDependencyInfo, State TranslationState, NameIdGen] r =>
   Abstract.ModuleBody ->
   Sem r ModuleBody
-goModuleBody (Abstract.ModuleBody stmts) = do
+goModuleBody b@(Abstract.ModuleBody stmts) = do
   preDefs <- concatMapM goDefinition stmts
   sccs <- buildMutualBlocks preDefs
-  let imports :: [Abstract.TopModule] = [t | Abstract.StatementImport t <- stmts]
+  let imports :: [Abstract.TopModule] = scanImports b
       statements' = map goSCC sccs
   imports' <- map StatementInclude <$> mapMaybeM goImport imports
   return
@@ -235,17 +245,6 @@ goImport m = do
                   { _includeModule = m'
                   }
             )
-
--- goStatement ::
---   (Members '[Reader ExportsTable, State TranslationState, NameIdGen, Reader NameDependencyInfo] r) =>
---   Abstract.Statement ->
---   Sem r (Maybe Statement)
--- goStatement = \case
---   Abstract.StatementAxiom d -> Just . StatementAxiom <$> goAxiomDef d
---   Abstract.StatementFunction {} -> return Nothing
---   Abstract.StatementImport i -> fmap StatementInclude <$> goImport i
---   Abstract.StatementLocalModule m -> Just . StatementModule <$> goModule m
---   Abstract.StatementInductive i -> Just . StatementInductive <$> goInductiveDef i
 
 goTypeIden :: Abstract.Iden -> Iden
 goTypeIden = \case

--- a/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromAbstract.hs
@@ -183,14 +183,15 @@ goDefinition = \case
   Abstract.StatementImport {} -> return []
 
 scanImports :: Abstract.ModuleBody -> [Abstract.TopModule]
-scanImports (Abstract.ModuleBody stmts) = mconcatMap go stmts where
-  go :: Abstract.Statement -> [Abstract.TopModule]
-  go = \case
-    Abstract.StatementLocalModule m -> scanImports (m ^. Abstract.moduleBody)
-    Abstract.StatementImport t -> [t]
-    Abstract.StatementInductive {} -> []
-    Abstract.StatementFunction {} -> []
-    Abstract.StatementAxiom {} -> []
+scanImports (Abstract.ModuleBody stmts) = mconcatMap go stmts
+  where
+    go :: Abstract.Statement -> [Abstract.TopModule]
+    go = \case
+      Abstract.StatementLocalModule m -> scanImports (m ^. Abstract.moduleBody)
+      Abstract.StatementImport t -> [t]
+      Abstract.StatementInductive {} -> []
+      Abstract.StatementFunction {} -> []
+      Abstract.StatementAxiom {} -> []
 
 goModuleBody ::
   forall r.

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -226,6 +226,10 @@ tests =
       $(mkRelDir ".")
       $(mkRelFile "MutualLet.juvix"),
     posTest
+      "import inside local module"
+      $(mkRelDir "issue2163")
+      $(mkRelFile "Main.juvix"),
+    posTest
       "id application in type"
       $(mkRelDir ".")
       $(mkRelFile "IdInType.juvix"),

--- a/tests/positive/issue2163/Main.juvix
+++ b/tests/positive/issue2163/Main.juvix
@@ -1,0 +1,8 @@
+module Main;
+
+  module B;
+
+  import Stdlib.Prelude open;
+  idNat : Nat -> Nat;
+  idNat x := x;
+  end;

--- a/tests/positive/issue2163/Main.juvix
+++ b/tests/positive/issue2163/Main.juvix
@@ -1,8 +1,8 @@
 module Main;
 
-  module B;
-
+module B;
   import Stdlib.Prelude open;
+
   idNat : Nat -> Nat;
   idNat x := x;
-  end;
+end;

--- a/tests/positive/issue2163/juvix.yaml
+++ b/tests/positive/issue2163/juvix.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- .juvix-build/stdlib/
+name: issue2163
+version: 0.0.0


### PR DESCRIPTION
- Closes #2163 

Nested imports where not scanned properly when building the Internal InfoTable. That is no fixed