### PR TITLE
Build and cache smoke binary keyed using icu4c version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,7 @@ jobs:
           stack-arguments: --copy-bins
           working-directory: smoke-repo
           cache-prefix: ${{ steps.icuversion.outputs.version }}
+          pedantic: false
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,40 @@ jobs:
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v3
 
+      # smoke dynamically links to icu4c, so a cached binary of smoke will break
+      # when brew bumps the icu4c version. In the following steps we use the
+      # icu4c version in the cache key of the smoke build to avoid this issue.
+      #
+      # NB: The smoke build cannot be done as a separate job because the smoke
+      # binary must be built using exactly the same version of the macos-12
+      # runner image as the smoke testing step to make sure that the icu4c
+      # versions match.
+      - name: Checkout smoke repo
+        uses: actions/checkout@v3
+        with:
+          repository: jonaprieto/smoke
+          ref: regex-icu
+          path: smoke-repo
+
+      - name: Install ICU4C
+        run: |
+          brew install icu4c
+          brew link icu4c --force
+
+      - name: Get ICU4C version
+        id: icuversion
+        run: |
+          ICUVERSION=$(echo -n $(brew list --versions icu4c | head -n 1 | sed -E 's/ /-/g'))
+          echo "version=$ICUVERSION" >> $GITHUB_OUTPUT
+
+      - name: Build smoke
+        uses: freckle/stack-action@v4
+        with:
+          test: false
+          stack-arguments: --copy-bins
+          working-directory: smoke-repo
+          cache-prefix: ${{ steps.icuversion.outputs.version }}
+
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
         run: |
           echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
@@ -239,40 +273,6 @@ jobs:
         run: |
           cd main
           make check-format-juvix-files && make typecheck-juvix-examples
-
-      # smoke dynamically links to icu4c, so a cached binary of smoke will break
-      # when brew bumps the icu4c version. In the following steps we use the
-      # icu4c version in the cache key of the smoke build to avoid this issue.
-      #
-      # NB: The smoke build cannot be done as a separate job because the smoke
-      # binary must be built using exactly the same version of the macos-12
-      # runner image as the smoke testing step to make sure that the icu4c
-      # versions match.
-      - name: Checkout smoke repo
-        uses: actions/checkout@v3
-        with:
-          repository: jonaprieto/smoke
-          ref: regex-icu
-          path: smoke-repo
-
-      - name: Install ICU4C
-        run: |
-          brew install icu4c
-          brew link icu4c --force
-
-      - name: Get ICU4C version
-        id: icuversion
-        run: |
-          ICUVERSION=$(echo -n $(brew list --versions icu4c | head -n 1 | sed -E 's/ /-/g'))
-          echo "version=$ICUVERSION" >> $GITHUB_OUTPUT
-
-      - name: Build smoke
-        uses: freckle/stack-action@v4
-        with:
-          test: false
-          stack-arguments: --copy-bins
-          working-directory: smoke-repo
-          cache-prefix: ${{ steps.icuversion.outputs.version }}
 
       - name: Smoke testing (macOS)
         id: smoke-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,6 @@ jobs:
           echo "version=$ICUVERSION" >> $GITHUB_OUTPUT
 
       - name: Build smoke
-        id: stack
         uses: freckle/stack-action@v4
         with:
           test: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,11 +172,6 @@ jobs:
         run: |
           sed --version
 
-      - name: Install ICU4C
-        run: |
-          brew install icu4c
-          brew link icu4c --force
-
       - name: Download and extract wasi-sysroot
         run: >
           curl
@@ -245,15 +240,40 @@ jobs:
           cd main
           make check-format-juvix-files && make typecheck-juvix-examples
 
