### PR TITLE
Check that type functions are supported

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
@@ -22,6 +22,7 @@ data TypeCheckerError
   | ErrTooFewArgumentsIndType WrongNumberArgumentsIndType
   | ErrImpracticalPatternMatching ImpracticalPatternMatching
   | ErrNoPositivity NoPositivity
+  | ErrUnsupportedTypeFunction UnsupportedTypeFunction
 
 instance ToGenericError TypeCheckerError where
   genericError :: (Member (Reader GenericOptions) r) => TypeCheckerError -> Sem r GenericError
@@ -36,3 +37,4 @@ instance ToGenericError TypeCheckerError where
     ErrTooFewArgumentsIndType e -> genericError e
     ErrImpracticalPatternMatching e -> genericError e
     ErrNoPositivity e -> genericError e
+    ErrUnsupportedTypeFunction e -> genericError e

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -322,3 +322,26 @@ instance ToGenericError NoPositivity where
                 <> line
                 <> "It appears at a negative position in one of the arguments of the constructor"
               <+> ppCode opts' ctor <> "."
+
+newtype UnsupportedTypeFunction = UnsupportedTypeFunction
+  { _unsupportedTypeFunction :: FunctionDef
+  }
+
+instance ToGenericError UnsupportedTypeFunction where
+  genericError UnsupportedTypeFunction {..} = do
+    opts <- fromGenericOptions <$> ask
+    let msg =
+          "Unsupported type function"
+            <+> ppCode opts (_unsupportedTypeFunction ^. funDefName)
+              <> "."
+              <> line
+              <> "Only functions with a single clause and no pattern matching are supported."
+    return
+      GenericError
+        { _genericErrorLoc = i,
+          _genericErrorMessage = mkAnsiText msg,
+          _genericErrorIntervals = [i]
+        }
+    where
+      i :: Interval
+      i = getLoc _unsupportedTypeFunction

--- a/test/Typecheck/Negative.hs
+++ b/test/Typecheck/Negative.hs
@@ -138,6 +138,13 @@ tests =
       $(mkRelFile "LiteralIntegerString.juvix")
       $ \case
         ErrWrongType {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Unsupported type function"
+      $(mkRelDir "Internal")
+      $(mkRelFile "UnsupportedTypeFunction.juvix")
+      $ \case
+        ErrUnsupportedTypeFunction {} -> Nothing
         _ -> wrongError
   ]
 

--- a/tests/negative/Internal/UnsupportedTypeFunction.juvix
+++ b/tests/negative/Internal/UnsupportedTypeFunction.juvix
@@ -1,0 +1,9 @@
+module UnsupportedTypeFunction;
+
+type Bool :=
+  | true
+  | false;
+
+f : Bool → Type
+  | true := Type
+  | false := Bool;


### PR DESCRIPTION
- Closes #2297 

When the type of  function definition is of the form `... -> Type` it has to have only one clause and no pattern matching.