### PR TITLE
Separate modules namespace

### DIFF
--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -258,7 +258,8 @@ printDocumentation = replParseIdentifiers >=> printIdentifiers
             KNameLocal -> return Nothing
             KNameFunction -> getDocFunction n
             KNameConstructor -> getDocConstructor n
-            _ -> impossible
+            KNameLocalModule -> impossible
+            KNameTopModule -> impossible
           printDoc mdoc
           where
             printDoc :: Maybe (Concrete.Judoc 'Concrete.Scoped) -> Repl ()
@@ -313,7 +314,8 @@ printDefinition = replParseIdentifiers >=> printIdentifiers
                 KNameLocal -> return ()
                 KNameFunction -> printFunction n
                 KNameConstructor -> printConstructor n
-                _ -> impossible
+                KNameLocalModule -> impossible
+                KNameTopModule -> impossible
           where
             printLocation :: HasLoc s => s -> Repl ()
             printLocation def = do

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -15,7 +15,7 @@ data InfoTableBuilder m a where
   RegisterTypeSignature :: TypeSignature 'Scoped -> InfoTableBuilder m ()
   RegisterFunctionDef :: FunctionDef 'Scoped -> InfoTableBuilder m ()
   RegisterFunctionClause :: FunctionClause 'Scoped -> InfoTableBuilder m ()
-  RegisterName :: (HasLoc c) => S.Name' c -> InfoTableBuilder m ()
+  RegisterName :: HasLoc c => S.Name' c -> InfoTableBuilder m ()
   RegisterModule :: Module 'Scoped 'ModuleTop -> InfoTableBuilder m ()
 
 makeSem ''InfoTableBuilder

--- a/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
@@ -1,8 +1,8 @@
 module Juvix.Compiler.Concrete.Data.NameSpace where
 
 import Data.Kind qualified as GHC
-import Juvix.Prelude
 import Juvix.Data.NameKind
+import Juvix.Prelude
 
 data NameSpace
   = NameSpaceSymbols

--- a/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
@@ -1,0 +1,14 @@
+module Juvix.Compiler.Concrete.Data.NameSpace where
+
+import Data.Kind qualified as GHC
+import Juvix.Prelude
+
+data NameSpace
+  = NameSpaceSymbols
+  | NameSpaceModules
+  deriving stock (Eq)
+
+type AnyNameSpace (k :: NameSpace -> GHC.Type) =
+  Σ NameSpace (TyCon1 k)
+
+$(genSingletons [''NameSpace])

--- a/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
@@ -2,13 +2,26 @@ module Juvix.Compiler.Concrete.Data.NameSpace where
 
 import Data.Kind qualified as GHC
 import Juvix.Prelude
+import Juvix.Data.NameKind
 
 data NameSpace
   = NameSpaceSymbols
   | NameSpaceModules
-  deriving stock (Eq)
+  deriving stock (Eq, Generic, Enum, Bounded, Show, Ord)
+
+instance Hashable NameSpace
 
 type AnyNameSpace (k :: NameSpace -> GHC.Type) =
   Σ NameSpace (TyCon1 k)
 
 $(genSingletons [''NameSpace])
+
+type NameKindNameSpace :: NameKind -> NameSpace
+type family NameKindNameSpace s = res where
+  NameKindNameSpace 'KNameLocal = 'NameSpaceSymbols
+  NameKindNameSpace 'KNameConstructor = 'NameSpaceSymbols
+  NameKindNameSpace 'KNameInductive = 'NameSpaceSymbols
+  NameKindNameSpace 'KNameFunction = 'NameSpaceSymbols
+  NameKindNameSpace 'KNameAxiom = 'NameSpaceSymbols
+  NameKindNameSpace 'KNameLocalModule = 'NameSpaceModules
+  NameKindNameSpace 'KNameTopModule = 'NameSpaceModules

--- a/src/Juvix/Compiler/Concrete/Data/Scope.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope.hs
@@ -70,6 +70,7 @@ makeLenses ''ScopeParameters
 
 data ScoperState = ScoperState
   { _scoperModulesCache :: ModulesCache,
+    -- | Local and top modules
     _scoperModules :: HashMap S.ModuleNameId (ModuleRef' 'S.NotConcrete),
     _scoperScope :: HashMap TopModulePath Scope,
     _scoperSignatures :: HashMap S.NameId NameSignature

--- a/src/Juvix/Compiler/Concrete/Data/Scope.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope.hs
@@ -49,16 +49,22 @@ data Scope = Scope
     -- should map to itself. This is needed because we may query it with a
     -- symbol with a different location but we may want the location of the
     -- original symbol
-    _scopeLocalSymbols :: HashMap Symbol S.Symbol
+    _scopeLocalSymbols :: HashMap Symbol S.Symbol,
+    _scopeLocalModuleSymbols :: HashMap Symbol S.Symbol
   }
 
 makeLenses ''SymbolInfo
 makeLenses ''Scope
 
-scopeNameSpace :: forall ns. SingI ns => Lens' Scope (HashMap Symbol (SymbolInfo ns))
+scopeNameSpace :: forall (ns :: NameSpace). SingI ns => Lens' Scope (HashMap Symbol (SymbolInfo ns))
 scopeNameSpace = case sing :: SNameSpace ns of
   SNameSpaceSymbols -> scopeSymbols
   SNameSpaceModules -> scopeModuleSymbols
+
+scopeNameSpaceLocal :: forall (ns :: NameSpace). Sing ns -> Lens' Scope (HashMap Symbol S.Symbol)
+scopeNameSpaceLocal s = case s of
+  SNameSpaceSymbols -> scopeLocalSymbols
+  SNameSpaceModules -> scopeLocalModuleSymbols
 
 newtype ModulesCache = ModulesCache
   { _cachedModules :: HashMap TopModulePath (ModuleRef'' 'S.NotConcrete 'ModuleTop)
@@ -118,5 +124,6 @@ emptyScope absPath =
       _scopeSymbols = mempty,
       _scopeModuleSymbols = mempty,
       _scopeTopModules = mempty,
-      _scopeLocalSymbols = mempty
+      _scopeLocalSymbols = mempty,
+      _scopeLocalModuleSymbols = mempty
     }

--- a/src/Juvix/Compiler/Concrete/Data/Scope.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope.hs
@@ -12,13 +12,17 @@ import Juvix.Prelude
 
 type LocalVariable = S.Symbol
 
-newtype SymbolInfo = SymbolInfo
+newtype SymbolInfo' entry = SymbolInfo
   { -- | This map must have at least one entry. If there are more than one
     -- entry, it means that the same symbol has been brought into scope from two
     -- different places
-    _symbolInfo :: HashMap S.AbsModulePath SymbolEntry
+    _symbolInfo :: HashMap S.AbsModulePath entry
   }
   deriving newtype (Show, Semigroup, Monoid)
+
+type SymbolInfo = SymbolInfo' SymbolEntry
+
+type ModuleSymbolInfo = SymbolInfo' ModuleSymbolEntry
 
 mkModuleRef' :: SingI t => ModuleRef'' 'S.NotConcrete t -> ModuleRef' 'S.NotConcrete
 mkModuleRef' m = ModuleRef' (sing :&: m)
@@ -32,6 +36,7 @@ data BindingStrategy
 data Scope = Scope
   { _scopePath :: S.AbsModulePath,
     _scopeSymbols :: HashMap Symbol SymbolInfo,
+    _scopeModuleSymbols :: HashMap Symbol ModuleSymbolInfo,
     -- | The map from S.NameId to Modules is needed because we support merging
     -- several imports under the same name. E.g.
     -- import A as X;
@@ -46,7 +51,7 @@ data Scope = Scope
   deriving stock (Show)
 
 makeLenses ''ExportInfo
-makeLenses ''SymbolInfo
+makeLenses ''SymbolInfo'
 makeLenses ''Scope
 
 newtype ModulesCache = ModulesCache
@@ -104,6 +109,7 @@ emptyScope absPath =
   Scope
     { _scopePath = absPath,
       _scopeSymbols = mempty,
+      _scopeModuleSymbols = mempty,
       _scopeTopModules = mempty,
       _scopeLocalSymbols = mempty
     }

--- a/src/Juvix/Compiler/Concrete/Data/Scope.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope.hs
@@ -5,7 +5,6 @@ module Juvix.Compiler.Concrete.Data.Scope
   )
 where
 
-import Data.Kind qualified as GHC
 import Juvix.Compiler.Concrete.Data.InfoTable
 import Juvix.Compiler.Concrete.Data.NameSignature.Base
 import Juvix.Compiler.Concrete.Data.NameSpace
@@ -22,11 +21,6 @@ newtype SymbolInfo (n :: NameSpace) = SymbolInfo
     _symbolInfo :: HashMap S.AbsModulePath (NameSpaceEntryType n)
   }
   deriving newtype (Semigroup, Monoid)