-      - name: Install Smoke
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
+      # smoke dynamically links to icu4c, so a cached binary of smoke will break
+      # when brew bumps the icu4c version. In the following steps we use the
+      # icu4c version in the cache key of the smoke build to avoid this issue.
+      #
+      # NB: The smoke build cannot be done as a separate job because the smoke
+      # binary must be built using exactly the same version of the macos-12
+      # runner image as the smoke testing step to make sure that the icu4c
+      # versions match.
+      - name: Checkout smoke repo
+        uses: actions/checkout@v3
         with:
-          repo: jonaprieto/smoke
-          tag: latest
-          extension-matching: disable
-          rename-to: smoke
-          chmod: 0755
-          cache: enable
+          repository: jonaprieto/smoke
+          ref: regex-icu
+          path: smoke-repo
+
+      - name: Install ICU4C
+        run: |
+          brew install icu4c
+          brew link icu4c --force
+
+      - name: Get ICU4C version
+        id: icuversion
+        run: |
+          ICUVERSION=$(echo -n $(brew list --versions icu4c | head -n 1 | sed -E 's/ /-/g'))
+          echo "version=$ICUVERSION" >> $GITHUB_OUTPUT
+
+      - name: Build smoke
+        id: stack
+        uses: freckle/stack-action@v4
+        with:
+          test: false
+          stack-arguments: --copy-bins
+          working-directory: smoke-repo
+          cache-prefix: ${{ steps.icuversion.outputs.version }}
 
       - name: Smoke testing (macOS)
         id: smoke-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,10 @@ jobs:
           echo "version=$ICUVERSION" >> $GITHUB_OUTPUT
 
       - name: Build smoke
+        env:
+          LDFLAGS: -L/usr/local/opt/icu4c/lib
+          CPPFLAGS: -I/usr/local/opt/icu4c/include
+          PKG_CONFIG_PATH: /usr/local/opt/icu4c/lib/pkgconfig
         uses: freckle/stack-action@v4
         with:
           test: false


### PR DESCRIPTION
This PR replaces fetching a precompiled binary of smoke with a build/cache for macOS smoke tests on CI.

smoke dynamically links to icu4c, so a cached binary of smoke will break when brew bumps the icu4c version. In this PR we use the icu4c version in the cache key of the smoke build to avoid this issue.

NB: The smoke build cannot be done as a separate job because the smoke binary must be built using exactly the same version of the macos-12 runner image as the smoke testing step to make sure that the icu4c versions match.

Motivation for doing this is this failure: https://github.com/anoma/juvix/actions/runs/5325094406/jobs/9645334642

which uses this release of the runner image https://github.com/actions/runner-images/releases/tag/macOS-12%2F20230618.1

which contains the updated brew version of icu4c.

20230618.1 is currently a prerelease, but will start to run on more jobs shortly.

```
2023-06-20T17:10:13.2222310Z Copied executables to /Users/runner/.local/bin:
2023-06-20T17:10:13.2223440Z - juvix
2023-06-20T17:10:13.5312790Z dyld[90256]: Library not loaded: '/usr/local/opt/icu4c/lib/libicuuc.72.dylib'
2023-06-20T17:10:13.5331930Z   Referenced from: '/Users/runner/hostedtoolcache/jonaprieto/smoke/latest/darwin-x64/smoke'
2023-06-20T17:10:13.5333610Z   Reason: tried: '/usr/local/opt/icu4c/lib/libicuuc.72.dylib' (no such file), '/usr/local/lib/libicuuc.72.dylib' (no such file), '/usr/lib/libicuuc.72.dylib' (no such file), '/usr/local/Cellar/icu4c/73.2/lib/libicuuc.72.dylib' (no such file), '/usr/local/lib/libicuuc.72.dylib' (no such file), '/usr/lib/libicuuc.72.dylib' (no such file)
2023-06-20T17:10:13.5334690Z make[1]: *** [smoke-only] Abort trap: 6
2023-06-20T17:10:13.5335310Z make: *** [smoke] Error 2
2023-06-20T17:10:13.5363170Z ##[error]Process completed with exit code 2.
```