### PR TITLE
Global offline flag

### DIFF
--- a/app/Commands/Doctor.hs
+++ b/app/Commands/Doctor.hs
@@ -1,11 +1,11 @@
 module Commands.Doctor where
 
+import Commands.Base hiding (info)
 import Commands.Doctor.Options
 import Commands.Extra.Compile
 import Data.Aeson
 import Data.Aeson.TH
 import Juvix.Extra.Version qualified as V
-import Juvix.Prelude
 import Network.HTTP.Simple
 import Safe (headMay)
 import System.Environment qualified as E
@@ -68,7 +68,7 @@ warning = log . ("  ! " <>)
 info :: (Member Log r) => Text -> Sem r ()
 info = log . ("  | " <>)
 
-type DoctorEff = '[Log, Embed IO]
+type DoctorEff = '[Log, Embed IO, App]
 
 checkCmdOnPath :: (Members DoctorEff r) => String -> [Text] -> Sem r ()
 checkCmdOnPath cmd errMsg =
@@ -173,4 +173,5 @@ runCommand :: (Members DoctorEff r) => DoctorOptions -> Sem r ()
 runCommand opts = do
   checkClang (opts ^. doctorVerbose)
   checkWasmer
-  unless (opts ^. doctorOffline) checkVersion
+  offlineMode <- (^. globalOffline) <$> askGlobalOptions
+  unless offlineMode checkVersion

--- a/app/Commands/Doctor/Options.hs
+++ b/app/Commands/Doctor/Options.hs
@@ -2,19 +2,13 @@ module Commands.Doctor.Options where
 
 import CommonOptions
 
-data DoctorOptions = DoctorOptions
-  { _doctorOffline :: Bool,
-    _doctorVerbose :: Bool
+newtype DoctorOptions = DoctorOptions
+  { _doctorVerbose :: Bool
   }
   deriving stock (Data)
 
 parseDoctorOptions :: Parser DoctorOptions
 parseDoctorOptions = do
-  _doctorOffline <-
-    switch
-      ( long "offline"
-          <> help "Run the doctor offline"
-      )
   _doctorVerbose <-
     switch
       ( long "verbose"

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -19,7 +19,8 @@ data GlobalOptions = GlobalOptions
     _globalNoPositivity :: Bool,
     _globalNoCoverage :: Bool,
     _globalNoStdlib :: Bool,
-    _globalUnrollLimit :: Int
+    _globalUnrollLimit :: Int,
+    _globalOffline :: Bool
   }
   deriving stock (Eq, Show)
 
@@ -58,7 +59,8 @@ defaultGlobalOptions =
       _globalNoPositivity = False,
       _globalNoCoverage = False,
       _globalNoStdlib = False,
-      _globalUnrollLimit = defaultUnrollLimit
+      _globalUnrollLimit = defaultUnrollLimit,
+      _globalOffline = False
     }
 
 -- | Get a parser for global flags which can be hidden or not depending on
@@ -118,6 +120,11 @@ parseGlobalFlags = do
       ( long "unroll"
           <> value defaultUnrollLimit
           <> help ("Recursion unrolling limit (default: " <> show defaultUnrollLimit <> ")")
+      )
+  _globalOffline <-
+    switch
+      ( long "offline"
+          <> help "Disable access to network resources"
       )
   return GlobalOptions {..}
 

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -157,7 +157,8 @@ entryPointFromGlobalOptions roots mainFile opts = do
         _entryPointNoStdlib = opts ^. globalNoStdlib,
         _entryPointUnrollLimit = opts ^. globalUnrollLimit,
         _entryPointGenericOptions = project opts,
-        _entryPointBuildDir = maybe (def ^. entryPointBuildDir) Abs mabsBuildDir
+        _entryPointBuildDir = maybe (def ^. entryPointBuildDir) Abs mabsBuildDir,
+        _entryPointOffline = opts ^. globalOffline
       }
   where
     optBuildDir :: Maybe (Prepath Dir)
@@ -177,7 +178,8 @@ entryPointFromGlobalOptionsNoFile roots opts = do
         _entryPointNoStdlib = opts ^. globalNoStdlib,
         _entryPointUnrollLimit = opts ^. globalUnrollLimit,
         _entryPointGenericOptions = project opts,
-        _entryPointBuildDir = maybe (def ^. entryPointBuildDir) Abs mabsBuildDir
+        _entryPointBuildDir = maybe (def ^. entryPointBuildDir) Abs mabsBuildDir,
+        _entryPointOffline = opts ^. globalOffline
       }
   where
     optBuildDir :: Maybe (Prepath Dir)

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -44,7 +44,8 @@ makeSem ''PathResolver
 data ResolverEnv = ResolverEnv
   { _envRoot :: Path Abs Dir,
     -- | The path of the input file *if* we are using the global project
-    _envSingleFile :: Maybe (Path Abs File)
+    _envSingleFile :: Maybe (Path Abs File),
+    _envOffline :: Bool
   }
 
 data ResolverState = ResolverState
