### PR TITLE
Install wasmer binary from Github releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,12 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v2
+      - name: Install the latest Wasmer version
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: wasmerio/wasmer
+          binaries-location: bin
+          chmod: 0755
 
       - name: Install libs
         run: sudo apt install -y libncurses5
@@ -184,8 +188,12 @@ jobs:
         run: |
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
-      - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v3
+      - name: Install the latest Wasmer version
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: wasmerio/wasmer
+          binaries-location: bin
+          chmod: 0755
 
       # smoke dynamically links to icu4c, so a cached binary of smoke will break
       # when brew bumps the icu4c version. In the following steps we use the


### PR DESCRIPTION
The wasmerio/setup-wasmer action is causing failures on CI

e.g https://github.com/anoma/juvix/actions/runs/5978292661/job/16220075597

This PR installs wasmer directly from GitHub releases instead.