-
-type NameSpaceEntryType :: NameSpace -> GHC.Type
-type family NameSpaceEntryType s = res | res -> s where
-  NameSpaceEntryType 'NameSpaceSymbols = SymbolEntry
-  NameSpaceEntryType 'NameSpaceModules = ModuleSymbolEntry
 
 nsEntry :: forall ns. SingI ns => Lens' (NameSpaceEntryType ns) (S.Name' ())
 nsEntry = case sing :: SNameSpace ns of

--- a/src/Juvix/Compiler/Concrete/Data/ScopedName.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ScopedName.hs
@@ -112,8 +112,11 @@ isConstructor n = case n ^. nameKind of
 fromQualifiedName :: C.QualifiedName -> C.Symbol
 fromQualifiedName (C.QualifiedName _ s) = s
 
-topModulePathName :: TopModulePath -> Symbol
-topModulePathName = over nameConcrete (^. C.modulePathName)
+topModulePathSymbol :: TopModulePath -> Symbol
+topModulePathSymbol = over nameConcrete (^. C.modulePathName)
+
+topModulePathName :: TopModulePath -> Name
+topModulePathName = over nameConcrete C.topModulePathToName
 
 unConcrete :: Name' a -> Name' ()
 unConcrete = set nameConcrete ()

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -771,8 +771,8 @@ getNameRefId = case sing :: S.SIsConcrete c of
   S.SConcrete -> (^. S.nameId)
   S.SNotConcrete -> (^. S.nameId)
 
