### PR TITLE
Change terminal colours to be more align with the scheme

### DIFF
--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -42,7 +42,7 @@ stylize a = case a of
   AnnJudoc -> colorDull Cyan
   AnnDelimiter -> colorDull White
   AnnLiteralString -> colorDull Red
-  AnnLiteralInteger -> colorDull Cyan
+  AnnLiteralInteger -> colorDull Green
   AnnDef {} -> mempty
   AnnRef {} -> mempty
 

--- a/src/Juvix/Data/NameKind.hs
+++ b/src/Juvix/Data/NameKind.hs
@@ -95,9 +95,9 @@ canBeIterator k = case getNameKind k of
 
 nameKindAnsi :: NameKind -> AnsiStyle
 nameKindAnsi k = case k of
-  KNameConstructor -> colorDull Magenta
+  KNameConstructor -> colorDull Blue
   KNameInductive -> colorDull Green
-  KNameAxiom -> colorDull Red
+  KNameAxiom -> colorDull Magenta
   KNameLocalModule -> color Cyan
   KNameFunction -> colorDull Yellow
   KNameLocal -> mempty


### PR DESCRIPTION
Colouring in the REPL now is a bit closer to the scheme we have for Juvix.
Because of the allowed colors in the `prettyprinter-ansi-terminal` we can use one of the standard colours only:
<img width="896" alt="Screenshot 2023-06-07 at 07 05 34" src="https://github.com/anoma/juvix/assets/8126674/c0077c7c-edba-4ed8-9824-f9b9e773e943">

- Fixes https://github.com/anoma/vscode-juvix/issues/107