### PR TITLE
Check for incomparable precedences

### DIFF
--- a/runtime/src/juvix/info.h
+++ b/runtime/src/juvix/info.h
@@ -11,9 +11,9 @@ typedef struct {
     assoc_t assoc;
 } fixity_t;
 
-#define PREC_UPDATE (-(1LL << 63))
-#define PREC_ARROW (PREC_UPDATE + 1)
-#define PREC_APP (9223372036854775807LL)
+#define PREC_ARROW (-(1LL << 63))
+#define PREC_UPDATE (9223372036854775807LL)
+#define PREC_APP (PREC_UPDATE - 1)
 
 #define APP_FIXITY \
     { PREC_APP, assoc_left }

--- a/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTable.hs
@@ -40,7 +40,8 @@ data InfoTable = InfoTable
     _infoInductives :: HashMap S.NameId InductiveInfo,
     _infoFunctions :: HashMap S.NameId FunctionInfo,
     _infoFixities :: HashMap S.NameId FixityDef,
-    _infoPriorities :: IntSet
+    _infoPriorities :: IntSet,
+    _infoPrecedenceGraph :: HashMap S.NameId (HashSet S.NameId)
   }
 
 emptyInfoTable :: InfoTable
@@ -52,7 +53,8 @@ emptyInfoTable =
       _infoInductives = mempty,
       _infoFunctions = mempty,
       _infoFixities = mempty,
-      _infoPriorities = mempty
+      _infoPriorities = mempty,
+      _infoPrecedenceGraph = mempty
     }
 
 makeLenses ''InfoTable

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -8,6 +8,8 @@ module Juvix.Compiler.Concrete.Extra
     flattenStatement,
     migrateFunctionSyntax,
     recordNameSignatureByIndex,
+    getExpressionAtomIden,
+    getPatternAtomIden,
   )
 where
 
@@ -198,3 +200,15 @@ migrateFunctionSyntax m = over moduleBody (mapMaybe goStatement) m
 
 recordNameSignatureByIndex :: RecordNameSignature -> IntMap Symbol
 recordNameSignatureByIndex = IntMap.fromList . (^.. recordNames . each . to swap)
+
+getExpressionAtomIden :: ExpressionAtom 'Scoped -> Maybe S.Name
+getExpressionAtomIden = \case
+  AtomIdentifier nm -> Just (nm ^. scopedIden)
+  _ -> Nothing
+
+getPatternAtomIden :: PatternAtom 'Scoped -> Maybe S.Name
+getPatternAtomIden = \case
+  PatternAtomIden i -> case i of
+    PatternScopedConstructor c -> Just c
+    _ -> Nothing
+  _ -> Nothing

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -574,10 +574,10 @@ instance SingI s => PrettyPrint (Lambda s) where
 
 instance PrettyPrint Precedence where
   ppCode = \case
-    PrecUpdate -> noLoc (pretty ("-ω₁" :: Text))
     PrecArrow -> noLoc (pretty ("-ω" :: Text))
     PrecNat n -> noLoc (pretty n)
     PrecApp -> noLoc (pretty ("ω" :: Text))
+    PrecUpdate -> noLoc (pretty ("ω₁" :: Text))
 
 instance SingI s => PrettyPrint (FixitySyntaxDef s) where
   ppCode FixitySyntaxDef {..} = do

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -2327,26 +2327,14 @@ checkExpressionPrecedences (ExpressionAtoms atoms _) =
   checkPrecedences opers
   where
     opers :: [S.Name]
-    opers = mapMaybe getIden (toList atoms)
-
-    getIden :: ExpressionAtom 'Scoped -> Maybe S.Name
-    getIden a = case a of
-      AtomIdentifier nm -> Just (nm ^. scopedIden)
-      _ -> Nothing
+    opers = mapMaybe P.getExpressionAtomIden (toList atoms)
 
 checkPatternPrecedences :: Members '[Error ScoperError, InfoTableBuilder] r => PatternAtoms 'Scoped -> Sem r ()
 checkPatternPrecedences (PatternAtoms atoms _) =
   checkPrecedences opers
   where
     opers :: [S.Name]
