### PR TITLE
Fix de Bruijn indices in LetRecs

### DIFF
--- a/src/Juvix/Compiler/Core/Transformation/LambdaLetRecLifting.hs
+++ b/src/Juvix/Compiler/Core/Transformation/LambdaLetRecLifting.hs
@@ -159,7 +159,7 @@ lambdaLiftNode aboveBl top =
                   ]
           declareTopSyms
 
-          let -- TODO it can probably be simplified
+          let -- TODO it can probably be simplified, and it's wrong
               shiftHelper :: Node -> NonEmpty (Node, Binder) -> Node
               shiftHelper b = goShift 0
                 where
@@ -171,7 +171,7 @@ lambdaLiftNode aboveBl top =
                         | otherwise -> impossible
                       (y : ys) -> mkLet mempty bnd' (shift k x) (goShift (k + 1) (y :| ys))
                       where
-                        bnd' = over binderType (shift k . subsCalls) bnd
+                        bnd' = over binderType (shift k) bnd
           let res :: Node
               res = shiftHelper body' (nonEmpty' (zipExact letItems letRecBinders'))
           return (Recur res)

--- a/src/Juvix/Compiler/Core/Transformation/LambdaLetRecLifting.hs
+++ b/src/Juvix/Compiler/Core/Transformation/LambdaLetRecLifting.hs
@@ -159,8 +159,7 @@ lambdaLiftNode aboveBl top =
                   ]
           declareTopSyms
 
-          let -- TODO it can probably be simplified, and it's wrong
-              shiftHelper :: Node -> NonEmpty (Node, Binder) -> Node
+          let shiftHelper :: Node -> NonEmpty (Node, Binder) -> Node
               shiftHelper b = goShift 0
                 where
                   goShift :: Int -> NonEmpty (Node, Binder) -> Node

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -514,7 +514,7 @@ goLet l = goClauses (toList (l ^. Internal.letClauses))
                 pragmas = map (^. Internal.funDefPragmas) lfuns
             tys' <- mapM goType tys
             localAddNames names $ do
-              vals' <- sequence [mkFunBody ty f | (ty, f) <- zipExact tys' lfuns]
+              vals' <- sequence [mkFunBody (shift (length names) ty) f | (ty, f) <- zipExact tys' lfuns]
               let items = nonEmpty' (zipWith3Exact (\ty n v -> LetItem (Binder (n ^. nameText) (Just $ n ^. nameLoc) ty) v) tys' names vals')
               rest <- goClauses cs
               return (mkLetRec (setInfoPragmas pragmas mempty) items rest)


### PR DESCRIPTION
* Closes #2226 

For the program
```juvix
module letrec;

import Stdlib.Prelude open;

myfun : {A : Type} -> (A -> A) -> A -> A;
myfun {A} f a :=
      let
        go : Nat -> A -> A;
        go' : Nat -> A -> A;

        go zero a := a;
        go (suc n) a := f (go' n a);

        go' zero a := a;
        go' (suc n) a := f (go n a);
      in
      go 5 a;

main : Nat;
main := myfun ((+) 1) 7;
```
after translating to Core and lambda-lifting we got the incorrect indices in types of the let-bindings.
```
def myfun : Π A : Type, (A$0 → A$1) → A$1 → A$2 :=
  λ(A : Type)
    λ(f : A$0 → A$1)
      λ(a : A$1)
        let go' : Int → a$1 → a$2 := go'_9 A$2 f$1 in
        let go : Int → a$2 → a$3 := go_10 A$3 f$2 in
        go$0 5 a$2;
```
The indices have been corrected in this PR.