@@ -120,12 +121,16 @@ getDependencyPath i = case i ^. packageDepdendencyInfoDependency of
   DependencyGit g -> do
     r <- rootBuildDir <$> asks (^. envRoot)
     let cloneDir = r <//> relDependenciesDir <//> relDir (T.unpack (g ^. gitDependencyName))
-        cloneArgs = CloneArgs {_cloneArgsCloneDir = cloneDir, _cloneArgsRepoUrl = g ^. gitDependencyUrl}
-        errorHandler' = errorHandler cloneDir
-    scoped @CloneArgs @Git cloneArgs $ do
-      fetch errorHandler'
-      checkout errorHandler' (g ^. gitDependencyRef)
-      return cloneDir
+    offline <- asks (^. envOffline)
+    if
+        | offline -> return cloneDir
+        | otherwise -> do
+            let cloneArgs = CloneArgs {_cloneArgsCloneDir = cloneDir, _cloneArgsRepoUrl = g ^. gitDependencyUrl}
+                errorHandler' = errorHandler cloneDir
+            scoped @CloneArgs @Git cloneArgs $ do
+              fetch errorHandler'
+              checkout errorHandler' (g ^. gitDependencyRef)
+              return cloneDir
     where
       errorHandler :: Path Abs Dir -> GitError -> Sem (Git ': r) a
       errorHandler p c =
@@ -262,7 +267,8 @@ runPathResolver' st root x = do
       env =
         ResolverEnv
           { _envRoot = root,
-            _envSingleFile
+            _envSingleFile,
+            _envOffline = e ^. entryPointOffline
           }
   runState st (runReader env (re x))
 

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -37,7 +37,8 @@ data EntryPoint = EntryPoint
     _entryPointInliningDepth :: Int,
     _entryPointGenericOptions :: GenericOptions,
     _entryPointModulePaths :: [Path Abs File],
-    _entryPointSymbolPruningMode :: SymbolPruningMode
+    _entryPointSymbolPruningMode :: SymbolPruningMode,
+    _entryPointOffline :: Bool
   }
   deriving stock (Eq, Show)
 
@@ -81,7 +82,8 @@ defaultEntryPointNoFile roots =
       _entryPointOptimizationLevel = defaultOptimizationLevel,
       _entryPointInliningDepth = defaultInliningDepth,
       _entryPointModulePaths = [],
-      _entryPointSymbolPruningMode = FilterUnreachable
+      _entryPointSymbolPruningMode = FilterUnreachable,
+      _entryPointOffline = False
     }
 
 defaultUnrollLimit :: Int

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -204,13 +204,17 @@ compileReplInputIO ::
   Path Abs File ->
   Text ->
   Sem r (Either JuvixError ReplPipelineResult)
-compileReplInputIO fp txt =
+compileReplInputIO fp txt = do
+  offline <- asks (^. entryPointOffline)
+  let gitProcessMode
+        | offline = GitProcessOffline
+        | otherwise = GitProcessOnline
   runError
     . runLogIO
     . runFilesIO
     . mapError (JuvixError @GitProcessError)
     . runProcessIO
-    . runGitProcess
+    . runGitProcess gitProcessMode
     . mapError (JuvixError @DependencyError)
     . runPathResolverArtifacts
     $ do

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -54,7 +54,7 @@ testDescr PosTest {..} = helper renderCodeNew
                         . ignoreLog
                         . runProcessIO
                         . mapError (JuvixError @GitProcessError)
-                        . runGitProcess
+                        . runGitProcess GitProcessOffline
                         . mapError (JuvixError @DependencyError)
                         . runPathResolverPipe
                     evalHelper :: HashMap (Path Abs File) Text -> Sem PipelineEff a -> IO a

--- a/tests/smoke/Commands/compile-dependencies.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies.smoke.yaml
@@ -59,6 +59,71 @@ tests:
       contains: Hello from dep
     exit-status: 0
 
+  - name: git-dependencies-success-then-offline
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+
+        # create dependency
+        mkdir $temp/dep
+        cd $temp/dep
+        git init
+
+        cat <<-EOF > HelloDep.juvix
+        module HelloDep;
+        import Stdlib.Prelude open;
+        main : IO := printStringLn "Hello from dep";
+        EOF
+        touch juvix.yaml
+
+        git add -A
+        git commit -m "commit1"
+
+        dep1hash=$(git rev-parse HEAD)
+
+        # create project that uses dependency
+        mkdir $temp/base
+        cd $temp/base
+
+        cat <<-EOF > juvix.yaml
+        name: HelloWorld
+        main: HelloWorld.juvix
+        dependencies:
+          - .juvix-build/stdlib
+          - git:
+              url: $temp/dep
+              name: dep1
+              ref: $dep1hash
+        version: 0.1.0
+        EOF
+
+        cat <<-EOF > HelloWorld.juvix
+        -- HelloWorld.juvix
+        module HelloWorld;
+
+        import Stdlib.Prelude open;
+        import HelloDep;
+
+        main : IO := HelloDep.main;
+        EOF
+
+        # compile project
+        juvix compile HelloWorld.juvix
+
+        # Delete the dependency
+        rm -rf $temp/dep
+        rm HelloWorld
+
+        # Compile using the offline clone
+        juvix --offline compile HelloWorld.juvix
+        ./HelloWorld
+    stdout:
+      contains: Hello from dep
+    exit-status: 0
+
   - name: git-dependencies-fetch-new-commits
     command:
       shell:
