### PR TITLE
Record updates

### DIFF
--- a/runtime/src/juvix/info.h
+++ b/runtime/src/juvix/info.h
@@ -10,6 +10,7 @@ typedef struct {
     assoc_t assoc;
 } fixity_t;
 
+#define PREC_MINUS_OMEGA1 (-2)
 #define PREC_MINUS_OMEGA (-1)
 #define PREC_OMEGA 100000
 

--- a/src/Juvix/Compiler/Backend/C/Translation/FromReg.hs
+++ b/src/Juvix/Compiler/Backend/C/Translation/FromReg.hs
@@ -66,6 +66,7 @@ fromReg lims tab =
 
         getPrec :: Precedence -> Expression
         getPrec = \case
+          PrecMinusOmega1 -> macroVar "PREC_MINUS_OMEGA1"
           PrecMinusOmega -> macroVar "PREC_MINUS_OMEGA"
           PrecOmega -> macroVar "PREC_OMEGA"
           PrecNat n -> integer n

--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -97,3 +97,8 @@ moduleNameToTopModulePath = \case
   NameQualified (QualifiedName (SymbolPath p) s) -> TopModulePath (toList p) s
 
 instance Hashable TopModulePath
+
+splitName :: Name -> ([Symbol], Symbol)
+splitName = \case
+  NameQualified (QualifiedName (SymbolPath p) s) -> (toList p, s)
+  NameUnqualified s -> ([], s)

--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Base.hs
@@ -17,5 +17,11 @@ newtype NameSignature = NameSignature
   }
   deriving stock (Show)
 
+newtype RecordNameSignature = RecordNameSignature
+  { _recordNames :: HashMap Symbol (Symbol, Int)
+  }
+  deriving stock (Show)
+
 makeLenses ''NameSignature
+makeLenses ''RecordNameSignature
 makeLenses ''NameBlock

--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
@@ -1,5 +1,6 @@
 module Juvix.Compiler.Concrete.Data.NameSignature.Builder
   ( mkNameSignature,
+    mkRecordNameSignature,
     HasNameSignature,
     module Juvix.Compiler.Concrete.Data.NameSignature.Base,
     -- to supress unused warning
@@ -7,6 +8,7 @@ module Juvix.Compiler.Concrete.Data.NameSignature.Builder
   )
 where
 
+import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Concrete.Data.NameSignature.Base
 import Juvix.Compiler.Concrete.Data.NameSignature.Error
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error
@@ -182,3 +184,11 @@ addSymbol' impl sym = do
 
 endBuild' :: Sem (Re r) a
 endBuild' = get @BuilderState >>= throw
+
+mkRecordNameSignature :: RhsRecord 'Parsed -> RecordNameSignature
+mkRecordNameSignature rhs =
+  RecordNameSignature
+    ( HashMap.fromList
+        [ (s, (s, idx)) | (Indexed idx field) <- indexFrom 0 (toList (rhs ^. rhsRecordFields)), let s = field ^. fieldName
+        ]
+    )

--- a/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
@@ -52,7 +52,9 @@ data ScoperState = ScoperState
     -- | Local and top modules
     _scoperModules :: HashMap S.ModuleNameId (ModuleRef' 'S.NotConcrete),
     _scoperScope :: HashMap TopModulePath Scope,
-    _scoperSignatures :: HashMap S.NameId NameSignature
+    _scoperSignatures :: HashMap S.NameId NameSignature,
+    -- | Indexed by the inductive type. This is meant to be used for record updates
+    _scoperRecordSignatures :: HashMap S.NameId RecordNameSignature
   }
 
 data SymbolFixity = SymbolFixity

--- a/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
@@ -47,6 +47,11 @@ data ScopeParameters = ScopeParameters
     _scopeParsedModules :: HashMap TopModulePath (Module 'Parsed 'ModuleTop)
   }
 
+data RecordInfo = RecordInfo
+  { _recordInfoConstructor :: S.Symbol,
+    _recordInfoSignature :: RecordNameSignature
+  }
+
 data ScoperState = ScoperState
   { _scoperModulesCache :: ModulesCache,
     -- | Local and top modules
@@ -54,7 +59,7 @@ data ScoperState = ScoperState
     _scoperScope :: HashMap TopModulePath Scope,
     _scoperSignatures :: HashMap S.NameId NameSignature,
     -- | Indexed by the inductive type. This is meant to be used for record updates
-    _scoperRecordSignatures :: HashMap S.NameId RecordNameSignature
+    _scoperRecordSignatures :: HashMap S.NameId RecordInfo
   }
 
 data SymbolFixity = SymbolFixity
