### PR TITLE
Improve iterator and named arguments parsing

### DIFF
--- a/tests/positive/NamedArguments.juvix
+++ b/tests/positive/NamedArguments.juvix
@@ -89,5 +89,5 @@ module FakeRecord;
     mkPair (snd := unit; fst := Type);
 
   pp2 : Pair (B := Unit; A := Type) :=
-    mkPair (fst := Type) unit;
+    mkPair (fst := Type) (unit);
 end;


### PR DESCRIPTION
Avoid excessive backtracking in iterator and named arguments parsing. This also improves error messages by committing to a parsing branch as early as possible.
