### PR TITLE
Format returns 0 when file is not formatted

### DIFF
--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -45,15 +45,16 @@ runCommand opts = do
                       "Use the --help option to display more usage information."
                     ]
                 return FormatResultFail
-    let exitFail = embed (exitWith (ExitFailure 1))
+    let exitFail :: IO a
+        exitFail = exitWith (ExitFailure 1)
     case res of
-      FormatResultFail -> exitFail
+      FormatResultFail -> embed exitFail
       FormatResultNotFormatted ->
         {- use exit code 1 for
          * unformatted files when using --check
          * when running the formatter on a Juvix project
         -}
-        when (opts ^. formatCheck || target == TargetDir) exitFail
+        when (opts ^. formatCheck || target == TargetDir) (embed exitFail)
       FormatResultOK -> pure ()
 
 renderModeFromOptions :: FormatTarget -> FormatOptions -> FormattedFileInfo -> FormatRenderMode

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -1,17 +1,17 @@
 module Juvix.Formatter where
 
-import qualified Data.Text                                                       as T
-import           Juvix.Compiler.Concrete.Language
-import           Juvix.Compiler.Concrete.Print                                   (ppOutDefault)
-import qualified Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping as Scoper
-import           Juvix.Compiler.Concrete.Translation.FromSource.Data.Context
-import           Juvix.Compiler.Pipeline.EntryPoint
-import           Juvix.Extra.Paths
-import           Juvix.Prelude
-import           Juvix.Prelude.Pretty
+import Data.Text qualified as T
+import Juvix.Compiler.Concrete.Language
+import Juvix.Compiler.Concrete.Print (ppOutDefault)
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
+import Juvix.Compiler.Concrete.Translation.FromSource.Data.Context
+import Juvix.Compiler.Pipeline.EntryPoint
+import Juvix.Extra.Paths
+import Juvix.Prelude
+import Juvix.Prelude.Pretty
 
 data FormattedFileInfo = FormattedFileInfo