-    opers = mapMaybe getIden (toList atoms)
-
-    getIden :: PatternAtom 'Scoped -> Maybe S.Name
-    getIden = \case
-      PatternAtomIden i -> case i of
-        PatternScopedConstructor c -> Just c
-        _ -> Nothing
-      _ -> Nothing
+    opers = mapMaybe P.getPatternAtomIden (toList atoms)
 
 -------------------------------------------------------------------------------
 -- Infix Expression

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -612,6 +612,11 @@ resolveFixitySyntaxDef fdef@FixitySyntaxDef {..} = topBindings $ do
   below <- mapM (checkFixitySymbol . WithLoc loc) $ fi ^. FI.fixityPrecBelow
   above <- mapM (checkFixitySymbol . WithLoc loc) $ fi ^. FI.fixityPrecAbove
   tab <- getInfoTable
+  fid <- maybe freshNameId (return . getFixityId tab) same
+  let below' = map (getFixityId tab) below
+      above' = map (getFixityId tab) above
+  forM_ above' (`registerPrecedence` fid)
+  forM_ below' (registerPrecedence fid)
   let samePrec = getPrec tab <$> same
       belowPrec :: Integer
       belowPrec = fromIntegral $ maximum (minInt + 1 : map (getPrec tab) above)
@@ -625,7 +630,8 @@ resolveFixitySyntaxDef fdef@FixitySyntaxDef {..} = topBindings $ do
   let prec = fromMaybe (fromInteger $ (abovePrec + belowPrec) `div` 2) samePrec
       fx =
         Fixity
