### PR TITLE
Add Internet effect

### DIFF
--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -138,21 +138,20 @@ loadFile f = do
 loadDefaultPrelude :: Repl ()
 loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
   root <- Reader.asks (^. replRoots . rootsRootDir)
-  let gitProcessMode
-        | e ^. entryPointOffline = GitProcessOffline
-        | otherwise = GitProcessOnline
+  let hasInternet = not (e ^. entryPointOffline)
   -- The following is needed to ensure that the default location of the
   -- standard library exists
   void
     . liftIO
     . runM
+    . evalInternet hasInternet
     . runFilesIO
     . runError @Text
     . runReader e
     . runLogIO
     . runProcessIO
     . runError @GitProcessError
-    . runGitProcess gitProcessMode
+    . runGitProcess
     . runError @DependencyError
     . runPathResolver root
     $ entrySetup

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -205,16 +205,14 @@ compileReplInputIO ::
   Text ->
   Sem r (Either JuvixError ReplPipelineResult)
 compileReplInputIO fp txt = do
-  offline <- asks (^. entryPointOffline)
-  let gitProcessMode
-        | offline = GitProcessOffline
-        | otherwise = GitProcessOnline
+  hasInternet <- not <$> asks (^. entryPointOffline)
   runError
+    . evalInternet hasInternet
     . runLogIO
     . runFilesIO
     . mapError (JuvixError @GitProcessError)
     . runProcessIO
-    . runGitProcess gitProcessMode
+    . runGitProcess
     . mapError (JuvixError @DependencyError)
     . runPathResolverArtifacts
     $ do

--- a/src/Juvix/Data/Effect.hs
+++ b/src/Juvix/Data/Effect.hs
@@ -5,12 +5,14 @@ module Juvix.Data.Effect
     module Juvix.Data.Effect.NameIdGen,
     module Juvix.Data.Effect.Visit,
     module Juvix.Data.Effect.Log,
+    module Juvix.Data.Effect.Internet,
   )
 where
 
 import Juvix.Data.Effect.Cache
 import Juvix.Data.Effect.Fail
 import Juvix.Data.Effect.Files
+import Juvix.Data.Effect.Internet
 import Juvix.Data.Effect.Log
 import Juvix.Data.Effect.NameIdGen hiding (toState)
 import Juvix.Data.Effect.Visit

--- a/src/Juvix/Data/Effect/Internet.hs
+++ b/src/Juvix/Data/Effect/Internet.hs
@@ -1,15 +1,16 @@
 -- | This effect indicates whether we can use the internet or not.
-module Juvix.Data.Effect.Internet.Base (
-  InternetWitness,
-  Online,
-  Internet,
-  getInternet,
-  evalInternetOnline,
-  evalInternetOffline,
-  evalInternet,
-  whenHasInternet,
-  ifHasInternet,
-  ) where
+module Juvix.Data.Effect.Internet
+  ( InternetWitness,
+    Online,
+    Internet,
+    getInternet,
+    evalInternetOnline,
+    evalInternetOffline,
+    evalInternet,
+    whenHasInternet,
+    ifHasInternet,
+  )
+where
 
 import Juvix.Prelude.Base
 
@@ -23,20 +24,20 @@ data Internet m a where
 
 makeSem ''Internet
 
-ifHasInternet :: Members '[Internet] r => Sem (Online ': r) () -> Sem r () -> Sem r ()
+ifHasInternet :: (Members '[Internet] r) => Sem (Online ': r) () -> Sem r () -> Sem r ()
 ifHasInternet ifonline ifoffline = do
   x <- getInternet
   case x of
     Nothing -> ifoffline
     Just w -> runReader w ifonline
 
-whenHasInternet :: Members '[Internet] r => Sem (Online ': r) () -> Sem r ()
+whenHasInternet :: (Members '[Internet] r) => Sem (Online ': r) () -> Sem r ()
 whenHasInternet m = ifHasInternet m (return ())
 
 evalInternet :: Bool -> Sem (Internet ': r) a -> Sem r a
 evalInternet hasInternet
- | hasInternet = evalInternetOnline
- | otherwise = evalInternetOffline
+  | hasInternet = evalInternetOnline
+  | otherwise = evalInternetOffline
 
 evalInternetOffline :: Sem (Internet ': r) a -> Sem r a
 evalInternetOffline = interpret $ \case

--- a/src/Juvix/Data/Effect/Internet/Base.hs
+++ b/src/Juvix/Data/Effect/Internet/Base.hs
@@ -1,0 +1,47 @@
+-- | This effect indicates whether we can use the internet or not.
+module Juvix.Data.Effect.Internet.Base (
+  InternetWitness,
+  Online,
+  Internet,
+  getInternet,
+  evalInternetOnline,
+  evalInternetOffline,
+  evalInternet,
+  whenHasInternet,
+  ifHasInternet,
+  ) where
+
+import Juvix.Prelude.Base
+
+data InternetWitness = InternetWitness
+
+type Online = Reader InternetWitness
+
+data Internet m a where
+  -- | Returns `Nothing` if we are offline
+  GetInternet :: Internet m (Maybe InternetWitness)
+
+makeSem ''Internet
+
+ifHasInternet :: Members '[Internet] r => Sem (Online ': r) () -> Sem r () -> Sem r ()
+ifHasInternet ifonline ifoffline = do
+  x <- getInternet
+  case x of
+    Nothing -> ifoffline
+    Just w -> runReader w ifonline
+
+whenHasInternet :: Members '[Internet] r => Sem (Online ': r) () -> Sem r ()
+whenHasInternet m = ifHasInternet m (return ())
+
+evalInternet :: Bool -> Sem (Internet ': r) a -> Sem r a
+evalInternet hasInternet
+ | hasInternet = evalInternetOnline
+ | otherwise = evalInternetOffline
+
+evalInternetOffline :: Sem (Internet ': r) a -> Sem r a
+evalInternetOffline = interpret $ \case
+  GetInternet -> return Nothing
+
+evalInternetOnline :: Sem (Internet ': r) a -> Sem r a
+evalInternetOnline = interpret $ \case
+  GetInternet -> return (Just InternetWitness)

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -45,6 +45,7 @@ testDescr PosTest {..} = helper renderCodeNew
                 let runHelper :: HashMap (Path Abs File) Text -> Sem PipelineEff a -> IO (ResolverState, a)
                     runHelper files =
                       runM
+                        . evalInternetOffline
                         . ignoreHighlightBuilder
                         . runErrorIO' @JuvixError
                         . evalTopBuiltins
@@ -54,7 +55,7 @@ testDescr PosTest {..} = helper renderCodeNew
                         . ignoreLog
                         . runProcessIO
                         . mapError (JuvixError @GitProcessError)
-                        . runGitProcess GitProcessOffline
+                        . runGitProcess
                         . mapError (JuvixError @DependencyError)
                         . runPathResolverPipe
                     evalHelper :: HashMap (Path Abs File) Text -> Sem PipelineEff a -> IO a


### PR DESCRIPTION
- This pr adds the `Internet` effect. The type of a function can inform whether that function requires internet connection. Moreover, now that we have the `--offline` flag (#2335), this effect will be part of the pipeline so that it can be accessed in any of the steps without having to pass some explicit argument such as `GitProcessMode`.