### PR TITLE
Fix bug in aritychecker

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Checker.hs
@@ -264,9 +264,9 @@ checkLhs loc guessedBody ariSignature pats = do
       [] -> case tailHelper a of
         Nothing -> return ([], a)
         Just tailUnderscores -> do
-          wildcard <- genWildcard
           let a' = foldArity (over ufoldArityParams (drop tailUnderscores) (unfoldArity' a))
-          return (replicate tailUnderscores wildcard, a')
+          wildcards <- replicateM tailUnderscores genWildcard
+          return (wildcards, a')
       lhs@(p : ps) -> case a of
         ArityUnit ->
           throw


### PR DESCRIPTION
When inserting wildcards on the LHS of a clause, we were reusing the same variable, which is wrong. Now fresh variables are generated.

- Closes #2235 