### PR TITLE
Fix benchmark wasmer command

### DIFF
--- a/bench/Variants.hs
+++ b/bench/Variants.hs
@@ -64,7 +64,7 @@ defaultExt :: [String]
 defaultExt = [".exe"]
 
 runWasm :: Path Abs File -> IO ()
-runWasm p = void (readProcess "wasmer" [toFilePath p, "--disable-cache"] "")
+runWasm p = void (readProcess "wasmer" [toFilePath p] "")
 
 runExe :: Path Abs File -> IO ()
 runExe p = void (readProcess (toFilePath p) [] "")


### PR DESCRIPTION
The benchmark run has been failing since the latest release of wasmer.

https://github.com/anoma/juvix-nightly-builds/actions/runs/5746121923/job/15575622923

wasmer no longer supports the --disable-cache option and there's no equivalent that I can find in the new CLI.