### PR TITLE
Add record declaration syntax

### DIFF
--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
@@ -43,9 +43,18 @@ instance HasNameSignature (FunctionDef 'Parsed) where
     addAtoms (a ^. signRetType)
 
 instance HasNameSignature (InductiveDef 'Parsed, ConstructorDef 'Parsed) where
+  addArgs ::
+    forall r.
+    Members '[NameSignatureBuilder] r =>
+    (InductiveDef 'Parsed, ConstructorDef 'Parsed) ->
+    Sem r ()
   addArgs (i, c) = do
     mapM_ addConstructorParams (i ^. inductiveParameters)
-    addAtoms (c ^. constructorType)
+    addRhs (c ^. constructorRhs)
+    where
+      addRhs :: ConstructorRhs 'Parsed -> Sem r ()
+      addRhs = \case
+        ConstructorRhsGadt g -> addAtoms (g ^. rhsGadtType)
 
 instance HasNameSignature (InductiveDef 'Parsed) where
   addArgs a = do

--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
@@ -52,9 +52,15 @@ instance HasNameSignature (InductiveDef 'Parsed, ConstructorDef 'Parsed) where
     mapM_ addConstructorParams (i ^. inductiveParameters)
     addRhs (c ^. constructorRhs)
     where
+      addRecord :: RhsRecord 'Parsed -> Sem r ()
+      addRecord RhsRecord {..} = mapM_ addField _rhsRecordFields
+        where
+          addField :: RecordField 'Parsed -> Sem r ()
+          addField RecordField {..} = addSymbol Explicit _fieldName
       addRhs :: ConstructorRhs 'Parsed -> Sem r ()
       addRhs = \case
         ConstructorRhsGadt g -> addAtoms (g ^. rhsGadtType)
+        ConstructorRhsRecord g -> addRecord g
 
 instance HasNameSignature (InductiveDef 'Parsed) where
   addArgs a = do

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -381,55 +381,67 @@ data RecordField (s :: Stage) = RecordField
     _fieldType :: ExpressionType s
   }
 
-instance SingI s => Show (RecordField s) where
-  show = deriveStageShow
+deriving stock instance Show (RecordField 'Parsed)
 
-instance SingI s => Eq (RecordField s) where
-  (==) = deriveStageEq
+deriving stock instance Show (RecordField 'Scoped)
 
-instance SingI s => Ord (RecordField s) where
-  compare = deriveStageOrd
+deriving stock instance Eq (RecordField 'Parsed)
+
+deriving stock instance Eq (RecordField 'Scoped)
+
+deriving stock instance Ord (RecordField 'Parsed)
+
+deriving stock instance Ord (RecordField 'Scoped)
 
 data RhsRecord (s :: Stage) = RhsRecord
   { _rhsRecordDelim :: Irrelevant (KeywordRef, KeywordRef),
     _rhsRecordFields :: NonEmpty (RecordField s)
   }
 
-instance SingI s => Show (RhsRecord s) where
-  show = deriveStageShow
+deriving stock instance Show (RhsRecord 'Parsed)
 
-instance SingI s => Eq (RhsRecord s) where
-  (==) = deriveStageEq
+deriving stock instance Show (RhsRecord 'Scoped)
 
-instance SingI s => Ord (RhsRecord s) where
-  compare = deriveStageOrd
+deriving stock instance Eq (RhsRecord 'Parsed)
+
+deriving stock instance Eq (RhsRecord 'Scoped)
+
+deriving stock instance Ord (RhsRecord 'Parsed)
+
+deriving stock instance Ord (RhsRecord 'Scoped)
 
 data RhsGadt (s :: Stage) = RhsGadt
   { _rhsGadtColon :: Irrelevant KeywordRef,
     _rhsGadtType :: ExpressionType s
   }
 
-instance SingI s => Show (RhsGadt s) where
-  show = deriveStageShow
+deriving stock instance Show (RhsGadt 'Parsed)
 
-instance SingI s => Eq (RhsGadt s) where
-  (==) = deriveStageEq
+deriving stock instance Show (RhsGadt 'Scoped)
 
-instance SingI s => Ord (RhsGadt s) where
-  compare = deriveStageOrd
+deriving stock instance Eq (RhsGadt 'Parsed)
+
+deriving stock instance Eq (RhsGadt 'Scoped)
+
+deriving stock instance Ord (RhsGadt 'Parsed)
+
+deriving stock instance Ord (RhsGadt 'Scoped)
 
 data ConstructorRhs (s :: Stage)
   = ConstructorRhsGadt (RhsGadt s)
   | ConstructorRhsRecord (RhsRecord s)
 
-instance SingI s => Show (ConstructorRhs s) where
-  show = deriveStageShow
+deriving stock instance Show (ConstructorRhs 'Parsed)
 
-instance SingI s => Eq (ConstructorRhs s) where
-  (==) = deriveStageEq
+deriving stock instance Show (ConstructorRhs 'Scoped)
 
-instance SingI s => Ord (ConstructorRhs s) where
-  compare = deriveStageOrd
+deriving stock instance Eq (ConstructorRhs 'Parsed)
+
+deriving stock instance Eq (ConstructorRhs 'Scoped)
+
+deriving stock instance Ord (ConstructorRhs 'Parsed)
+
+deriving stock instance Ord (ConstructorRhs 'Scoped)
 
 data InductiveParameters (s :: Stage) = InductiveParameters
   { _inductiveParametersNames :: NonEmpty (SymbolType s),

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -357,11 +357,10 @@ type InductiveName s = SymbolType s
 
 data ConstructorDef (s :: Stage) = ConstructorDef
   { _constructorPipe :: Irrelevant (Maybe KeywordRef),
-    _constructorColonKw :: Irrelevant KeywordRef,
     _constructorName :: InductiveConstructorName s,
     _constructorDoc :: Maybe (Judoc s),
     _constructorPragmas :: Maybe ParsedPragmas,
-    _constructorType :: ExpressionType s
+    _constructorRhs :: ConstructorRhs s
   }
 
 deriving stock instance Show (ConstructorDef 'Parsed)
@@ -375,6 +374,32 @@ deriving stock instance Eq (ConstructorDef 'Scoped)
 deriving stock instance Ord (ConstructorDef 'Parsed)
 
 deriving stock instance Ord (ConstructorDef 'Scoped)
+
+data RhsGadt (s :: Stage) = RhsGadt
+  { _rhsGadtColon :: Irrelevant KeywordRef,
+    _rhsGadtType :: ExpressionType s
+  }
+
+instance SingI s => Show (RhsGadt s) where
+  show = deriveStageShow
+
+instance SingI s => Eq (RhsGadt s) where
+  (==) = deriveStageEq
+
+instance SingI s => Ord (RhsGadt s) where
+  compare = deriveStageOrd
+
+newtype ConstructorRhs (s :: Stage)
+  = ConstructorRhsGadt (RhsGadt s)
+
+instance SingI s => Show (ConstructorRhs s) where
+  show = deriveStageShow
+
+instance SingI s => Eq (ConstructorRhs s) where
+  (==) = deriveStageEq
+
+instance SingI s => Ord (ConstructorRhs s) where
+  compare = deriveStageOrd
 
 data InductiveParameters (s :: Stage) = InductiveParameters
   { _inductiveParametersNames :: NonEmpty (SymbolType s),
@@ -1334,6 +1359,7 @@ newtype ModuleIndex = ModuleIndex
   }
 
 makeLenses ''PatternArg
+makeLenses ''RhsGadt
 makeLenses ''List
 makeLenses ''ListPattern
 makeLenses ''UsingItem

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -375,6 +375,35 @@ deriving stock instance Ord (ConstructorDef 'Parsed)
 
 deriving stock instance Ord (ConstructorDef 'Scoped)
 
+data RecordField (s :: Stage) = RecordField
+  { _fieldName :: SymbolType s,
+    _fieldColon :: Irrelevant (KeywordRef),
+    _fieldType :: ExpressionType s
+  }
+
+instance SingI s => Show (RecordField s) where
+  show = deriveStageShow
+
+instance SingI s => Eq (RecordField s) where
+  (==) = deriveStageEq
+
+instance SingI s => Ord (RecordField s) where
+  compare = deriveStageOrd
+
+data RhsRecord (s :: Stage) = RhsRecord
+  { _rhsRecordDelim :: Irrelevant (KeywordRef, KeywordRef),
+    _rhsRecordFields :: NonEmpty (RecordField s)
+  }
+
+instance SingI s => Show (RhsRecord s) where
+  show = deriveStageShow
+
+instance SingI s => Eq (RhsRecord s) where
+  (==) = deriveStageEq
+
+instance SingI s => Ord (RhsRecord s) where
+  compare = deriveStageOrd
+
 data RhsGadt (s :: Stage) = RhsGadt
   { _rhsGadtColon :: Irrelevant KeywordRef,
     _rhsGadtType :: ExpressionType s
@@ -389,8 +418,9 @@ instance SingI s => Eq (RhsGadt s) where
 instance SingI s => Ord (RhsGadt s) where
   compare = deriveStageOrd
 
-newtype ConstructorRhs (s :: Stage)
+data ConstructorRhs (s :: Stage)
   = ConstructorRhsGadt (RhsGadt s)
+  | ConstructorRhsRecord (RhsRecord s)
 
 instance SingI s => Show (ConstructorRhs s) where
   show = deriveStageShow
@@ -1359,6 +1389,8 @@ newtype ModuleIndex = ModuleIndex
   }
 
 makeLenses ''PatternArg
+makeLenses ''RecordField
+makeLenses ''RhsRecord
 makeLenses ''RhsGadt
 makeLenses ''List
 makeLenses ''ListPattern

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -897,14 +897,22 @@ instance SingI s => PrettyPrint (NonEmpty (InductiveParameters s)) where
 instance PrettyPrint a => PrettyPrint (Irrelevant a) where
   ppCode (Irrelevant a) = ppCode a
 
+instance SingI s => PrettyPrint (RhsGadt s) where
+  ppCode RhsGadt {..} =
+    ppCode _rhsGadtColon <+> ppExpressionType _rhsGadtType
+
+instance SingI s => PrettyPrint (ConstructorRhs s) where
+  ppCode = \case
+    ConstructorRhsGadt r -> ppCode r
+
 instance SingI s => PrettyPrint (ConstructorDef s) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => ConstructorDef s -> Sem r ()
   ppCode ConstructorDef {..} = do
     let constructorName' = annDef _constructorName (ppSymbolType _constructorName)
-        constructorType' = ppExpressionType _constructorType
+        constructorRhs' = ppCode _constructorRhs
         doc' = ppCode <$> _constructorDoc
         pragmas' = ppCode <$> _constructorPragmas
-    pipeHelper <+> nest (doc' ?<> pragmas' ?<> constructorName' <+> ppCode _constructorColonKw <+> constructorType')
+    pipeHelper <+> nest (doc' ?<> pragmas' ?<> constructorName' <+> constructorRhs')
     where
       -- we use this helper so that comments appear before the first optional pipe if the pipe was omitted
       pipeHelper :: Sem r ()

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -901,9 +901,20 @@ instance SingI s => PrettyPrint (RhsGadt s) where
   ppCode RhsGadt {..} =
     ppCode _rhsGadtColon <+> ppExpressionType _rhsGadtType
 
+instance SingI s => PrettyPrint (RecordField s) where
+  ppCode RecordField {..} =
+    ppSymbolType _fieldName <+> ppCode _fieldColon <+> ppExpressionType _fieldType
+
+instance SingI s => PrettyPrint (RhsRecord s) where
+  ppCode RhsRecord {..} = do
+    let Irrelevant (l, r) = _rhsRecordDelim
+        fields' = sepSemicolon (ppCode <$> _rhsRecordFields)
+    ppCode l <> oneLineOrNext fields' <> ppCode r
+
 instance SingI s => PrettyPrint (ConstructorRhs s) where
   ppCode = \case
     ConstructorRhsGadt r -> ppCode r
+    ConstructorRhsRecord r -> ppCode r
 
 instance SingI s => PrettyPrint (ConstructorDef s) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => ConstructorDef s -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -736,25 +736,6 @@ checkInductiveDef InductiveDef {..} = do
       ConstructorRhsGadt r -> ConstructorRhsGadt <$> checkGadt r
       ConstructorRhsRecord r -> ConstructorRhsRecord <$> checkRecord r
 
-    -- checkFunction ::
-    --   forall r.
-    --   Members '[Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r =>
-    --   Function 'Parsed ->
-    --   Sem r (Function 'Scoped)
-    -- checkFunction f = do
-    --   _paramType <- checkParseExpressionAtoms (f ^. funParameters . paramType)
-    --   withLocalScope $ do
-    --     _paramNames <- forM (f ^. funParameters . paramNames) $ \case
-    --       FunctionParameterWildcard w -> return (FunctionParameterWildcard w)
-    --       FunctionParameterName p -> FunctionParameterName <$> bindVariableSymbol p
-    --     _funReturn <- checkParseExpressionAtoms (f ^. funReturn)
-    --     let _paramImplicit = f ^. funParameters . paramImplicit
-    --         _paramColon = f ^. funParameters . paramColon
-    --         _paramDelims = f ^. funParameters . paramDelims
-    --         _funParameters = FunctionParameters {..}
-    --         _funKw = f ^. funKw
-    --     return Function {..}
-
     checkRecord :: RhsRecord 'Parsed -> Sem r (RhsRecord 'Scoped)
     checkRecord RhsRecord {..} = do
       fields' <- checkFields _rhsRecordFields

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -720,16 +720,28 @@ checkInductiveDef InductiveDef {..} = do
     -- note that the constructor name is not bound here
     checkConstructorDef :: S.Symbol -> S.Symbol -> ConstructorDef 'Parsed -> Sem r (ConstructorDef 'Scoped)
     checkConstructorDef tyName constructorName' ConstructorDef {..} = do
-      constructorType' <- checkParseExpressionAtoms _constructorType
       doc' <- mapM checkJudoc _constructorDoc
+      rhs' <- checkRhs _constructorRhs
       registerConstructor tyName
         @$> ConstructorDef
           { _constructorName = constructorName',
-            _constructorType = constructorType',
+            _constructorRhs = rhs',
             _constructorDoc = doc',
             _constructorPragmas = _constructorPragmas,
-            _constructorPipe,
-            _constructorColonKw
+            _constructorPipe
+          }
+
+    checkRhs :: ConstructorRhs 'Parsed -> Sem r (ConstructorRhs 'Scoped)
+    checkRhs = \case
+      ConstructorRhsGadt r -> ConstructorRhsGadt <$> checkGadt r
+
+    checkGadt :: RhsGadt 'Parsed -> Sem r (RhsGadt 'Scoped)
+    checkGadt RhsGadt {..} = do
+      constructorType' <- checkParseExpressionAtoms _rhsGadtType
+      return
+        RhsGadt
+          { _rhsGadtType = constructorType',
+            _rhsGadtColon
           }
 
 createExportsTable :: ExportInfo -> HashSet NameId

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -1034,9 +1034,25 @@ rhsGadt = P.label "<constructor gadt>" $ do
   _rhsGadtType <- parseExpressionAtoms P.<?> "<constructor type>"
   return RhsGadt {..}
 
+recordField :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (RecordField 'Parsed)
+recordField = do
+  _fieldName <- symbol
+  _fieldColon <- Irrelevant <$> kw kwColon
+  _fieldType <- parseExpressionAtoms
+  return RecordField {..}
+
+rhsRecord :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (RhsRecord 'Parsed)
+rhsRecord = P.label "<constructor record>" $ do
+  l <- kw delimBraceL
+  _rhsRecordFields <- P.sepEndBy1 recordField semicolon
+  r <- kw delimBraceR
+  let _rhsRecordDelim = Irrelevant (l, r)
+  return RhsRecord {..}
+
 pconstructorRhs :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (ConstructorRhs 'Parsed)
 pconstructorRhs =
   ConstructorRhsGadt <$> rhsGadt
+    <|> ConstructorRhsRecord <$> rhsRecord
 
 constructorDef :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => Irrelevant (Maybe KeywordRef) -> ParsecS r (ConstructorDef 'Parsed)
 constructorDef _constructorPipe = do

--- a/src/Juvix/Compiler/Internal/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Internal/Data/InfoTable.hs
@@ -216,6 +216,7 @@ constructorReturnType c = do
   info <- lookupConstructor c
   let inductiveParams = fst (constructorArgTypes info)
       ind = ExpressionIden (IdenInductive (info ^. constructorInfoInductive))
+      saturatedTy1 = foldExplicitApplication ind (map (ExpressionIden . IdenVar) inductiveParams)
       saturatedTy =
         foldl'
           ( \t v ->
@@ -229,6 +230,7 @@ constructorReturnType c = do
           )
           ind
           inductiveParams
+  unless (saturatedTy1 == saturatedTy) impossible
   return saturatedTy
 
 getAxiomBuiltinInfo :: Member (Reader InfoTable) r => Name -> Sem r (Maybe BuiltinAxiom)

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -265,7 +265,7 @@ patternVariables f p = case p of
     goApp :: Traversal' ConstructorApp VarName
     goApp g = traverseOf constrAppParameters (traverse (patternArgVariables g))
 
-inductiveTypeVarsAssoc :: (Foldable f) => InductiveDef -> f a -> HashMap VarName a
+inductiveTypeVarsAssoc :: Foldable f => InductiveDef -> f a -> HashMap VarName a
 inductiveTypeVarsAssoc def l
   | length vars < n = impossible
   | otherwise = HashMap.fromList (zip vars (toList l))
@@ -334,7 +334,7 @@ foldExplicitApplication f = foldApplication f . map (ApplicationArg Explicit)
 foldApplication :: Expression -> [ApplicationArg] -> Expression
 foldApplication f args = case args of
   [] -> f
-  ((ApplicationArg i a) : as) -> foldApplication (ExpressionApplication (Application f a i)) as
+  ApplicationArg i a : as -> foldApplication (ExpressionApplication (Application f a i)) as
 
 unfoldApplication' :: Application -> (Expression, NonEmpty ApplicationArg)
 unfoldApplication' (Application l' r' i') = second (|: (ApplicationArg i' r')) (unfoldExpressionApp l')

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -654,11 +654,12 @@ goInductive ty@InductiveDef {..} = do
   return indDef
 
 goConstructorDef ::
+  forall r.
   Members [Builtins, NameIdGen, Error ScoperError, Reader Pragmas] r =>
   ConstructorDef 'Scoped ->
   Sem r Internal.ConstructorDef
 goConstructorDef ConstructorDef {..} = do
-  ty' <- goExpression _constructorType
+  ty' <- goRhs _constructorRhs
   examples' <- goExamples _constructorDoc
   pragmas' <- goPragmas _constructorPragmas
   return
@@ -668,6 +669,13 @@ goConstructorDef ConstructorDef {..} = do
         _inductiveConstructorName = goSymbol _constructorName,
         _inductiveConstructorPragmas = pragmas'
       }
+  where
+    goGadt :: Concrete.RhsGadt 'Scoped -> Sem r Internal.Expression
+    goGadt = goExpression . (^. Concrete.rhsGadtType)
+
+    goRhs :: Concrete.ConstructorRhs 'Scoped -> Sem r Internal.Expression
+    goRhs = \case
+      ConstructorRhsGadt r -> goGadt r
 
 goLiteral :: LiteralLoc -> Internal.LiteralLoc
 goLiteral = fmap go

--- a/src/Juvix/Data/Effect/ExactPrint.hs
+++ b/src/Juvix/Data/Effect/ExactPrint.hs
@@ -95,7 +95,13 @@ blockIndent :: Members '[ExactPrint] r => Sem r () -> Sem r ()
 blockIndent d = hardline <> indent d <> line
 
 sepSemicolon :: (Members '[ExactPrint] r, Foldable l) => l (Sem r ()) -> Sem r ()
-sepSemicolon = sequenceWith (semicolon <> space)
+sepSemicolon = grouped . vsepSemicolon
+
+vsepSemicolon :: (Members '[ExactPrint] r, Foldable l) => l (Sem r ()) -> Sem r ()
+vsepSemicolon = sequenceWith (semicolon <> line)
+
+hsepSemicolon :: (Members '[ExactPrint] r, Foldable l) => l (Sem r ()) -> Sem r ()
+hsepSemicolon = sequenceWith (semicolon <> space)
 
 dotted :: (Foldable f, Members '[ExactPrint] r) => f (Sem r ()) -> Sem r ()
 dotted = sequenceWith (noLoc C.kwDot)

--- a/src/Juvix/Prelude/Lens.hs
+++ b/src/Juvix/Prelude/Lens.hs
@@ -6,6 +6,11 @@ import Juvix.Prelude.Base
 _head1 :: Lens' (NonEmpty a) a
 _head1 = singular each
 
+_tail1 :: Lens' (NonEmpty a) [a]
+_tail1 f (h :| hs) = do
+  hs' <- f hs
+  pure (h :| hs')
+
 -- | View a non-empty list as the init part plus the last element.
 _unsnoc1 :: Lens (NonEmpty a) (NonEmpty b) ([a], a) ([b], b)
 _unsnoc1 afb la = uncurryF (|:) (afb (maybe [] toList minit, lasta))

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -244,7 +244,11 @@ tests =
     posTest
       "Named arguments"
       $(mkRelDir ".")
-      $(mkRelFile "NamedArguments.juvix")
+      $(mkRelFile "NamedArguments.juvix"),
+    posTest
+      "Record declaration"
+      $(mkRelDir ".")
+      $(mkRelFile "Records.juvix")
   ]
     <> [ compilationTest t | t <- Compilation.tests
        ]

--- a/tests/positive/Records.juvix
+++ b/tests/positive/Records.juvix
@@ -1,0 +1,18 @@
+module Records;
+
+type T :=
+  | t : T;
+
+type Pair (A B : Type) :=
+  | mkPair { fst : A; snd : A};
+
+p1 : Pair T T := mkPair (fst := t; snd := t);
+
+type EnumRecord :=
+  | C1 { c1a : T; c1b : T}
+  | C2 { c2a : T; c2b : T};
+
+p2 : Pair EnumRecord EnumRecord :=
+  mkPair
+    (fst := C1 (c1a := t; c1b := t); snd := C2
+      (c2a := t; c2b := t));

--- a/tests/positive/Records.juvix
+++ b/tests/positive/Records.juvix
@@ -6,7 +6,7 @@ type T :=
 type Pair (A B : Type) :=
   | mkPair {
       fst : A;
-      snd : A
+      snd : B
     };
 
 p1 : Pair T T :=

--- a/tests/positive/Records.juvix
+++ b/tests/positive/Records.juvix
@@ -1,18 +1,31 @@
 module Records;
 
 type T :=
-  | t : T;
+  | constructT : T;
 
 type Pair (A B : Type) :=
-  | mkPair { fst : A; snd : A};
+  | mkPair {
+      fst : A;
+      snd : A
+    };
 
-p1 : Pair T T := mkPair (fst := t; snd := t);
+p1 : Pair T T :=
+  mkPair (fst := constructT; snd := constructT);
 
 type EnumRecord :=
-  | C1 { c1a : T; c1b : T}
-  | C2 { c2a : T; c2b : T};
+  | C1 {
+      c1a : T;
+      c1b : T
+    }
+  | C2 {
+      c2a : T;
+      c2b : T
+    };
 
 p2 : Pair EnumRecord EnumRecord :=
   mkPair
-    (fst := C1 (c1a := t; c1b := t); snd := C2
-      (c2a := t; c2b := t));
+    (fst := C1 (c1a := constructT; c1b := constructT);
+     snd := C2 (c2a := constructT; c2b := constructT));
+
+type newtype :=
+  | mknewtype {f : T};


### PR DESCRIPTION
- Closes #1641 

This pr adds the option to declare constructors with fields. E.g.
```
type Pair (A B : Type) :=
  | mkPair {
      fst : A;
      snd : B
    };
```
Which is desugared to
```
type Pair (A B : Type) :=
  | mkPair :  (fst : A) -> (snd : B) -> Pair A B;
```
making it possible to write ` mkPair (fst := 1; snd := 2)`.


Mutli-constructor types are also allowed to have fields.