### PR TITLE
add Rhs to SigArg and InductiveParameters

### DIFF
--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -329,12 +329,30 @@ data IteratorSyntaxDef = IteratorSyntaxDef
 instance HasLoc IteratorSyntaxDef where
   getLoc IteratorSyntaxDef {..} = getLoc _iterSyntaxKw <> getLoc _iterSymbol
 
+data SigArgRhs (s :: Stage) = SigArgRhs
+  { _sigArgColon :: Irrelevant KeywordRef,
+    _sigArgType :: ExpressionType s
+  }
+
+deriving stock instance Show (SigArgRhs 'Parsed)
+
+deriving stock instance Show (SigArgRhs 'Scoped)
+
+deriving stock instance Eq (SigArgRhs 'Parsed)
+
+deriving stock instance Eq (SigArgRhs 'Scoped)
+
+deriving stock instance Ord (SigArgRhs 'Parsed)
+
+deriving stock instance Ord (SigArgRhs 'Scoped)
+
 data SigArg (s :: Stage) = SigArg
   { _sigArgDelims :: Irrelevant (KeywordRef, KeywordRef),
     _sigArgImplicit :: IsImplicit,
-    _sigArgColon :: Maybe (Irrelevant KeywordRef),
     _sigArgNames :: NonEmpty (Argument s),
-    _sigArgType :: ExpressionType s
+    -- | The rhs is only optional for implicit arguments. Omitting the rhs is
+    -- equivalent to writing `: Type`.
+    _sigArgRhs :: Maybe (SigArgRhs s)
   }
 
 deriving stock instance Show (SigArg 'Parsed)
@@ -582,10 +600,26 @@ deriving stock instance Ord (ConstructorRhs 'Parsed)
 
 deriving stock instance Ord (ConstructorRhs 'Scoped)
 
+data InductiveParametersRhs (s :: Stage) = InductiveParametersRhs
+  { _inductiveParametersColon :: Irrelevant KeywordRef,
+    _inductiveParametersType :: ExpressionType s
+  }
+
+deriving stock instance Show (InductiveParametersRhs 'Parsed)
+
+deriving stock instance Show (InductiveParametersRhs 'Scoped)
+
+deriving stock instance Eq (InductiveParametersRhs 'Parsed)
+
+deriving stock instance Eq (InductiveParametersRhs 'Scoped)
+
+deriving stock instance Ord (InductiveParametersRhs 'Parsed)
+
+deriving stock instance Ord (InductiveParametersRhs 'Scoped)
+
 data InductiveParameters (s :: Stage) = InductiveParameters
   { _inductiveParametersNames :: NonEmpty (SymbolType s),
-    _inductiveParametersType :: ExpressionType s,
-    _inductiveParametersColon :: Maybe KeywordRef
+    _inductiveParametersRhs :: Maybe (InductiveParametersRhs s)
   }
 
 deriving stock instance Show (InductiveParameters 'Parsed)
@@ -1689,11 +1723,13 @@ makeLenses ''ConstructorDef
 makeLenses ''Module
 makeLenses ''TypeSignature
 makeLenses ''SigArg
+makeLenses ''SigArgRhs
 makeLenses ''FunctionDef
 makeLenses ''AxiomDef
 makeLenses ''ExportInfo
 makeLenses ''FunctionClause
 makeLenses ''InductiveParameters
+makeLenses ''InductiveParametersRhs
 makeLenses ''ModuleRef'
 makeLenses ''ModuleRef''
 makeLenses ''OpenModule
@@ -1784,7 +1820,7 @@ instance HasLoc ScopedIden where
   getLoc = getLoc . (^. scopedIden)
 
 instance SingI s => HasLoc (InductiveParameters s) where
-  getLoc i = getLocSymbolType (i ^. inductiveParametersNames . _head1) <> getLocExpressionType (i ^. inductiveParametersType)
+  getLoc i = getLocSymbolType (i ^. inductiveParametersNames . _head1) <>? (getLocExpressionType <$> (i ^? inductiveParametersRhs . _Just . inductiveParametersType))
 
 instance HasLoc (InductiveDef s) where
   getLoc i = (getLoc <$> i ^. inductivePositive) ?<> getLoc (i ^. inductiveKw)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -759,18 +759,18 @@ instance SingI s => PrettyPrint (Argument s) where
     ArgumentSymbol s -> ppSymbolType s
     ArgumentWildcard w -> ppCode w
 
+instance SingI s => PrettyPrint (SigArgRhs s) where
+  ppCode :: (Members '[ExactPrint, Reader Options] r) => SigArgRhs s -> Sem r ()
+  ppCode SigArgRhs {..} =
+    ppCode _sigArgColon <+> ppExpressionType _sigArgType
+
 instance SingI s => PrettyPrint (SigArg s) where
   ppCode :: Members '[ExactPrint, Reader Options] r => SigArg s -> Sem r ()
   ppCode SigArg {..} = do
     let Irrelevant (l, r) = _sigArgDelims
         names' = hsep (fmap ppCode _sigArgNames)
-    case _sigArgColon of
-      Just c -> do
-        let colon' = ppCode c
-            ty' = ppExpressionType _sigArgType
-        ppCode l <> names' <+> colon' <+> ty' <> ppCode r
-      Nothing ->
-        ppCode l <> names' <> ppCode r
+        rhs = ppCode <$> _sigArgRhs
+    ppCode l <> names' <+?> rhs <> ppCode r
 
 instance SingI s => PrettyPrint (FunctionDef s) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => FunctionDef s -> Sem r ()
@@ -968,12 +968,15 @@ ppPatternAtom = case sing :: SStage s of
       PatternVariable s | s ^. S.nameVerbatim == "=" -> parens (ppCodeAtom pat)
       _ -> ppCodeAtom pat
 
+instance SingI s => PrettyPrint (InductiveParametersRhs s) where
+  ppCode InductiveParametersRhs {..} =
+    ppCode _inductiveParametersColon <+> ppExpressionType _inductiveParametersType
+
 instance SingI s => PrettyPrint (InductiveParameters s) where
   ppCode InductiveParameters {..} = do
     let names' = fmap (\nm -> annDef nm (ppSymbolType nm)) _inductiveParametersNames
-        ty' = ppExpressionType _inductiveParametersType
-    case _inductiveParametersColon of
-      Just {} -> parens (hsep names' <+> ppCode Kw.kwColon <+> ty')
+    case _inductiveParametersRhs of
+      Just rhs -> parens (hsep names' <+> ppCode rhs)
       Nothing -> hsep names'
 
 instance SingI s => PrettyPrint (NonEmpty (InductiveParameters s)) where

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -744,13 +744,22 @@ checkFunctionDef FunctionDef {..} = do
       names' <- forM _sigArgNames $ \case
         ArgumentSymbol s -> ArgumentSymbol <$> bindVariableSymbol s
         ArgumentWildcard w -> return $ ArgumentWildcard w
-      ty' <- checkParseExpressionAtoms _sigArgType
+      rhs' <- mapM checkArgRhs _sigArgRhs
       return
         SigArg
           { _sigArgNames = names',
-            _sigArgType = ty',
+            _sigArgRhs = rhs',
             ..
           }
+      where
+        checkArgRhs :: SigArgRhs 'Parsed -> Sem r (SigArgRhs 'Scoped)
+        checkArgRhs SigArgRhs {..} = do
+          ty' <- checkParseExpressionAtoms _sigArgType
+          return
+            SigArgRhs
+              { _sigArgType = ty',
+                _sigArgColon
+              }
     checkBody :: Sem r (FunctionDefBody 'Scoped)
     checkBody = case _signBody of
       SigBodyExpression e -> SigBodyExpression <$> checkParseExpressionAtoms e
@@ -793,10 +802,15 @@ checkInductiveParameters ::
   InductiveParameters 'Parsed ->
   Sem r (InductiveParameters 'Scoped)
 checkInductiveParameters params = do
-  _inductiveParametersType <- checkParseExpressionAtoms (params ^. inductiveParametersType)
+  _inductiveParametersRhs <- mapM checkRhs (params ^. inductiveParametersRhs)
   _inductiveParametersNames <- mapM bindVariableSymbol (params ^. inductiveParametersNames)
-  let _inductiveParametersColon = params ^. inductiveParametersColon
   return InductiveParameters {..}
+  where
+    checkRhs :: InductiveParametersRhs 'Parsed -> Sem r (InductiveParametersRhs 'Scoped)
+    checkRhs rhs = do
+      let _inductiveParametersColon = rhs ^. inductiveParametersColon
+      _inductiveParametersType <- checkParseExpressionAtoms (rhs ^. inductiveParametersType)
+      return InductiveParametersRhs {..}
 
 checkInductiveDef ::
   forall r.


### PR DESCRIPTION
This refactor avoids adding a type in the concrete syntax that is omitted in the source code. Even though it requires two extra data types, I think the AST better reflects the structure of the actual concrete syntax.