### PR TITLE
Fix runtime C maybe benchmark example

### DIFF
--- a/tests/benchmark/compile.sh
+++ b/tests/benchmark/compile.sh
@@ -34,7 +34,6 @@ do
             cd juvix
             for f in *.juvix; do
                 execute "juvix compile -o `basename $f .juvix`.exe $f"
-                execute "juvix compile --target=wasm -o `basename $f .juvix`.wasm $f"
             done
             cd ..
         fi

--- a/tests/benchmark/maybe/runtime/maybe.c
+++ b/tests/benchmark/maybe/runtime/maybe.c
@@ -9,7 +9,11 @@
 #define CONSTRS_NUM (BUILTIN_UIDS_NUM + 4)
 
 static constr_info_t juvix_constr_info_array[CONSTRS_NUM] = {
-    BUILTIN_UIDS_INFO, {"leaf"}, {"node"}, {"nothing"}, {"just"}};
+    BUILTIN_UIDS_INFO,
+    {"leaf", 0, APP_FIXITY},
+    {"node", 0, APP_FIXITY},
+    {"nothing", 0, APP_FIXITY},
+    {"just", 0, APP_FIXITY}};
 
 #define UID_LEAF FIRST_USER_UID
 #define UID_NODE (FIRST_USER_UID + 1)


### PR DESCRIPTION
The constr_info_t struct has changed, so this example must be changed accordingly.

The benchmark builds are still broken because I missed this file in https://github.com/anoma/juvix/pull/2192

I've removed the unsupported wasm target from the `compile.sh` script in the benchmark directory to make it easier to spot errors.