@@ -86,3 +91,4 @@ makeLenses ''SymbolFixity
 makeLenses ''ScoperState
 makeLenses ''ScopeParameters
 makeLenses ''ModulesCache
+makeLenses ''RecordInfo

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -7,11 +7,14 @@ module Juvix.Compiler.Concrete.Extra
     groupStatements,
     flattenStatement,
     migrateFunctionSyntax,
+    recordNameSignatureByIndex,
   )
 where
 
 import Data.HashMap.Strict qualified as HashMap
+import Data.IntMap.Strict qualified as IntMap
 import Data.List.NonEmpty qualified as NonEmpty
+import Juvix.Compiler.Concrete.Data.NameSignature.Base
 import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
 import Juvix.Compiler.Concrete.Keywords
 import Juvix.Compiler.Concrete.Language
@@ -191,3 +194,6 @@ migrateFunctionSyntax m = over moduleBody (mapMaybe goStatement) m
             }
     getClauses :: S.Symbol -> [FunctionClause 'Scoped]
     getClauses name = [c | StatementFunctionClause c <- ss', name == c ^. clauseOwnerFunction]
+
+recordNameSignatureByIndex :: RecordNameSignature -> IntMap Symbol
+recordNameSignatureByIndex = IntMap.fromList . (^.. recordNames . each . to swap)

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -405,6 +405,24 @@ deriving stock instance Ord (ConstructorDef 'Parsed)
 
 deriving stock instance Ord (ConstructorDef 'Scoped)
 
+data RecordUpdateField (s :: Stage) = RecordUpdateField
+  { _fieldUpdateName :: Symbol,
+    _fieldUpdateAssignKw :: Irrelevant (KeywordRef),
+    _fieldUpdateValue :: ExpressionType s
+  }
+
+deriving stock instance Show (RecordUpdateField 'Parsed)
+
+deriving stock instance Show (RecordUpdateField 'Scoped)
+
+deriving stock instance Eq (RecordUpdateField 'Parsed)
+
+deriving stock instance Eq (RecordUpdateField 'Scoped)
+
+deriving stock instance Ord (RecordUpdateField 'Parsed)
+
+deriving stock instance Ord (RecordUpdateField 'Scoped)
+
 data RecordField (s :: Stage) = RecordField
   { _fieldName :: SymbolType s,
     _fieldColon :: Irrelevant (KeywordRef),
@@ -1252,6 +1270,25 @@ deriving stock instance Ord (ArgumentBlock 'Parsed)
 
 deriving stock instance Ord (ArgumentBlock 'Scoped)
 
+data RecordUpdate (s :: Stage) = RecordUpdate
+  { _recordUpdateAtKw :: Irrelevant KeywordRef,
+    _recordUpdateDelims :: Irrelevant (KeywordRef, KeywordRef),
+    _recordUpdateTypeName :: IdentifierType s,
+    _recordUpdateFields :: NonEmpty (RecordUpdateField s)
+  }
+
+deriving stock instance Show (RecordUpdate 'Parsed)
+
+deriving stock instance Show (RecordUpdate 'Scoped)
+
+deriving stock instance Eq (RecordUpdate 'Parsed)
+
+deriving stock instance Eq (RecordUpdate 'Scoped)
+
+deriving stock instance Ord (RecordUpdate 'Parsed)
+
+deriving stock instance Ord (RecordUpdate 'Scoped)
+
 data NamedApplication (s :: Stage) = NamedApplication
   { _namedAppName :: IdentifierType s,
     _namedAppArgs :: NonEmpty (ArgumentBlock s),
@@ -1279,6 +1316,7 @@ data ExpressionAtom (s :: Stage)
   | AtomHole (HoleType s)
   | AtomBraces (WithLoc (ExpressionType s))
   | AtomLet (Let s)
+  | AtomRecordUpdate (RecordUpdate s)
   | AtomUniverse Universe
   | AtomFunction (Function s)
   | AtomFunArrow KeywordRef
@@ -1440,6 +1478,8 @@ newtype ModuleIndex = ModuleIndex
   }
 
 makeLenses ''PatternArg
+makeLenses ''RecordUpdate
+makeLenses ''RecordUpdateField
 makeLenses ''NonDefinitionsSection
 makeLenses ''DefinitionsSection
 makeLenses ''ProjectionDef

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -411,7 +411,7 @@ deriving stock instance Ord (ConstructorDef 'Parsed)
 deriving stock instance Ord (ConstructorDef 'Scoped)
 
 data RecordUpdateField (s :: Stage) = RecordUpdateField
-  { _fieldUpdateName :: SymbolType s,
+  { _fieldUpdateName :: Symbol,
     _fieldUpdateArgIx :: FieldUpdateArgIxType s,
     _fieldUpdateAssignKw :: Irrelevant (KeywordRef),
     _fieldUpdateValue :: ExpressionType s
@@ -1266,6 +1266,8 @@ deriving stock instance Ord (ArgumentBlock 'Scoped)
 
 data RecordUpdateExtra = RecordUpdateExtra
   { _recordUpdateExtraConstructor :: S.Symbol,
+    -- | Implicitly bound fields sorted by index
+    _recordUpdateExtraVars :: [S.Symbol],
     _recordUpdateExtraSignature :: RecordNameSignature
   }
   deriving stock (Show)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -577,6 +577,7 @@ instance SingI s => PrettyPrint (Lambda s) where
 
 instance PrettyPrint Precedence where
   ppCode = \case
+    PrecMinusOmega1 -> noLoc (pretty ("-ω₁" :: Text))
     PrecMinusOmega -> noLoc (pretty ("-ω" :: Text))
     PrecNat n -> noLoc (pretty n)
     PrecOmega -> noLoc (pretty ("ω" :: Text))
@@ -610,6 +611,9 @@ instance PrettyPrint IteratorSyntaxDef where
       <+> iterSymbol'
       <+?> fmap ppCode _iterAttribs
 
+instance PrettyPrint RecordUpdateApp where
+  ppCode = apeHelper
+
 instance PrettyPrint Expression where
   ppCode = \case
     ExpressionIdentifier n -> ppCode n
@@ -628,6 +632,7 @@ instance PrettyPrint Expression where
     ExpressionCase c -> ppCode c
     ExpressionIterator i -> ppCode i
     ExpressionNamedApplication i -> ppCode i
+    ExpressionRecordUpdate i -> ppCode i
 
 instance PrettyPrint (WithSource Pragmas) where
   ppCode pragma = do

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -961,12 +961,12 @@ instance SingI s => PrettyPrint (ConstructorDef s) where
       constructorRhsHelper :: ConstructorRhs s -> Sem r ()
       constructorRhsHelper r = spaceMay <> ppCode r
         where
-        spaceMay = case r of
-          ConstructorRhsGadt {} -> space
-          ConstructorRhsRecord {} -> space
-          ConstructorRhsAdt a
-            | null (a ^. rhsAdtArguments) -> mempty
-            | otherwise -> space
+          spaceMay = case r of
+            ConstructorRhsGadt {} -> space
+            ConstructorRhsRecord {} -> space
+            ConstructorRhsAdt a
+              | null (a ^. rhsAdtArguments) -> mempty
+              | otherwise -> space
 
       -- we use this helper so that comments appear before the first optional pipe if the pipe was omitted
       pipeHelper :: Sem r ()

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -961,12 +961,12 @@ instance SingI s => PrettyPrint (ConstructorDef s) where
       constructorRhsHelper :: ConstructorRhs s -> Sem r ()
       constructorRhsHelper r = spaceMay <> ppCode r
         where
-          spaceMay = case r of
-            ConstructorRhsGadt {} -> space
-            ConstructorRhsRecord {} -> space
-            ConstructorRhsAdt a
-              | null (a ^. rhsAdtArguments) -> mempty
-              | otherwise -> space
+        spaceMay = case r of
+          ConstructorRhsGadt {} -> space
+          ConstructorRhsRecord {} -> space
+          ConstructorRhsAdt a
+            | null (a ^. rhsAdtArguments) -> mempty
+            | otherwise -> space
 
       -- we use this helper so that comments appear before the first optional pipe if the pipe was omitted
       pipeHelper :: Sem r ()

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -614,6 +614,9 @@ instance PrettyPrint IteratorSyntaxDef where
 instance PrettyPrint RecordUpdateApp where
   ppCode = apeHelper
 
+instance PrettyPrint ParensRecordUpdate where
+  ppCode = parens . ppCode . (^. parensRecordUpdate)
+
 instance PrettyPrint Expression where
   ppCode = \case
     ExpressionIdentifier n -> ppCode n
@@ -633,6 +636,7 @@ instance PrettyPrint Expression where
     ExpressionIterator i -> ppCode i
     ExpressionNamedApplication i -> ppCode i
     ExpressionRecordUpdate i -> ppCode i
+    ExpressionParensRecordUpdate i -> ppCode i
 
 instance PrettyPrint (WithSource Pragmas) where
   ppCode pragma = do

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -273,7 +273,7 @@ instance SingI s => PrettyPrint (NamedApplication s) where
 
 instance SingI s => PrettyPrint (RecordUpdateField s) where
   ppCode RecordUpdateField {..} =
-    ppCode _fieldUpdateName <+> ppCode _fieldUpdateAssignKw <+> ppExpressionType _fieldUpdateValue
+    ppSymbolType _fieldUpdateName <+> ppCode _fieldUpdateAssignKw <+> ppExpressionType _fieldUpdateValue
 
 instance SingI s => PrettyPrint (RecordUpdate s) where
   ppCode RecordUpdate {..} = do

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1857,7 +1857,7 @@ checkRecordUpdate RecordUpdate {..} = do
         _recordUpdateDelims
       }
   where
-    -- TODO check repetitions? done by bindvariablesymbol, but error msg is not that good
+    -- TODO checking repetitions is done by bindVariableSymbol, but error msg is not that good
     checkField :: RecordNameSignature -> RecordUpdateField 'Parsed -> Sem r (RecordUpdateField 'Scoped)
     checkField sig f = do
       name' <- bindVariableSymbol (f ^. fieldUpdateName)
@@ -1872,7 +1872,7 @@ checkRecordUpdate RecordUpdate {..} = do
           }
       where
         unexpectedField :: ScoperError
-        unexpectedField = error "TODO: unexpected field"
+        unexpectedField = ErrUnexpectedField (UnexpectedField (f ^. fieldUpdateName))
 
 checkNamedApplication ::
   forall r.

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -2019,12 +2019,15 @@ checkParens ::
   ExpressionAtoms 'Parsed ->
   Sem r Expression
 checkParens e@(ExpressionAtoms as _) = case as of
-  AtomIdentifier s :| [] -> do
-    scopedId <- checkName s
-    let scopedIdenNoFix = over scopedIden (set S.nameFixity Nothing) scopedId
-    return (ExpressionParensIdentifier scopedIdenNoFix)
-  AtomIterator i :| [] -> ExpressionIterator . set iteratorParens True <$> checkIterator i
-  AtomCase c :| [] -> ExpressionCase . set caseParens True <$> checkCase c
+  p :| [] -> case p of
+    AtomIdentifier s -> do
+      scopedId <- checkName s
+      let scopedIdenNoFix = over scopedIden (set S.nameFixity Nothing) scopedId
+      return (ExpressionParensIdentifier scopedIdenNoFix)
+    AtomIterator i -> ExpressionIterator . set iteratorParens True <$> checkIterator i
+    AtomCase c -> ExpressionCase . set caseParens True <$> checkCase c
+    AtomRecordUpdate u -> ExpressionParensRecordUpdate . ParensRecordUpdate <$> checkRecordUpdate u
+    _ -> checkParseExpressionAtoms e
   _ -> checkParseExpressionAtoms e
 
 checkExpressionAtoms ::

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -44,6 +44,7 @@ data ScoperError
   | ErrNamedArgumentsError NamedArgumentsError
   | ErrNotARecord NotARecord
   | ErrUnexpectedField UnexpectedField
+  | ErrRepeatedField RepeatedField
 
 instance ToGenericError ScoperError where
   genericError = \case
@@ -79,3 +80,4 @@ instance ToGenericError ScoperError where
     ErrNamedArgumentsError e -> genericError e
     ErrNotARecord e -> genericError e
     ErrUnexpectedField e -> genericError e
+    ErrRepeatedField e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -43,6 +43,7 @@ data ScoperError
   | ErrNoNameSignature NoNameSignature
   | ErrNamedArgumentsError NamedArgumentsError
   | ErrNotARecord NotARecord
+  | ErrUnexpectedField UnexpectedField
 
 instance ToGenericError ScoperError where
   genericError = \case
@@ -77,3 +78,4 @@ instance ToGenericError ScoperError where
     ErrNoNameSignature e -> genericError e
     ErrNamedArgumentsError e -> genericError e
     ErrNotARecord e -> genericError e
+    ErrUnexpectedField e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -42,6 +42,7 @@ data ScoperError
   | ErrNameSignature NameSignatureError
   | ErrNoNameSignature NoNameSignature
   | ErrNamedArgumentsError NamedArgumentsError
+  | ErrNotARecord NotARecord
 
 instance ToGenericError ScoperError where
   genericError = \case
@@ -75,3 +76,4 @@ instance ToGenericError ScoperError where
     ErrNameSignature e -> genericError e
     ErrNoNameSignature e -> genericError e
     ErrNamedArgumentsError e -> genericError e
+    ErrNotARecord e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -788,3 +788,24 @@ instance ToGenericError NotARecord where
     where
       i :: Interval
       i = getLoc _notARecord
+
+newtype UnexpectedField = UnexpectedField
+  { _unexpectedField :: Symbol
+  }
+  deriving stock (Show)
+
+instance ToGenericError UnexpectedField where
+  genericError UnexpectedField {..} = do
+    opts <- fromGenericOptions <$> ask
+    let msg =
+          "Unexpected field"
+            <+> ppCode opts _unexpectedField
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = mkAnsiText msg,
+          _genericErrorIntervals = [i]
+        }
+    where
+      i :: Interval
+      i = getLoc _unexpectedField

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -319,7 +319,7 @@ makeLenses ''NotInScope
 instance ToGenericError NotInScope where
   genericError e@NotInScope {..} = ask >>= generr
     where
-      loc =getLoc  (e ^. notInScopeSymbol)
+      loc = getLoc (e ^. notInScopeSymbol)
       generr opts =
         return
           GenericError
@@ -766,3 +766,25 @@ instance ToGenericError NoNameSignature where
     where
       i :: Interval
       i = getLoc _noNameSignatureIden
+
+newtype NotARecord = NotARecord
+  { _notARecord :: ScopedIden
+  }
+  deriving stock (Show)
+
+instance ToGenericError NotARecord where
+  genericError NotARecord {..} = do
+    opts <- fromGenericOptions <$> ask
+    let msg =
+          "The identifier"
+            <+> ppCode opts _notARecord
+            <+> "is not a record type"
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = mkAnsiText msg,
+          _genericErrorIntervals = [i]
+        }
+    where
+      i :: Interval
+      i = getLoc _notARecord

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -809,3 +809,24 @@ instance ToGenericError UnexpectedField where
     where
       i :: Interval
       i = getLoc _unexpectedField
+
+newtype RepeatedField = RepeatedField
+  { _repeatedField :: Symbol
+  }
+  deriving stock (Show)
+
+instance ToGenericError RepeatedField where
+  genericError RepeatedField {..} = do
+    opts <- fromGenericOptions <$> ask
+    let msg =
+          "Repeated field"
+            <+> ppCode opts _repeatedField
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = mkAnsiText msg,
+          _genericErrorIntervals = [i]
+        }
+    where
+      i :: Interval
+      i = getLoc _repeatedField

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -319,12 +319,13 @@ makeLenses ''NotInScope
 instance ToGenericError NotInScope where
   genericError e@NotInScope {..} = ask >>= generr
     where
+      loc =getLoc  (e ^. notInScopeSymbol)
       generr opts =
         return
           GenericError
-            { _genericErrorLoc = e ^. notInScopeSymbol . symbolLoc,
+            { _genericErrorLoc = loc,
               _genericErrorMessage = prettyError msg,
-              _genericErrorIntervals = [e ^. notInScopeSymbol . symbolLoc]
+              _genericErrorIntervals = [loc]
             }
         where
           opts' = fromGenericOptions opts

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -596,6 +596,7 @@ recordUpdateField = do
   _fieldUpdateName <- symbol
   _fieldUpdateAssignKw <- Irrelevant <$> kw kwAssign
   _fieldUpdateValue <- parseExpressionAtoms
+  let _fieldUpdateArgIx = ()
   return RecordUpdateField {..}
 
 recordUpdate :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (RecordUpdate 'Parsed)
@@ -606,6 +607,7 @@ recordUpdate = do
   _recordUpdateFields <- P.sepEndBy1 recordUpdateField semicolon
   r <- kw delimBraceR
   let _recordUpdateDelims = Irrelevant (l, r)
+      _recordUpdateExtra = Irrelevant ()
   return RecordUpdate {..}
 
 expressionAtom :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (ExpressionAtom 'Parsed)

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -594,7 +594,7 @@ importedModule t = unlessM (moduleVisited t) go
 recordUpdateField :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (RecordUpdateField 'Parsed)
 recordUpdateField = do
   _fieldUpdateName <- symbol
-  _fieldUpdateAssignKw <- Irrelevant <$> kw kwColon
+  _fieldUpdateAssignKw <- Irrelevant <$> kw kwAssign
   _fieldUpdateValue <- parseExpressionAtoms
   return RecordUpdateField {..}
 
@@ -604,7 +604,7 @@ recordUpdate = do
   _recordUpdateTypeName <- name
   l <- kw delimBraceL
   _recordUpdateFields <- P.sepEndBy1 recordUpdateField semicolon
-  r <- kw delimBraceL
+  r <- kw delimBraceR
   let _recordUpdateDelims = Irrelevant (l, r)
   return RecordUpdate {..}
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -591,11 +591,24 @@ importedModule t = unlessM (moduleVisited t) go
       txt <- readFile' path
       eitherM throw (const (return ())) (runModuleParser path txt)
 
---------------------------------------------------------------------------------
--- Expression
---------------------------------------------------------------------------------
+recordUpdateField :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (RecordUpdateField 'Parsed)
+recordUpdateField = do
+  _fieldUpdateName <- symbol
+  _fieldUpdateAssignKw <- Irrelevant <$> kw kwColon
+  _fieldUpdateValue <- parseExpressionAtoms
+  return RecordUpdateField {..}
 
-expressionAtom :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (ExpressionAtom 'Parsed)
+recordUpdate :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (RecordUpdate 'Parsed)
+recordUpdate = do
+  _recordUpdateAtKw <- Irrelevant <$> kw kwAt
+  _recordUpdateTypeName <- name
+  l <- kw delimBraceL
+  _recordUpdateFields <- P.sepEndBy1 recordUpdateField semicolon
+  r <- kw delimBraceL
+  let _recordUpdateDelims = Irrelevant (l, r)
+  return RecordUpdate {..}
+
+expressionAtom :: Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r => ParsecS r (ExpressionAtom 'Parsed)
 expressionAtom =
   P.label "<expression>" $
     AtomLiteral <$> P.try literal
@@ -612,6 +625,7 @@ expressionAtom =
       <|> AtomHole <$> hole
       <|> AtomParens <$> parens parseExpressionAtoms
       <|> AtomBraces <$> withLoc (braces parseExpressionAtoms)
+      <|> AtomRecordUpdate <$> recordUpdate
 
 parseExpressionAtoms ::
   (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) =>

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -830,8 +830,8 @@ goExpression = \case
               whenM (gets @(IntMap (RecordUpdateField 'Scoped)) (IntMap.member idx)) (throw repeated)
               modify' (IntMap.insert idx f)
               where
-              repeated :: ScoperError
-              repeated = ErrRepeatedField (RepeatedField (f ^. fieldUpdateName))
+                repeated :: ScoperError
+                repeated = ErrRepeatedField (RepeatedField (f ^. fieldUpdateName))
 
         mkArgs :: [Indexed Internal.VarName] -> Sem r [Internal.Expression]
         mkArgs vs = do

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -803,9 +803,14 @@ goExpression = \case
   ExpressionHole h -> return (Internal.ExpressionHole h)
   ExpressionIterator i -> goIterator i
   ExpressionNamedApplication i -> goNamedApplication i
+  ExpressionRecordUpdate i -> goRecordUpdate i
   where
     goNamedApplication :: Concrete.NamedApplication 'Scoped -> Sem r Internal.Expression
     goNamedApplication = runNamedArguments >=> goExpression
+
+    -- TODO record update
+    goRecordUpdate :: Concrete.RecordUpdateApp -> Sem r Internal.Expression
+    goRecordUpdate = goExpression . (^. Concrete.recordAppExpression)
 
     goList :: Concrete.List 'Scoped -> Sem r Internal.Expression
     goList l = do

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -831,7 +831,7 @@ goExpression = \case
               modify' (IntMap.insert idx f)
               where
               repeated :: ScoperError
-              repeated = undefined
+              repeated = ErrRepeatedField (RepeatedField (f ^. fieldUpdateName))
 
         mkArgs :: [Indexed Internal.VarName] -> Sem r [Internal.Expression]
         mkArgs vs = do

--- a/src/Juvix/Data/Fixity.hs
+++ b/src/Juvix/Data/Fixity.hs
@@ -2,21 +2,15 @@ module Juvix.Data.Fixity where
 
 import Juvix.Prelude.Base
 
+-- | Note that the order of the constructors is important due to the `Ord`
+-- instance.
+-- TODO should we rename PrecMinusOmega to PrecApp, PrecMinusOmega1 to PrecUpdate, and PrecOmega to PrecFunction/Arrow?
 data Precedence
-  = PrecMinusOmega
+  = PrecMinusOmega1
+  | PrecMinusOmega
   | PrecNat Natural
   | PrecOmega
-  deriving stock (Show, Eq, Data)
-
-instance Ord Precedence where
-  compare a b = case (a, b) of
-    (PrecMinusOmega, PrecMinusOmega) -> EQ
-    (PrecMinusOmega, _) -> LT
-    (PrecNat _, PrecMinusOmega) -> GT
-    (PrecNat n, PrecNat m) -> compare n m
-    (PrecNat _, PrecOmega) -> LT
-    (PrecOmega, PrecOmega) -> EQ
-    (PrecOmega, _) -> GT
+  deriving stock (Show, Eq, Data, Ord)
 
 data UnaryAssoc = AssocPostfix
   deriving stock (Show, Eq, Ord, Data)
@@ -79,6 +73,9 @@ appFixity = Fixity PrecOmega (Binary AssocLeft)
 
 funFixity :: Fixity
 funFixity = Fixity PrecMinusOmega (Binary AssocRight)
+
+updateFixity :: Fixity
+updateFixity = Fixity PrecMinusOmega1 (Unary AssocPostfix)
 
 atomParens :: (Fixity -> Bool) -> Atomicity -> Fixity -> Bool
 atomParens associates argAtom opInf = case argAtom of

--- a/test/Compilation/Positive.hs
+++ b/test/Compilation/Positive.hs
@@ -354,5 +354,10 @@ tests =
       "Test059: Builtin list"
       $(mkRelDir ".")
       $(mkRelFile "test059.juvix")
-      $(mkRelFile "out/test059.out")
+      $(mkRelFile "out/test059.out"),
+    posTest
+      "Test060: Record update"
+      $(mkRelDir ".")
+      $(mkRelFile "test060.juvix")
+      $(mkRelFile "out/test060.out")
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -321,6 +321,6 @@ scoperErrorTests =
       $(mkRelDir ".")
       $(mkRelFile "NoNamedArguments.juvix")
       $ \case
-        ErrNoNameSignature ErrNoNameSignature {} -> Nothing
+        ErrNoNameSignature NoNameSignature {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -322,5 +322,12 @@ scoperErrorTests =
       $(mkRelFile "NoNamedArguments.juvix")
       $ \case
         ErrNoNameSignature NoNameSignature {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Not a record"
+      $(mkRelDir ".")
+      $(mkRelFile "NotARecord.juvix")
+      $ \case
+        ErrNotARecord NotARecord {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -329,5 +329,12 @@ scoperErrorTests =
       $(mkRelFile "NotARecord.juvix")
       $ \case
         ErrNotARecord NotARecord {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Unexpected field in record update"
+      $(mkRelDir ".")
+      $(mkRelFile "UnexpectedFieldUpdate.juvix")
+      $ \case
+        ErrUnexpectedField UnexpectedField {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -315,5 +315,12 @@ scoperErrorTests =
       $(mkRelFile "RepeatedNameSignature.juvix")
       $ \case
         ErrNameSignature ErrDuplicateName {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "No named arguments"
+      $(mkRelDir ".")
+      $(mkRelFile "NoNamedArguments.juvix")
+      $ \case
+        ErrNoNameSignature ErrNoNameSignature {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -254,6 +254,10 @@ tests =
       $(mkRelDir ".")
       $(mkRelFile "Records.juvix"),
     posTest
+      "Record update"
+      $(mkRelDir ".")
+      $(mkRelFile "Records2.juvix"),
+    posTest
       "Record projections"
       $(mkRelDir ".")
       $(mkRelFile "Projections.juvix")

--- a/tests/Compilation/positive/out/test060.out
+++ b/tests/Compilation/positive/out/test060.out
@@ -1,0 +1,1 @@
+mkTriple 3 6 2

--- a/tests/Compilation/positive/out/test060.out
+++ b/tests/Compilation/positive/out/test060.out
@@ -1,1 +1,1 @@
-mkTriple 30 6 2
+mkTriple 30 10 2

--- a/tests/Compilation/positive/out/test060.out
+++ b/tests/Compilation/positive/out/test060.out
@@ -1,1 +1,1 @@
-mkTriple 3 6 2
+mkTriple 30 6 2

--- a/tests/Compilation/positive/test060.juvix
+++ b/tests/Compilation/positive/test060.juvix
@@ -19,7 +19,7 @@ main :=
       Triple Nat Nat Nat :=
         p @Triple{
           fst := fst + 1;
-          snd := snd * 3
+          snd := snd * 3 + thd + fst
         };
     f : Triple Nat Nat Nat -> Triple Nat Nat Nat := (@Triple {fst := fst * 10});
   in f p';

--- a/tests/Compilation/positive/test060.juvix
+++ b/tests/Compilation/positive/test060.juvix
@@ -1,0 +1,24 @@
+-- record updates
+module test060;
+
+import Stdlib.Data.Nat open;
+import Stdlib.System.IO open;
+
+type Triple (A B C : Type) :=
+  | mkTriple {
+      fst : A;
+      snd : B;
+      thd : C;
+    };
+
+main : Triple Nat Nat Nat;
+main :=
+  let
+    p : Triple Nat Nat Nat := mkTriple 2 2 2;
+    p' :
+      Triple Nat Nat Nat :=
+        p @Triple{
+          fst := fst + 1;
+          snd := snd * 3
+        };
+  in p';

--- a/tests/Compilation/positive/test060.juvix
+++ b/tests/Compilation/positive/test060.juvix
@@ -21,4 +21,5 @@ main :=
           fst := fst + 1;
           snd := snd * 3
         };
-  in p';
+    f : Triple Nat Nat Nat -> Triple Nat Nat Nat := (@Triple {fst := fst * 10});
+  in f p';

--- a/tests/negative/NoNamedArguments.juvix
+++ b/tests/negative/NoNamedArguments.juvix
@@ -1,0 +1,5 @@
+module NoNamedArguments;
+
+axiom T : Type;
+
+axiom B : T (x := Type);

--- a/tests/negative/NotARecord.juvix
+++ b/tests/negative/NotARecord.juvix
@@ -1,0 +1,6 @@
+module NotARecord;
+
+type T := t;
+
+f : T;
+f := t @T{x := 1};

--- a/tests/negative/UnexpectedField.juvix
+++ b/tests/negative/UnexpectedField.juvix
@@ -1,0 +1,10 @@
+module UnexpectedField;
+
+type T := t;
+
+type R := mkR {
+ r : T;
+};
+
+f : R;
+f := (mkR t) @R{x := 1};

--- a/tests/negative/UnexpectedFieldUpdate.juvix
+++ b/tests/negative/UnexpectedFieldUpdate.juvix
@@ -1,4 +1,4 @@
-module UnexpectedField;
+module UnexpectedFieldUpdate;
 
 type T := t;
 

--- a/tests/positive/Records.juvix
+++ b/tests/positive/Records.juvix
@@ -36,11 +36,13 @@ open Pair;
 
 p4 {A : Type} : Pair A T -> A := fst;
 
-type Bool := false | true;
+type Bool :=
+  | false
+  | true;
 
 module Update;
- x : Pair Bool Bool := mkPair false false;
+  x : Pair Bool Bool := mkPair false false;
 
- x' : Pair Bool Bool := x @Pair {fst := true};
-
+  x' : Pair Bool Bool := x @Pair{fst := fst true};
+  -- x' : Pair Bool Bool := λ {(Pair fst0 snd1) := Pair (val1 [ghost ↦ fst0]) (val2)} x @Pair{fst := true};
 end;

--- a/tests/positive/Records.juvix
+++ b/tests/positive/Records.juvix
@@ -35,3 +35,12 @@ p3 : Pair T T -> T := Pair.fst;
 open Pair;
 
 p4 {A : Type} : Pair A T -> A := fst;
+
+type Bool := false | true;
+
+module Update;
+ x : Pair Bool Bool := mkPair false false;
+
+ x' : Pair Bool Bool := x @Pair {fst := true};
+
+end;

--- a/tests/positive/Records.juvix
+++ b/tests/positive/Records.juvix
@@ -41,8 +41,6 @@ type Bool :=
   | true;
 
 module Update;
-  x : Pair Bool Bool := mkPair false false;
-
-  x' : Pair Bool Bool := x @Pair{fst := fst true};
-  -- x' : Pair Bool Bool := λ {(Pair fst0 snd1) := Pair (val1 [ghost ↦ fst0]) (val2)} x @Pair{fst := true};
+  f {A B : Type} (p : Pair A B) : Pair Bool B :=
+    p @Pair{fst := true};
 end;

--- a/tests/positive/Records2.juvix
+++ b/tests/positive/Records2.juvix
@@ -1,0 +1,15 @@
+module Records2;
+
+import Stdlib.Data.Nat.Base open;
+
+type Pair (A B : Type) :=
+  | mkPair {
+      pfst : A;
+      psnd : B
+    };
+
+main : Pair Nat Nat;
+main :=
+  let
+    p : Pair Nat Nat := mkPair 2 2;
+  in p @Pair{pfst := pfst + psnd};


### PR DESCRIPTION
- Closes #1642.

This pr introduces syntax for convenient record updates.
Example:
```
type Triple (A B C : Type) :=
  | mkTriple {
      fst : A;
      snd : B;
      thd : C;
    };

main : Triple Nat Nat Nat;
main :=
  let
    p : Triple Nat Nat Nat := mkTriple 2 2 2;
    p' :
      Triple Nat Nat Nat :=
        p @Triple{
          fst := fst + 1;
          snd := snd * 3
        };
    f : Triple Nat Nat Nat -> Triple Nat Nat Nat := (@Triple{fst := fst * 10});
  in f p';
```
We write `@InductiveType{..}` to update the contents of a record. The `@` is used for parsing. The `InductiveType` symbol indicates the type of the record update. Inside the braces we have a list of `fieldName := newValue` items separated by semicolon. The `fieldName` is bound in `newValue` with the old value of the field. Thus, we can write something like `p @Triple{fst := fst + 1;}`.

Record updates `X@{..}` are parsed as postfix operators with higher priority than application, so `f x y @X{q := 1}` is equivalent to `f x (y @X{q := 1})`.

It is possible the use a record update with no argument by wrapping the update in parentheses. See `f` in the above example.