### PR TITLE
Fixes behaviour of default stdlib when internal-build-flag is set

### DIFF
--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -50,7 +50,7 @@ getPackage = do
         _packageVersion = tversion,
         _packageBuildDir = Nothing,
         _packageMain = Nothing,
-        _packageDependencies = [defaultStdlibDep]
+        _packageDependencies = [defaultStdlibDep (Just (Rel relBuildDir))]
       }
 
 getProjName :: forall r. (Members '[Embed IO] r) => Sem r Text

--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -50,7 +50,7 @@ getPackage = do
         _packageVersion = tversion,
         _packageBuildDir = Nothing,
         _packageMain = Nothing,
-        _packageDependencies = [defaultStdlibDep (Just (Rel relBuildDir))]
+        _packageDependencies = [defaultStdlibDep DefaultBuildDir]
       }
 
 getProjName :: forall r. (Members '[Embed IO] r) => Sem r Text

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -74,9 +74,9 @@ mkPackageInfo ::
   Sem r PackageInfo
 mkPackageInfo mpackageEntry _packageRoot = do
   let buildDir :: Path Abs Dir = maybe (rootBuildDir _packageRoot) (someBaseToAbs _packageRoot . (^. entryPointBuildDir)) mpackageEntry
-      buildDirDep :: Maybe (SomeBase Dir)
-        | isJust mpackageEntry = Just (Abs buildDir)
-        | otherwise = Nothing
+      buildDirDep :: BuildDir
+        | isJust mpackageEntry = CustomBuildDir (Abs buildDir)
+        | otherwise = DefaultBuildDir
 
   _packagePackage <- maybe (readPackage _packageRoot buildDirDep) (return . (^. entryPointPackage)) mpackageEntry
   let deps :: [Dependency] = _packagePackage ^. packageDependencies

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -118,14 +118,15 @@ registerDependencies' = do
       | isGlobal -> do
           glob <- globalRoot
           let globDep = Dependency (mkPrepath (toFilePath glob))
-          addDependency' globDep
-      | otherwise -> addDependency' (Dependency (mkPrepath (toFilePath (e ^. entryPointRoot))))
+          addDependency' (Just e) globDep
+      | otherwise -> addDependency' (Just e) (Dependency (mkPrepath (toFilePath (e ^. entryPointRoot))))
 
 addDependency' ::
   (Members '[State ResolverState, Reader ResolverEnv, Files, Error Text] r) =>
+  Maybe EntryPoint ->
   Dependency ->
   Sem r ()
-addDependency' = addDependencyHelper Nothing
+addDependency' me = addDependencyHelper me
 
 addDependencyHelper ::
   (Members '[State ResolverState, Reader ResolverEnv, Files, Error Text] r) =>
@@ -139,7 +140,7 @@ addDependencyHelper me d = do
     modify' (set (resolverPackages . at p) (Just pkgInfo))
     forM_ (pkgInfo ^. packageRelativeFiles) $ \f -> do
       modify' (over resolverFiles (HashMap.insertWith (<>) f (pure pkgInfo)))
-    forM_ (pkgInfo ^. packagePackage . packageDependencies) addDependency'
+    forM_ (pkgInfo ^. packagePackage . packageDependencies) (addDependency' Nothing)
 
 currentPackage :: (Members '[State ResolverState, Reader ResolverEnv] r) => Sem r PackageInfo
 currentPackage = do

--- a/src/Juvix/Compiler/Pipeline/Root.hs
+++ b/src/Juvix/Compiler/Pipeline/Root.hs
@@ -49,7 +49,7 @@ findRootAndChangeDir minputFileDir mbuildDir _rootsInvokeDir = do
           let _rootsRootDir = parent yamlPath
               _rootsPackageGlobal = False
               _rootsBuildDir = getBuildDir mbuildDir _rootsRootDir
-          _rootsPackage <- readPackageIO _rootsRootDir (Abs _rootsBuildDir)
+          _rootsPackage <- readPackageIO _rootsRootDir (CustomBuildDir (Abs _rootsBuildDir))
           return Roots {..}
 
 getBuildDir :: Maybe (Path Abs Dir) -> Path Abs Dir -> Path Abs Dir

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -70,14 +70,26 @@ tests:
       shell:
         - bash
       script: |
-        temp=$(mktemp -d)
-        cd ./examples/milestone/HelloWorld
-        juvix compile HelloWorld.juvix --internal-build-dir "$temp"
-        find "$temp" | wc -l
-        rm -rf "$temp"
-    stdout:
-      matches: |
-        \s*([2-9]|[1-9][0-9]+)
+        buildDir=$(mktemp -d)
+        rootDir=$(mktemp -d)
+        trap 'rm -rf -- "$buildDir"' EXIT
+        trap 'rm -rf -- "$rootDir"' EXIT
+
+        cp ./examples/milestone/HelloWorld/HelloWorld.juvix "$rootDir"
+        touch "$rootDir/juvix.yaml"
+
+        cd "$rootDir"
+        juvix compile HelloWorld.juvix --internal-build-dir "$buildDir"
+
+        num_files=$(ls -1qA "$buildDir" | wc -l)
+        if [ $num_files -le 0 ]; then
+          exit 1
+        fi
+
+        if [ -d "$rootDir/.juvix-build" ]; then
+          exit 1
+        fi
+    stdout: ""
     exit-status: 0
 
   - name: default-output-file-in-invoke-dir

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -92,6 +92,27 @@ tests:
     stdout: ""
     exit-status: 0
 
+  - name: stdlib-in-default-build-dir
+    command:
+      shell:
+        - bash
+      script: |
+        rootDir=$(mktemp -d)
+        trap 'rm -rf -- "$rootDir"' EXIT
+
+        cp ./examples/milestone/HelloWorld/HelloWorld.juvix "$rootDir"
+        touch "$rootDir/juvix.yaml"
+        echo "dependencies: [.juvix-build/stdlib]" >> "$rootDir/juvix.yaml"
+
+        cd "$rootDir"
+        juvix compile HelloWorld.juvix
+
+        if [ ! -d "$rootDir/.juvix-build" ]; then
+          exit 1
+        fi
+    stdout: ""
+    exit-status: 0
+
   - name: default-output-file-in-invoke-dir
     command:
       shell:


### PR DESCRIPTION
The mechanism for using `--internal-build-flag` to set the build directory for the default stdlib location already existed, it was just unused (Nothing always passed in, instead of the entry point):

https://github.com/anoma/juvix/blob/11ebc4acde4d1c7e70568b35326074e5ee671a77/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs#L128

This PR fixes that issue, adds some smoke tests to check the behaviour of the stdlib dependency. 

* Closes https://github.com/anoma/juvix/issues/2273

The issue with what to do with relative stdlib dependency paths when `--internal-build-flag` is set remains open: https://github.com/anoma/juvix/issues/2274
