### PR TITLE
Aliasing

### DIFF
--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -286,6 +286,7 @@ printDocumentation = replParseIdentifiers >=> printIdentifiers
             KNameConstructor -> getDocConstructor n
             KNameLocalModule -> impossible
             KNameTopModule -> impossible
+            KNameAlias -> impossible
             KNameFixity -> impossible
           printDoc mdoc
           where
@@ -344,6 +345,7 @@ printDefinition = replParseIdentifiers >=> printIdentifiers
                 KNameLocalModule -> impossible
                 KNameTopModule -> impossible
                 KNameFixity -> impossible
+                KNameAlias -> impossible
           where
             printLocation :: HasLoc s => s -> Repl ()
             printLocation def = do

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -277,7 +277,7 @@ printDocumentation = replParseIdentifiers >=> printIdentifiers
 
         printIdentifier :: Concrete.ScopedIden -> Repl ()
         printIdentifier s = do
-          let n = s ^. Concrete.scopedIden . Scoped.nameId
+          let n = s ^. Concrete.scopedIdenFinal . Scoped.nameId
           mdoc <- case getNameKind s of
             KNameAxiom -> getDocAxiom n
             KNameInductive -> getDocInductive n
@@ -334,7 +334,7 @@ printDefinition = replParseIdentifiers >=> printIdentifiers
 
         printIdentifier :: Concrete.ScopedIden -> Repl ()
         printIdentifier s =
-          let n = s ^. Concrete.scopedIden . Scoped.nameId
+          let n = s ^. Concrete.scopedIdenFinal . Scoped.nameId
            in case getNameKind s of
                 KNameAxiom -> printAxiom n
                 KNameInductive -> printInductive n

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped/Source.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped/Source.hs
@@ -293,6 +293,7 @@ putTag ann x = case ann of
               S.KNameLocal -> "ju-var"
               S.KNameAxiom -> "ju-axiom"
               S.KNameLocalModule -> "ju-var"
+              S.KNameAlias -> "ju-var"
               S.KNameTopModule -> "ju-var"
               S.KNameFixity -> "ju-fixity"
           )

--- a/src/Juvix/Compiler/Concrete/Data/Highlight.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight.hs
@@ -67,14 +67,14 @@ goFaceName n = do
   return (WithLoc (getLoc n) (PropertyFace f))
 
 goGotoProperty :: AName -> WithLoc PropertyGoto
-goGotoProperty (AName n) = WithLoc (getLoc n) PropertyGoto {..}
+goGotoProperty n = WithLoc (getLoc n) PropertyGoto {..}
   where
-    _gotoPos = n ^. nameDefined . intervalStart
-    _gotoFile = n ^. nameDefined . intervalFile
+    _gotoPos = n ^. anameDefinedLoc . intervalStart
+    _gotoFile = n ^. anameDefinedLoc . intervalFile
 
 goDocProperty :: Scoped.DocTable -> Internal.TypesTable -> AName -> Maybe (WithLoc PropertyDoc)
-goDocProperty doctbl tbl a@(AName n) = do
-  let ty :: Maybe Internal.Expression = tbl ^. at (n ^. nameId)
-  d <- ppDocDefault a ty (doctbl ^. at (n ^. nameId))
+goDocProperty doctbl tbl a = do
+  let ty :: Maybe Internal.Expression = tbl ^. at (a ^. anameDocId)
+  d <- ppDocDefault a ty (doctbl ^. at (a ^. anameDocId))
   let (_docText, _docSExp) = renderEmacs (layoutPretty defaultLayoutOptions d)
-  return (WithLoc (getLoc n) PropertyDoc {..})
+  return (WithLoc (getLoc a) PropertyDoc {..})

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/RenderEmacs.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/RenderEmacs.hs
@@ -16,6 +16,7 @@ nameKindFace = \case
   KNameLocalModule -> Just FaceModule
   KNameAxiom -> Just FaceAxiom
   KNameLocal -> Nothing
+  KNameAlias -> Nothing
   KNameFixity -> Nothing
 
 fromCodeAnn :: CodeAnn -> Maybe EmacsProperty

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -57,7 +57,7 @@ toState = reinterpret $ \case
      in do
           modify (set (infoFunctions . at ref) (Just info))
           registerDoc (f ^. signName . nameId) j
-  RegisterName n -> modify (over highlightNames (cons (S.AName n)))
+  RegisterName n -> modify (over highlightNames (cons (S.anameFromName n)))
   RegisterModule m -> do
     let j = m ^. moduleDoc
     modify (over infoModules (HashMap.insert (m ^. modulePath) m))

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -92,7 +92,7 @@ anameFromScopedIden s =
   AName
     { _anameLoc = getLoc s,
       _anameKind = getNameKind s,
-      _anameDocId = s ^. scopedIden . nameId,
+      _anameDocId = s ^. scopedIdenFinal . nameId,
       _anameDefinedLoc = s ^. scopedIdenName . nameDefined,
       _anameVerbatim = s ^. scopedIdenName . nameVerbatim
     }

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -16,6 +16,7 @@ data InfoTableBuilder m a where
   RegisterInductive :: InductiveDef 'Scoped -> InfoTableBuilder m ()
   RegisterFunctionDef :: FunctionDef 'Scoped -> InfoTableBuilder m ()
   RegisterName :: HasLoc c => S.Name' c -> InfoTableBuilder m ()