-  { _formattedFileInfoPath         :: Path Abs File,
+  { _formattedFileInfoPath :: Path Abs File,
     _formattedFileInfoContentsAnsi :: NonEmpty AnsiText
   }
 
@@ -29,11 +29,11 @@ data FormatResult
   deriving stock (Eq)
 
 instance Semigroup FormatResult where
-  FormatResultFail <> _         = FormatResultFail
-  _ <> FormatResultFail         = FormatResultFail
+  FormatResultFail <> _ = FormatResultFail
+  _ <> FormatResultFail = FormatResultFail
   FormatResultNotFormatted <> _ = FormatResultNotFormatted
   _ <> FormatResultNotFormatted = FormatResultNotFormatted
-  _ <> _                        = FormatResultOK
+  _ <> _ = FormatResultOK
 
 instance Monoid FormatResult where
   mempty = FormatResultOK

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -1,17 +1,17 @@
 module Juvix.Formatter where
 
-import Data.Text qualified as T
-import Juvix.Compiler.Concrete.Language
-import Juvix.Compiler.Concrete.Print (ppOutDefault)
-import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
-import Juvix.Compiler.Concrete.Translation.FromSource.Data.Context
-import Juvix.Compiler.Pipeline.EntryPoint
-import Juvix.Extra.Paths
-import Juvix.Prelude
-import Juvix.Prelude.Pretty
+import qualified Data.Text                                                       as T
+import           Juvix.Compiler.Concrete.Language
+import           Juvix.Compiler.Concrete.Print                                   (ppOutDefault)
+import qualified Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping as Scoper
+import           Juvix.Compiler.Concrete.Translation.FromSource.Data.Context
+import           Juvix.Compiler.Pipeline.EntryPoint
+import           Juvix.Extra.Paths
+import           Juvix.Prelude
+import           Juvix.Prelude.Pretty
 
 data FormattedFileInfo = FormattedFileInfo
-  { _formattedFileInfoPath :: Path Abs File,
+  { _formattedFileInfoPath         :: Path Abs File,
     _formattedFileInfoContentsAnsi :: NonEmpty AnsiText
   }
 
@@ -24,13 +24,22 @@ makeSem ''ScopeEff
 
 data FormatResult
   = FormatResultOK
+  | FormatResultNotFormatted
   | FormatResultFail
   deriving stock (Eq)
 
+instance Semigroup FormatResult where
+  FormatResultFail <> _         = FormatResultFail
+  _ <> FormatResultFail         = FormatResultFail
+  FormatResultNotFormatted <> _ = FormatResultNotFormatted
+  _ <> FormatResultNotFormatted = FormatResultNotFormatted
+  _ <> _                        = FormatResultOK
+
+instance Monoid FormatResult where
+  mempty = FormatResultOK
+
 combineResults :: [FormatResult] -> FormatResult
-combineResults rs
-  | FormatResultFail `elem` rs = FormatResultFail
-  | otherwise = FormatResultOK
+combineResults = mconcat
 
 ansiPlainText :: NonEmpty AnsiText -> Text
 ansiPlainText = T.concat . toList . fmap toPlainText
@@ -43,11 +52,11 @@ formattedFileInfoContentsText = to infoToPlainText
 
 -- | Format a single Juvix file.
 --
--- If the file requires formatting then the function returns FormatResultFail
+-- If the file requires formatting then the function returns 'FormatResultNotFormatted'
 -- and outputs a FormattedFileInfo containing the formatted contents of the file.
 --
 -- If the file does not require formatting then the function returns
--- FormatResultOK and nothing is output.
+-- 'FormatResultOK' and nothing is output.
 format ::
   forall r.
   Members '[ScopeEff, Files, Output FormattedFileInfo] r =>
@@ -62,12 +71,12 @@ format p = do
 --
 -- Format all files in the Juvix project containing the passed directory.
 --
--- If any file requires formatting then the function returns FormatResultFail.
+-- If any file requires formatting then the function returns 'FormatResultNotFormatted'
 -- This function also outputs a FormattedFileInfo (containing the formatted
 -- contents of a file) for every file in the project that requires formatting.
 --
 -- If all files in the project are already formatted then the function returns
--- FormatResultOK and nothing is output.
+-- 'FormatResultOK' and nothing is output.
 --
 -- NB: This function does not traverse into Juvix sub-projects, i.e into
 -- subdirectories that contain a juvix.yaml file.
@@ -122,7 +131,7 @@ formatResultFromContents originalContents mfc filepath =
                   _formattedFileInfoContentsAnsi = formattedContents
                 }
             )
-          return FormatResultFail
+          return FormatResultNotFormatted
       | otherwise -> return FormatResultOK
     Nothing ->
       return FormatResultOK

--- a/test/Formatter/Positive.hs
+++ b/test/Formatter/Positive.hs
@@ -25,7 +25,8 @@ makeFormatTest' Scope.PosTest {..} =
             d <- runM $ runError $ runOutputList @FormattedFileInfo $ runScopeEffIO $ runFilesIO $ format file'
             case d of
               Right (_, FormatResultOK) -> return ()
-              Right (_, FormatResultFail) -> assertFailure ("File: " <> show file' <> " is not formatted")
+              Right (_, FormatResultNotFormatted) -> assertFailure ("File: " <> show file' <> " is not formatted")
+              Right (_, FormatResultFail) -> assertFailure ("File: " <> show file' <> " is failed to format")
               Left {} -> assertFailure ("Error: ")
         }
 

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -31,7 +31,7 @@ tests:
         juvix format Foo.juvix
     stdout:
       contains: module Foo;
-    exit-status: 1
+    exit-status: 0
 
   - name: format-unformatted-file-check-no-stdout
     command:
@@ -168,7 +168,7 @@ tests:
 
         main : Nat;
         main := 5;
-    exit-status: 1
+    exit-status: 0
 
   - name: format-stdin-file-does-not-exist
     command:
@@ -207,7 +207,7 @@ tests:
 
         main : Nat;
         main := 5;
-    exit-status: 1
+    exit-status: 0
 
   - name: format-no-stdin-no-file-name
     command:


### PR DESCRIPTION
`format` command now returns code `0` most of the time.

It will return `1` when:
* some error occur, so can not format
* file is unformatted and `--check` option is used
* One or more files are not formatted in a Juvix project.

- Fixes #2171 