-getModuleExportInfo :: ModuleSymbolEntry -> ExportInfo
-getModuleExportInfo (ModuleSymbolEntry (ModuleRef' (_ :&: ModuleRef'' {..}))) = _moduleExportInfo
+getModuleRefExportInfo :: ModuleRef' c -> ExportInfo
+getModuleRefExportInfo (ModuleRef' (_ :&: ModuleRef'' {..})) = _moduleExportInfo
 
 getModuleRefNameType :: ModuleRef' c -> RefNameType c
 getModuleRefNameType (ModuleRef' (_ :&: ModuleRef'' {..})) = _moduleRefName
@@ -806,7 +806,7 @@ newtype SymbolEntry = SymbolEntry
   deriving stock (Show)
 
 newtype ModuleSymbolEntry = ModuleSymbolEntry
-  { _moduleEntry :: ModuleRef' 'S.NotConcrete
+  { _moduleEntry :: S.Name' ()
   }
   deriving stock (Show)
 
@@ -1977,15 +1977,16 @@ judocExamples (Judoc bs) = concatMap goGroup bs
 instance HasLoc SymbolEntry where
   getLoc = (^. symbolEntry . S.nameDefined)
 
+-- instance HasNameKind ModuleSymbolEntry where
+--   getNameKind (ModuleSymbolEntry (ModuleRef' (t :&: _))) = case t of
+--     SModuleTop -> KNameTopModule
+--     SModuleLocal -> KNameLocalModule
+
 instance HasNameKind ModuleSymbolEntry where
-  getNameKind (ModuleSymbolEntry (ModuleRef' (t :&: _))) = case t of
-    SModuleTop -> KNameTopModule
-    SModuleLocal -> KNameLocalModule
+  getNameKind (ModuleSymbolEntry s) = getNameKind s
 
 instance HasLoc ModuleSymbolEntry where
-  getLoc (ModuleSymbolEntry (ModuleRef' (t :&: m))) = case t of
-    SModuleTop -> getLoc (m ^. moduleRefModule . modulePath)
-    SModuleLocal -> getLoc (m ^. moduleRefModule . modulePath)
+  getLoc (ModuleSymbolEntry s) = s ^. S.nameDefined
 
 overModuleRef'' :: forall s s'. (forall t. ModuleRef'' s t -> ModuleRef'' s' t) -> ModuleRef' s -> ModuleRef' s'
 overModuleRef'' f = over unModuleRef' (\(t :&: m'') -> t :&: f m'')

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -2008,15 +2008,7 @@ instance HasNameKind ScopedIden where
 instance HasNameKind SymbolEntry where
   getNameKind = getNameKind . (^. symbolEntry)
 
--- TODO move to prelude
-
--- | Like a Traversal but requires `Semigroup (f s)` so that we can join
--- traversals using `<>`.
-type TraversalS s t a b = forall f. (Applicative f, Semigroup (f s)) => LensLike f s t a b
-
-type TraversalS' s a = TraversalS s s a a
-
-exportAllNames :: TraversalS' ExportInfo (S.Name' ())
+exportAllNames :: SimpleFold ExportInfo (S.Name' ())
 exportAllNames =
   exportSymbols . each . symbolEntry
     <> exportModuleSymbols . each . moduleEntry

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -805,8 +805,9 @@ newtype SymbolEntry = SymbolEntry
   }
   deriving stock (Show)
 
-newtype ModuleSymbolEntry = ModuleSymbolEntry {
-  _moduleEntry :: ModuleRef' 'S.NotConcrete}
+newtype ModuleSymbolEntry = ModuleSymbolEntry
+  { _moduleEntry :: ModuleRef' 'S.NotConcrete
+  }
   deriving stock (Show)
 
 instance SingI t => CanonicalProjection (ModuleRef'' c t) (ModuleRef' c) where

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1424,6 +1424,7 @@ makeLenses ''TypeSignature
 makeLenses ''SigArg
 makeLenses ''FunctionDef
 makeLenses ''AxiomDef
+makeLenses ''ExportInfo
 makeLenses ''FunctionClause
 makeLenses ''InductiveParameters
 makeLenses ''ModuleRef'
@@ -1999,3 +2000,16 @@ instance HasNameKind ScopedIden where
 
 instance HasNameKind SymbolEntry where
   getNameKind = getNameKind . (^. symbolEntry)
+
+-- TODO move to prelude
+
+-- | Like a Traversal but requires `Semigroup (f s)` so that we can join
+-- traversals using `<>`.
+type TraversalS s t a b = forall f. (Applicative f, Semigroup (f s)) => LensLike f s t a b
+
+type TraversalS' s a = TraversalS s s a a
+
+exportAllNames :: TraversalS' ExportInfo (S.Name' ())
+exportAllNames =
+  exportSymbols . each . symbolEntry
+    <> exportModuleSymbols . each . moduleEntry

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1985,11 +1985,6 @@ judocExamples (Judoc bs) = concatMap goGroup bs
 instance HasLoc SymbolEntry where
   getLoc = (^. symbolEntry . S.nameDefined)
 
--- instance HasNameKind ModuleSymbolEntry where
---   getNameKind (ModuleSymbolEntry (ModuleRef' (t :&: _))) = case t of
---     SModuleTop -> KNameTopModule
---     SModuleLocal -> KNameLocalModule
-
 instance HasNameKind ModuleSymbolEntry where
   getNameKind (ModuleSymbolEntry s) = getNameKind s
 

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -802,7 +802,10 @@ ppUnkindedSymbol :: Members '[Reader Options, ExactPrint] r => WithLoc Text -> S
 ppUnkindedSymbol = region (annotate AnnUnkindedSym) . ppCode
 
 instance SingI s => PrettyPrint (HidingItem s) where
-  ppCode = ppSymbolType . (^. hidingSymbol)
+  ppCode h = do
+    let sym = ppSymbolType (h ^. hidingSymbol)
+        kwmodule = ppCode <$> (h ^. hidingModuleKw)
+    kwmodule <?+> sym
 
 instance SingI s => PrettyPrint (HidingList s) where
   ppCode HidingList {..} = do
@@ -828,7 +831,8 @@ instance SingI s => PrettyPrint (UsingItem s) where
     let kwAs' :: Maybe (Sem r ()) = ppCode <$> ui ^. usingAsKw . unIrrelevant
         alias' = ppSymbolType <$> ui ^. usingAs
         sym' = ppSymbolType (ui ^. usingSymbol)
-    sym' <+?> kwAs' <+?> alias'
+        kwmodule = ppCode <$> (ui ^. usingModuleKw)
+    kwmodule <?+> (sym' <+?> kwAs' <+?> alias')
 
 instance PrettyPrint (ModuleRef' 'S.NotConcrete) where
   ppCode (ModuleRef' (t :&: m)) =

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -23,6 +23,7 @@ import Juvix.Data.CodeAnn qualified as C
 import Juvix.Data.Effect.ExactPrint
 import Juvix.Data.IteratorAttribs
 import Juvix.Data.Keyword.All qualified as Kw
+import Juvix.Data.NameKind
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude hiding ((<+>), (<+?>), (<?+>), (?<>))
 import Juvix.Prelude.Pretty (annotate, pretty)
@@ -377,16 +378,14 @@ instance PrettyPrint QualifiedName where
     let symbols = _qualifiedPath ^. pathParts NonEmpty.|> _qualifiedSymbol
     dotted (ppSymbolType <$> symbols)
 
-instance PrettyPrint (ModuleRef'' 'S.Concrete 'ModuleTop) where
+instance SingI t => PrettyPrint (ModuleRef'' 'S.NotConcrete t) where
+  ppCode = ppCode @(ModuleRef' 'S.NotConcrete) . project
+
+instance PrettyPrint (ModuleRef'' 'S.Concrete t) where
   ppCode m = ppCode (m ^. moduleRefName)
 
 instance PrettyPrint ScopedIden where
-  ppCode = \case
-    ScopedAxiom a -> ppCode a
-    ScopedInductive i -> ppCode i
-    ScopedVar n -> ppCode n
-    ScopedFunction f -> ppCode f
-    ScopedConstructor c -> ppCode c
+  ppCode = ppCode . (^. scopedIden)
 
 instance SingI s => PrettyPrint (Import s) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => Import s -> Sem r ()
@@ -831,6 +830,14 @@ instance SingI s => PrettyPrint (UsingItem s) where
         sym' = ppSymbolType (ui ^. usingSymbol)
     sym' <+?> kwAs' <+?> alias'
 
+instance PrettyPrint (ModuleRef' 'S.NotConcrete) where
+  ppCode (ModuleRef' (t :&: m)) =
+    let path = m ^. moduleRefModule . modulePath
+        txt = case t of
+          SModuleTop -> annotate (AnnKind KNameTopModule) (pretty path)
+          SModuleLocal -> annotate (AnnKind KNameLocalModule) (pretty path)
+     in noLoc txt
+
 instance PrettyPrint ModuleRef where
   ppCode (ModuleRef' (_ :&: ModuleRef'' {..})) = ppCode _moduleRefName
 
@@ -991,19 +998,26 @@ instance PrettyPrint SymbolEntry where
   ppCode ent =
     noLoc
       ( kindWord
-          P.<+> C.code (kindAnn (pretty (entryName ent ^. S.nameVerbatim)))
+          P.<+> C.code (kindAnn (pretty (ent ^. symbolEntry . S.nameVerbatim)))
           P.<+> "defined at"
           P.<+> pretty (getLoc ent)
       )
     where
       pretty' :: Text -> Doc a
       pretty' = pretty
-      (kindAnn :: Doc Ann -> Doc Ann, kindWord :: Doc Ann) = case ent of
-        EntryAxiom {} -> (C.annotateKind S.KNameAxiom, pretty' Str.axiom)
-        EntryInductive {} -> (C.annotateKind S.KNameInductive, pretty' Str.inductive)
-        EntryFunction {} -> (C.annotateKind S.KNameFunction, pretty' Str.function)
-        EntryConstructor {} -> (C.annotateKind S.KNameConstructor, pretty' Str.constructor)
-        EntryVariable {} -> (C.annotateKind S.KNameLocal, pretty' Str.variable)
-        EntryModule (ModuleRef' (isTop :&: _))
-          | SModuleTop <- isTop -> (C.annotateKind S.KNameTopModule, pretty' Str.topModule)
-          | SModuleLocal <- isTop -> (C.annotateKind S.KNameLocalModule, pretty' Str.localModule)
+      (kindAnn :: Doc Ann -> Doc Ann, kindWord :: Doc Ann) =
+        let k = getNameKind ent
+         in (annotate (AnnKind k), pretty' (nameKindText k))
+
+instance PrettyPrint ModuleSymbolEntry where
+  ppCode ent = do
+    let mname = ppCode (ent ^. moduleEntry)
+    noLoc
+       kindWord
+       <+> mname
+       <+> noLoc "defined at"
+       <+> noLoc (pretty (getLoc ent))
+    where
+      kindWord :: Doc Ann =
+        let k = getNameKind ent
+         in (pretty (nameKindText k))

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -1011,7 +1011,7 @@ instance PrettyPrint SymbolEntry where
 
 instance PrettyPrint ModuleSymbolEntry where
   ppCode ent = do
-    let mname = ppCode (ent ^. moduleEntry)
+    let mname = ppCode (ent ^. moduleEntry . S.nameVerbatim)
     noLoc
       kindWord
       <+> mname

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -1013,10 +1013,10 @@ instance PrettyPrint ModuleSymbolEntry where
   ppCode ent = do
     let mname = ppCode (ent ^. moduleEntry)
     noLoc
-       kindWord
-       <+> mname
-       <+> noLoc "defined at"
-       <+> noLoc (pretty (getLoc ent))
+      kindWord
+      <+> mname
+      <+> noLoc "defined at"
+      <+> noLoc (pretty (getLoc ent))
     where
       kindWord :: Doc Ann =
         let k = getNameKind ent

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1051,8 +1051,6 @@ checkLocalModule Module {..} = do
       doc' <- mapM checkJudoc _moduleDoc
       return (e, b, doc')
   _modulePath' <- reserveLocalModuleSymbol _modulePath
-
-  -- modify (over scopeModuleSymbols (HashMap.alter (Just . addS) _modulePath))
   let moduleId = _modulePath' ^. S.nameId
       _moduleRefName = S.unConcrete _modulePath'
       _moduleRefModule =

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1044,7 +1044,6 @@ checkLocalModule ::
   Module 'Parsed 'ModuleLocal ->
   Sem r (Module 'Scoped 'ModuleLocal)
 checkLocalModule Module {..} = do
-  -- path <- gets (^. scopePath)
   (_moduleExportInfo, moduleBody', moduleDoc') <-
     withLocalScope $ do
       inheritScope
@@ -1052,14 +1051,6 @@ checkLocalModule Module {..} = do
       doc' <- mapM checkJudoc _moduleDoc
       return (e, b, doc')
   _modulePath' <- reserveLocalModuleSymbol _modulePath
-  -- let entry = ModuleSymbolEntry (S.unConcrete _modulePath')
-
-  --     addS :: Maybe (SymbolInfo 'NameSpaceModules) -> SymbolInfo 'NameSpaceModules
-  --     addS m = case m of
-  --       Nothing -> symbolInfoSingle entry
-  --       Just si -> case strat of
-  --         BindingLocal -> symbolInfoSingle entry
-  --         BindingTop -> set (symbolInfo . at path) (Just entry) si
 
   -- modify (over scopeModuleSymbols (HashMap.alter (Just . addS) _modulePath))
   let moduleId = _modulePath' ^. S.nameId

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -338,6 +338,7 @@ bindLocalModuleSymbol ::
   Symbol ->
   Sem r S.Symbol
 bindLocalModuleSymbol _moduleExportInfo _moduleRefModule = undefined
+
 -- bindSymbolOf
 --   S.KNameLocalModule
 --   (\_moduleRefName -> EntryModule (mkModuleRef' (ModuleRef'' {..})))
@@ -447,8 +448,11 @@ lookupQualifiedSymbol ::
   Sem r ([SymbolEntry], [ModuleSymbolEntry])
 lookupQualifiedSymbol = runOutputList . execOutputList . go
   where
-    go :: forall r'. Members [State Scope, Output SymbolEntry, Output ModuleSymbolEntry] r'
-        => ([Symbol], Symbol) -> Sem r' ()
+    go ::
+      forall r'.
+      Members [State Scope, Output SymbolEntry, Output ModuleSymbolEntry] r' =>
+      ([Symbol], Symbol) ->
+      Sem r' ()
     go (path, sym) = do
       here
       there
@@ -1280,7 +1284,8 @@ checkOpenModuleNoImport OpenModule {..}
       where
         alterEntry :: SymbolEntry -> SymbolEntry
         alterEntry =
-          over symbolEntry
+          over
+            symbolEntry
             ( set S.nameWhyInScope S.BecauseImportedOpened
                 . set S.nameVisibilityAnn (publicAnnToVis _openPublic)
             )

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -118,14 +118,14 @@ scopeCheckImport ::
   Members '[Error JuvixError, InfoTableBuilder, NameIdGen, State Scope, Reader ScopeParameters, State ScoperState] r =>
   Import 'Parsed ->
   Sem r (Import 'Scoped)
-scopeCheckImport i = mapError (JuvixError @ScoperError) $ checkImport i
+scopeCheckImport = mapError (JuvixError @ScoperError) . checkImport
 
 scopeCheckOpenModule ::
   forall r.
   Members '[Error JuvixError, InfoTableBuilder, NameIdGen, State Scope, Reader ScopeParameters, State ScoperState] r =>
   OpenModule 'Parsed ->
   Sem r (OpenModule 'Scoped)
-scopeCheckOpenModule i = mapError (JuvixError @ScoperError) $ checkOpenModule i
+scopeCheckOpenModule = mapError (JuvixError @ScoperError) . checkOpenModule
 
 freshVariable :: Members '[NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState] r => Symbol -> Sem r S.Symbol
 freshVariable = freshSymbol S.KNameLocal
@@ -165,7 +165,7 @@ freshSymbol _nameKind _nameConcrete = do
 
 reserveSymbolSignatureOf ::
   forall r d.
-  (Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy] r, HasNameSignature d) =>
+  (Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder] r, HasNameSignature d) =>
   S.NameKind ->
   d ->
   Symbol ->
@@ -176,22 +176,22 @@ reserveSymbolSignatureOf k d s = do
 
 reserveSymbolOf ::
   forall r.
-  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy] r =>
+  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder] r =>
   S.NameKind ->
   Maybe NameSignature ->
   Symbol ->
   Sem r S.Symbol
 reserveSymbolOf k nameSig s = do
   checkNotBound
-  s' <- freshSymbol k s
-  whenJust nameSig (modify' . set (scoperSignatures . at (s' ^. S.nameId)) . Just)
   path <- gets (^. scopePath)
   strat <- ask
+  s' <- freshSymbol k s
+  whenJust nameSig (modify' . set (scoperSignatures . at (s' ^. S.nameId)) . Just)
   modify (set (scopeLocalSymbols . at s) (Just s'))
-  let c = S.unConcrete s'
-      mentry :: Maybe SymbolEntry
+  registerName (S.unqualifiedSymbol s')
+  let mentry :: Maybe SymbolEntry
       mentry =
-        let e = SymbolEntry c
+        let e = SymbolEntry (S.unConcrete s')
          in case k of
               S.KNameConstructor -> Just e
               S.KNameInductive -> Just e
@@ -200,7 +200,7 @@ reserveSymbolOf k nameSig s = do
               S.KNameLocal -> Just e
               S.KNameLocalModule -> Nothing
               S.KNameTopModule -> Nothing
-      addS :: SymbolEntry -> Maybe SymbolInfo -> SymbolInfo
+      addS :: SingI ns => NameSpaceEntryType ns -> Maybe (SymbolInfo ns) -> SymbolInfo ns
       addS entry m = case m of
         Nothing -> symbolInfoSingle entry
         Just SymbolInfo {..} -> case strat of
@@ -224,37 +224,13 @@ reserveSymbolOf k nameSig s = do
                 }
           )
 
-bindReservedSymbol ::
-  Members '[State Scope, InfoTableBuilder, Reader BindingStrategy] r =>
-  S.Symbol ->
-  SymbolEntry ->
-  Sem r ()
-bindReservedSymbol s' entry = do
-  path <- gets (^. scopePath)
-  strat <- ask
-  -- TODO only modules are meant to be stored here?
-  modify (over scopeSymbols (HashMap.alter (Just . addS strat path) s))
-  registerName (S.unqualifiedSymbol s')
-  where
-    s :: Symbol
-    s = s' ^. S.nameConcrete
-    addS :: BindingStrategy -> S.AbsModulePath -> Maybe SymbolInfo -> SymbolInfo
-    addS strat path m = case m of
-      Nothing -> symbolInfoSingle entry
-      Just si -> case strat of
-        BindingLocal -> symbolInfoSingle entry
-        BindingTop -> over symbolInfo (HashMap.insert path entry) si
-
 -- | Only for variables and local modules
 bindSymbolOf ::
   Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State ScoperIterators, State Scope, InfoTableBuilder, State ScoperState, Reader BindingStrategy] r =>
   S.NameKind ->
   Symbol ->
   Sem r S.Symbol
-bindSymbolOf k s = do
-  s' <- reserveSymbolOf k Nothing s
-  bindReservedSymbol s' (SymbolEntry (S.unConcrete s'))
-  return s'
+bindSymbolOf k = reserveSymbolOf k Nothing
 
 bindReservedDefinitionSymbol ::
   Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State ScoperIterators, State Scope, InfoTableBuilder, State ScoperState, Reader BindingStrategy] r =>
@@ -264,7 +240,6 @@ bindReservedDefinitionSymbol s = do
   m <- gets (^. scopeLocalSymbols)
   let s' = fromMaybe err (m ^. at s)
       err = error ("impossible. Contents of scope:\n" <> ppTrace (toList m))
-  bindReservedSymbol s' (SymbolEntry (S.unConcrete s'))
   return s'
 
 ignoreFixities :: Sem (State ScoperFixities ': r) a -> Sem r a
@@ -281,27 +256,27 @@ bindVariableSymbol ::
 bindVariableSymbol = localBindings . ignoreFixities . ignoreIterators . bindSymbolOf S.KNameLocal
 
 reserveInductiveSymbol ::
-  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy] r =>
+  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder] r =>
   InductiveDef 'Parsed ->
   Sem r S.Symbol
 reserveInductiveSymbol d = reserveSymbolSignatureOf S.KNameInductive d (d ^. inductiveName)
 
 reserveConstructorSymbol ::
-  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy] r =>
+  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder] r =>
   InductiveDef 'Parsed ->
   ConstructorDef 'Parsed ->
   Sem r S.Symbol
 reserveConstructorSymbol d c = reserveSymbolSignatureOf S.KNameConstructor (d, c) (c ^. constructorName)
 
 reserveFunctionSymbol ::
-  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy] r =>
+  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder] r =>
   FunctionDef 'Parsed ->
   Sem r S.Symbol
 reserveFunctionSymbol f =
   reserveSymbolSignatureOf S.KNameFunction f (f ^. signName)
 
 reserveAxiomSymbol ::
-  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy] r =>
+  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder] r =>
   AxiomDef 'Parsed ->
   Sem r S.Symbol
 reserveAxiomSymbol a = reserveSymbolSignatureOf S.KNameAxiom a (a ^. axiomName)
@@ -330,18 +305,6 @@ bindConstructorSymbol ::
   Symbol ->
   Sem r S.Symbol
 bindConstructorSymbol = bindReservedDefinitionSymbol
-
-bindLocalModuleSymbol ::
-  Members '[Error ScoperError, NameIdGen, State ScoperFixities, State ScoperIterators, State Scope, InfoTableBuilder, State ScoperState, Reader BindingStrategy] r =>
-  ExportInfo ->
-  Module 'Scoped 'ModuleLocal ->
-  Symbol ->
-  Sem r S.Symbol
-bindLocalModuleSymbol _moduleExportInfo _moduleRefModule = undefined
-
--- bindSymbolOf
---   S.KNameLocalModule
---   (\_moduleRefName -> EntryModule (mkModuleRef' (ModuleRef'' {..})))
 
 checkImport ::
   forall r.
@@ -413,11 +376,15 @@ lookupSymbolAux modules final = do
     hereOrInLocalModule :: Sem r () =
       case modules of
         [] -> do
-          let helper :: Members '[Output e, State Scope] r' => Lens' Scope (HashMap Symbol (SymbolInfo' e)) -> Sem r' ()
-              helper symbolsLens =
-                gets (^.. symbolsLens . at final . _Just . symbolInfo . each) >>= mapM_ output
-          helper scopeSymbols
-          helper scopeModuleSymbols
+          let helper ::
+                forall ns r'.
+                (SingI ns, Members '[Output (NameSpaceEntryType ns), State Scope] r') =>
+                Proxy ns ->
+                Sem r' ()
+              helper Proxy =
+                gets (^.. scopeNameSpace @ns . at final . _Just . symbolInfo . each) >>= mapM_ output
+          helper (Proxy @'NameSpaceSymbols)
+          helper (Proxy @'NameSpaceModules)
         p : ps ->
           gets (^.. scopeModuleSymbols . at p . _Just . symbolInfo . each)
             >>= mapM_ (getModuleExportInfo >=> lookInExport final ps)
@@ -454,14 +421,14 @@ lookInExport sym remaining e = case remaining of
 -- modules due to nesting.
 lookupQualifiedSymbol ::
   forall r.
-  Members '[State Scope] r =>
+  Members '[State Scope, State ScoperState] r =>
   ([Symbol], Symbol) ->
   Sem r ([SymbolEntry], [ModuleSymbolEntry])
 lookupQualifiedSymbol = runOutputList . execOutputList . go
   where
     go ::
       forall r'.
-      Members [State Scope, Output SymbolEntry, Output ModuleSymbolEntry] r' =>
+      Members [State ScoperState, State Scope, Output SymbolEntry, Output ModuleSymbolEntry] r' =>
       ([Symbol], Symbol) ->
       Sem r' ()
     go (path, sym) = do
@@ -522,39 +489,37 @@ exportScope ::
   Scope ->
   Sem r ExportInfo
 exportScope Scope {..} = do
-  _exportSymbols <- HashMap.fromList <$> mapMaybeM (mkentry symbolErr symbolShouldExport) (HashMap.toList _scopeSymbols)
-  _exportModuleSymbols <- HashMap.fromList <$> mapMaybeM (mkentry moduleErr moduleShouldExport) (HashMap.toList _scopeModuleSymbols)
+  _exportSymbols <- HashMap.fromList <$> mapMaybeM mkentry (HashMap.toList _scopeSymbols)
+  _exportModuleSymbols <- HashMap.fromList <$> mapMaybeM mkentry (HashMap.toList _scopeModuleSymbols)
   return ExportInfo {..}
   where
-    moduleShouldExport :: ModuleSymbolEntry -> Bool
-    moduleShouldExport ent = undefined
-
-    symbolShouldExport :: SymbolEntry -> Bool
-    symbolShouldExport ent = ent ^. symbolEntry . S.nameVisibilityAnn == VisPublic
-
-    symbolErr :: Symbol -> NonEmpty SymbolEntry -> Sem r a
-    symbolErr s es =
-      throw
-        ( ErrMultipleExport
-            (MultipleExportConflict _scopePath s (Left es))
-        )
-    moduleErr :: Symbol -> NonEmpty ModuleSymbolEntry -> Sem r a
-    moduleErr s es =
-      throw
-        ( ErrMultipleExport
-            (MultipleExportConflict _scopePath s (Right es))
-        )
-
     mkentry ::
-      (forall a. Symbol -> NonEmpty entry -> Sem r a) ->
-      (entry -> Bool) ->
-      (Symbol, SymbolInfo' entry) ->
-      Sem r (Maybe (Symbol, entry))
-    mkentry err shouldExport (s, SymbolInfo {..}) =
+      forall ns.
+      SingI ns =>
+      (Symbol, SymbolInfo ns) ->
+      Sem r (Maybe (Symbol, NameSpaceEntryType ns))
+    mkentry (s, SymbolInfo {..}) =
       case filter shouldExport (toList _symbolInfo) of
         [] -> return Nothing
         [e] -> return (Just (s, e))
-        e : es -> err s (e :| es)
+        e : es -> err (e :| es)
+      where
+        shouldExport :: NameSpaceEntryType ns -> Bool
+        shouldExport ent = ent ^. nsEntry . S.nameVisibilityAnn == VisPublic
+
+        err :: NonEmpty (NameSpaceEntryType ns) -> Sem r a
+        err es =
+          throw
+            ( ErrMultipleExport
+                ( MultipleExportConflict
+                    _scopePath
+                    s
+                    ( case sing :: SNameSpace ns of
+                        SNameSpaceSymbols -> Left es
+                        SNameSpaceModules -> Right es
+                    )
+                )
+            )
 
 getParsedModule :: Members '[Reader ScopeParameters] r => TopModulePath -> Sem r (Module 'Parsed 'ModuleTop)
 getParsedModule i = asks (^?! scopeParsedModules . at i . _Just)
@@ -714,7 +679,6 @@ checkInductiveDef InductiveDef {..} = do
             | (cname, cdef) <- zipExact (toList constructorNames') (toList _inductiveConstructors)
           ]
     return (inductiveParameters', inductiveType', inductiveDoc', inductiveConstructors')
-  forM_ inductiveConstructors' bindConstructor
   registerInductive
     @$> InductiveDef
       { _inductiveName = inductiveName',
@@ -729,15 +693,6 @@ checkInductiveDef InductiveDef {..} = do
         _inductiveKw
       }
   where
-    bindConstructor :: ConstructorDef 'Scoped -> Sem r ()
-    bindConstructor d =
-      topBindings $
-        bindReservedSymbol
-          (d ^. constructorName)
-          ( SymbolEntry
-              ( S.unConcrete (d ^. constructorName)
-              )
-          )
     -- note that the constructor name is not bound here
     checkConstructorDef :: S.Symbol -> S.Symbol -> ConstructorDef 'Parsed -> Sem r (ConstructorDef 'Scoped)
     checkConstructorDef tyName constructorName' ConstructorDef {..} = do
@@ -790,12 +745,8 @@ checkInductiveDef InductiveDef {..} = do
             _rhsGadtColon
           }
 
--- TODO add modules  to the table
 createExportsTable :: ExportInfo -> HashSet NameId
-createExportsTable ei = foldr (HashSet.insert . getNameId) HashSet.empty (HashMap.elems (ei ^. exportSymbols))
-  where
-    getNameId :: SymbolEntry -> NameId
-    getNameId = (^. symbolEntry . S.nameId)
+createExportsTable = HashSet.fromList . (^.. exportAllNames . S.nameId)
 
 checkTopModules ::
   forall r.
@@ -1083,12 +1034,27 @@ reserveLocalModuleSymbol ::
 reserveLocalModuleSymbol =
   ignoreFixities . ignoreIterators . reserveSymbolOf S.KNameLocalModule Nothing
 
+-- bindReservedSymbol :: forall ns r.
+--   (SingI ns, Members '[State Scope, Reader BindingStrategy] r) =>
+--   S.Symbol ->
+--   NameSpaceEntryType ns ->
+--   Sem r ()
+-- bindReservedSymbol s' entry = do
+--   path <- gets (^. scopePath)
+--   strat <- ask
+--   -- TODO only modules are meant to be stored here?
+--   modify (over scopeNameSpace (HashMap.alter (Just . addS strat path) s))
+--   where
+--     s :: Symbol
+--     s = s' ^. S.nameConcrete
+
 checkLocalModule ::
   forall r.
   Members '[Error ScoperError, State Scope, Reader ScopeParameters, State ScoperState, InfoTableBuilder, NameIdGen, Reader BindingStrategy] r =>
   Module 'Parsed 'ModuleLocal ->
   Sem r (Module 'Scoped 'ModuleLocal)
 checkLocalModule Module {..} = do
+  strat <- ask
   (_moduleExportInfo, moduleBody', moduleDoc') <-
     withLocalScope $ do
       inheritScope
@@ -1097,6 +1063,7 @@ checkLocalModule Module {..} = do
       return (e, b, doc')
   _modulePath' <- reserveLocalModuleSymbol _modulePath
   let moduleId = _modulePath' ^. S.nameId
+      entry = ModuleSymbolEntry (S.unConcrete _modulePath')
       _moduleRefName = S.unConcrete _modulePath'
       _moduleRefModule =
         Module
@@ -1107,11 +1074,19 @@ checkLocalModule Module {..} = do
             _moduleKw,
             _moduleKwEnd
           }
-      entry :: ModuleRef' 'S.NotConcrete
-      entry = mkModuleRef' @'ModuleLocal ModuleRef'' {..}
-  bindReservedSymbol _modulePath' (undefined entry)
+      addS :: S.AbsModulePath -> Maybe (SymbolInfo 'NameSpaceModules) -> (SymbolInfo 'NameSpaceModules)
+      addS path m = case m of
+        Nothing -> symbolInfoSingle entry
+        Just si -> case strat of
+          BindingLocal -> symbolInfoSingle entry
+          BindingTop -> set (symbolInfo . at path) (Just entry) si
+
+      mref :: ModuleRef' 'S.NotConcrete
+      mref = mkModuleRef' @'ModuleLocal ModuleRef'' {..}
+  path <- gets (^. scopePath)
+  modify (over scopeModuleSymbols (HashMap.alter (Just . addS path) _modulePath))
+  modify (over scoperModules (HashMap.insert moduleId mref))
   registerName (S.unqualifiedSymbol _modulePath')
-  modify (over scoperModules (HashMap.insert moduleId entry))
   return _moduleRefModule
   where
     inheritScope :: Sem r ()
@@ -1119,16 +1094,15 @@ checkLocalModule Module {..} = do
       absPath <- (S.<.> _modulePath) <$> gets (^. scopePath)
       modify (set scopePath absPath)
       modify (over scopeSymbols (fmap inheritSymbol))
+      modify (over scopeModuleSymbols (fmap inheritSymbol))
       where
-        -- TODO modules
-
-        inheritSymbol :: SymbolInfo -> SymbolInfo
+        inheritSymbol :: forall ns. SingI ns => SymbolInfo ns -> SymbolInfo ns
         inheritSymbol (SymbolInfo s) = SymbolInfo (inheritEntry <$> s)
-
-        inheritEntry :: SymbolEntry -> SymbolEntry
-        inheritEntry =
-          over (symbolEntry . S.nameWhyInScope) S.BecauseInherited
-            . set (symbolEntry . S.nameVisibilityAnn) VisPrivate
+          where
+            inheritEntry :: NameSpaceEntryType ns -> NameSpaceEntryType ns
+            inheritEntry =
+              over (nsEntry . S.nameWhyInScope) S.BecauseInherited
+                . set (nsEntry . S.nameVisibilityAnn) VisPrivate
 
 checkOrphanFixities :: forall r. Members '[Error ScoperError, State ScoperFixities] r => Sem r ()
 checkOrphanFixities = do
@@ -1146,8 +1120,8 @@ checkOrphanIterators = do
     Nothing -> return ()
     Just x -> throw (ErrUnusedIteratorDef (UnusedIteratorDef x))
 
-symbolInfoSingle :: SymbolEntry -> SymbolInfo
-symbolInfoSingle p = SymbolInfo $ HashMap.singleton (p ^. symbolEntry . S.nameDefinedIn) p
+symbolInfoSingle :: SingI ns => NameSpaceEntryType ns -> SymbolInfo ns
+symbolInfoSingle p = SymbolInfo $ HashMap.singleton (p ^. nsEntry . S.nameDefinedIn) p
 
 getModuleRef ::
   Members '[State ScoperState] r =>
@@ -1164,7 +1138,7 @@ lookupModuleSymbol ::
   Sem r ModuleRef
 lookupModuleSymbol n = do
   es <- snd <$> lookupQualifiedSymbol (path, sym)
-  case nonEmpty es of
+  case nonEmpty (resolveShadowing es) of
     Nothing -> notInScope
     Just (x :| []) -> getModuleRef x n
     Just more -> throw (ErrAmbiguousModuleSym (AmbiguousModuleSym n more))
@@ -1306,32 +1280,30 @@ checkOpenModuleNoImport OpenModule {..}
     mergeScope :: ExportInfo -> Sem r ()
     mergeScope ExportInfo {..} = do
       mapM_ mergeSymbol (HashMap.toList _exportSymbols)
-      mapM_ mergeModuleSymbol (HashMap.toList _exportModuleSymbols)
+      mapM_ mergeSymbol (HashMap.toList _exportModuleSymbols)
       where
-        mergeModuleSymbol :: (Symbol, ModuleSymbolEntry) -> Sem r ()
-        mergeModuleSymbol = undefined
-
-        mergeSymbol :: (Symbol, SymbolEntry) -> Sem r ()
+        mergeSymbol :: SingI ns => (Symbol, NameSpaceEntryType ns) -> Sem r ()
         mergeSymbol (s, entry) =
           modify
-            (over scopeSymbols (HashMap.insertWith (<>) s (symbolInfoSingle entry)))
+            (over scopeNameSpace (HashMap.insertWith (<>) s (symbolInfoSingle entry)))
 
     alterScope :: Maybe (UsingHiding 'Scoped) -> ExportInfo -> ExportInfo
     alterScope openModif = alterEntries . filterScope
       where
-        alterModuleEntry :: ModuleSymbolEntry -> ModuleSymbolEntry
-        alterModuleEntry = undefined
+        alterEntries :: ExportInfo -> ExportInfo
+        alterEntries nfo =
+          ExportInfo
+            { _exportSymbols = alterEntry <$> nfo ^. exportSymbols,
+              _exportModuleSymbols = alterEntry <$> nfo ^. exportModuleSymbols
+            }
 
-        alterEntry :: SymbolEntry -> SymbolEntry
+        alterEntry :: SingI ns => NameSpaceEntryType ns -> NameSpaceEntryType ns
         alterEntry =
           over
-            symbolEntry
+            nsEntry
             ( set S.nameWhyInScope S.BecauseImportedOpened
                 . set S.nameVisibilityAnn (publicAnnToVis _openPublic)
             )
-        alterEntries :: ExportInfo -> ExportInfo
-        alterEntries = over exportSymbols (fmap alterEntry)
-
         publicAnnToVis :: PublicAnn -> VisibilityAnn
         publicAnnToVis = \case
           Public -> VisPublic
@@ -1605,9 +1577,7 @@ checkUnqualified s = do
   scope <- get
   -- Lookup at the global scope
   let err = throw (ErrSymNotInScope (NotInScope s scope))
-  entries <-
-    filter S.isExprKind . fst
-      <$> lookupQualifiedSymbol ([], s)
+  entries <- fst <$> lookupQualifiedSymbol ([], s)
   case resolveShadowing entries of
     [] -> err
     [x] -> entryToScopedIden n x
@@ -1619,10 +1589,10 @@ checkUnqualified s = do
 -- shadowing rules for modules. For example, a symbol defined in the outer
 -- module with the same name as a symbol defined in the inner module will be
 -- removed.
-resolveShadowing :: [SymbolEntry] -> [SymbolEntry]
-resolveShadowing es = go [(e, e ^. symbolEntry . S.nameWhyInScope) | e <- es]
+resolveShadowing :: forall ns. SingI ns => [NameSpaceEntryType ns] -> [NameSpaceEntryType ns]
+resolveShadowing es = go [(e, e ^. nsEntry . S.nameWhyInScope) | e <- es]
   where
-    go :: [(SymbolEntry, S.WhyInScope)] -> [SymbolEntry]
+    go :: [(NameSpaceEntryType ns, S.WhyInScope)] -> [NameSpaceEntryType ns]
     go itms
       | any (((== S.BecauseImportedOpened) .||. (== S.BecauseDefined)) . snd) itms =
           [e | (e, w) <- itms, not (isInherited w)]

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -10,7 +10,6 @@ import Juvix.Compiler.Concrete.Data.NameSignature.Error
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error.Pretty
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error.Types
 import Juvix.Compiler.Internal.Translation.FromConcrete.NamedArguments.Error
-import Juvix.Prelude
 
 data ScoperError
   = ErrInfixParser InfixError
@@ -43,7 +42,6 @@ data ScoperError
   | ErrNameSignature NameSignatureError
   | ErrNoNameSignature NoNameSignature
   | ErrNamedArgumentsError NamedArgumentsError
-  deriving stock (Show)
 
 instance ToGenericError ScoperError where
   genericError = \case

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -469,11 +469,11 @@ instance ToGenericError AmbiguousSym where
           opts' = fromGenericOptions opts
           i = getLoc _ambiguousSymName
           is = map getLoc _ambiguousSymEntires
-          msg = ambiguousMessage opts' _ambiguousSymName _ambiguousSymEntires
+          msg = ambiguousMessage opts' _ambiguousSymName (map (ppCode opts') _ambiguousSymEntires)
 
 data AmbiguousModuleSym = AmbiguousModuleSym
   { _ambiguousModName :: Name,
-    _ambiguousModSymEntires :: [SymbolEntry]
+    _ambiguousModSymEntires :: NonEmpty ModuleSymbolEntry
   }
   deriving stock (Show)
 
@@ -490,8 +490,9 @@ instance ToGenericError AmbiguousModuleSym where
         where
           opts' = fromGenericOptions opts
           i = getLoc _ambiguousModName
-          is = map getLoc _ambiguousModSymEntires
-          msg = ambiguousMessage opts' _ambiguousModName _ambiguousModSymEntires
+          entries = toList _ambiguousModSymEntires
+          is = map getLoc entries
+          msg = ambiguousMessage opts' _ambiguousModName (map (ppCode opts') entries)
 
 infixErrorAux :: Doc Ann -> Doc Ann -> Doc Ann
 infixErrorAux kind pp =
@@ -501,7 +502,7 @@ infixErrorAux kind pp =
       <> line
       <> indent' pp
 
-ambiguousMessage :: Options -> Name -> [SymbolEntry] -> Doc Ann
+ambiguousMessage :: Options -> Name -> [Doc Ann] -> Doc Ann
 ambiguousMessage opts' n es =
   "The symbol"
     <+> ppCode opts' n
@@ -511,7 +512,7 @@ ambiguousMessage opts' n es =
       <> line
       <> "It could be any of:"
       <> line
-      <> itemize (map (ppMessage opts') es)
+      <> itemize es
 
 newtype DoubleBracesPattern = DoubleBracesPattern
   { _doubleBracesPatternArg :: PatternArg

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -286,7 +286,7 @@ instance ToGenericError DuplicateIterator where
 data MultipleExportConflict = MultipleExportConflict
   { _multipleExportModule :: S.AbsModulePath,
     _multipleExportSymbol :: Symbol,
-    _multipleExportEntries :: NonEmpty SymbolEntry
+    _multipleExportEntries :: Either (NonEmpty SymbolEntry) (NonEmpty ModuleSymbolEntry)
   }
   deriving stock (Show)
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -313,7 +313,6 @@ data NotInScope = NotInScope
   { _notInScopeSymbol :: Symbol,
     _notInScopeScope :: Scope
   }
-  deriving stock (Show)
 
 makeLenses ''NotInScope
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -231,6 +231,7 @@ mkTopModulePath l = TopModulePath (NonEmpty.init l) (NonEmpty.last l)
 
 usingItem :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (UsingItem 'Parsed)
 usingItem = do
+  _usingModuleKw <- optional (kw kwModule)
   _usingSymbol <- symbol
   alias <- optional $ do
     k <- Irrelevant <$> kw kwAs
@@ -240,7 +241,10 @@ usingItem = do
   return UsingItem {..}
 
 hidingItem :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (HidingItem 'Parsed)
-hidingItem = HidingItem <$> symbol
+hidingItem = do
+  _hidingModuleKw <- optional (kw kwModule)
+  _hidingSymbol <- symbol
+  return HidingItem {..}
 
 phidingList :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (HidingList 'Parsed)
 phidingList = do

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -775,12 +775,13 @@ goExpression = \case
 
     goIden :: Concrete.ScopedIden -> Internal.Expression
     goIden x = Internal.ExpressionIden $ case getNameKind x of
-      KNameAxiom {} -> Internal.IdenAxiom n'
-      KNameInductive {} -> Internal.IdenInductive n'
-      KNameLocal {} -> Internal.IdenVar n'
-      KNameFunction {} -> Internal.IdenFunction n'
-      KNameConstructor {} -> Internal.IdenConstructor n'
-      _ -> impossible
+      KNameAxiom -> Internal.IdenAxiom n'
+      KNameInductive -> Internal.IdenInductive n'
+      KNameLocal -> Internal.IdenVar n'
+      KNameFunction -> Internal.IdenFunction n'
+      KNameConstructor -> Internal.IdenConstructor n'
+      KNameLocalModule -> impossible
+      KNameTopModule -> impossible
       where
         n' = goName (x ^. scopedIden)
 

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -228,7 +228,7 @@ toPreModule Module {..} = do
       SModuleLocal -> goSymbol _modulePath
 
 goTopModulePath :: S.TopModulePath -> Internal.Name
-goTopModulePath p = goSymbolPretty (prettyText p) (S.topModulePathName p)
+goTopModulePath p = goSymbolPretty (prettyText p) (S.topModulePathSymbol p)
 
 fromPreModule ::
   forall r.

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -774,12 +774,15 @@ goExpression = \case
         loc = getLoc l
 
     goIden :: Concrete.ScopedIden -> Internal.Expression
-    goIden x = Internal.ExpressionIden $ case x of
-      ScopedAxiom a -> Internal.IdenAxiom (goName a)
-      ScopedInductive i -> Internal.IdenInductive (goName i)
-      ScopedVar v -> Internal.IdenVar (goSymbol v)
-      ScopedFunction fun -> Internal.IdenFunction (goName fun)
-      ScopedConstructor c -> Internal.IdenConstructor (goName c)
+    goIden x = Internal.ExpressionIden $ case getNameKind x of
+      KNameAxiom {} -> Internal.IdenAxiom n'
+      KNameInductive {} -> Internal.IdenInductive n'
+      KNameLocal {} -> Internal.IdenVar n'
+      KNameFunction {} -> Internal.IdenFunction n'
+      KNameConstructor {} -> Internal.IdenConstructor n'
+      _ -> impossible
+      where
+        n' = goName (x ^. scopedIden)
 
     goLet :: Let 'Scoped -> Sem r Internal.Let
     goLet l = do

--- a/src/Juvix/Data/NameId.hs
+++ b/src/Juvix/Data/NameId.hs
@@ -7,6 +7,7 @@ newtype NameId = NameId
   { _unNameId :: Word64
   }
   deriving stock (Show, Eq, Ord, Generic, Data)
+  deriving newtype (Enum)
 
 makeLenses ''NameId
 

--- a/src/Juvix/Data/NameKind.hs
+++ b/src/Juvix/Data/NameKind.hs
@@ -21,6 +21,8 @@ data NameKind
     KNameTopModule
   deriving stock (Show, Eq, Data)
 
+$(genSingletons [''NameKind])
+
 class HasNameKind a where
   getNameKind :: a -> NameKind
 
@@ -45,11 +47,6 @@ nameKindText = \case
   KNameAxiom -> "axiom"
   KNameLocalModule -> "local module"
   KNameTopModule -> "module"
-
-isLocallyBounded :: HasNameKind a => a -> Bool
-isLocallyBounded k = case getNameKind k of
-  KNameLocal -> True
-  _ -> False
 
 isExprKind :: HasNameKind a => a -> Bool
 isExprKind k = case getNameKind k of

--- a/src/Juvix/Data/NameKind.hs
+++ b/src/Juvix/Data/NameKind.hs
@@ -46,24 +46,24 @@ nameKindText = \case
   KNameLocalModule -> "local module"
   KNameTopModule -> "module"
 
-isLocallyBounded :: (HasNameKind a) => a -> Bool
+isLocallyBounded :: HasNameKind a => a -> Bool
 isLocallyBounded k = case getNameKind k of
   KNameLocal -> True
   _ -> False
 
-isExprKind :: (HasNameKind a) => a -> Bool
+isExprKind :: HasNameKind a => a -> Bool
 isExprKind k = case getNameKind k of
   KNameLocalModule -> False
   KNameTopModule -> False
   _ -> True
 
-isModuleKind :: (HasNameKind a) => a -> Bool
+isModuleKind :: HasNameKind a => a -> Bool
 isModuleKind k = case getNameKind k of
   KNameLocalModule -> True
   KNameTopModule -> True
   _ -> False
 
-canBeCompiled :: (HasNameKind a) => a -> Bool
+canBeCompiled :: HasNameKind a => a -> Bool
 canBeCompiled k = case getNameKind k of
   KNameConstructor -> True
   KNameInductive -> True
@@ -73,7 +73,7 @@ canBeCompiled k = case getNameKind k of
   KNameLocalModule -> False
   KNameTopModule -> False
 
-canHaveFixity :: (HasNameKind a) => a -> Bool
+canHaveFixity :: HasNameKind a => a -> Bool
 canHaveFixity k = case getNameKind k of
   KNameConstructor -> True
   KNameInductive -> True
@@ -83,7 +83,7 @@ canHaveFixity k = case getNameKind k of
   KNameLocalModule -> False
   KNameTopModule -> False
 
-canBeIterator :: (HasNameKind a) => a -> Bool
+canBeIterator :: HasNameKind a => a -> Bool
 canBeIterator k = case getNameKind k of
   KNameFunction -> True
   KNameAxiom -> True
@@ -103,7 +103,7 @@ nameKindAnsi k = case k of
   KNameLocal -> mempty
   KNameTopModule -> color Cyan
 
-isFunctionKind :: (HasNameKind a) => a -> Bool
+isFunctionKind :: HasNameKind a => a -> Bool
 isFunctionKind k = case getNameKind k of
   KNameFunction -> True
   _ -> False

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -242,5 +242,9 @@ tests =
     PosTest
       "Format pragma"
       $(mkRelDir ".")
-      $(mkRelFile "FormatPragma.juvix")
+      $(mkRelFile "FormatPragma.juvix"),
+    PosTest
+      "Namespaces"
+      $(mkRelDir ".")
+      $(mkRelFile "Namespaces.juvix")
   ]

--- a/tests/positive/Namespaces.juvix
+++ b/tests/positive/Namespaces.juvix
@@ -3,18 +3,32 @@ module Namespaces;
 module Main;
 
   module M;
-
     axiom A : Type;
-
   end;
 
   axiom M : Type;
 
 end;
 
-open Main using {module M; M};
-open M;
+module Test1;
+  open Main using {module M; M};
+  open M;
 
-axiom x : M.A;
-axiom x1 : A;
-axiom x2 : M;
+  axiom x : M.A;
+
+  axiom x1 : A;
+
+  axiom x2 : M;
+end;
+
+module Test2;
+  open Main hiding {module M};
+
+  axiom x2 : M;
+
+  module M;
+
+  end;
+
+  open M;
+end;

--- a/tests/positive/Namespaces.juvix
+++ b/tests/positive/Namespaces.juvix
@@ -1,0 +1,20 @@
+module Namespaces;
+
+module Main;
+
+  module M;
+
+    axiom A : Type;
+
+  end;
+
+  axiom M : Type;
+
+end;
+
+open Main using {module M; M};
+open M;
+
+axiom x : M.A;
+axiom x1 : A;
+axiom x2 : M;

--- a/tests/positive/Namespaces.juvix
+++ b/tests/positive/Namespaces.juvix
@@ -32,3 +32,15 @@ module Test2;
 
   open M;
 end;
+
+module Test3;
+  open Main using {M};
+
+  axiom x2 : M;
+
+  module M;
+
+  end;
+
+  open M;
+end;

--- a/tests/positive/Namespaces.juvix
+++ b/tests/positive/Namespaces.juvix
@@ -1,7 +1,6 @@
 module Namespaces;
 
 module Main;
-
   module M;
     axiom A : Type;
   end;


### PR DESCRIPTION
- Closes #2110 

Now module names are separated from other symbols (types, functions, constructors, etc).
In practice this means that:
1. A module can now export a module symbol `S` and a non-module symbol `S` at the same time.
2. In `using` and `hiding` lists, we need to prefix module symbols with the `module` keyword. E.g. `open M using {module Aux}`. Other non-module symbols do not need a prefix.