### PR TITLE
Replace gitrev with githash for obtaining build-time git info

### DIFF
--- a/.github/workflows/linux-static-binary.yaml
+++ b/.github/workflows/linux-static-binary.yaml
@@ -40,6 +40,11 @@ jobs:
       - name: Stack permissions bug workaround
         run: "chown -R $(id -un):$(id -gn) ~"
 
+      # Without this the git command used by githash TemplateHaskell fails with permission error
+      # https://github.com/anoma/juvix/issues/2294
+      - name: Git permissions workaround
+        run: "chown -R $(id -un):$(id -gn) ."
+
       - name: Install clang14
         run: apk add --update clang14
 

--- a/package.yaml
+++ b/package.yaml
@@ -55,7 +55,7 @@ dependencies:
   - extra == 1.7.*
   - file-embed == 0.0.*
   - filepath == 1.4.*
-  - gitrev == 1.3.*
+  - githash == 0.1.*
   - hashable == 1.4.*
   - language-c == 0.9.*
   - libyaml == 0.1.*

--- a/src/Juvix/Extra/Version.hs
+++ b/src/Juvix/Extra/Version.hs
@@ -1,7 +1,7 @@
 module Juvix.Extra.Version where
 
 import Data.Version (showVersion)
-import Development.GitRev (gitBranch, gitCommitDate, gitHash)
+import GitHash
 import Juvix.Prelude.Base hiding (Doc)
 import Juvix.Prelude.Path
 import Paths_juvix qualified
@@ -12,20 +12,26 @@ import System.Environment (getProgName)
 versionDir :: Path Rel Dir
 versionDir = relDir (unpack versionDoc)
 
+gitInfo :: Maybe GitInfo
+gitInfo = eitherToMaybe $$tGitInfoCwdTry
+
+projectOrUnknown :: (GitInfo -> String) -> Text
+projectOrUnknown p = maybe "UNKNOWN" (pack . p) gitInfo
+
 versionDoc :: Text
 versionDoc = pack (showVersion Paths_juvix.version)
 
 branch :: Text
-branch = pack $(gitBranch)
+branch = projectOrUnknown giBranch
 
 commit :: Text
-commit = pack $(gitHash)
+commit = projectOrUnknown giHash
 
 commitDate :: Text
-commitDate = pack $(gitCommitDate)
+commitDate = projectOrUnknown giCommitDate
 
 shortHash :: Text
-shortHash = pack (take 7 $(gitHash))
+shortHash = projectOrUnknown (take 7 . giHash)
 
 versionTag :: Text
 versionTag = versionDoc <> "-" <> shortHash


### PR DESCRIPTION
This PR replaces [gitrev](https://hackage.haskell.org/package/gitrev) with [githash](https://hackage.haskell.org/package/githash) which provides more reliable git information about the current git info, it seems to work as expected. githash originated as a fork of gitrev containing fixes https://github.com/snoyberg/githash/issues/11

This PR also fixes the issue with git info detection in the linux static build. There was a permission issue in the build container that caused git cli calls to fail.

Closes:
* https://github.com/anoma/juvix/issues/2294
* https://github.com/anoma/juvix/issues/2130