### PR TITLE
Fix shell variables in linux static build stack install

### DIFF
--- a/.github/workflows/linux-static-binary.yaml
+++ b/.github/workflows/linux-static-binary.yaml
@@ -33,9 +33,11 @@ jobs:
 
       - name: install stack
         run: |
-          curl https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64-static.tar.gz -OL
-          tar xf stack-STACK_VERSION-linux-x86_64-static.tar.gz
-          cp stack-STACK_VERSION-linux-x86_64-static/stack /usr/local/bin
+          TAR_BASE_NAME=stack-$STACK_VERSION-linux-x86_64-static
+          TAR_FILE_NAME=$TAR_BASE_NAME.tar.gz
+          curl https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/$TAR_FILE_NAME -OL
+          tar xf $TAR_FILE_NAME
+          cp $TAR_BASE_NAME/stack /usr/local/bin
 
       - name: Stack permissions bug workaround
         run: "chown -R $(id -un):$(id -gn) ~"


### PR DESCRIPTION
Failing build https://github.com/anoma/juvix/actions/runs/5954878467/job/16152344474

The STACK_VERSION variable was missing the $ prefix.

Tested at https://github.com/paulcadman/megajuvix/actions/runs/5955101309/job/16153000784
