### PR TITLE
Fix bug in arity checker with pi types

### DIFF
--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -272,7 +272,11 @@ tests =
     posTest
       "Omit Type annotation"
       $(mkRelDir ".")
-      $(mkRelFile "OmitType.juvix")
+      $(mkRelFile "OmitType.juvix"),
+    posTest
+      "Issue 2296 (Pi types with lhs arity other than unit)"
+      $(mkRelDir "issue2296")
+      $(mkRelFile "M.juvix")
   ]
     <> [ compilationTest t | t <- Compilation.tests
        ]

--- a/tests/positive/issue2296/M.juvix
+++ b/tests/positive/issue2296/M.juvix
@@ -1,0 +1,4 @@
+module M;
+
+f : (F : Type → Type) → (A : Type) → F A → F A;
+f _ _ x := x;

--- a/tests/positive/issue2296/juvix.yaml
+++ b/tests/positive/issue2296/juvix.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- .juvix-build/stdlib/
+name: issue2296
+version: 0.0.0


### PR DESCRIPTION
All variables bound in a pi type were assumed to be of arity unit. This pr fixes that.

- Closes #2296 