### PR TITLE
Prettyprint aggregate ADT constructor types with parentheses

### DIFF
--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -121,6 +121,11 @@ ppExpressionType = case sing :: SStage s of
   SParsed -> ppCode
   SScoped -> ppCode
 
+ppExpressionAtomType :: forall s. SingI s => PrettyPrinting (ExpressionType s)
+ppExpressionAtomType = case sing :: SStage s of
+  SParsed -> ppCodeAtom
+  SScoped -> ppCodeAtom
+
 ppPatternAtomType :: forall s. SingI s => PrettyPrinting (PatternAtomType s)
 ppPatternAtomType = case sing :: SStage s of
   SParsed -> ppCodeAtom
@@ -985,7 +990,7 @@ instance SingI s => PrettyPrint (RhsRecord s) where
     ppCode l <> fields' <> ppCode r
 
 instance SingI s => PrettyPrint (RhsAdt s) where
-  ppCode = align . sep . fmap ppExpressionType . (^. rhsAdtArguments)
+  ppCode = align . sep . fmap ppExpressionAtomType . (^. rhsAdtArguments)
 
 instance SingI s => PrettyPrint (ConstructorRhs s) where
   ppCode :: Members '[ExactPrint, Reader Options] r => ConstructorRhs s -> Sem r ()

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -229,6 +229,9 @@ module Comments;
   using -- before brace
   {-- before first f
   f; f};
+
+  type list (A : Type) : Type :=
+    | cons A (list A);
 end;
 
 -- Comment at the end of a module


### PR DESCRIPTION
This PR fixes an issue with formatting ADT definitions.

Previously the pretty printer would remove required parentheses from aggregate constructor arguments: `type t (A : Type) :=  c A (t A) ` -> `type t (A : Type) :=  c A t A`. 

We now handle this in the same way as patterns.

* https://github.com/anoma/juvix/issues/2277