### PR TITLE
Report termination errors after typechecking

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -4,6 +4,7 @@ import CommonOptions
 import Data.ByteString qualified as ByteString
 import GlobalOptions
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Pipeline
 import Juvix.Data.Error qualified as Error
 import Juvix.Extra.Paths.Base
@@ -11,7 +12,6 @@ import Juvix.Prelude.Pretty hiding
   ( Doc,
   )
 import System.Console.ANSI qualified as Ansi
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 
 data App m a where
   ExitMsg :: ExitCode -> Text -> App m a

--- a/app/Commands/Dev/Internal/Arity.hs
+++ b/app/Commands/Dev/Internal/Arity.hs
@@ -4,15 +4,9 @@ import Commands.Base
 import Commands.Dev.Internal.Arity.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context qualified as InternalArity
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 
 runCommand :: (Members '[Embed IO, App] r) => InternalArityOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
-  micro <-
-    head . (^. InternalArity.resultModules)
-      <$> ( runPipeline (opts ^. internalArityInputFile)
-              . evalTermination iniTerminationState
-              $ upToInternalArity
-          )
+  micro <- head . (^. InternalArity.resultModules) <$> runPipelineTermination (opts ^. internalArityInputFile) upToInternalArity
   renderStdOut (Internal.ppOut globalOpts micro)

--- a/app/Commands/Dev/Internal/Pretty.hs
+++ b/app/Commands/Dev/Internal/Pretty.hs
@@ -4,9 +4,15 @@ import Commands.Base
 import Commands.Dev.Internal.Pretty.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 
 runCommand :: (Members '[Embed IO, App] r) => InternalPrettyOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
-  intern <- head . (^. Internal.resultModules) <$> runPipeline (opts ^. internalPrettyInputFile) upToInternal
+  intern <-
+    head . (^. Internal.resultModules)
+      <$> ( runPipeline (opts ^. internalPrettyInputFile)
+              . evalTermination iniTerminationState
+              $ upToInternal
+          )
   renderStdOut (Internal.ppOut globalOpts intern)

--- a/app/Commands/Dev/Internal/Pretty.hs
+++ b/app/Commands/Dev/Internal/Pretty.hs
@@ -4,15 +4,9 @@ import Commands.Base
 import Commands.Dev.Internal.Pretty.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 
 runCommand :: (Members '[Embed IO, App] r) => InternalPrettyOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
-  intern <-
-    head . (^. Internal.resultModules)
-      <$> ( runPipeline (opts ^. internalPrettyInputFile)
-              . evalTermination iniTerminationState
-              $ upToInternal
-          )
+  intern <- head . (^. Internal.resultModules) <$> runPipelineTermination (opts ^. internalPrettyInputFile) upToInternal
   renderStdOut (Internal.ppOut globalOpts intern)

--- a/app/Commands/Dev/Internal/Reachability.hs
+++ b/app/Commands/Dev/Internal/Reachability.hs
@@ -4,9 +4,15 @@ import Commands.Base
 import Commands.Dev.Internal.Reachability.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 
 runCommand :: (Members '[Embed IO, App] r) => InternalReachabilityOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
-  depInfo <- (^. Internal.resultDepInfo) <$> runPipeline (opts ^. internalReachabilityInputFile) upToInternal
+  depInfo <-
+    (^. Internal.resultDepInfo)
+      <$> ( runPipeline (opts ^. internalReachabilityInputFile)
+              . evalTermination iniTerminationState
+              $ upToInternal
+          )
   renderStdOut (Internal.ppOut globalOpts depInfo)

--- a/app/Commands/Dev/Internal/Reachability.hs
+++ b/app/Commands/Dev/Internal/Reachability.hs
@@ -4,15 +4,9 @@ import Commands.Base
 import Commands.Dev.Internal.Reachability.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 
 runCommand :: (Members '[Embed IO, App] r) => InternalReachabilityOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
-  depInfo <-
-    (^. Internal.resultDepInfo)
-      <$> ( runPipeline (opts ^. internalReachabilityInputFile)
-              . evalTermination iniTerminationState
-              $ upToInternal
-          )
+  depInfo <- (^. Internal.resultDepInfo) <$> runPipelineTermination (opts ^. internalReachabilityInputFile) upToInternal
   renderStdOut (Internal.ppOut globalOpts depInfo)

--- a/app/Commands/Dev/Termination/CallGraph.hs
+++ b/app/Commands/Dev/Termination/CallGraph.hs
@@ -12,10 +12,7 @@ import Juvix.Prelude.Pretty
 runCommand :: (Members '[Embed IO, App] r) => CallGraphOptions -> Sem r ()
 runCommand CallGraphOptions {..} = do
   globalOpts <- askGlobalOptions
-  results <-
-    runPipeline _graphInputFile
-      . Termination.evalTermination Termination.iniTerminationState
-      $ upToInternal
+  results <- runPipelineTermination _graphInputFile upToInternal
   let topModules = results ^. Internal.resultModules
       mainModule = head topModules
       toAnsiText' :: forall a. (HasAnsiBackend a, HasTextBackend a) => a -> Text

--- a/app/Commands/Dev/Termination/CallGraph.hs
+++ b/app/Commands/Dev/Termination/CallGraph.hs
@@ -12,13 +12,16 @@ import Juvix.Prelude.Pretty
 runCommand :: (Members '[Embed IO, App] r) => CallGraphOptions -> Sem r ()
 runCommand CallGraphOptions {..} = do
   globalOpts <- askGlobalOptions
-  results <- runPipeline _graphInputFile upToInternal
+  results <-
+    runPipeline _graphInputFile
+      . Termination.evalTermination Termination.iniTerminationState
+      $ upToInternal
   let topModules = results ^. Internal.resultModules
       mainModule = head topModules
       toAnsiText' :: forall a. (HasAnsiBackend a, HasTextBackend a) => a -> Text
       toAnsiText' = toAnsiText (not (globalOpts ^. globalNoColors))
       infotable = Internal.buildTable topModules
-      callMap = Termination.buildCallMap infotable mainModule
+      callMap = Termination.buildCallMap mainModule
       completeGraph = Termination.completeCallGraph callMap
       filteredGraph =
         maybe

--- a/app/Commands/Dev/Termination/Calls.hs
+++ b/app/Commands/Dev/Termination/Calls.hs
@@ -9,10 +9,7 @@ import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination qua
 runCommand :: (Members '[Embed IO, App] r) => CallsOptions -> Sem r ()
 runCommand localOpts@CallsOptions {..} = do
   globalOpts <- askGlobalOptions
-  results <-
-    runPipeline _callsInputFile
-      . Termination.evalTermination Termination.iniTerminationState
-      $ upToInternal
+  results <- runPipelineTermination _callsInputFile upToInternal
   let topModules = results ^. Internal.resultModules
       callMap0 = Termination.buildCallMap (head topModules)
       callMap = case _callsFunctionNameFilter of

--- a/app/Commands/Dev/Termination/Calls.hs
+++ b/app/Commands/Dev/Termination/Calls.hs
@@ -2,7 +2,6 @@ module Commands.Dev.Termination.Calls where
 
 import Commands.Base
 import Commands.Dev.Termination.Calls.Options
-import Juvix.Compiler.Internal.Data.InfoTable qualified as Internal
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination qualified as Termination
@@ -10,10 +9,12 @@ import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination qua
 runCommand :: (Members '[Embed IO, App] r) => CallsOptions -> Sem r ()
 runCommand localOpts@CallsOptions {..} = do
   globalOpts <- askGlobalOptions
-  results <- runPipeline _callsInputFile upToInternal
+  results <-
+    runPipeline _callsInputFile
+      . Termination.evalTermination Termination.iniTerminationState
+      $ upToInternal
   let topModules = results ^. Internal.resultModules
-      infotable = Internal.buildTable topModules
-      callMap0 = Termination.buildCallMap infotable (head topModules)
+      callMap0 = Termination.buildCallMap (head topModules)
       callMap = case _callsFunctionNameFilter of
         Nothing -> callMap0
         Just f -> Termination.filterCallMap f callMap0

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -752,7 +752,7 @@ instance (SingI s) => PrettyPrint (AxiomDef s) where
       ?<> ppCode _axiomKw
       <+> axiomName'
       <+> ppCode _axiomColonKw
-      <+> nest (ppExpressionType _axiomType)
+      <+> ppExpressionType _axiomType
 
 instance PrettyPrint BuiltinInductive where
   ppCode i = ppCode Kw.kwBuiltin <+> keywordText (P.prettyText i)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -752,7 +752,7 @@ instance (SingI s) => PrettyPrint (AxiomDef s) where
       ?<> ppCode _axiomKw
       <+> axiomName'
       <+> ppCode _axiomColonKw
-      <+> ppExpressionType _axiomType
+      <+> nest (ppExpressionType _axiomType)
 
 instance PrettyPrint BuiltinInductive where
   ppCode i = ppCode Kw.kwBuiltin <+> keywordText (P.prettyText i)

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
@@ -11,6 +11,7 @@ import Juvix.Compiler.Internal.Data.InfoTable
 import Juvix.Compiler.Internal.Data.NameDependencyInfo
 import Juvix.Compiler.Internal.Language
 import Juvix.Compiler.Internal.Language qualified as Internal
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Pipeline.EntryPoint qualified as E
 import Juvix.Prelude
 
@@ -18,13 +19,9 @@ import Juvix.Prelude
 newtype ModulesCache = ModulesCache
   {_cachedModules :: HashMap Concrete.ModuleIndex Internal.Module}
 
-newtype NonTerminating = NonTerminating {_nonTerminating :: HashSet FunctionName}
-  deriving newtype (Monoid, Semigroup)
-
 data InternalResult = InternalResult
   { _resultScoper :: Concrete.ScoperResult,
     _resultTable :: InfoTable,
-    _resultNonTerminating :: NonTerminating,
     _resultModules :: NonEmpty Module,
     _resultDepInfo :: NameDependencyInfo,
     _resultModulesCache :: ModulesCache

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
@@ -11,7 +11,6 @@ import Juvix.Compiler.Internal.Data.InfoTable
 import Juvix.Compiler.Internal.Data.NameDependencyInfo
 import Juvix.Compiler.Internal.Language
 import Juvix.Compiler.Internal.Language qualified as Internal
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Pipeline.EntryPoint qualified as E
 import Juvix.Prelude
 
@@ -29,7 +28,6 @@ data InternalResult = InternalResult
 
 makeLenses ''InternalResult
 makeLenses ''ModulesCache
-makeLenses ''NonTerminating
 
 internalResultEntryPoint :: Lens' InternalResult E.EntryPoint
 internalResultEntryPoint = resultScoper . Concrete.resultParserResult . Concrete.resultEntry

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
@@ -18,9 +18,13 @@ import Juvix.Prelude
 newtype ModulesCache = ModulesCache
   {_cachedModules :: HashMap Concrete.ModuleIndex Internal.Module}
 
+newtype NonTerminating = NonTerminating {_nonTerminating :: HashSet FunctionName}
+  deriving newtype (Monoid, Semigroup)
+
 data InternalResult = InternalResult
   { _resultScoper :: Concrete.ScoperResult,
     _resultTable :: InfoTable,
+    _resultNonTerminating :: NonTerminating,
     _resultModules :: NonEmpty Module,
     _resultDepInfo :: NameDependencyInfo,
     _resultModulesCache :: ModulesCache
@@ -28,6 +32,7 @@ data InternalResult = InternalResult
 
 makeLenses ''InternalResult
 makeLenses ''ModulesCache
+makeLenses ''NonTerminating
 
 internalResultEntryPoint :: Lens' InternalResult E.EntryPoint
 internalResultEntryPoint = resultScoper . Concrete.resultParserResult . Concrete.resultEntry

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -14,11 +14,10 @@ import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Builtins.Effect
 import Juvix.Compiler.Concrete.Data.Highlight.Input
 import Juvix.Compiler.Internal.Language
-import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete.Data.Context
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking qualified as ArityChecking
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Reachability
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker (NoLexOrder (NoLexOrder), TerminationError (ErrNoLexOrder))
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking
 import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.EntryPoint
@@ -70,14 +69,12 @@ arityCheckImport i = do
 
 typeCheckExpressionType ::
   forall r.
-  (Members '[Error JuvixError, State Artifacts] r) =>
+  (Members '[Error JuvixError, State Artifacts, Termination] r) =>
   Expression ->
   Sem r TypedExpression
 typeCheckExpressionType exp = do
   table <- extendedTableReplArtifacts exp
-  nonTermin <- gets (^. artifactNonTerminating)
-  mapError (JuvixError @TypeCheckerError)
-    . runTypesTableArtifacts
+  runTypesTableArtifacts
     . ignoreHighlightBuilder
     . runFunctionsTableArtifacts
     . runBuiltinsArtifacts
@@ -85,23 +82,23 @@ typeCheckExpressionType exp = do
     . runReader table
     . ignoreOutput @Example
     . withEmptyVars
+    . mapError (JuvixError @TypeCheckerError)
     . runInferenceDef
-    . runReader nonTermin
-    $ inferExpression' Nothing exp >>= traverseOf typedType strongNormalize
+    $ inferExpression' Nothing exp
+      >>= traverseOf typedType strongNormalize
 
 typeCheckExpression ::
-  (Members '[Error JuvixError, State Artifacts] r) =>
+  (Members '[Error JuvixError, State Artifacts, Termination] r) =>
   Expression ->
   Sem r Expression
 typeCheckExpression exp = (^. typedExpression) <$> typeCheckExpressionType exp
 
 typeCheckImport ::
-  (Members '[Reader EntryPoint, Error JuvixError, State Artifacts] r) =>
+  (Members '[Reader EntryPoint, Error JuvixError, State Artifacts, Termination] r) =>
   Import ->
   Sem r Import
 typeCheckImport i = do
   artiTable <- gets (^. artifactInternalTypedTable)
-  nonTermin <- gets (^. artifactNonTerminating)
   let table = buildTable [i ^. importModule . moduleIxModule] <> artiTable
   modify (set artifactInternalTypedTable table)
   mapError (JuvixError @TypeCheckerError)
@@ -113,7 +110,6 @@ typeCheckImport i = do
     . ignoreOutput @Example
     . runReader table
     . withEmptyVars
-    . runReader nonTermin
     -- TODO Store cache in Artifacts and use it here
     . evalCacheEmpty checkModuleNoCache
     $ checkImport i
@@ -121,40 +117,32 @@ typeCheckImport i = do
 typeChecking ::
   forall r.
   (Members '[HighlightBuilder, Error JuvixError, Builtins, NameIdGen] r) =>
-  ArityChecking.InternalArityResult ->
+  Sem (Termination ': r) ArityChecking.InternalArityResult ->
   Sem r InternalTypedResult
-typeChecking res@ArityChecking.InternalArityResult {..} = do
-  mapError (JuvixError @TypeCheckerError) $ do
-    (normalized, (idens, (funs, r))) <-
-      runOutputList
-        . runReader entryPoint
-        . runState (mempty :: TypesTable)
-        . runState (mempty :: FunctionsTable)
-        . runReader table
-        . runReader nonTermin
-        . evalCacheEmpty checkModuleNoCache
-        $ mapM checkModule _resultModules
-    mapError (JuvixError @TerminationError) checkTerminating
-    return
-      InternalTypedResult
-        { _resultInternalArityResult = res,
-          _resultModules = r,
-          _resultNormalized = HashMap.fromList [(e ^. exampleId, e ^. exampleExpression) | e <- normalized],
-          _resultIdenTypes = idens,
-          _resultFunctions = funs,
-          _resultInfoTable = buildTable r
-        }
-  where
-    nonTermin :: NonTerminating
-    nonTermin = _resultInternalResult ^. Internal.resultNonTerminating
+typeChecking a = do
+  (termin, (res, (normalized, (idens, (funs, r))))) <- runTermination iniTerminationState $ do
+    res <- a
+    let table :: InfoTable
+        table = buildTable (res ^. ArityChecking.resultModules)
 
-    checkTerminating :: (Members '[Error TerminationError] s) => Sem s ()
-    checkTerminating = case nonTermin ^? nonTerminating . to toList . _head of
-      Nothing -> return ()
-      Just x -> throw (ErrNoLexOrder (NoLexOrder x))
-
-    table :: InfoTable
-    table = buildTable _resultModules
-
-    entryPoint :: EntryPoint
-    entryPoint = res ^. ArityChecking.internalArityResultEntryPoint
+        entryPoint :: EntryPoint
+        entryPoint = res ^. ArityChecking.internalArityResultEntryPoint
+    fmap (res,)
+      . runOutputList
+      . runReader entryPoint
+      . runState (mempty :: TypesTable)
+      . runState (mempty :: FunctionsTable)
+      . runReader table
+      . mapError (JuvixError @TypeCheckerError)
+      . evalCacheEmpty checkModuleNoCache
+      $ mapM checkModule (res ^. ArityChecking.resultModules)
+  return
+    InternalTypedResult
+      { _resultInternalArityResult = res,
+        _resultModules = r,
+        _resultTermination = termin,
+        _resultNormalized = HashMap.fromList [(e ^. exampleId, e ^. exampleExpression) | e <- normalized],
+        _resultIdenTypes = idens,
+        _resultFunctions = funs,
+        _resultInfoTable = buildTable r
+      }

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/FunctionCall.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/FunctionCall.hs
@@ -70,6 +70,12 @@ addCall fun c = over callMap (HashMap.alter (Just . insertCall c) fun)
       HashMap FunctionRef [FunCall]
     addFunCall fc = HashMap.insertWith (flip (<>)) (fc ^. callRef) [fc]
 
+registerFunctionDef ::
+  (Members '[State CallMap] r) =>
+  FunctionDef ->
+  Sem r ()
+registerFunctionDef f = modify' (set ((callMapScanned . at (f ^. funDefName))) (Just f))
+
 registerCall ::
   (Members '[State CallMap, Reader FunctionRef] r) =>
   FunCall ->

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Checker.hs
@@ -6,26 +6,27 @@ module Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Che
 where
 
 import Data.HashMap.Internal.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Internal.Data.InfoTable as Internal
 import Juvix.Compiler.Internal.Language as Internal
+import Juvix.Compiler.Internal.Translation.FromConcrete.Data.Context (NonTerminating (..))
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.FunctionCall
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Data
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Error
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.LexOrder
 import Juvix.Prelude
-import Data.HashSet qualified as HashSet
 
 -- | Returns the set of non-terminating functions.
 checkTermination ::
   InfoTable ->
   Module ->
-  HashSet Name
+  NonTerminating
 checkTermination infotable topModule = do
   let callmap = buildCallMap infotable topModule
       completeGraph = completeCallGraph callmap
       rEdges = reflexiveEdges completeGraph
       recBehav = map recursiveBehaviour rEdges
-  HashSet.fromList . run . execOutputList $ forM_ recBehav $ \r -> do
+  NonTerminating . HashSet.fromList . run . execOutputList $ forM_ recBehav $ \r -> do
     let funName = r ^. recursiveBehaviourFun
         markedTerminating :: Bool = funInfo ^. (Internal.functionInfoDef . Internal.funDefTerminating)
         funInfo :: FunctionInfo

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Checker.hs
@@ -74,13 +74,13 @@ re = reinterpret $ \case
   CheckTerminationShallow m -> checkTerminationShallow' m
   FunctionTermination m -> functionTermination' m
 
--- TODO if the function is missing, can we assume that it is not recursive?
+-- | If the function is missing, can we assume that it is not recursive
 functionTermination' ::
   forall r.
   (Members '[State TerminationState] r) =>
   FunctionName ->
   Sem r IsTerminating
-functionTermination' f = gets (^?! terminationTable . at f . _Just)
+functionTermination' f = fromMaybe TerminatingChecked <$> gets (^. terminationTable . at f)
 
 -- | Returns the set of non-terminating functions. Does not go into imports.
 checkTerminationShallow' ::

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/FunctionCall.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/FunctionCall.hs
@@ -9,10 +9,10 @@ import Juvix.Prelude
 
 type FunctionRef = FunctionName
 
-newtype CallMap = CallMap
-  { _callMap :: HashMap FunctionRef (HashMap FunctionRef [FunCall])
+data CallMap = CallMap
+  { _callMap :: HashMap FunctionRef (HashMap FunctionRef [FunCall]),
+    _callMapScanned :: HashMap FunctionRef FunctionDef
   }
-  deriving newtype (Semigroup, Monoid)
 
 data FunCall = FunCall
   { _callRef :: FunctionRef,
@@ -91,7 +91,7 @@ instance PrettyCode CallMap where
     (Members '[Reader Options] r) =>
     CallMap ->
     Sem r (Doc Ann)
-  ppCode (CallMap m) = vsep <$> mapM ppEntry (HashMap.toList m)
+  ppCode (CallMap m _) = vsep <$> mapM ppEntry (HashMap.toList m)
     where
       ppEntry :: (FunctionRef, HashMap FunctionRef [FunCall]) -> Sem r (Doc Ann)
       ppEntry (fun, mcalls) = do
@@ -115,3 +115,10 @@ kwQuestion = keyword Str.questionMark
 
 kwWaveArrow :: Doc Ann
 kwWaveArrow = keyword Str.waveArrow
+
+emptyCallMap :: CallMap
+emptyCallMap =
+  CallMap
+    { _callMap = mempty,
+      _callMapScanned = mempty
+    }

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/TerminationState.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/TerminationState.hs
@@ -13,12 +13,10 @@ import Juvix.Compiler.Internal.Language
 import Juvix.Prelude
 
 data IsTerminating
-  = -- | Has been checked for termination.
-    TerminatingChecked
+  = -- | Has been checked or marked for termination.
+    TerminatingCheckedOrMarked
   | -- | Has been checked for termination but failed.
     TerminatingFailed
-  | -- | Has been marked as terminating in the source code.
-    TerminatingMarked
 
 data TerminationState = TerminationState
   { _iterminationTable :: HashMap FunctionName IsTerminating,
@@ -42,8 +40,7 @@ addTerminating f i = do
     isFailed :: Bool
     isFailed = case i of
       TerminatingFailed -> True
-      TerminatingChecked -> False
-      TerminatingMarked -> False
+      TerminatingCheckedOrMarked -> False
 
 terminationTable :: SimpleGetter TerminationState (HashMap FunctionName IsTerminating)
 terminationTable = iterminationTable

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/TerminationState.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/TerminationState.hs
@@ -1,0 +1,52 @@
+module Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Data.TerminationState
+  ( IsTerminating (..),
+    TerminationState,
+    iniTerminationState,
+    addTerminating,
+    terminationTable,
+    terminationFailedSet,
+  )
+where
+
+import Data.HashSet qualified as HashSet
+import Juvix.Compiler.Internal.Language
+import Juvix.Prelude
+
+data IsTerminating
+  = -- | Has been checked for termination.
+    TerminatingChecked
+  | -- | Has been checked for termination but failed.
+    TerminatingFailed
+  | -- | Has been marked as terminating in the source code.
+    TerminatingMarked
+
+data TerminationState = TerminationState
+  { _iterminationTable :: HashMap FunctionName IsTerminating,
+    _iterminationFailed :: HashSet FunctionName
+  }
+
+makeLenses ''TerminationState
+
+iniTerminationState :: TerminationState
+iniTerminationState =
+  TerminationState
+    { _iterminationTable = mempty,
+      _iterminationFailed = mempty
+    }
+
+addTerminating :: (Members '[State TerminationState] r) => FunctionName -> IsTerminating -> Sem r ()
+addTerminating f i = do
+  modify' (set (iterminationTable . at f) (Just i))
+  when isFailed (modify' (over iterminationFailed (HashSet.insert f)))
+  where
+    isFailed :: Bool
+    isFailed = case i of
+      TerminatingFailed -> True
+      TerminatingChecked -> False
+      TerminatingMarked -> False
+
+terminationTable :: SimpleGetter TerminationState (HashMap FunctionName IsTerminating)
+terminationTable = iterminationTable
+
+terminationFailedSet :: SimpleGetter TerminationState (HashSet FunctionName)
+terminationFailedSet = iterminationFailed

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Error/Types.hs
@@ -5,7 +5,7 @@ import Juvix.Data.PPOutput
 import Juvix.Prelude
 
 newtype NoLexOrder = NoLexOrder
-  { _noLexOrderFun :: Name
+  { _noLexOrderFun :: NonEmpty Name
   }
   deriving stock (Show)
 
@@ -20,11 +20,26 @@ instance ToGenericError NoLexOrder where
           _genericErrorIntervals = [i]
         }
     where
-      name = _noLexOrderFun
-      i = getLoc name
+      names = _noLexOrderFun
+      i = getLocSpan names
 
+      single = case names of
+        _ :| [] -> True
+        _ -> False
       msg :: Doc Ann
       msg = do
-        "The function"
-          <+> code (pretty name)
-          <+> "fails the termination checker."
+        "The following"
+          <+> function
+          <+> fails
+          <+> "the termination checker:"
+            <> line
+            <> itemize (fmap (code . pretty) names)
+        where
+          function :: Doc Ann
+          function
+            | single = "function"
+            | otherwise = "functions"
+          fails :: Doc Ann
+          fails
+            | single = "fails"
+            | otherwise = "fail"

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
@@ -10,6 +10,7 @@ import Juvix.Compiler.Internal.Data.InfoTable
 import Juvix.Compiler.Internal.Language
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context (InternalArityResult)
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context qualified as Arity
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker (TerminationState)
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.FunctionsTable
 import Juvix.Compiler.Pipeline.EntryPoint qualified as E
 import Juvix.Prelude
@@ -21,6 +22,7 @@ type NormalizedTable = HashMap NameId Expression
 data InternalTypedResult = InternalTypedResult
   { _resultInternalArityResult :: InternalArityResult,
     _resultModules :: NonEmpty Module,
+    _resultTermination :: TerminationState,
     _resultNormalized :: NormalizedTable,
     _resultIdenTypes :: TypesTable,
     _resultFunctions :: FunctionsTable,

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -335,7 +335,7 @@ instance ToGenericError UnsupportedTypeFunction where
             <+> ppCode opts (_unsupportedTypeFunction ^. funDefName)
               <> "."
               <> line
-              <> "Only functions with a single clause and no pattern matching are supported."
+              <> "Only terminating functions with a single clause and no pattern matching are supported."
     return
       GenericError
         { _genericErrorLoc = i,

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -259,6 +259,7 @@ corePipelineIOEither entry = do
                 _artifactParsing = parserResult ^. P.resultBuilderState,
                 _artifactInternalModuleCache = internalResult ^. Internal.resultModulesCache,
                 _artifactInternalTypedTable = typedTable,
+                _artifactTerminationState = typedResult ^. Typed.resultTermination,
                 _artifactCoreTable = coreTable,
                 _artifactScopeTable = resultScoperTable,
                 _artifactScopeExports = scopedResult ^. Scoped.resultExports,

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -163,6 +163,9 @@ coreToVampIR' = Core.toVampIR' >=> return . VampIR.toResult . VampIR.fromCore
 runIOEither :: forall a. EntryPoint -> Sem PipelineEff a -> IO (Either JuvixError (ResolverState, a))
 runIOEither entry = fmap snd . runIOEitherHelper entry
 
+runIOEitherTermination :: forall a. EntryPoint -> Sem (Termination ': PipelineEff) a -> IO (Either JuvixError (ResolverState, a))
+runIOEitherTermination entry = fmap snd . runIOEitherHelper entry . evalTermination iniTerminationState
+
 runPipelineHighlight :: forall a. EntryPoint -> Sem PipelineEff a -> IO HighlightInput
 runPipelineHighlight entry = fmap fst . runIOEitherHelper entry
 

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -253,20 +253,22 @@ corePipelineIOEither entry = do
           mainModuleScope_ :: Scope
           mainModuleScope_ = Scoped.mainModuleSope scopedResult
        in Right $
-            foldl'
-              (flip ($))
-              art
-              [ set artifactMainModuleScope (Just mainModuleScope_),
-                set artifactParsing (parserResult ^. P.resultBuilderState),
-                set artifactInternalModuleCache (internalResult ^. Internal.resultModulesCache),
-                set artifactInternalTypedTable typedTable,
-                set artifactCoreTable coreTable,
-                set artifactScopeTable resultScoperTable,
-                set artifactScopeExports (scopedResult ^. Scoped.resultExports),
-                set artifactTypes typesTable,
-                set artifactFunctions functionsTable,
-                set artifactScoperState (scopedResult ^. Scoped.resultScoperState)
-              ]
+            Artifacts
+              { _artifactMainModuleScope = Just mainModuleScope_,
+                _artifactParsing = parserResult ^. P.resultBuilderState,
+                _artifactInternalModuleCache = internalResult ^. Internal.resultModulesCache,
+                _artifactNonTerminating = internalResult ^. Internal.resultNonTerminating,
+                _artifactInternalTypedTable = typedTable,
+                _artifactCoreTable = coreTable,
+                _artifactScopeTable = resultScoperTable,
+                _artifactScopeExports = scopedResult ^. Scoped.resultExports,
+                _artifactTypes = typesTable,
+                _artifactFunctions = functionsTable,
+                _artifactScoperState = scopedResult ^. Scoped.resultScoperState,
+                _artifactResolver = art ^. artifactResolver,
+                _artifactBuiltins = art ^. artifactBuiltins,
+                _artifactNameIdState = art ^. artifactNameIdState
+              }
   where
     initialArtifacts :: Artifacts
     initialArtifacts =
@@ -275,6 +277,7 @@ corePipelineIOEither entry = do
           _artifactMainModuleScope = Nothing,
           _artifactInternalTypedTable = mempty,
           _artifactTypes = mempty,
+          _artifactNonTerminating = mempty,
           _artifactResolver = PathResolver.iniResolverState,
           _artifactNameIdState = allNameIds,
           _artifactFunctions = mempty,

--- a/src/Juvix/Compiler/Pipeline/Artifacts.hs
+++ b/src/Juvix/Compiler/Pipeline/Artifacts.hs
@@ -19,7 +19,7 @@ import Juvix.Compiler.Core.Data.InfoTableBuilder qualified as Core
 import Juvix.Compiler.Internal.Extra.DependencyBuilder (ExportsTable)
 import Juvix.Compiler.Internal.Language qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
-import Juvix.Compiler.Internal.Translation.FromConcrete.Data.Context (NonTerminating)
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Prelude
@@ -38,7 +38,7 @@ data Artifacts = Artifacts
     _artifactScoperState :: Scoped.ScoperState,
     -- Concrete -> Internal
     _artifactInternalModuleCache :: Internal.ModulesCache,
-    _artifactNonTerminating :: NonTerminating,
+    _artifactTerminationState :: TerminationState,
     -- Typechecking
     _artifactTypes :: TypesTable,
     _artifactFunctions :: FunctionsTable,
@@ -95,8 +95,8 @@ runFunctionsTableArtifacts = runStateArtifacts artifactFunctions
 readerTypesTableArtifacts :: (Members '[State Artifacts] r) => Sem (Reader TypesTable ': r) a -> Sem r a
 readerTypesTableArtifacts = runReaderArtifacts artifactTypes
 
-runNonTerminatingArtifacts :: (Members '[State Artifacts] r) => Sem (State NonTerminating ': r) a -> Sem r a
-runNonTerminatingArtifacts = runStateArtifacts artifactNonTerminating
+runTerminationArtifacts :: (Members '[Error JuvixError, State Artifacts] r) => Sem (Termination ': r) a -> Sem r a
+runTerminationArtifacts = runStateLikeArtifacts runTermination artifactTerminationState
 
 runTypesTableArtifacts :: (Members '[State Artifacts] r) => Sem (State TypesTable ': r) a -> Sem r a
 runTypesTableArtifacts = runStateArtifacts artifactTypes
@@ -139,5 +139,5 @@ runFromConcreteCache =
     $ mapError (JuvixError @ScoperError)
       . runReader (mempty :: Pragmas)
       . evalState (mempty :: Internal.ConstructorInfos)
-      . runNonTerminatingArtifacts
+      . runTerminationArtifacts
       . Internal.goModuleNoCache

--- a/test/Arity/Negative.hs
+++ b/test/Arity/Negative.hs
@@ -98,7 +98,7 @@ tests =
       $ \case
         ErrBuiltinNotFullyApplied {} -> Nothing
         _ -> wrongError,
-     NegTest
+    NegTest
       "issue 2293: Non-terminating function with arity error"
       $(mkRelDir "Internal")
       $(mkRelFile "issue2293.juvix")

--- a/test/Arity/Negative.hs
+++ b/test/Arity/Negative.hs
@@ -21,7 +21,7 @@ testDescr NegTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             entryPoint <- defaultEntryPointCwdIO file'
-            result <- runIOEither entryPoint upToInternalArity
+            result <- runIOEitherTermination entryPoint upToInternalArity
             case mapLeft fromJuvixError result of
               Left (Just tyError) -> whenJust (_checkErr tyError) assertFailure
               Left Nothing -> assertFailure "The arity checker did not find an error."

--- a/test/Arity/Negative.hs
+++ b/test/Arity/Negative.hs
@@ -97,5 +97,12 @@ tests =
       $(mkRelFile "LazyBuiltin.juvix")
       $ \case
         ErrBuiltinNotFullyApplied {} -> Nothing
+        _ -> wrongError,
+     NegTest
+      "issue 2293: Non-terminating function with arity error"
+      $(mkRelDir "Internal")
+      $(mkRelFile "issue2293.juvix")
+      $ \case
+        ErrWrongConstructorAppLength {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -24,7 +24,7 @@ testDescr NegTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             entryPoint <- defaultEntryPointCwdIO file'
-            res <- runIOEither entryPoint upToInternal
+            res <- runIOEitherTermination entryPoint upToInternal
             case mapLeft fromJuvixError res of
               Left (Just err) -> whenJust (_checkErr err) assertFailure
               Left Nothing -> assertFailure "An error ocurred but it was not in the scoper."

--- a/test/Termination/Negative.hs
+++ b/test/Termination/Negative.hs
@@ -74,5 +74,11 @@ tests =
       $(mkRelDir ".")
       $(mkRelFile "Data/QuickSort.juvix")
       $ \case
+        ErrNoLexOrder {} -> Nothing,
+    NegTest
+      "Loop in axiom type"
+      $(mkRelDir ".")
+      $(mkRelFile "Axiom.juvix")
+      $ \case
         ErrNoLexOrder {} -> Nothing
   ]

--- a/test/Termination/Negative.hs
+++ b/test/Termination/Negative.hs
@@ -21,7 +21,7 @@ testDescr NegTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             entryPoint <- set entryPointNoStdlib True <$> defaultEntryPointCwdIO file'
-            result <- runIOEither entryPoint upToInternal
+            result <- runIOEither entryPoint upToInternalTyped
             case mapLeft fromJuvixError result of
               Left (Just lexError) -> whenJust (_checkErr lexError) assertFailure
               Left Nothing -> assertFailure "The termination checker did not find an error."

--- a/test/Termination/Positive.hs
+++ b/test/Termination/Positive.hs
@@ -21,7 +21,7 @@ testDescr PosTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             entryPoint <- set entryPointNoStdlib True <$> defaultEntryPointCwdIO file'
-            (void . runIO' entryPoint) upToInternal
+            (void . runIO' entryPoint) upToInternalTyped
         }
 
 --------------------------------------------------------------------------------
@@ -43,7 +43,7 @@ testDescrFlag N.NegTest {..} =
               set entryPointNoTermination True
                 . set entryPointNoStdlib True
                 <$> defaultEntryPointCwdIO file'
-            (void . runIO' entryPoint) upToInternal
+            (void . runIO' entryPoint) upToInternalTyped
         }
 
 tests :: [PosTest]

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -47,7 +47,7 @@ testNoPositivityFlag N.NegTest {..} =
             entryPoint <-
               set entryPointNoPositivity True
                 <$> defaultEntryPointCwdIO file'
-            (void . runIO' entryPoint) upToInternal
+            (void . runIO' entryPoint) upToInternalTyped
         }
 
 negPositivityTests :: [N.NegTest]

--- a/tests/negative/Internal/issue2293.juvix
+++ b/tests/negative/Internal/issue2293.juvix
@@ -1,0 +1,7 @@
+module issue2293;
+
+type List A := nil | cons A (List A);
+
+map {A B} (f : A → B) : List A → List B
+  | nil := nil
+  | cons h t := cons (f h) (map f t);

--- a/tests/negative/Termination/Axiom.juvix
+++ b/tests/negative/Termination/Axiom.juvix
@@ -1,0 +1,5 @@
+module Axiom;
+
+axiom A : let
+    x : Type := x;
+  in x;

--- a/tests/negative/Termination/Data/Bool.juvix
+++ b/tests/negative/Termination/Data/Bool.juvix
@@ -18,9 +18,9 @@ syntax operator && logical;
   | false _ := false
   | true a := a;
 
-ite : (a : Type) → Bool → a → a → a
-  | _ true a _ := a
-  | _ false _ b := b;
+ite : {a : Type} → Bool → a → a → a
+  | true a _ := a
+  | false _ b := b;
 
 not : Bool → Bool
   | true := false

--- a/tests/negative/Termination/Data/QuickSort.juvix
+++ b/tests/negative/Termination/Data/QuickSort.juvix
@@ -10,33 +10,30 @@ type List (A : Type) :=
   | nil : List A
   | cons : A → List A → List A;
 
-filter : (A : Type) → (A → Bool) → List A → List A
-  | A f nil := nil A
-  | A f (cons h hs) :=
+filter : {A : Type} → (A → Bool) → List A → List A
+  | f nil := nil
+  | f (cons h hs) :=
     ite
-      (List A)
       (f h)
-      (cons A h (filter A f hs))
-      (filter A f hs);
+      (cons h (filter f hs))
+      (filter f hs);
 
-concat : (A : Type) → List A → List A → List A
-  | A nil ys := ys
-  | A (cons x xs) ys := cons A x (concat A xs ys);
+concat : {A : Type} → List A → List A → List A
+  | nil ys := ys
+  | (cons x xs) ys := cons x (concat xs ys);
 
-ltx : (A : Type) → (A → A → Bool) → A → A → Bool
-  | A lessThan x y := lessThan y x;
+ltx : {A : Type} → (A → A → Bool) → A → A → Bool
+  | lessThan x y := lessThan y x;
 
-gex : (A : Type) → (A → A → Bool) → A → A → Bool
-  | A lessThan x y := not (ltx A lessThan x y);
+gex : {A : Type} → (A → A → Bool) → A → A → Bool
+  | lessThan x y := not (ltx lessThan x y);
 
-quicksort : (A : Type) → (A → A → Bool) → List A → List A
-  | A _ nil := nil A
-  | A _ (cons x nil) := cons A x (nil A)
-  | A lessThan (cons x ys) :=
+quicksort : {A : Type} → (A → A → Bool) → List A → List A
+  | _ nil := nil
+  | _ (cons x nil) := cons x nil
+  | lessThan (cons x ys) :=
     concat
-      A
-      (quicksort A lessThan (filter A (ltx A lessThan x) ys))
+      (quicksort lessThan (filter (ltx lessThan x) ys))
       (concat
-        A
-        (cons A x (nil A))
-        (quicksort A lessThan (filter A (gex A lessThan x)) ys));
+        (cons x nil)
+        (quicksort lessThan (filter (gex lessThan x) ys)));

--- a/tests/negative/Termination/Ord.juvix
+++ b/tests/negative/Termination/Ord.juvix
@@ -17,4 +17,3 @@ addord : Ord -> Ord -> Ord
 aux-addord : (ℕ -> Ord) -> Ord -> ℕ -> Ord
   
   | f y z := addord (f z) y;
-

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -1,6 +1,20 @@
 working-directory: ./../../../tests/
 
 tests:
+  - name: repl-non-terminating
+    command:
+      - juvix
+      - repl
+    stdin: "let x : Bool := x in x"
+    stdout:
+      matches: |
+        .*
+    stderr:
+      contains: |
+        The following function fails the termination checker:
+        • x
+    exit-status: 0
+
   - name: repl-doc
     command:
       - juvix


### PR DESCRIPTION
- Closes #2293.
- Closes #2319 

I've added an effect for termination. It keeps track of which functions failed the termination checker, which is run just after translating to Internal. During typechecking, non-terminating functions are not normalized. After typechecking, if there is at least one function which failed the termination checker, an error is reported.
Additionally, we now properly check for termination of functions defined in a let expression in the repl.