### PR TITLE
Update to GEB version 0.3.2

### DIFF
--- a/src/Juvix/Compiler/Backend/Geb/Extra.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Extra.hs
@@ -16,8 +16,7 @@ morphismTrue :: Morphism
 morphismTrue =
   MorphismLeft
     LeftInj
-      { _leftInjLeftType = ObjectTerminal,
-        _leftInjRightType = ObjectTerminal,
+      { _leftInjRightType = ObjectTerminal,
         _leftInjValue = MorphismUnit
       }
 
@@ -26,7 +25,6 @@ morphismFalse =
   MorphismRight
     RightInj
       { _rightInjLeftType = ObjectTerminal,
-        _rightInjRightType = ObjectTerminal,
         _rightInjValue = MorphismUnit
       }
 
@@ -35,40 +33,9 @@ mkOr :: Morphism -> Morphism -> Morphism
 mkOr arg1 arg2 =
   MorphismCase
     Case
-      { _caseLeftType = ObjectTerminal,
-        _caseRightType = ObjectTerminal,
-        _caseCodomainType = objectBool,
-        _caseOn = arg1,
-        _caseLeft =
-          MorphismLambda
-            Lambda
-              { _lambdaVarType = ObjectTerminal,
-                _lambdaBodyType = objectBool,
-                _lambdaBody = morphismTrue
-              },
-        _caseRight =
-          MorphismLambda
-            Lambda
-              { _lambdaVarType = ObjectTerminal,
-                _lambdaBodyType = objectBool,
-                _lambdaBody = arg2
-              }
-      }
-
-objectLeftCase :: Case -> Object
-objectLeftCase Case {..} =
-  ObjectHom
-    Hom
-      { _homDomain = _caseLeftType,
-        _homCodomain = _caseCodomainType
-      }
-
-objectRightCase :: Case -> Object
-objectRightCase Case {..} =
-  ObjectHom
-    Hom
-      { _homDomain = _caseRightType,
-        _homCodomain = _caseCodomainType
+      { _caseOn = arg1,
+        _caseLeft = morphismTrue,
+        _caseRight = arg2
       }
 
 mkHoms :: [Object] -> Object -> Object

--- a/src/Juvix/Compiler/Backend/Geb/Language.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Language.hs
@@ -17,10 +17,7 @@ import Juvix.Prelude hiding (First, Product)
 -- _caseCodomainType` and `_caseRight` has type `_caseRightType ->
 -- _caseCodomainType`.
 data Case = Case
-  { _caseLeftType :: Object,
-    _caseRightType :: Object,
-    _caseCodomainType :: Object,
-    _caseOn :: Morphism,
+  { _caseOn :: Morphism,
     _caseLeft :: Morphism,
     _caseRight :: Morphism
   }
@@ -33,8 +30,7 @@ data Absurd = Absurd
   deriving stock (Show, Eq, Generic)
 
 data LeftInj' a = LeftInj
-  { _leftInjLeftType :: Object,
-    _leftInjRightType :: Object,
+  { _leftInjRightType :: Object,
     _leftInjValue :: a
   }
   deriving stock (Show, Eq, Generic)
@@ -43,7 +39,6 @@ type LeftInj = LeftInj' Morphism
 
 data RightInj' a = RightInj
   { _rightInjLeftType :: Object,
-    _rightInjRightType :: Object,
     _rightInjValue :: a
   }
   deriving stock (Show, Eq, Generic)
@@ -51,40 +46,31 @@ data RightInj' a = RightInj
 type RightInj = RightInj' Morphism
 
 data Pair' a = Pair
-  { _pairLeftType :: Object,
-    _pairRightType :: Object,
-    _pairLeft :: a,
+  { _pairLeft :: a,
     _pairRight :: a
   }
   deriving stock (Show, Eq, Generic)
 
 type Pair = Pair' Morphism
 
-data First = First
-  { _firstLeftType :: Object,
-    _firstRightType :: Object,
-    _firstValue :: Morphism
+newtype First = First
+  { _firstValue :: Morphism
   }
   deriving stock (Show, Eq, Generic)
 
-data Second = Second
-  { _secondLeftType :: Object,
-    _secondRightType :: Object,
-    _secondValue :: Morphism
+newtype Second = Second
+  { _secondValue :: Morphism
   }
   deriving stock (Show, Eq, Generic)
 
 data Lambda = Lambda
   { _lambdaVarType :: Object,
-    _lambdaBodyType :: Object,
     _lambdaBody :: Morphism
   }
   deriving stock (Show, Eq, Generic)
 
 data Application = Application
-  { _applicationDomainType :: Object,
-    _applicationCodomainType :: Object,
-    _applicationLeft :: Morphism,
+  { _applicationLeft :: Morphism,
     _applicationRight :: Morphism
   }
   deriving stock (Show, Eq, Generic)

--- a/src/Juvix/Compiler/Backend/Geb/Pretty/Keywords.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Pretty/Keywords.hs
@@ -28,6 +28,9 @@ kwPair = keyword Str.gebPair
 kwLamb :: Doc Ann
 kwLamb = keyword Str.gebLamb
 
+kwList :: Doc Ann
+kwList = keyword Str.gebList
+
 kwClosure :: Doc Ann
 kwClosure = keyword Str.gebValueClosure
 

--- a/src/Juvix/Compiler/Backend/Geb/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Translation/FromSource.hs
@@ -14,7 +14,7 @@ import Text.Megaparsec.Char.Lexer qualified as P
 
 data LispDefParameter = LispDefParameter
   { _lispDefParameterName :: Text,
-    _lispDefParameterMorphism :: Geb.TypedMorphism
+    _lispDefParameterMorphism :: Geb.Morphism
   }
 
 makeLenses ''LispDefParameter
@@ -82,7 +82,7 @@ parseDefParameter =
     parens $ do
       symbol "defparameter"
       n <- parseLispSymbol
-      m <- parseTypedMorphism
+      m <- morphism
       return
         LispDefParameter
           { _lispDefParameterName = n,
@@ -97,7 +97,7 @@ parseGebLisp = do
   entry <- parseDefParameter
   P.eof
   return $
-    Geb.ExpressionTypedMorphism $
+    Geb.ExpressionMorphism $
       entry
         ^. lispDefParameterMorphism
 
@@ -117,7 +117,8 @@ morphism =
     morphismUnit
       <|> Geb.MorphismInteger <$> morphismInteger
       <|> parens
-        ( Geb.MorphismAbsurd <$> morphismAbsurd
+        ( morphismUnit
+            <|> Geb.MorphismAbsurd <$> morphismAbsurd
             <|> Geb.MorphismLeft <$> morphismLeftInj
             <|> Geb.MorphismRight <$> morphismRightInj
             <|> Geb.MorphismCase <$> morphismCase
@@ -130,6 +131,11 @@ morphism =
             <|> Geb.MorphismBinop <$> morphismBinop
             <|> Geb.MorphismFail <$> morphismFail
         )
+
+morphismList :: ParsecS r Geb.Morphism
+morphismList = parens $ do
+  kw kwList
+  morphism
 
 parseNatural :: ParsecS r Integer
 parseNatural = lexeme P.decimal
@@ -180,6 +186,11 @@ object =
             <|> Geb.ObjectHom <$> objectHom
         )
 
+objectList :: ParsecS r Geb.Object
+objectList = parens $ do
+  kw kwList
+  object
+
 morphismUnit :: ParsecS r Geb.Morphism
 morphismUnit = do
   P.label "<geb MorphismUnit>" $ do
@@ -202,13 +213,11 @@ morphismLeftInj :: ParsecS r Geb.LeftInj
 morphismLeftInj = do
   P.label "<geb MorphismLeft>" $ do
     kw kwGebMorphismLeft
-    lType <- object
     rType <- object
     lValue <- morphism
     return $
       Geb.LeftInj
-        { _leftInjLeftType = lType,
-          _leftInjRightType = rType,
+        { _leftInjRightType = rType,
           _leftInjValue = lValue
         }
 
@@ -217,12 +226,10 @@ morphismRightInj = do
   P.label "<geb MorphismRight>" $ do
     kw kwGebMorphismRight
     lType <- object
-    rType <- object
     rValue <- morphism
     return $
       Geb.RightInj
         { _rightInjLeftType = lType,
-          _rightInjRightType = rType,
           _rightInjValue = rValue
         }
 
@@ -230,9 +237,6 @@ morphismCase :: ParsecS r Geb.Case
 morphismCase = do
   P.label "<geb MorphismCase>" $ do
     kw kwGebMorphismCase
-    _caseLeftType <- object
-    _caseRightType <- object
-    _caseCodomainType <- object
     _caseOn <- morphism
     _caseLeft <- morphism
     _caseRight <- morphism
@@ -242,8 +246,6 @@ morphismPair :: ParsecS r Geb.Pair
 morphismPair = do
   P.label "<geb MorphismPair>" $ do
     kw kwGebMorphismPair
-    _pairLeftType <- object
-    _pairRightType <- object
     _pairLeft <- morphism
     _pairRight <- morphism
     return Geb.Pair {..}
@@ -252,8 +254,6 @@ morphismFirst :: ParsecS r Geb.First
 morphismFirst = do
   P.label "<geb MorphismFirst>" $ do
     kw kwGebMorphismFirst
-    _firstLeftType <- object
-    _firstRightType <- object
     _firstValue <- morphism
     return Geb.First {..}
 
@@ -261,8 +261,6 @@ morphismSecond :: ParsecS r Geb.Second
 morphismSecond = do
   P.label "<geb MorphismSecond>" $ do
     kw kwGebMorphismSecond
-    _secondLeftType <- object
-    _secondRightType <- object
     _secondValue <- morphism
     return Geb.Second {..}
 
@@ -270,8 +268,7 @@ morphismLambda :: ParsecS r Geb.Lambda
 morphismLambda = do
   P.label "<geb MorphismLambda>" $ do
     kw kwGebMorphismLambda
-    _lambdaVarType <- object
-    _lambdaBodyType <- object
+    _lambdaVarType <- objectList
     _lambdaBody <- morphism
     return Geb.Lambda {..}
 
@@ -279,10 +276,8 @@ morphismApplication :: ParsecS r Geb.Application
 morphismApplication = do
   P.label "<geb MorphismApplication>" $ do
     kw kwGebMorphismApplication
-    _applicationDomainType <- object
-    _applicationCodomainType <- object
     _applicationLeft <- morphism
-    _applicationRight <- morphism
+    _applicationRight <- morphismList
     return Geb.Application {..}
 
 morphismVar :: ParsecS r Geb.Var

--- a/src/Juvix/Compiler/Backend/Geb/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Translation/FromSource.hs
@@ -170,9 +170,8 @@ morphismBinop = do
 morphismFail :: ParsecS r Geb.Failure
 morphismFail = do
   P.label "<geb MorphismFail>" $ do
-    kw kwFail
-    msg <- fst <$> string
-    Geb.Failure msg <$> object
+    kw kwErr
+    Geb.Failure "" <$> object
 
 object :: ParsecS r Geb.Object
 object =

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -196,6 +196,9 @@ kwTrace = asciiKw Str.trace_
 kwFail :: Keyword
 kwFail = asciiKw Str.fail_
 
+kwErr :: Keyword
+kwErr = asciiKw Str.err
+
 kwList :: Keyword
 kwList = asciiKw Str.list
 

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -196,6 +196,9 @@ kwTrace = asciiKw Str.trace_
 kwFail :: Keyword
 kwFail = asciiKw Str.fail_
 
+kwList :: Keyword
+kwList = asciiKw Str.list
+
 kwFun :: Keyword
 kwFun = asciiKw Str.fun_
 

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -639,7 +639,7 @@ gebCoprod :: IsString s => s
 gebCoprod = "coprod"
 
 gebHom :: IsString s => s
-gebHom = "!->"
+gebHom = "so-hom-obj"
 
 gebInteger :: IsString s => s
 gebInteger = "int"

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -584,6 +584,9 @@ gebSnd = "snd"
 gebLamb :: IsString s => s
 gebLamb = "lamb"
 
+gebList :: IsString s => s
+gebList = "list"
+
 gebValueClosure :: IsString s => s
 gebValueClosure = "cls"
 
@@ -615,7 +618,7 @@ gebMod :: IsString s => s
 gebMod = "mod"
 
 gebFail :: IsString s => s
-gebFail = "fail"
+gebFail = "err"
 
 gebEq :: IsString s => s
 gebEq = "eq"

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -317,6 +317,9 @@ trace_ = "trace"
 fail_ :: (IsString s) => s
 fail_ = "fail"
 
+err :: (IsString s) => s
+err = "err"
+
 show_ :: (IsString s) => s
 show_ = "show"
 

--- a/tests/Geb/positive/Compilation/out/test001.geb
+++ b/tests/Geb/positive/Compilation/out/test001.geb
@@ -1,4 +1,3 @@
 (right
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Compilation/out/test002.geb
+++ b/tests/Geb/positive/Compilation/out/test002.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Compilation/out/test003.geb
+++ b/tests/Geb/positive/Compilation/out/test003.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Compilation/out/test004.geb
+++ b/tests/Geb/positive/Compilation/out/test004.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Compilation/out/test008.geb
+++ b/tests/Geb/positive/Compilation/out/test008.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Compilation/out/test028.geb
+++ b/tests/Geb/positive/Compilation/out/test028.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Eval/out/app-case-on.out
+++ b/tests/Geb/positive/Eval/out/app-case-on.out
@@ -1,4 +1,3 @@
 (right
   int
-  int
   1)

--- a/tests/Geb/positive/Eval/out/app-lambda.out
+++ b/tests/Geb/positive/Eval/out/app-lambda.out
@@ -4,12 +4,10 @@
       (env
         nil)
       (lamb
-        so1
-        so1
+        (list
+          so1)
         (index 0))))
   (lamb
-    int
-    (!->
-      so1
-      so1)
+    (list
+      int)
     (index 1)))

--- a/tests/Geb/positive/Eval/out/case-on.out
+++ b/tests/Geb/positive/Eval/out/case-on.out
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
   unit)

--- a/tests/Geb/positive/Eval/out/lamb.out
+++ b/tests/Geb/positive/Eval/out/lamb.out
@@ -2,11 +2,9 @@
   (env
     nil)
   (lamb
-    so1
-    (!->
-      so1
+    (list
       so1)
     (lamb
-      so1
-      so1
+      (list
+        so1)
       (index 1))))

--- a/tests/Geb/positive/Eval/out/left-unit.out
+++ b/tests/Geb/positive/Eval/out/left-unit.out
@@ -2,11 +2,8 @@
   (env
     nil)
   (lamb
-    so1
-    (coprod
-      so1
+    (list
       so1)
     (left
       so1
-      so1
-      unit)))
+      (unit))))

--- a/tests/Geb/positive/Eval/out/test001.geb
+++ b/tests/Geb/positive/Eval/out/test001.geb
@@ -1,4 +1,3 @@
 (right
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Eval/out/test002.geb
+++ b/tests/Geb/positive/Eval/out/test002.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Eval/out/test003.geb
+++ b/tests/Geb/positive/Eval/out/test003.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Eval/out/test004.geb
+++ b/tests/Geb/positive/Eval/out/test004.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/Eval/out/test008.geb
+++ b/tests/Geb/positive/Eval/out/test008.geb
@@ -1,4 +1,3 @@
 (left
   so1
-  so1
-  unit)
+  (unit))

--- a/tests/Geb/positive/app-app-lambda.geb
+++ b/tests/Geb/positive/app-app-lambda.geb
@@ -1,40 +1,23 @@
 (typed
   (app
-    so1
-    so1
     (app
-      int
-      (!->
-        so1
-        so1)
       (app
-        (!->
-          so1
-          so1)
-        (!->
-          int
-          (!->
-            so1
-            so1))
         (lamb
-          (!->
-            so1
-            so1)
-          (!->
-            int
-            (!->
+          (list
+            (so-hom-obj
               so1
               so1))
           (lamb
-            int
-            (!->
-              so1
-              so1)
+            (list
+              int)
             (index 1)))
-        (lamb
-          so1
-          so1
-          (index 0)))
-      12345)
-    unit)
+        (list
+          (lamb
+            (list
+              so1)
+            (index 0))))
+      (list
+        12345))
+    (list
+      (unit)))
   so1)

--- a/tests/Geb/positive/app-case-on.geb
+++ b/tests/Geb/positive/app-case-on.geb
@@ -1,47 +1,22 @@
 (typed
   (app
-    (coprod
-      int
-      int)
-    (coprod
-      int
-      int)
     (lamb
-      (coprod
-        int
-        int)
-      (coprod
-        int
-        int)
-      (case-on
-        int
-        int
+      (list
         (coprod
           int
-          int)
+          int))
+      (case-on
         (index 0)
-        (lamb
+        (right
           int
-          (coprod
-            int
-            int)
-          (right
-            int
-            int
-            1))
-        (lamb
+          1)
+        (left
           int
-          (coprod
-            int
-            int)
-          (left
-            int
-            int
-            2))))
-    (left
-      int
-      int
-      3))
+          2)))
+    (list
+      (left
+        int
+        3)))
   (coprod
     int
     int))

--- a/tests/Geb/positive/app-fst-pair.geb
+++ b/tests/Geb/positive/app-fst-pair.geb
@@ -1,17 +1,14 @@
 (typed
   (app
-    (prod int int)
-    int
     (lamb
-      (prod int int)
-      int
+      (list
+        (prod
+          int
+          int))
       (fst
-        int
-        int
         (index 0)))
-    (pair
-      int
-      int
-      10
-      20))
+    (list
+      (pair
+        10
+        20)))
   int)

--- a/tests/Geb/positive/app-lambda.geb
+++ b/tests/Geb/positive/app-lambda.geb
@@ -1,28 +1,21 @@
-;; ↓ app fun arg where
-;;     fun := cls (λ . (index 1)) with env := []
-;;     arg := cls (index 0) with env := []
-;; → (eval (λ . (index 1)) with env := (arg : [])
-;; → cls (arg : []) (index 1).
-
-;; λ.(λ.0)
 (typed
-(app 
-   (!-> so1 so1)
-   (!-> int (!-> so1 so1))
-    ;; fun: ↓ cls [] (lamb (index 1))
-    ;; λλ.1
-   (lamb
-     (!-> so1 so1)
-     (!-> int (!-> so1 so1))
-     (lamb
-       int
-       (!-> so1 so1)
-       (index 1)))
-   ;; ↓ arg: cls [] (index 0)   
-   ;; λ.0
+  (app
+    (lamb
+      (list
+        (so-hom-obj
+          so1
+          so1))
       (lamb
-        so1
-        so1
-        (index 0)))
-
-(!-> int (!-> so1 so1)))
+        (list
+          int)
+        (index 1)))
+    (list
+      (lamb
+        (list
+          so1)
+        (index 0))))
+  (so-hom-obj
+    int
+    (so-hom-obj
+      so1
+      so1)))

--- a/tests/Geb/positive/basic-app.geb
+++ b/tests/Geb/positive/basic-app.geb
@@ -1,12 +1,11 @@
 (typed
   (app
-    int
-    int
     (lamb
-      int
-      int
+      (list
+        int)
       (index 0))
-    (add
-      1000
-      2000))
+    (list
+      (add
+        1000
+        2000)))
   int)

--- a/tests/Geb/positive/case-on.geb
+++ b/tests/Geb/positive/case-on.geb
@@ -1,32 +1,14 @@
 (typed
   (case-on
-    so1
-    int
-    (coprod
-      so1
-      so1)
     (right
       so1
-      int
-      10)
-    (lamb
+      (unit))
+    (right
       so1
-      (coprod
-        so1
-        so1)
-      (right
-        so1
-        so1
-        unit))
-    (lamb
-      int
-      (coprod
-        so1
-        so1)
-      (left
-        so1
-        so1
-        unit)))
+      (unit))
+    (left
+      so1
+      (unit)))
   (coprod
     so1
     so1))

--- a/tests/Geb/positive/lamb.geb
+++ b/tests/Geb/positive/lamb.geb
@@ -1,15 +1,13 @@
 (typed
   (lamb
-    so1
-    (!->
-      so1
+    (list
       so1)
     (lamb
-      so1
-      so1
+      (list
+        so1)
       (index 1)))
-  (!->
+  (so-hom-obj
     so1
-    (!->
+    (so-hom-obj
       so1
       so1)))

--- a/tests/Geb/positive/left-unit.geb
+++ b/tests/Geb/positive/left-unit.geb
@@ -1,14 +1,11 @@
 (typed
   (lamb
-    so1
-    (coprod
-      so1
+    (list
       so1)
     (left
       so1
-      so1
-      unit))
-  (!->
+      (unit)))
+  (so-hom-obj
     so1
     (coprod
       so1

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -33,7 +33,7 @@ tests:
         cd ./examples/milestone/
         cp -r HelloWorld "$temp"
         cd "$temp/HelloWorld"
-        sed -i '' '/^main:/d' juvix.yaml
+        sed -i '/^main:/d' juvix.yaml
         juvix compile
     exit-status: 1
     stdout: |

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -33,7 +33,7 @@ tests:
         cd ./examples/milestone/
         cp -r HelloWorld "$temp"
         cd "$temp/HelloWorld"
-        sed -i '/^main:/d' juvix.yaml
+        sed -i '' '/^main:/d' juvix.yaml
         juvix compile
     exit-status: 1
     stdout: |

--- a/tests/smoke/Commands/dev/geb.smoke.yaml
+++ b/tests/smoke/Commands/dev/geb.smoke.yaml
@@ -135,36 +135,23 @@ tests:
     stdout: |
       (typed
         (app
-          (!->
-            so1
-            so1)
-          (!->
-            int
-            (!->
-              so1
-              so1))
           (lamb
-            (!->
-              so1
-              so1)
-            (!->
-              int
-              (!->
+            (list
+              (so-hom-obj
                 so1
                 so1))
             (lamb
-              int
-              (!->
-                so1
-                so1)
+              (list
+                int)
               (index 1)))
-          (lamb
-            so1
-            so1
-            (index 0)))
-        (!->
+          (list
+            (lamb
+              (list
+                so1)
+              (index 0))))
+        (so-hom-obj
           int
-          (!->
+          (so-hom-obj
             so1
             so1)))
     exit-status: 0


### PR DESCRIPTION
GEB 0.3.2 introduces the following changes.
* The STLC frontend no longer requires full type information in terms. The syntax of the terms changed.
* An error node has been introduced which allows to compile Juvix `fail` nodes.

The following features required for compilation from Juvix are still missing in GEB.
* Modular arithmetic types ([GEB issue #61](https://github.com/anoma/geb/issues/61)).
* Functor/algebra iteration to implement bounded inductive types ([GEB issue #62](https://github.com/anoma/geb/issues/62)).