+  RegisterScopedIden :: ScopedIden -> InfoTableBuilder m ()
   RegisterModule :: Module 'Scoped 'ModuleTop -> InfoTableBuilder m ()
   RegisterFixity :: FixityDef -> InfoTableBuilder m ()
   RegisterPrecedence :: S.NameId -> S.NameId -> InfoTableBuilder m ()
@@ -58,6 +59,7 @@ toState = reinterpret $ \case
           modify (set (infoFunctions . at ref) (Just info))
           registerDoc (f ^. signName . nameId) j
   RegisterName n -> modify (over highlightNames (cons (S.anameFromName n)))
+  RegisterScopedIden n -> modify (over highlightNames (cons (anameFromScopedIden n)))
   RegisterModule m -> do
     let j = m ^. moduleDoc
     modify (over infoModules (HashMap.insert (m ^. modulePath) m))
@@ -84,3 +86,13 @@ runInfoTableBuilder tab = runState tab . toState
 
 ignoreInfoTableBuilder :: Members '[HighlightBuilder] r => Sem (InfoTableBuilder ': r) a -> Sem r a
 ignoreInfoTableBuilder = evalState emptyInfoTable . toState
+
+anameFromScopedIden :: ScopedIden -> AName
+anameFromScopedIden s =
+  AName
+    { _anameLoc = getLoc s,
+      _anameKind = getNameKind s,
+      _anameDocId = s ^. scopedIden . nameId,
+      _anameDefinedLoc = s ^. scopedIdenName . nameDefined,
+      _anameVerbatim = s ^. scopedIdenName . nameVerbatim
+    }

--- a/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSpace.hs
@@ -20,6 +20,7 @@ $(genSingletons [''NameSpace])
 type NameKindNameSpace :: NameKind -> NameSpace
 type family NameKindNameSpace s = res where
   NameKindNameSpace 'KNameLocal = 'NameSpaceSymbols
+  NameKindNameSpace 'KNameAlias = 'NameSpaceSymbols
   NameKindNameSpace 'KNameConstructor = 'NameSpaceSymbols
   NameKindNameSpace 'KNameInductive = 'NameSpaceSymbols
   NameKindNameSpace 'KNameFunction = 'NameSpaceSymbols

--- a/src/Juvix/Compiler/Concrete/Data/Scope.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope.hs
@@ -16,7 +16,7 @@ import Juvix.Prelude
 nsEntry :: forall ns. SingI ns => Lens' (NameSpaceEntryType ns) (S.Name' ())
 nsEntry = case sing :: SNameSpace ns of
   SNameSpaceModules -> moduleEntry
-  SNameSpaceSymbols -> symbolEntry
+  SNameSpaceSymbols -> preSymbolName
   SNameSpaceFixities -> fixityEntry
 
 mkModuleRef' :: SingI t => ModuleRef'' 'S.NotConcrete t -> ModuleRef' 'S.NotConcrete

--- a/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
@@ -59,6 +59,7 @@ data ScoperState = ScoperState
     -- | Local and top modules
     _scoperModules :: HashMap S.ModuleNameId (ModuleRef' 'S.NotConcrete),
     _scoperScope :: HashMap TopModulePath Scope,
+    _scoperAlias :: HashMap S.NameId PreSymbolEntry,
     _scoperSignatures :: HashMap S.NameId NameSignature,
     -- | Indexed by the inductive type. This is used for record updates
     _scoperRecordFields :: HashMap S.NameId RecordInfo,

--- a/src/Juvix/Compiler/Concrete/Data/ScopedName.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ScopedName.hs
@@ -79,7 +79,27 @@ data Name' n = Name'
   }
   deriving stock (Show)
 
+-- | For highlighting
+data AName = AName
+  { _anameLoc :: Interval,
+    _anameDefinedLoc :: Interval,
+    _anameKind :: NameKind,
+    _anameDocId :: NameId,
+    _anameVerbatim :: Text
+  }
+
 makeLenses ''Name'