@@ -246,6 +311,53 @@ tests:
       contains: error
     stdout:
       contains: cloning
+    exit-status: 1
+
+  - name: git-dependencies-offline
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+
+        # create project that uses dependency
+        mkdir $temp/base
+        cd $temp/base
+
+        cat <<-EOF > juvix.yaml
+        name: HelloWorld
+        main: HelloWorld.juvix
+        dependencies:
+          - .juvix-build/stdlib
+          - git:
+              url: $temp/dep
+              name: dep1
+              ref: main
+        version: 0.1.0
+        EOF
+
+        cat <<-EOF > HelloWorld.juvix
+        -- HelloWorld.juvix
+        module HelloWorld;
+
+        import Stdlib.Prelude open;
+        import HelloDep;
+
+        main : IO := HelloDep.main;
+        EOF
+
+        # compile project
+        juvix --offline compile HelloWorld.juvix
+    stderr:
+      contains: dep1
+    stdout:
+      matches:
+        # compile should not attempt to clone the dependency
+        regex: |-
+          ^((?!cloning).)*$
+        options:
+          - dot-all
     exit-status: 1
 
   - name: git-dependencies-corrupt-clone

--- a/tests/smoke/Commands/compile-dependencies.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies.smoke.yaml
@@ -214,6 +214,99 @@ tests:
       contains: This is from the second commit
     exit-status: 0
 
+  - name: git-dependencies-update-ref-offline
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+
+        # create dependency
+        mkdir $temp/dep
+        cd $temp/dep
+        git init
+
+        # Make the first commit
+        cat <<-EOF > HelloDep.juvix
+        module HelloDep;
+        import Stdlib.Prelude open;
+        main : IO := printStringLn "Hello from dep";
+        EOF
+        touch juvix.yaml
+
+        git add -A
+        git commit -m "commit1"
+
+        dep1hash1=$(git rev-parse HEAD)
+
+        # Make the second commit
+        cat <<-EOF > HelloDep.juvix
+        module HelloDep;
+        import Stdlib.Prelude open;
+        main : IO := printStringLn "This is from the second commit";
+        EOF
+
+        git add -A
+        git commit -m "commit2"
+
+        dep1hash2=$(git rev-parse HEAD)
+
+        # create project that uses dependency
+        mkdir $temp/base
+        cd $temp/base
+
+        cat <<-EOF > juvix.yaml
+        name: HelloWorld
+        main: HelloWorld.juvix
+        dependencies:
+          - .juvix-build/stdlib
+          - git:
+              url: $temp/dep
+              name: dep1
+              ref: $dep1hash1
+        version: 0.1.0
+        EOF
+
+        cat <<-EOF > HelloWorld.juvix
+        -- HelloWorld.juvix
+        module HelloWorld;
+
+        import Stdlib.Prelude open;
+        import HelloDep;
+
+        main : IO := HelloDep.main;
+        EOF
+
+        # compile project the first time
+        # It should use code from the first commit
+        juvix compile HelloWorld.juvix
+        output=$(./HelloWorld)
+
+        if [ "$output" != "Hello from dep" ]; then
+          exit 1
+        fi
+
+        # Update the ref and compile in offline mode
+        # It should use code from the second commit
+        cat <<-EOF > juvix.yaml
+        name: HelloWorld
+        main: HelloWorld.juvix
+        dependencies:
+          - .juvix-build/stdlib
+          - git:
+              url: $temp/dep
+              name: dep1
+              ref: $dep1hash2
+        version: 0.1.0
+        EOF
+
+        juvix --offline compile HelloWorld.juvix
+        ./HelloWorld
+    stdout:
+      contains: This is from the second commit
+    exit-status: 0
+
   - name: git-dependencies-invalid-ref
     command:
       shell:


### PR DESCRIPTION
This PR introduces a global `--offline` flag.

## Doctor

This replaces the `--offline` flag on the doctor command.

## Juvix package builds

The flag applies to juvix build commands like `juvix compile`, `juvix repl`. This is so that users can continue to build packages offline that have external dependencies when there's no network connection (as long as they built the same package online previously).

Specifically, when the `--offline` flag is used in a package that has external git dependencies.
* No `git clone` or `git fetch` commands are used
* `git checkout` will continue to be used
* Clones from previous builds are reused

This means that you can update the `ref` field in a git dependency, as long as the ref existed the last time that the project was built without the `--offline` flag.

* Closes https://github.com/anoma/juvix/issues/2333