-          { _fixityPrecedence = PrecNat prec,
+          { _fixityId = Just fid,
+            _fixityPrecedence = PrecNat prec,
             _fixityArity =
               case fi ^. FI.fixityArity of
                 FI.Unary -> Unary AssocPostfix
@@ -653,8 +659,14 @@ resolveFixitySyntaxDef fdef@FixitySyntaxDef {..} = topBindings $ do
       Just same -> Just <$> checkFixitySymbol (WithLoc loc same)
       Nothing -> return Nothing
 
+    getFixityDef :: InfoTable -> S.Symbol -> FixityDef
+    getFixityDef tab = fromJust . flip HashMap.lookup (tab ^. infoFixities) . (^. S.nameId)
+
     getPrec :: InfoTable -> S.Symbol -> Int
-    getPrec tab = (^. fixityDefPrec) . fromJust . flip HashMap.lookup (tab ^. infoFixities) . (^. S.nameId)
+    getPrec tab = (^. fixityDefPrec) . getFixityDef tab
+
+    getFixityId :: InfoTable -> S.Symbol -> S.NameId
+    getFixityId tab = fromJust . (^. fixityDefFixity . fixityId) . getFixityDef tab
 
 resolveOperatorSyntaxDef ::
   forall r.
@@ -2283,6 +2295,60 @@ resolveSyntaxDef = \case
   SyntaxIterator iterDef -> resolveIteratorSyntaxDef iterDef
 
 -------------------------------------------------------------------------------
+-- Check precedences are comparable
+-------------------------------------------------------------------------------
+
+checkPrecedences ::
+  forall r.
+  Members '[Error ScoperError, InfoTableBuilder] r =>
+  [S.Name] ->
+  Sem r ()
+checkPrecedences opers = do
+  tab <- getInfoTable
+  let fids = mapMaybe (^. fixityId) $ mapMaybe (^. S.nameFixity) opers
+      deps = createDependencyInfo (tab ^. infoPrecedenceGraph) mempty
+  mapM_ (uncurry (checkPath deps)) $
+    [(fid1, fid2) | fid1 <- fids, fid2 <- fids, fid1 /= fid2]
+  where
+    checkPath :: DependencyInfo S.NameId -> S.NameId -> S.NameId -> Sem r ()
+    checkPath deps fid1 fid2 =
+      unless (isPath deps fid1 fid2 || isPath deps fid2 fid1) $
+        throw (ErrIncomparablePrecedences (IncomaprablePrecedences (findOper fid1) (findOper fid2)))
+
+    findOper :: S.NameId -> S.Name
+    findOper fid =
+      fromJust $
+        find
+          (maybe False (\fx -> Just fid == (fx ^. fixityId)) . (^. S.nameFixity))
+          opers
+
+checkExpressionPrecedences :: Members '[Error ScoperError, InfoTableBuilder] r => ExpressionAtoms 'Scoped -> Sem r ()
+checkExpressionPrecedences (ExpressionAtoms atoms _) =
+  checkPrecedences opers
+  where
+    opers :: [S.Name]
+    opers = mapMaybe getIden (toList atoms)
+
+    getIden :: ExpressionAtom 'Scoped -> Maybe S.Name
+    getIden a = case a of
+      AtomIdentifier nm -> Just (nm ^. scopedIden)
+      _ -> Nothing
+
+checkPatternPrecedences :: Members '[Error ScoperError, InfoTableBuilder] r => PatternAtoms 'Scoped -> Sem r ()
+checkPatternPrecedences (PatternAtoms atoms _) =
+  checkPrecedences opers
+  where
+    opers :: [S.Name]
+    opers = mapMaybe getIden (toList atoms)
+
+    getIden :: PatternAtom 'Scoped -> Maybe S.Name
+    getIden = \case
+      PatternAtomIden i -> case i of
+        PatternScopedConstructor c -> Just c
+        _ -> Nothing
+      _ -> Nothing
+
+-------------------------------------------------------------------------------
 -- Infix Expression
 -------------------------------------------------------------------------------
 
@@ -2385,10 +2451,11 @@ makeExpressionTable (ExpressionAtoms atoms _) = [recordUpdate] : [appOpExplicit]
 
 parseExpressionAtoms ::
   forall r.
-  (Members '[Error ScoperError, State Scope] r) =>
+  (Members '[Error ScoperError, State Scope, InfoTableBuilder] r) =>
   ExpressionAtoms 'Scoped ->
   Sem r Expression
-parseExpressionAtoms a@(ExpressionAtoms sections _) = do
+parseExpressionAtoms a@(ExpressionAtoms atoms _) = do
+  checkExpressionPrecedences a
   case res of
     Left {} ->
       throw
@@ -2399,7 +2466,7 @@ parseExpressionAtoms a@(ExpressionAtoms sections _) = do
   where
     parser :: Parse Expression
     parser = runM (mkExpressionParser tbl) <* P.eof
-    res = P.parse parser filePath (toList sections)
+    res = P.parse parser filePath (toList atoms)
     tbl = makeExpressionTable a
     filePath :: FilePath
     filePath = ""
@@ -2731,7 +2798,7 @@ mkPatternParser table = embed @ParsePat pPattern
         parseTermRec = runReader pPattern parsePatternTerm
 
 parsePatternAtom ::
-  (Members '[Error ScoperError, State Scope] r) =>
+  (Members '[Error ScoperError, State Scope, InfoTableBuilder] r) =>
   PatternAtom 'Scoped ->
   Sem r PatternArg
 parsePatternAtom = parsePatternAtoms . singletonAtom
@@ -2740,10 +2807,11 @@ parsePatternAtom = parsePatternAtoms . singletonAtom
     singletonAtom a = PatternAtoms (NonEmpty.singleton a) (Irrelevant (getLoc a))
 
 parsePatternAtoms ::
-  (Members '[Error ScoperError, State Scope] r) =>
+  (Members '[Error ScoperError, State Scope, InfoTableBuilder] r) =>
   PatternAtoms 'Scoped ->
   Sem r PatternArg
 parsePatternAtoms atoms@(PatternAtoms sec' _) = do
+  checkPatternPrecedences atoms
   case run (runError res) of
     Left e -> throw e -- Scoper effect error
     Right Left {} -> throw (ErrInfixPattern (InfixErrorP atoms)) -- Megaparsec error

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -47,6 +47,7 @@ data ScoperError
   | ErrRepeatedField RepeatedField
   | ErrConstructorNotARecord ConstructorNotARecord
   | ErrPrecedenceInconsistency PrecedenceInconsistencyError
+  | ErrIncomparablePrecedences IncomaprablePrecedences
 
 instance ToGenericError ScoperError where
   genericError = \case
@@ -85,3 +86,4 @@ instance ToGenericError ScoperError where
     ErrRepeatedField e -> genericError e
     ErrConstructorNotARecord e -> genericError e
     ErrPrecedenceInconsistency e -> genericError e
+    ErrIncomparablePrecedences e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -879,3 +879,28 @@ instance ToGenericError PrecedenceInconsistencyError where
     where
       i :: Interval
       i = getLoc _precedenceInconsistencyErrorFixityDef
+
+data IncomaprablePrecedences = IncomaprablePrecedences
+  { _incomparablePrecedencesName1 :: S.Name,
+    _incomparablePrecedencesName2 :: S.Name
+  }
+  deriving stock (Show)
+
+instance ToGenericError IncomaprablePrecedences where
+  genericError IncomaprablePrecedences {..} = do
+    opts <- fromGenericOptions <$> ask
+    let msg =
+          "Operators"
+            <+> ppCode opts _incomparablePrecedencesName1
+            <+> "and"
+            <+> ppCode opts _incomparablePrecedencesName2
+            <+> "have incomparable precedences"
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = mkAnsiText msg,
+          _genericErrorIntervals = [i]
+        }
+    where
+      i :: Interval
+      i = getLoc _incomparablePrecedencesName1

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -307,7 +307,7 @@ instance HasAtomicity (Bottom' i a) where
   atomicity _ = Atom
 
 lambdaFixity :: Fixity
-lambdaFixity = Fixity (PrecNat 0) (Unary AssocPostfix)
+lambdaFixity = Fixity (PrecNat 0) (Unary AssocPostfix) Nothing
 
 makeLenses ''LambdaLhs'
 makeLenses ''PiLhs'

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -307,7 +307,12 @@ instance HasAtomicity (Bottom' i a) where
   atomicity _ = Atom
 
 lambdaFixity :: Fixity
-lambdaFixity = Fixity (PrecNat 0) (Unary AssocPostfix) Nothing
+lambdaFixity =
+  Fixity
+    { _fixityPrecedence = PrecNat 0,
+      _fixityArity = Unary AssocPostfix,
+      _fixityId = Nothing
+    }
 
 makeLenses ''LambdaLhs'
 makeLenses ''PiLhs'

--- a/src/Juvix/Data/DependencyInfo.hs
+++ b/src/Juvix/Data/DependencyInfo.hs
@@ -6,10 +6,6 @@ import Data.HashSet qualified as HashSet
 import Juvix.Prelude.Base
 import Juvix.Prelude.Pretty
 
--- | DependencyInfo is polymorphic to anticipate future use with other identifier
--- types in JuvixCore and further. The graph algorithms don't depend on the
--- exact type of names (the polymorphic type n), so there is no reason to
--- specialise DependencyInfo to any particular name type
 data DependencyInfo n = DependencyInfo
   { _depInfoGraph :: Graph,
     _depInfoNodeFromVertex :: Vertex -> (n, HashSet n),
@@ -59,6 +55,12 @@ nameFromVertex depInfo = fst . (depInfo ^. depInfoNodeFromVertex)
 
 isReachable :: (Hashable n) => DependencyInfo n -> n -> Bool
 isReachable depInfo n = HashSet.member n (depInfo ^. depInfoReachable)
+
+isPath :: DependencyInfo n -> n -> n -> Bool
+isPath depInfo n n' = Graph.path (depInfo ^. depInfoGraph) v v'
+  where
+    v = fromJust $ (depInfo ^. depInfoVertexFromName) n
+    v' = fromJust $ (depInfo ^. depInfoVertexFromName) n'
 
 buildSCCs :: Ord n => DependencyInfo n -> [SCC n]
 buildSCCs = Graph.stronglyConnComp . (^. depInfoEdgeList)

--- a/src/Juvix/Data/Fixity.hs
+++ b/src/Juvix/Data/Fixity.hs
@@ -1,14 +1,15 @@
 module Juvix.Data.Fixity where
 
+import Juvix.Data.NameId
 import Juvix.Prelude.Base
 
 -- | Note that the order of the constructors is important due to the `Ord`
 -- instance.
 data Precedence
-  = PrecUpdate
-  | PrecArrow
+  = PrecArrow
   | PrecNat Int
   | PrecApp
+  | PrecUpdate
   deriving stock (Show, Eq, Data, Ord)
 
 data UnaryAssoc = AssocPostfix
@@ -27,7 +28,8 @@ data OperatorArity
 
 data Fixity = Fixity
   { _fixityPrecedence :: Precedence,
-    _fixityArity :: OperatorArity
+    _fixityArity :: OperatorArity,
+    _fixityId :: Maybe NameId
   }
   deriving stock (Show, Eq, Ord, Data)
 
@@ -68,13 +70,13 @@ isUnary :: Fixity -> Bool
 isUnary = not . isBinary
 
 appFixity :: Fixity
-appFixity = Fixity PrecApp (Binary AssocLeft)
+appFixity = Fixity PrecApp (Binary AssocLeft) Nothing
 
 funFixity :: Fixity
-funFixity = Fixity PrecArrow (Binary AssocRight)
+funFixity = Fixity PrecArrow (Binary AssocRight) Nothing
 
 updateFixity :: Fixity
-updateFixity = Fixity PrecUpdate (Unary AssocPostfix)
+updateFixity = Fixity PrecUpdate (Unary AssocPostfix) Nothing
 
 atomParens :: (Fixity -> Bool) -> Atomicity -> Fixity -> Bool
 atomParens associates argAtom opInf = case argAtom of

--- a/src/Juvix/Data/Fixity.hs
+++ b/src/Juvix/Data/Fixity.hs
@@ -70,13 +70,28 @@ isUnary :: Fixity -> Bool
 isUnary = not . isBinary
 
 appFixity :: Fixity
-appFixity = Fixity PrecApp (Binary AssocLeft) Nothing
+appFixity =
+  Fixity
+    { _fixityPrecedence = PrecApp,
+      _fixityArity = (Binary AssocLeft),
+      _fixityId = Nothing
+    }
 
 funFixity :: Fixity
-funFixity = Fixity PrecArrow (Binary AssocRight) Nothing
+funFixity =
+  Fixity
+    { _fixityPrecedence = PrecArrow,
+      _fixityArity = (Binary AssocRight),
+      _fixityId = Nothing
+    }
 
 updateFixity :: Fixity
-updateFixity = Fixity PrecUpdate (Unary AssocPostfix) Nothing
+updateFixity =
+  Fixity
+    { _fixityPrecedence = PrecUpdate,
+      _fixityArity = (Unary AssocPostfix),
+      _fixityId = Nothing
+    }
 
 atomParens :: (Fixity -> Bool) -> Atomicity -> Fixity -> Bool
 atomParens associates argAtom opInf = case argAtom of

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -343,5 +343,12 @@ scoperErrorTests =
       $(mkRelFile "RepeatedFieldPattern.juvix")
       $ \case
         ErrRepeatedField RepeatedField {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Incomparable precedences"
+      $(mkRelDir ".")
+      $(mkRelFile "IncomparablePrecedences.juvix")
+      $ \case
+        ErrIncomparablePrecedences {} -> Nothing
         _ -> wrongError
   ]

--- a/tests/Compilation/positive/test060.juvix
+++ b/tests/Compilation/positive/test060.juvix
@@ -17,8 +17,7 @@ type Pair (A B : Type) :=
     };
 
 mf : Pair (Pair Bool (List Nat)) (List Nat) → Bool
-  | mkPair@{fst := mkPair@{fst; snd := nil};
-  snd := zero :: _} := fst
+  | mkPair@{fst := mkPair@{fst; snd := nil}; snd := zero :: _} := fst
   | _ := false;
 
 main : Triple Nat Nat Nat :=
@@ -33,7 +32,7 @@ main : Triple Nat Nat Nat :=
     f :
       Triple Nat Nat Nat -> Triple Nat Nat Nat :=
         (@Triple{fst := fst * 10});
-  in if
-    (mf (mkPair (fst := mkPair true nil; snd := 0 :: nil)))
+  in
+  if (mf (mkPair (fst := mkPair true nil; snd := 0 :: nil)))
     (f p')
     (mkTriple (fst := 0; thd := 0; snd := 0));

--- a/tests/Compilation/positive/test060.juvix
+++ b/tests/Compilation/positive/test060.juvix
@@ -17,7 +17,8 @@ type Pair (A B : Type) :=
     };
 
 mf : Pair (Pair Bool (List Nat)) (List Nat) → Bool
-  | mkPair@{fst := mkPair@{fst; snd := nil}; snd := zero :: _} := fst
+  | mkPair@{fst := mkPair@{fst; snd := nil};
+  snd := zero :: _} := fst
   | _ := false;
 
 main : Triple Nat Nat Nat :=
@@ -32,7 +33,7 @@ main : Triple Nat Nat Nat :=
     f :
       Triple Nat Nat Nat -> Triple Nat Nat Nat :=
         (@Triple{fst := fst * 10});
-  in
-  if (mf (mkPair (fst := mkPair true nil; snd := 0 :: nil)))
+  in if
+    (mf (mkPair (fst := mkPair true nil; snd := 0 :: nil)))
     (f p')
     (mkTriple (fst := 0; thd := 0; snd := 0));

--- a/tests/negative/IncomparablePrecedences.juvix
+++ b/tests/negative/IncomparablePrecedences.juvix
@@ -1,0 +1,19 @@
+module IncomparablePrecedences;
+
+type Bool := true | false;
+
+syntax fixity log1 {arity: binary, assoc: left};
+syntax fixity log2 {arity: binary, assoc: right};
+
+syntax operator && log1;
+syntax operator || log2;
+
+&& : Bool -> Bool -> Bool
+  | true x := x
+  | false _ := false;
+
+|| : Bool -> Bool -> Bool
+  | true _ := true
+  | false x := x;
+
+main : Bool := false && true || true;


### PR DESCRIPTION
Give an error when there are two operators with incomparable precedences instead of linearising the ordering arbitrarily.