+makeLenses ''AName
+
+anameFromName :: HasLoc c => Name' c -> AName
+anameFromName n =
+  AName
+    { _anameLoc = getLoc n,
+      _anameDefinedLoc = n ^. nameDefined,
+      _anameKind = getNameKind n,
+      _anameDocId = n ^. nameId,
+      _anameVerbatim = n ^. nameVerbatim
+    }
 
 instance HasNameKind (Name' n) where
   getNameKind = (^. nameKind)
@@ -90,16 +110,11 @@ instance (HasLoc n) => HasLoc (Name' n) where
 instance (Pretty a) => Pretty (Name' a) where
   pretty = pretty . (^. nameConcrete)
 
-data AName = forall c.
-  (HasLoc c) =>
-  AName
-  {_aName :: Name' c}
-
 instance HasLoc AName where
-  getLoc (AName c) = getLoc c
+  getLoc = (^. anameLoc)
 
 instance HasNameKind AName where
-  getNameKind (AName c) = getNameKind c
+  getNameKind = (^. anameKind)
 
 hasFixity :: Name' s -> Bool
 hasFixity n = isJust (n ^. nameFixity)

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -147,6 +147,6 @@ getExpressionAtomIden = \case
 getPatternAtomIden :: PatternAtom 'Scoped -> Maybe S.Name
 getPatternAtomIden = \case
   PatternAtomIden i -> case i of
-    PatternScopedConstructor c -> Just c
+    PatternScopedConstructor c -> Just (c ^. scopedIdenName)
     _ -> Nothing
   _ -> Nothing

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -87,6 +87,7 @@ groupStatements = \case
       (StatementSyntax (SyntaxFixity _), _) -> False
       (StatementSyntax (SyntaxOperator o), s) -> definesSymbol (o ^. opSymbol) s
       (StatementSyntax (SyntaxIterator i), s) -> definesSymbol (i ^. iterSymbol) s
+      (StatementSyntax (SyntaxAlias {}), _) -> False
       (StatementImport _, StatementImport _) -> True
       (StatementImport i, StatementOpenModule o) -> case sing :: SStage s of
         SParsed -> True

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -141,7 +141,7 @@ recordNameSignatureByIndex = IntMap.fromList . (^.. recordNames . each . to swap
 
 getExpressionAtomIden :: ExpressionAtom 'Scoped -> Maybe S.Name
 getExpressionAtomIden = \case
-  AtomIdentifier nm -> Just (nm ^. scopedIden)
+  AtomIdentifier nm -> Just (nm ^. scopedIdenName)
   _ -> Nothing
 
 getPatternAtomIden :: PatternAtom 'Scoped -> Maybe S.Name

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -39,6 +39,7 @@ import Juvix.Data.Keyword.All
     kwLambda,
     kwLet,
     kwMapsTo,
+    kwAlias,
     kwModule,
     kwOpen,
     kwOperator,
@@ -94,5 +95,6 @@ nonKeywords =
     kwEq,
     kwFixity,
     kwOperator,
+    kwAlias,
     kwIterator
   ]

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -18,6 +18,8 @@ import Juvix.Data.Keyword.All
     delimParenR,
     delimSemicolon,
     -- keywords
+
+    kwAlias,
     kwAs,
     kwAssign,
     kwAt,
@@ -39,7 +41,6 @@ import Juvix.Data.Keyword.All
     kwLambda,
     kwLet,
     kwMapsTo,
-    kwAlias,
     kwModule,
     kwOpen,
     kwOperator,

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1199,9 +1199,9 @@ data PostfixApplication = PostfixApplication
   }
   deriving stock (Show, Eq, Ord)
 
-data LetStatement (s :: Stage) =
-  LetFunctionDef (FunctionDef s)
-  | LetAlias (AliasDef s)
+data LetStatement (s :: Stage)
+  = LetFunctionDef (FunctionDef s)
+  | LetAliasDef (AliasDef s)
 
 deriving stock instance Show (LetStatement 'Parsed)
 

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1059,7 +1059,7 @@ deriving stock instance Ord (OpenModule 'Parsed)
 deriving stock instance Ord (OpenModule 'Scoped)
 
 data ScopedIden = ScopedIden
-  { _scopedIden :: S.Name,
+  { _scopedIdenFinal :: S.Name,
     _scopedIdenAlias :: Maybe S.Name
   }
   deriving stock (Show, Eq, Ord)
@@ -2176,7 +2176,7 @@ instance IsApe InfixApplication ApeLeaf where
         { _infixFixity = getFixity i,
           _infixLeft = toApe l,
           _infixRight = toApe r,
-          _infixIsDelimiter = isDelimiterStr (prettyText (op ^. scopedIden . S.nameConcrete)),
+          _infixIsDelimiter = isDelimiterStr (prettyText (op ^. scopedIdenName . S.nameConcrete)),
           _infixOp = ApeLeafExpression (ExpressionIdentifier op)
         }
 
@@ -2296,7 +2296,7 @@ symbolEntryNameId :: SymbolEntry -> NameId
 symbolEntryNameId = (^. symbolEntry . S.nameId)
 
 instance HasNameKind ScopedIden where
-  getNameKind = getNameKind . (^. scopedIden)
+  getNameKind = getNameKind . (^. scopedIdenFinal)
 
 instance HasNameKind SymbolEntry where
   getNameKind = getNameKind . (^. symbolEntry)
@@ -2336,22 +2336,16 @@ _SyntaxAlias f x = case x of
 
 scopedIdenName :: Lens' ScopedIden S.Name
 scopedIdenName f n = case n ^. scopedIdenAlias of
-  Nothing -> scopedIden f n
+  Nothing -> scopedIdenFinal f n
   Just a -> do
     a' <- f a
     pure (set scopedIdenAlias (Just a') n)
 
-scopedIdenFixity :: ScopedIden -> Maybe Fixity
-scopedIdenFixity s = fromMaybe (s ^. scopedIden . S.nameFixity) (s ^? scopedIdenAlias . _Just . S.nameFixity)
-
-scopedIdenNameId :: ScopedIden -> NameId
-scopedIdenNameId s = fromMaybe (s ^. scopedIden . S.nameId) (s ^? scopedIdenAlias . _Just . S.nameId)
-
 instance HasFixity PostfixApplication where
-  getFixity (PostfixApplication _ op) = fromMaybe impossible (op ^. scopedIden . S.nameFixity)
+  getFixity (PostfixApplication _ op) = fromMaybe impossible (op ^. scopedIdenName . S.nameFixity)
 
 instance HasFixity InfixApplication where
-  getFixity (InfixApplication _ op _) = fromMaybe impossible (op ^. scopedIden . S.nameFixity)
+  getFixity (InfixApplication _ op _) = fromMaybe impossible (op ^. scopedIdenName . S.nameFixity)
 
 preSymbolName :: Lens' PreSymbolEntry (S.Name' ())
 preSymbolName f = \case

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -37,7 +37,7 @@ import Juvix.Data.Keyword
 import Juvix.Data.NameKind
 import Juvix.Parser.Lexer (isDelimiterStr)
 import Juvix.Prelude hiding (show)
-import Juvix.Prelude.Pretty (prettyText)
+import Juvix.Prelude.Pretty (Pretty, pretty, prettyText)
 import Prelude (show)
 
 type Delims = Irrelevant (Maybe (KeywordRef, KeywordRef))
@@ -1748,6 +1748,9 @@ instance (SingI s) => HasAtomicity (FunctionParameters s) where
     | otherwise = case sing :: SStage s of
         SParsed -> atomicity (p ^. paramType)
         SScoped -> atomicity (p ^. paramType)
+
+instance Pretty ScopedIden where
+  pretty = pretty . (^. scopedIdenName)
 
 instance HasLoc ScopedIden where
   getLoc = getLoc . (^. scopedIden)

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1753,7 +1753,7 @@ instance Pretty ScopedIden where
   pretty = pretty . (^. scopedIdenName)
 
 instance HasLoc ScopedIden where
-  getLoc = getLoc . (^. scopedIden)
+  getLoc = getLoc . (^. scopedIdenName)
 
 instance SingI s => HasLoc (InductiveParameters s) where
   getLoc i = getLocSymbolType (i ^. inductiveParametersNames . _head1) <>? (getLocExpressionType <$> (i ^? inductiveParametersRhs . _Just . inductiveParametersType))

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1199,10 +1199,26 @@ data PostfixApplication = PostfixApplication
   }
   deriving stock (Show, Eq, Ord)
 
+data LetStatement (s :: Stage) =
+  LetFunctionDef (FunctionDef s)
+  | LetAlias (AliasDef s)
+
+deriving stock instance Show (LetStatement 'Parsed)
+
+deriving stock instance Show (LetStatement 'Scoped)
+
+deriving stock instance Eq (LetStatement 'Parsed)
+
+deriving stock instance Eq (LetStatement 'Scoped)
+
+deriving stock instance Ord (LetStatement 'Parsed)
+
+deriving stock instance Ord (LetStatement 'Scoped)
+
 data Let (s :: Stage) = Let
   { _letKw :: KeywordRef,
     _letInKw :: Irrelevant KeywordRef,
-    _letFunDefs :: NonEmpty (FunctionDef s),
+    _letFunDefs :: NonEmpty (LetStatement s),
     _letExpression :: ExpressionType s
   }
 

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -1065,7 +1065,15 @@ instance PrettyPrint PreSymbolEntry where
     PreSymbolFinal a -> ppCode a
 
 instance PrettyPrint Alias where
-  ppCode _ = noLoc "TODO PrettyPrint Alias"
+  ppCode a =
+    noLoc
+      ( kindWord
+          P.<+> C.code ((pretty (a ^. aliasName . S.nameVerbatim)))
+          P.<+> "defined at"
+          P.<+> pretty (getLoc a)
+      )
+    where
+      kindWord :: Doc Ann = "Alias"
 
 instance PrettyPrint SymbolEntry where
   ppCode ent =

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -423,8 +423,11 @@ instance SingI s => PrettyPrint (Import s) where
 
 instance SingI s => PrettyPrint (AliasDef s) where
   ppCode AliasDef {..} =
-    ppCode _aliasDefSyntaxKw <+> ppCode _aliasDefAliasKw <+> ppSymbolType _aliasDefName
-      <+> ppCode Kw.kwAssign <+> ppIdentifierType _aliasDefAsName
+    ppCode _aliasDefSyntaxKw
+      <+> ppCode _aliasDefAliasKw
+      <+> ppSymbolType _aliasDefName
+      <+> ppCode Kw.kwAssign
+      <+> ppIdentifierType _aliasDefAsName
 
 instance SingI s => PrettyPrint (SyntaxDef s) where
   ppCode = \case

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -406,6 +406,7 @@ instance SingI t => PrettyPrint (ModuleRef'' 'S.NotConcrete t) where
 instance PrettyPrint (ModuleRef'' 'S.Concrete t) where
   ppCode m = ppCode (m ^. moduleRefName)
 
+-- FIXME this is wrong
 instance PrettyPrint ScopedIden where
   ppCode = ppCode . (^. scopedIden)
 

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -423,8 +423,8 @@ instance SingI s => PrettyPrint (Import s) where
 
 instance SingI s => PrettyPrint (AliasDef s) where
   ppCode AliasDef {..} =
-    ppCode _aliasSyntaxKw <+> ppCode _aliasAliasKw <+> ppSymbolType _aliasName
-      <+> ppCode Kw.kwAssign <+> ppIdentifierType _aliasAsName
+    ppCode _aliasDefSyntaxKw <+> ppCode _aliasDefAliasKw <+> ppSymbolType _aliasDefName
+      <+> ppCode Kw.kwAssign <+> ppIdentifierType _aliasDefAsName
 
 instance SingI s => PrettyPrint (SyntaxDef s) where
   ppCode = \case
@@ -1055,6 +1055,11 @@ instance SingI s => PrettyPrint (Statement s) where
     StatementOpenModule o -> ppCode o
     StatementAxiom a -> ppCode a
     StatementProjectionDef a -> ppCode a
+
+instance PrettyPrint PreSymbolEntry where
+  ppCode = \case
+    PreSymbolAlias a -> undefined
+    PreSymbolFinal a -> undefined
 
 instance PrettyPrint SymbolEntry where
   ppCode ent =

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -1061,8 +1061,11 @@ instance SingI s => PrettyPrint (Statement s) where
 
 instance PrettyPrint PreSymbolEntry where
   ppCode = \case
-    PreSymbolAlias a -> undefined
-    PreSymbolFinal a -> undefined
+    PreSymbolAlias a -> ppCode a
+    PreSymbolFinal a -> ppCode a
+
+instance PrettyPrint Alias where
+  ppCode _ = noLoc "TODO PrettyPrint Alias"
 
 instance PrettyPrint SymbolEntry where
   ppCode ent =

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -451,6 +451,11 @@ instance SingI s => PrettyPrint (LambdaClause s) where
         lambdaPipe' = ppCode <$> _lambdaPipe ^. unIrrelevant
     lambdaPipe' <?+> lambdaParameters' <+> ppCode _lambdaAssignKw <> oneLineOrNext lambdaBody'
 
+instance SingI s => PrettyPrint (LetStatement s) where
+  ppCode = \case
+    LetFunctionDef f -> ppCode f
+    LetAliasDef f -> ppCode f
+
 instance SingI s => PrettyPrint (Let s) where
   ppCode Let {..} = do
     let letFunDefs' = blockIndent (ppBlock _letFunDefs)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -230,7 +230,7 @@ instance SingI s => PrettyPrint (Iterator s) where
       hang (n <+?> is' <+?> rngs' <> b')
 
 instance PrettyPrint S.AName where
-  ppCode (S.AName n) = annotated (AnnKind (S.getNameKind n)) (noLoc (pretty (n ^. S.nameVerbatim)))
+  ppCode n = annotated (AnnKind (S.getNameKind n)) (noLoc (pretty (n ^. S.anameVerbatim)))
 
 instance PrettyPrint FunctionInfo where
   ppCode = \case
@@ -406,9 +406,8 @@ instance SingI t => PrettyPrint (ModuleRef'' 'S.NotConcrete t) where
 instance PrettyPrint (ModuleRef'' 'S.Concrete t) where
   ppCode m = ppCode (m ^. moduleRefName)
 
--- FIXME this is wrong
 instance PrettyPrint ScopedIden where
-  ppCode = ppCode . (^. scopedIden)
+  ppCode = ppCode . (^. scopedIdenName)
 
 instance SingI s => PrettyPrint (Import s) where
   ppCode :: forall r. Members '[ExactPrint, Reader Options] r => Import s -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -421,11 +421,17 @@ instance SingI s => PrettyPrint (Import s) where
         Nothing -> Nothing
         Just as -> Just (ppCode Kw.kwAs <+> ppModulePathType as)
 
+instance SingI s => PrettyPrint (AliasDef s) where
+  ppCode AliasDef {..} =
+    ppCode _aliasSyntaxKw <+> ppCode _aliasAliasKw <+> ppSymbolType _aliasName
+      <+> ppCode Kw.kwAssign <+> ppIdentifierType _aliasAsName
+
 instance SingI s => PrettyPrint (SyntaxDef s) where
   ppCode = \case
     SyntaxFixity f -> ppCode f
     SyntaxOperator op -> ppCode op
     SyntaxIterator it -> ppCode it
+    SyntaxAlias it -> ppCode it
 
 instance PrettyPrint Literal where
   ppCode = noLoc . ppLiteral

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -245,7 +245,7 @@ reserveSymbolOf k nameSig s = do
   modify (over scopeNameSpace (HashMap.alter (Just . addS entry) s))
   return s'
   where
-    isAlias  = case k of
+    isAlias = case k of
       SKNameAlias -> True
       _ -> False
     sns :: Sing ns = sing

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -545,8 +545,10 @@ entryToScopedIden ::
   PreSymbolEntry ->
   Sem r ScopedIden
 entryToScopedIden name e = do
-  let scopedName :: S.Name
-      scopedName = set S.nameConcrete name (e ^. preSymbolName)
+  let helper :: S.Name' x -> S.Name
+      helper = set S.nameConcrete name
+      scopedName :: S.Name
+      scopedName = helper (e ^. preSymbolName)
   si <- case e of
     PreSymbolFinal {} ->
       return
@@ -558,10 +560,10 @@ entryToScopedIden name e = do
       e' <- normalizePreSymbolEntry e
       return
         ScopedIden
-          { _scopedIdenAlias = Just scopedName,
-            _scopedIden = set S.nameConcrete name (e' ^. symbolEntry)
+          { _scopedIdenAlias = Just (set S.nameKind (getNameKind e') scopedName),
+            _scopedIden = helper (e' ^. symbolEntry)
           }
-  registerName scopedName
+  registerName (si ^. scopedIdenName)
   return si
 
 -- | We gather all symbols which have been defined or marked to be public in the given scope.

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -2236,8 +2236,20 @@ checkSyntaxDef ::
   Sem r (SyntaxDef 'Scoped)
 checkSyntaxDef = \case
   SyntaxFixity fixDef -> SyntaxFixity <$> checkFixitySyntaxDef fixDef
+  SyntaxAlias a -> SyntaxAlias <$> checkAliasDef a
   SyntaxOperator opDef -> return $ SyntaxOperator opDef
   SyntaxIterator iterDef -> return $ SyntaxIterator iterDef
+
+checkAliasDef ::
+  (Members '[Error ScoperError, Reader ScopeParameters, State Scope, State ScoperState, InfoTableBuilder, NameIdGen, State ScoperSyntax] r) =>
+  AliasDef 'Parsed ->
+  Sem r (AliasDef 'Scoped)
+checkAliasDef = undefined
+
+reserveAliasDef :: (Members '[Error ScoperError, Reader ScopeParameters, State Scope, State ScoperState, InfoTableBuilder, NameIdGen, State ScoperSyntax] r) =>
+  AliasDef 'Parsed ->
+  Sem r ()
+reserveAliasDef = undefined
 
 resolveSyntaxDef ::
   (Members '[Error ScoperError, Reader ScopeParameters, State Scope, State ScoperState, InfoTableBuilder, NameIdGen, State ScoperSyntax] r) =>
@@ -2247,6 +2259,7 @@ resolveSyntaxDef = \case
   SyntaxFixity fixDef -> resolveFixitySyntaxDef fixDef
   SyntaxOperator opDef -> resolveOperatorSyntaxDef opDef
   SyntaxIterator iterDef -> resolveIteratorSyntaxDef iterDef
+  SyntaxAlias a -> reserveAliasDef a
 
 -------------------------------------------------------------------------------
 -- Check precedences are comparable

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -563,7 +563,7 @@ entryToScopedIden name e = do
           { _scopedIdenAlias = Just (set S.nameKind (getNameKind e') scopedName),
             _scopedIden = helper (e' ^. symbolEntry)
           }
-  registerName (si ^. scopedIdenName)
+  registerScopedIden si
   return si
 
 -- | We gather all symbols which have been defined or marked to be public in the given scope.

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -46,6 +46,7 @@ data ScoperError
   | ErrConstructorNotARecord ConstructorNotARecord
   | ErrPrecedenceInconsistency PrecedenceInconsistencyError
   | ErrIncomparablePrecedences IncomaprablePrecedences
+  | ErrAliasCycle AliasCycle
 
 instance ToGenericError ScoperError where
   genericError = \case
@@ -83,3 +84,4 @@ instance ToGenericError ScoperError where
     ErrConstructorNotARecord e -> genericError e
     ErrPrecedenceInconsistency e -> genericError e
     ErrIncomparablePrecedences e -> genericError e
+    ErrAliasCycle e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -829,3 +829,25 @@ instance ToGenericError IncomaprablePrecedences where
     where
       i :: Interval
       i = getLoc _incomparablePrecedencesName1
+
+newtype AliasCycle = AliasCycle
+  { _aliasCycleDef :: (AliasDef 'Parsed)
+  }
+  deriving stock (Show)
+
+instance ToGenericError AliasCycle where
+  genericError AliasCycle {..} = do
+    opts <- fromGenericOptions <$> ask
+    let msg =
+          "The definition of"
+            <+> ppCode opts (_aliasCycleDef ^. aliasDefName)
+            <+> "creates an alias cycle."
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = mkAnsiText msg,
+          _genericErrorIntervals = [i]
+        }
+    where
+      i :: Interval
+      i = getLoc _aliasCycleDef

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -209,7 +209,7 @@ instance ToGenericError DuplicateIterator where
               locs = vsep $ map (pretty . getLoc) [_dupIteratorFirst, _dupIteratorFirst]
 
 data ExportEntries
-  = ExportEntriesSymbols (NonEmpty SymbolEntry)
+  = ExportEntriesSymbols (NonEmpty PreSymbolEntry)
   | ExportEntriesModules (NonEmpty ModuleSymbolEntry)
   | ExportEntriesFixities (NonEmpty FixitySymbolEntry)
   deriving stock (Show)
@@ -382,7 +382,7 @@ instance ToGenericError UnusedIteratorDef where
 
 data AmbiguousSym = AmbiguousSym
   { _ambiguousSymName :: Name,
-    _ambiguousSymEntires :: [SymbolEntry]
+    _ambiguousSymEntires :: [PreSymbolEntry]
   }
   deriving stock (Show)
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -838,7 +838,7 @@ letFunDef = do
 
 letStatement :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (LetStatement 'Parsed)
 letStatement =
-  LetFunctionDef <$> functionDefinition Nothing
+  LetFunctionDef <$> letFunDef
     <|> LetAliasDef <$> (kw kwSyntax >>= aliasDef)
 
 letBlock :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (Let 'Parsed)

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -836,10 +836,15 @@ letFunDef = do
   optional_ stashPragmas
   functionDefinition Nothing
 
+letStatement :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (LetStatement 'Parsed)
+letStatement =
+  LetFunctionDef <$> functionDefinition Nothing
+    <|> LetAliasDef <$> (kw kwSyntax >>= aliasDef)
+
 letBlock :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (Let 'Parsed)
 letBlock = do
   _letKw <- kw kwLet
-  _letFunDefs <- P.sepEndBy1 letFunDef semicolon
+  _letFunDefs <- P.sepEndBy1 letStatement semicolon
   _letInKw <- Irrelevant <$> kw kwIn
   _letExpression <- parseExpressionAtoms
   return Let {..}

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -500,9 +500,19 @@ builtinStatement = do
 syntaxDef :: forall r. (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (SyntaxDef 'Parsed)
 syntaxDef = do
   syn <- kw kwSyntax
-  (SyntaxFixity <$> fixitySyntaxDef syn)
-    <|> (SyntaxOperator <$> operatorSyntaxDef syn)
-    <|> (SyntaxIterator <$> iteratorSyntaxDef syn)
+  SyntaxFixity <$> fixitySyntaxDef syn
+    <|> SyntaxOperator <$> operatorSyntaxDef syn
+    <|> SyntaxIterator <$> iteratorSyntaxDef syn
+    <|> SyntaxAlias <$> aliasDef syn
+
+aliasDef :: forall r. (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => KeywordRef -> ParsecS r (AliasDef 'Parsed)
+aliasDef synKw = do
+  let _aliasDefSyntaxKw = Irrelevant synKw
+  _aliasDefAliasKw <- Irrelevant <$> kw kwAlias
+  _aliasDefName <- symbol
+  kw kwAssign
+  _aliasDefAsName <- name
+  return AliasDef {..}
 
 --------------------------------------------------------------------------------
 -- Operator syntax declaration

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -457,6 +457,7 @@ instance IsExpression Name where
         KNameLocalModule -> impossible
         KNameTopModule -> impossible
         KNameFixity -> impossible
+        KNameAlias -> impossible
 
 instance IsExpression SmallUniverse where
   toExpression = ExpressionUniverse

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -187,7 +187,7 @@ goScopedIden iden =
   set Internal.namePretty prettyStr (goSymbol (S.nameUnqualify name))
   where
     name :: S.Name
-    name = iden ^. scopedIden
+    name = iden ^. scopedIdenFinal
     prettyStr :: Text
     prettyStr = prettyText name
 

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -834,6 +834,7 @@ goExpression = \case
       KNameFunction -> Internal.IdenFunction n'
       KNameConstructor -> Internal.IdenConstructor n'
       KNameLocalModule -> impossible
+      KNameAlias -> impossible
       KNameTopModule -> impossible
       KNameFixity -> impossible
       where

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -88,6 +88,9 @@ kwRightArrow = unicodeKw Str.toAscii Str.toUnicode
 kwSyntax :: Keyword
 kwSyntax = asciiKw Str.syntax
 
+kwAlias :: Keyword
+kwAlias = asciiKw Str.alias
+
 kwFixity :: Keyword
 kwFixity = asciiKw Str.fixity
 

--- a/src/Juvix/Data/NameKind.hs
+++ b/src/Juvix/Data/NameKind.hs
@@ -19,8 +19,10 @@ data NameKind
     KNameLocalModule
   | -- | A top module name.
     KNameTopModule
-  | -- | A fixity name
+  | -- | A fixity name.
     KNameFixity
+  | -- | An alias name. Only used in the declaration site.
+    KNameAlias
   deriving stock (Show, Eq, Data)
 
 $(genSingletons [''NameKind])
@@ -50,6 +52,7 @@ nameKindText = \case
   KNameLocalModule -> "local module"
   KNameTopModule -> "module"
   KNameFixity -> "fixity"
+  KNameAlias -> "alias"
 
 isExprKind :: HasNameKind a => a -> Bool
 isExprKind k = case getNameKind k of
@@ -73,6 +76,7 @@ canBeCompiled k = case getNameKind k of
   KNameLocalModule -> False
   KNameTopModule -> False
   KNameFixity -> False
+  KNameAlias -> False
 
 canHaveFixity :: HasNameKind a => a -> Bool
 canHaveFixity k = case getNameKind k of
@@ -80,6 +84,7 @@ canHaveFixity k = case getNameKind k of
   KNameInductive -> True
   KNameFunction -> True
   KNameAxiom -> True
+  KNameAlias -> True
   KNameLocal -> False
   KNameLocalModule -> False
   KNameTopModule -> False
@@ -90,6 +95,7 @@ canBeIterator k = case getNameKind k of
   KNameFunction -> True
   KNameAxiom -> True
   KNameConstructor -> False
+  KNameAlias -> False
   KNameInductive -> False
   KNameLocal -> False
   KNameLocalModule -> False
@@ -104,10 +110,6 @@ nameKindAnsi k = case k of
   KNameLocalModule -> color Cyan
   KNameFunction -> colorDull Yellow
   KNameLocal -> mempty
+  KNameAlias -> mempty
   KNameTopModule -> color Cyan
   KNameFixity -> mempty
-
-isFunctionKind :: HasNameKind a => a -> Bool
-isFunctionKind k = case getNameKind k of
-  KNameFunction -> True
-  _ -> False

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -56,6 +56,9 @@ hiding = "hiding"
 include :: (IsString s) => s
 include = "include"
 
+alias :: (IsString s) => s
+alias = "alias"
+
 import_ :: (IsString s) => s
 import_ = "import"
 

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -322,5 +322,12 @@ scoperErrorTests =
       $(mkRelFile "IncomparablePrecedences.juvix")
       $ \case
         ErrIncomparablePrecedences {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Alias cycle"
+      $(mkRelDir ".")
+      $(mkRelFile "AliasCycle.juvix")
+      $ \case
+        ErrAliasCycle {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -276,7 +276,11 @@ tests =
     posTest
       "Issue 2296 (Pi types with lhs arity other than unit)"
       $(mkRelDir "issue2296")
-      $(mkRelFile "M.juvix")
+      $(mkRelFile "M.juvix"),
+    posTest
+      "Alias"
+      $(mkRelDir ".")
+      $(mkRelFile "Alias.juvix")
   ]
     <> [ compilationTest t | t <- Compilation.tests
        ]

--- a/tests/negative/AliasCycle.juvix
+++ b/tests/negative/AliasCycle.juvix
@@ -1,0 +1,5 @@
+module AliasCycle;
+
+syntax alias x1 := x2;
+syntax alias x2 := x3;
+syntax alias x3 := x1;

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -48,3 +48,8 @@ syntax operator , pair;
 syntax alias , := mkPair;
 
 myPair : Pair := one , ⊥;
+
+localAlias : Binary -> Binary
+ | b := let
+ syntax alias b' := b
+ in b';

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -47,9 +47,10 @@ type Pair :=
 syntax operator , pair;
 syntax alias , := mkPair;
 
-myPair : Pair := one , ⊥;
+myPair : Pair := one, ⊥;
 
 localAlias : Binary -> Binary
- | b := let
- syntax alias b' := b
- in b';
+  | b :=
+    let
+      syntax alias b' := b;
+    in b';

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -40,3 +40,11 @@ syntax operator || logical;
 syntax alias or := ||;
 
 or3 (a b c : Binary) : Binary := or (or a b) c;
+
+type Pair :=
+  | mkPair Binary Binary;
+
+syntax operator , pair;
+syntax alias , := mkPair;
+
+myPair : Pair := one , ⊥;

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -1,11 +1,13 @@
 module Alias;
 
-module M;
-  axiom T : Type; -- line 4
-  syntax alias A := T; -- line 5
-end;
-syntax alias A := M.T; -- line 7
-open M;
-axiom K : A; -- line 9
+syntax alias Boolean := Bool;
+syntax alias ⊥ := false;
+syntax alias ⊤ := true;
 
-end;
+type Bool :=
+  | false
+  | true;
+
+not : Boolean -> Boolean
+  | ⊥ := ⊤
+  | ⊤ := ⊥;

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -1,0 +1,11 @@
+module Alias;
+
+module M;
+  axiom T : Type; -- line 4
+  syntax alias A := T; -- line 5
+end;
+syntax alias A := M.T; -- line 7
+open M;
+axiom K : A; -- line 9
+
+end;

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -1,9 +1,11 @@
 module Alias;
 
+-- aliases are allowed to forward reference
 syntax alias Boolean := Bool;
 syntax alias ⊥ := false;
 syntax alias ⊤ := true;
 
+--- Truth value
 type Bool :=
   | false
   | true;

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -1,5 +1,7 @@
 module Alias;
 
+import Stdlib.Data.Fixity open;
+
 -- aliases are allowed to forward reference
 syntax alias Boolean := Bool;
 syntax alias ⊥ := false;
@@ -13,3 +15,28 @@ type Bool :=
 not : Boolean -> Boolean
   | ⊥ := ⊤
   | ⊤ := ⊥;
+
+not2 (b : Boolean) : Boolean :=
+  let
+    syntax alias yes := ⊤;
+    syntax alias no := ⊥;
+  in case b
+    | no := yes
+    | yes := no;
+
+module ExportAlias;
+  syntax alias Binary := Bool;
+  syntax alias one := ⊤;
+  syntax alias zero := ⊥;
+end;
+
+open ExportAlias;
+
+syntax operator || logical;
+|| : Binary -> Binary -> Binary
+  | zero b := b
+  | one _ := one;
+
+syntax alias or := ||;
+
+or3 (a b c : Binary) : Binary := or (or a b) c;


### PR DESCRIPTION
- Closes #2188.

This pr introduces a new syntactical statement for defining aliases:
```
syntax alias newName := oldName;
```
where `oldName` can be any name in the expression namespace. Fixity and module aliases are not supported at the moment.

- The `newName` does not inherit the fixity of `oldName`. We have agreed that the goal is to inherit the fixity of `oldName` except if `newName` has a fixity statement, but this will be done in a separate pr as it requires #2310.