### PR TITLE
Fix benchmark runtime C examples

### DIFF
--- a/tests/benchmark/fold/runtime/fold.c
+++ b/tests/benchmark/fold/runtime/fold.c
@@ -10,7 +10,7 @@
 #define CONSTRS_NUM (BUILTIN_UIDS_NUM + 2)
 
 static constr_info_t juvix_constr_info_array[CONSTRS_NUM] = {
-    BUILTIN_UIDS_INFO, {"nil"}, {"cons"}};
+    BUILTIN_UIDS_INFO, {"nil", 0, APP_FIXITY}, {"cons", 0, APP_FIXITY}};
 
 #define UID_NIL FIRST_USER_UID
 #define UID_CONS (FIRST_USER_UID + 1)

--- a/tests/benchmark/mapfold/runtime/mapfold.c
+++ b/tests/benchmark/mapfold/runtime/mapfold.c
@@ -10,7 +10,7 @@
 #define CONSTRS_NUM (BUILTIN_UIDS_NUM + 2)
 
 static constr_info_t juvix_constr_info_array[CONSTRS_NUM] = {
-    BUILTIN_UIDS_INFO, {"nil"}, {"cons"}};
+    BUILTIN_UIDS_INFO, {"nil", 0, APP_FIXITY}, {"cons", 0, APP_FIXITY}};
 
 #define UID_NIL FIRST_USER_UID
 #define UID_CONS (FIRST_USER_UID + 1)

--- a/tests/benchmark/mapfun/runtime/mapfun.c
+++ b/tests/benchmark/mapfun/runtime/mapfun.c
@@ -10,7 +10,7 @@
 #define CONSTRS_NUM (BUILTIN_UIDS_NUM + 2)
 
 static constr_info_t juvix_constr_info_array[CONSTRS_NUM] = {
-    BUILTIN_UIDS_INFO, {"nil"}, {"cons"}};
+    BUILTIN_UIDS_INFO, {"nil", 0, APP_FIXITY}, {"cons", 0, APP_FIXITY}};
 
 #define UID_NIL FIRST_USER_UID
 #define UID_CONS (FIRST_USER_UID + 1)

--- a/tests/benchmark/mapfun/runtime/mapfun_spec.c
+++ b/tests/benchmark/mapfun/runtime/mapfun_spec.c
@@ -10,7 +10,7 @@
 #define CONSTRS_NUM (BUILTIN_UIDS_NUM + 2)
 
 static constr_info_t juvix_constr_info_array[CONSTRS_NUM] = {
-    BUILTIN_UIDS_INFO, {"nil"}, {"cons"}};
+    BUILTIN_UIDS_INFO, {"nil", 0, APP_FIXITY}, {"cons", 0, APP_FIXITY}};
 
 #define UID_NIL FIRST_USER_UID
 #define UID_CONS (FIRST_USER_UID + 1)

--- a/tests/benchmark/mergesort/runtime/mergesort.c
+++ b/tests/benchmark/mergesort/runtime/mergesort.c
@@ -10,7 +10,10 @@
 #define CONSTRS_NUM (BUILTIN_UIDS_NUM + 3)
 
 static constr_info_t juvix_constr_info_array[CONSTRS_NUM] = {
-    BUILTIN_UIDS_INFO, {"nil"}, {"cons"}, {"pair"}};
+    BUILTIN_UIDS_INFO,
+    {"nil", 0, APP_FIXITY},
+    {"cons", 0, APP_FIXITY},
+    {"pair", 0, APP_FIXITY}};
 
 #define UID_NIL FIRST_USER_UID
 #define UID_CONS (FIRST_USER_UID + 1)

--- a/tests/benchmark/prime/runtime/prime.c
+++ b/tests/benchmark/prime/runtime/prime.c
@@ -10,7 +10,7 @@
 #define CONSTRS_NUM (BUILTIN_UIDS_NUM + 2)
 
 static constr_info_t juvix_constr_info_array[CONSTRS_NUM] = {
-    BUILTIN_UIDS_INFO, {"nil"}, {"cons"}};
+    BUILTIN_UIDS_INFO, {"nil", 0, APP_FIXITY}, {"cons", 0, APP_FIXITY}};
 
 #define UID_NIL FIRST_USER_UID
 #define UID_CONS (FIRST_USER_UID + 1)


### PR DESCRIPTION
The constr_info_t struct has changed, so these examples must be changed accordingly.

This should fix the failing benchmark builds https://github.com/anoma/juvix-nightly-builds/actions/runs/5274325536/jobs/9538974076
