### PR TITLE
Support juvix format with no argument to format a project

### DIFF
--- a/app/TopCommand/Options.hs
+++ b/app/TopCommand/Options.hs
@@ -135,7 +135,8 @@ parseUtility =
                       [ "juvix format is used to format Juvix source files.",
                         "",
                         "Given a file, it prints the reformatted source to standard output.",
-                        "Given a project directory it prints a list of unformatted files in the project."
+                        "Given a project directory it prints a list of unformatted files in the project.",
+                        "Given no argument it prints a list of unformatted files in the project which contains the current directory."
                       ]
                   )
               )

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -110,6 +110,20 @@ tests:
     stdout: ''
     exit-status: 0
 
+  - name: format-project-with-all-formatted
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        touch $temp/juvix.yaml
+        cp positive/Format.juvix $temp
+        cd $temp
+        juvix format
+    stdout: ''
+    exit-status: 0
+
   - name: format-dir-containing-unformatted-and-formatted
     command:
       shell:
@@ -124,6 +138,42 @@ tests:
         mkdir Subdir
         echo "module Subdir.Bar;" >> Subdir/Bar.juvix
         juvix format $temp
+    stdout:
+      contains: 'Foo.juvix'
+    exit-status: 1
+
+  - name: format-project-containing-unformatted-and-unformatted
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        touch $temp/juvix.yaml
+        cp positive/Format.juvix $temp
+        cd $temp
+        echo "module Foo ;" >> Foo.juvix
+        mkdir Subdir
+        echo "module Subdir.Bar;" >> Subdir/Bar.juvix
+        juvix format
+    stdout:
+      contains: 'Foo.juvix'
+    exit-status: 1
+
+  - name: format-project-containing-unformatted-from-subdir
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        touch $temp/juvix.yaml
+        cp positive/Format.juvix $temp
+        cd $temp
+        echo "module Foo ;" >> Foo.juvix
+        mkdir -p $temp/subdir
+        cd $temp/subdir
+        juvix format
     stdout:
       contains: 'Foo.juvix'
     exit-status: 1
@@ -159,6 +209,22 @@ tests:
     stdout: ''
     exit-status: 1
 
+  - name: format-project-containing-unformatted-check-no-stdout
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        touch $temp/juvix.yaml
+        cp positive/Format.juvix $temp
+        cd $temp
+        echo "module Foo ;" >> Foo.juvix
+        cd $temp
+        juvix format --check
+    stdout: ''
+    exit-status: 1
+
   - name: format-dir-with-all-formatted-check-no-stdout
     command:
       shell:
@@ -169,6 +235,20 @@ tests:
         touch $temp/juvix.yaml
         cp positive/Format.juvix $temp
         juvix format --check $temp
+    stdout: ''
+    exit-status: 0
+
+  - name: format-project-with-all-formatted-check-no-stdout
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        touch $temp/juvix.yaml
+        cp positive/Format.juvix $temp
+        cd $temp
+        juvix format --check
     stdout: ''
     exit-status: 0
 


### PR DESCRIPTION
When `juvix format` is invoked from some directory within a juvix
project then the formatter is run on all the files contained in the
project.

If `juvix format` is run from some directory outside of a Juvix project
then an error is reported. The user gets the same error as they would get if
`juvix format` was run with a directory argument that is not within a
Juvix project.

* Closes https://github.com/anoma/juvix/issues/2087