### PR TITLE
Propogate formatter results when traversing subdirs

### DIFF
--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -100,10 +100,10 @@ formatProject p = do
       [Path Rel File] ->
       FormatResult ->
       Sem r (FormatResult, Recurse Rel)
-    handler cd _ files _ = do
+    handler cd _ files res = do
       let juvixFiles = [cd <//> f | f <- files, isJuvixFile f]
-      res <- combineResults <$> mapM format juvixFiles
-      return (res, RecurseFilter (\hasJuvixYaml d -> not hasJuvixYaml && not (isHiddenDirectory d)))
+      subRes <- combineResults <$> mapM format juvixFiles
+      return (res <> subRes, RecurseFilter (\hasJuvixYaml d -> not hasJuvixYaml && not (isHiddenDirectory d)))
 
 formatPath :: Members [Reader Text, ScopeEff] r => Path Abs File -> Sem r (NonEmpty AnsiText)
 formatPath p = do

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -110,7 +110,7 @@ tests:
     stdout: ''
     exit-status: 0
 
-  - name: format-dir-containing-unformatted
+  - name: format-dir-containing-unformatted-and-formatted
     command:
       shell:
         - bash
@@ -121,6 +121,8 @@ tests:
         cp positive/Format.juvix $temp
         cd $temp
         echo "module Foo ;" >> Foo.juvix
+        mkdir Subdir
+        echo "module Subdir.Bar;" >> Subdir/Bar.juvix
         juvix format $temp
     stdout:
       contains: 'Foo.juvix'


### PR DESCRIPTION
Previously if a project looked like (where `Unformatted.juvix` contains unformatted code, and `Formatted.juvix` is fully formatted):

```
Dir
|- juvix.yaml
|- Unformatted.juvix
|- Subdir
   |- Formatted.juvix
```

and the user ran `juvix format Dir/` then the command would return exit code 0 instead of exit code 1. This is because only the result from formatting files within `Subdir` was used, the result from `Dir` was discarded.

This PR fixes this, the results of formatting all subdirectories in a project are combined appropriately.