### PR TITLE
Small refactor for traits

### DIFF
--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
@@ -123,7 +123,6 @@ addAtoms atoms = addAtom . (^. expressionAtoms . _head1) $ atoms
         addParameter = \case
           FunctionParameterName s -> addSymbol _paramImplicit s
           FunctionParameterWildcard {} -> endBuild
-          FunctionParameterUnnamed {} -> endBuild
 
 addInductiveParams' :: (Members '[NameSignatureBuilder] r) => IsImplicit -> InductiveParameters 'Parsed -> Sem r ()
 addInductiveParams' i a = forM_ (a ^. inductiveParametersNames) (addSymbol i)

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -1080,8 +1080,6 @@ instance HasAtomicity (Lambda s) where
 data FunctionParameter (s :: Stage)
   = FunctionParameterName (SymbolType s)
   | FunctionParameterWildcard KeywordRef
-  | -- | Used for traits
-    FunctionParameterUnnamed Interval
 
 deriving stock instance Show (FunctionParameter 'Parsed)
 
@@ -1819,7 +1817,6 @@ instance HasLoc (FunctionParameter 'Scoped) where
   getLoc = \case
     FunctionParameterName n -> getLoc n
     FunctionParameterWildcard w -> getLoc w
-    FunctionParameterUnnamed i -> i
 
 instance HasLoc (FunctionParameters 'Scoped) where
   getLoc p = case p ^. paramDelims . unIrrelevant of

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -342,7 +342,8 @@ instance HasLoc IteratorSyntaxDef where
 data SigArg (s :: Stage) = SigArg
   { _sigArgDelims :: Irrelevant (KeywordRef, KeywordRef),
     _sigArgImplicit :: IsImplicit,
-    _sigArgNames :: NonEmpty (Argument s),
+    -- | Allowed to be empty only for Instance arguments
+    _sigArgNames :: [Argument s],
     _sigArgColon :: Maybe (Irrelevant KeywordRef),
     -- | The type is only optional for implicit arguments. Omitting the rhs is
     -- equivalent to writing `: Type`.

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -301,6 +301,11 @@ instance (SingI s) => PrettyPrint (RecordUpdate s) where
       <> fields'
       <> ppCode r
 
+instance (SingI s) => PrettyPrint (DoubleBracesExpression s) where
+  ppCode DoubleBracesExpression {..} = do
+    let (l, r) = _doubleBracesDelims ^. unIrrelevant
+    ppCode l <> ppExpressionType _doubleBracesExpression <> ppCode r
+
 instance (SingI s) => PrettyPrint (ExpressionAtom s) where
   ppCode = \case
     AtomIdentifier n -> ppIdentifierType n
@@ -314,7 +319,7 @@ instance (SingI s) => PrettyPrint (ExpressionAtom s) where
     AtomLiteral lit -> ppCode lit
     AtomFunArrow a -> ppCode a
     AtomParens e -> parens (ppExpressionType e)
-    AtomDoubleBraces e -> doubleBraces (ppExpressionType (e ^. withLocParam))
+    AtomDoubleBraces e -> ppCode e
     AtomBraces e -> braces (ppExpressionType (e ^. withLocParam))
     AtomHole w -> ppHoleType w
     AtomIterator i -> ppCode i
@@ -658,7 +663,7 @@ instance PrettyPrint Expression where
     ExpressionInstanceHole w -> ppCode w
     ExpressionParensIdentifier n -> parens (ppCode n)
     ExpressionBraces b -> braces (ppCode b)
-    ExpressionDoubleBraces b -> doubleBraces (ppCode b)
+    ExpressionDoubleBraces b -> ppCode b
     ExpressionApplication a -> ppCode a
     ExpressionList a -> ppCode a
     ExpressionInfixApplication a -> ppCode a

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -520,7 +520,8 @@ instance (SingI s) => PrettyPrint (FunctionParameters s) where
   ppCode :: forall r. (Members '[ExactPrint, Reader Options] r) => FunctionParameters s -> Sem r ()
   ppCode FunctionParameters {..} = do
     case _paramNames of
-      [] -> ppLeftExpression' funFixity _paramType
+      []
+        | _paramImplicit == Explicit -> ppLeftExpression' funFixity _paramType
       _ -> do
         let paramNames' = map ppCode _paramNames
             paramType' = ppExpressionType _paramType

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -539,7 +539,6 @@ instance (SingI s) => PrettyPrint (FunctionParameter s) where
   ppCode = \case
     FunctionParameterName n -> annDef n (ppSymbolType n)
     FunctionParameterWildcard w -> ppCode w
-    FunctionParameterUnnamed {} -> return ()
 
 instance (SingI s) => PrettyPrint (Function s) where
   ppCode :: forall r. (Members '[ExactPrint, Reader Options] r) => Function s -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -662,10 +662,10 @@ resolveFixitySyntaxDef fdef@FixitySyntaxDef {..} = topBindings $ do
       belowPrec = fromIntegral $ maximum (minInt + 1 : map (getPrec tab) above)
       abovePrec :: Integer
       abovePrec = fromIntegral $ minimum (maxInt - 1 : map (getPrec tab) below)
-  when (belowPrec >= abovePrec + 1)
-    $ throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
-  when (isJust same && not (null below && null above))
-    $ throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
+  when (belowPrec >= abovePrec + 1) $
+    throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
+  when (isJust same && not (null below && null above)) $
+    throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
   -- we need Integer to avoid overflow when computing prec
   let prec = fromMaybe (fromInteger $ (abovePrec + belowPrec) `div` 2) samePrec
       fx =
@@ -1187,11 +1187,11 @@ checkSections sec = do
                           | not (null cs) -> fail
                           | otherwise -> do
                               fs <-
-                                failMaybe
-                                  $ mkRec
-                                  ^? constructorRhs
-                                  . _ConstructorRhsRecord
-                                  . to mkRecordNameSignature
+                                failMaybe $
+                                  mkRec
+                                    ^? constructorRhs
+                                    . _ConstructorRhsRecord
+                                    . to mkRecordNameSignature
                               let info =
                                     RecordInfo
                                       { _recordInfoSignature = fs,
@@ -1496,8 +1496,8 @@ checkOpenModuleNoImport importModuleHint OpenModule {..}
                 let s = h ^. hidingSymbol
                 scopedSym <-
                   if
-                    | isJust (h ^. hidingModuleKw) -> scopeSymbol SNameSpaceModules s
-                    | otherwise -> scopeSymbol SNameSpaceSymbols s
+                      | isJust (h ^. hidingModuleKw) -> scopeSymbol SNameSpaceModules s
+                      | otherwise -> scopeSymbol SNameSpaceSymbols s
                 return
                   HidingItem
                     { _hidingSymbol = scopedSym,
@@ -1509,8 +1509,8 @@ checkOpenModuleNoImport importModuleHint OpenModule {..}
                 let s = i ^. usingSymbol
                 scopedSym <-
                   if
-                    | isJust (i ^. usingModuleKw) -> scopeSymbol SNameSpaceModules s
-                    | otherwise -> scopeSymbol SNameSpaceSymbols s
+                      | isJust (i ^. usingModuleKw) -> scopeSymbol SNameSpaceModules s
+                      | otherwise -> scopeSymbol SNameSpaceSymbols s
                 let scopedAs = do
                       c <- i ^. usingAs
                       return (set S.nameConcrete c scopedSym)
@@ -1698,10 +1698,10 @@ checkRecordPattern r = do
   fields <- fromMaybeM (return (RecordNameSignature mempty)) (gets (^. scoperConstructorFields . at (c' ^. scopedIdenName . S.nameId)))
   l' <-
     if
-      | null (r ^. recordPatternItems) -> return []
-      | otherwise -> do
-          when (null (fields ^. recordNames)) (throw (noFields c'))
-          runReader fields (mapM checkItem (r ^. recordPatternItems))
+        | null (r ^. recordPatternItems) -> return []
+        | otherwise -> do
+            when (null (fields ^. recordNames)) (throw (noFields c'))
+            runReader fields (mapM checkItem (r ^. recordPatternItems))
   return
     RecordPattern
       { _recordPatternConstructor = c',
@@ -1795,8 +1795,8 @@ checkCaseBranch CaseBranch {..} = withLocalScope $ do
   pattern' <- checkParsePatternAtoms _caseBranchPattern
   checkNotImplicit pattern'
   expression' <- (checkParseExpressionAtoms _caseBranchExpression)
-  return
-    $ CaseBranch
+  return $
+    CaseBranch
       { _caseBranchPattern = pattern',
         _caseBranchExpression = expression',
         ..
@@ -1815,8 +1815,8 @@ checkCase ::
 checkCase Case {..} = do
   caseBranches' <- mapM checkCaseBranch _caseBranches
   caseExpression' <- checkParseExpressionAtoms _caseExpression
-  return
-    $ Case
+  return $
+    Case
       { _caseExpression = caseExpression',
         _caseBranches = caseBranches',
         _caseKw,
@@ -1967,8 +1967,8 @@ checkPatternBinding (PatternBinding n p) = do
   p' <- checkParsePatternAtom p
   n' <- bindVariableSymbol n
   if
-    | isJust (p' ^. patternArgName) -> throw (ErrDoubleBinderPattern (DoubleBinderPattern n' p'))
-    | otherwise -> return (set patternArgName (Just n') p')
+      | isJust (p' ^. patternArgName) -> throw (ErrDoubleBinderPattern (DoubleBinderPattern n' p'))
+      | otherwise -> return (set patternArgName (Just n') p')
 
 checkPatternAtoms ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>
@@ -2330,18 +2330,18 @@ checkPrecedences opers = do
   tab <- getInfoTable
   let fids = mapMaybe (^. fixityId) $ mapMaybe (^. S.nameFixity) opers
       deps = createDependencyInfo (tab ^. infoPrecedenceGraph) mempty
-  mapM_ (uncurry (checkPath deps))
-    $ [(fid1, fid2) | fid1 <- fids, fid2 <- fids, fid1 /= fid2]
+  mapM_ (uncurry (checkPath deps)) $
+    [(fid1, fid2) | fid1 <- fids, fid2 <- fids, fid1 /= fid2]
   where
     checkPath :: DependencyInfo S.NameId -> S.NameId -> S.NameId -> Sem r ()
     checkPath deps fid1 fid2 =
-      unless (isPath deps fid1 fid2 || isPath deps fid2 fid1)
-        $ throw (ErrIncomparablePrecedences (IncomaprablePrecedences (findOper fid1) (findOper fid2)))
+      unless (isPath deps fid1 fid2 || isPath deps fid2 fid1) $
+        throw (ErrIncomparablePrecedences (IncomaprablePrecedences (findOper fid1) (findOper fid2)))
 
     findOper :: S.NameId -> S.Name
     findOper fid =
-      fromJust
-        $ find
+      fromJust $
+        find
           (maybe False (\fx -> Just fid == (fx ^. fixityId)) . (^. S.nameFixity))
           opers
 
@@ -2382,8 +2382,8 @@ makeExpressionTable (ExpressionAtoms atoms _) = [recordUpdate] : [appOpExplicit]
       where
         mkOperator :: ScopedIden -> Maybe (Precedence, P.Operator Parse Expression)
         mkOperator iden
-          | Just Fixity {..} <- _nameFixity = Just
-              $ case _fixityArity of
+          | Just Fixity {..} <- _nameFixity = Just $
+              case _fixityArity of
                 Unary u -> (_fixityPrecedence, P.Postfix (unaryApp <$> parseSymbolId _nameId))
                   where
                     unaryApp :: ScopedIden -> Expression -> Expression
@@ -2428,8 +2428,8 @@ makeExpressionTable (ExpressionAtoms atoms _) = [recordUpdate] : [appOpExplicit]
       where
         app :: Expression -> Expression -> Expression
         app f x =
-          ExpressionApplication
-            $ Application
+          ExpressionApplication $
+            Application
               { _applicationFunction = f,
                 _applicationParameter = x
               }
@@ -2499,21 +2499,21 @@ mkExpressionParser table = embed @Parse pExpression
 
 parseTerm :: (Members '[Embed Parse] r) => Sem r Expression
 parseTerm =
-  embed @Parse
-    $ parseUniverse
-    <|> parseNoInfixIdentifier
-    <|> parseParens
-    <|> parseHole
-    <|> parseFunction
-    <|> parseLambda
-    <|> parseCase
-    <|> parseList
-    <|> parseLiteral
-    <|> parseLet
-    <|> parseIterator
-    <|> parseDoubleBraces
-    <|> parseBraces
-    <|> parseNamedApplication
+  embed @Parse $
+    parseUniverse
+      <|> parseNoInfixIdentifier
+      <|> parseParens
+      <|> parseHole
+      <|> parseFunction
+      <|> parseLambda
+      <|> parseCase
+      <|> parseList
+      <|> parseLiteral
+      <|> parseLet
+      <|> parseIterator
+      <|> parseDoubleBraces
+      <|> parseBraces
+      <|> parseNamedApplication
   where
     parseHole :: Parse Expression
     parseHole = ExpressionHole <$> P.token lit mempty
@@ -2704,17 +2704,17 @@ parsePatternTerm ::
   (Members '[Embed ParsePat] r) =>
   Sem r PatternArg
 parsePatternTerm = do
-  embed @ParsePat
-    $ parseNoInfixConstructor
-    <|> parseVariable
-    <|> parseDoubleBraces
-    <|> parseParens
-    <|> parseBraces
-    <|> parseWildcard
-    <|> parseEmpty
-    <|> parseAt
-    <|> parseList
-    <|> parseRecord
+  embed @ParsePat $
+    parseNoInfixConstructor
+      <|> parseVariable
+      <|> parseDoubleBraces
+      <|> parseParens
+      <|> parseBraces
+      <|> parseWildcard
+      <|> parseEmpty
+      <|> parseAt
+      <|> parseList
+      <|> parseRecord
   where
     parseNoInfixConstructor :: ParsePat PatternArg
     parseNoInfixConstructor =

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -662,10 +662,10 @@ resolveFixitySyntaxDef fdef@FixitySyntaxDef {..} = topBindings $ do
       belowPrec = fromIntegral $ maximum (minInt + 1 : map (getPrec tab) above)
       abovePrec :: Integer
       abovePrec = fromIntegral $ minimum (maxInt - 1 : map (getPrec tab) below)
-  when (belowPrec >= abovePrec + 1) $
-    throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
-  when (isJust same && not (null below && null above)) $
-    throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
+  when (belowPrec >= abovePrec + 1)
+    $ throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
+  when (isJust same && not (null below && null above))
+    $ throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
   -- we need Integer to avoid overflow when computing prec
   let prec = fromMaybe (fromInteger $ (abovePrec + belowPrec) `div` 2) samePrec
       fx =
@@ -1187,11 +1187,11 @@ checkSections sec = do
                           | not (null cs) -> fail
                           | otherwise -> do
                               fs <-
-                                failMaybe $
-                                  mkRec
-                                    ^? constructorRhs
-                                    . _ConstructorRhsRecord
-                                    . to mkRecordNameSignature
+                                failMaybe
+                                  $ mkRec
+                                  ^? constructorRhs
+                                  . _ConstructorRhsRecord
+                                  . to mkRecordNameSignature
                               let info =
                                     RecordInfo
                                       { _recordInfoSignature = fs,
@@ -1496,8 +1496,8 @@ checkOpenModuleNoImport importModuleHint OpenModule {..}
                 let s = h ^. hidingSymbol
                 scopedSym <-
                   if
-                      | isJust (h ^. hidingModuleKw) -> scopeSymbol SNameSpaceModules s
-                      | otherwise -> scopeSymbol SNameSpaceSymbols s
+                    | isJust (h ^. hidingModuleKw) -> scopeSymbol SNameSpaceModules s
+                    | otherwise -> scopeSymbol SNameSpaceSymbols s
                 return
                   HidingItem
                     { _hidingSymbol = scopedSym,
@@ -1509,8 +1509,8 @@ checkOpenModuleNoImport importModuleHint OpenModule {..}
                 let s = i ^. usingSymbol
                 scopedSym <-
                   if
-                      | isJust (i ^. usingModuleKw) -> scopeSymbol SNameSpaceModules s
-                      | otherwise -> scopeSymbol SNameSpaceSymbols s
+                    | isJust (i ^. usingModuleKw) -> scopeSymbol SNameSpaceModules s
+                    | otherwise -> scopeSymbol SNameSpaceSymbols s
                 let scopedAs = do
                       c <- i ^. usingAs
                       return (set S.nameConcrete c scopedSym)
@@ -1633,7 +1633,6 @@ checkFunction f = do
     _paramNames <- forM (f ^. funParameters . paramNames) $ \case
       FunctionParameterWildcard w -> return (FunctionParameterWildcard w)
       FunctionParameterName p -> FunctionParameterName <$> bindVariableSymbol p
-      FunctionParameterUnnamed i -> return (FunctionParameterUnnamed i)
     _funReturn <- checkParseExpressionAtoms (f ^. funReturn)
     let _paramImplicit = f ^. funParameters . paramImplicit
         _paramColon = f ^. funParameters . paramColon
@@ -1699,10 +1698,10 @@ checkRecordPattern r = do
   fields <- fromMaybeM (return (RecordNameSignature mempty)) (gets (^. scoperConstructorFields . at (c' ^. scopedIdenName . S.nameId)))
   l' <-
     if
-        | null (r ^. recordPatternItems) -> return []
-        | otherwise -> do
-            when (null (fields ^. recordNames)) (throw (noFields c'))
-            runReader fields (mapM checkItem (r ^. recordPatternItems))
+      | null (r ^. recordPatternItems) -> return []
+      | otherwise -> do
+          when (null (fields ^. recordNames)) (throw (noFields c'))
+          runReader fields (mapM checkItem (r ^. recordPatternItems))
   return
     RecordPattern
       { _recordPatternConstructor = c',
@@ -1796,8 +1795,8 @@ checkCaseBranch CaseBranch {..} = withLocalScope $ do
   pattern' <- checkParsePatternAtoms _caseBranchPattern
   checkNotImplicit pattern'
   expression' <- (checkParseExpressionAtoms _caseBranchExpression)
-  return $
-    CaseBranch
+  return
+    $ CaseBranch
       { _caseBranchPattern = pattern',
         _caseBranchExpression = expression',
         ..
@@ -1816,8 +1815,8 @@ checkCase ::
 checkCase Case {..} = do
   caseBranches' <- mapM checkCaseBranch _caseBranches
   caseExpression' <- checkParseExpressionAtoms _caseExpression
-  return $
-    Case
+  return
+    $ Case
       { _caseExpression = caseExpression',
         _caseBranches = caseBranches',
         _caseKw,
@@ -1968,8 +1967,8 @@ checkPatternBinding (PatternBinding n p) = do
   p' <- checkParsePatternAtom p
   n' <- bindVariableSymbol n
   if
-      | isJust (p' ^. patternArgName) -> throw (ErrDoubleBinderPattern (DoubleBinderPattern n' p'))
-      | otherwise -> return (set patternArgName (Just n') p')
+    | isJust (p' ^. patternArgName) -> throw (ErrDoubleBinderPattern (DoubleBinderPattern n' p'))
+    | otherwise -> return (set patternArgName (Just n') p')
 
 checkPatternAtoms ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>
@@ -2331,18 +2330,18 @@ checkPrecedences opers = do
   tab <- getInfoTable
   let fids = mapMaybe (^. fixityId) $ mapMaybe (^. S.nameFixity) opers
       deps = createDependencyInfo (tab ^. infoPrecedenceGraph) mempty
-  mapM_ (uncurry (checkPath deps)) $
-    [(fid1, fid2) | fid1 <- fids, fid2 <- fids, fid1 /= fid2]
+  mapM_ (uncurry (checkPath deps))
+    $ [(fid1, fid2) | fid1 <- fids, fid2 <- fids, fid1 /= fid2]
   where
     checkPath :: DependencyInfo S.NameId -> S.NameId -> S.NameId -> Sem r ()
     checkPath deps fid1 fid2 =
-      unless (isPath deps fid1 fid2 || isPath deps fid2 fid1) $
-        throw (ErrIncomparablePrecedences (IncomaprablePrecedences (findOper fid1) (findOper fid2)))
+      unless (isPath deps fid1 fid2 || isPath deps fid2 fid1)
+        $ throw (ErrIncomparablePrecedences (IncomaprablePrecedences (findOper fid1) (findOper fid2)))
 
     findOper :: S.NameId -> S.Name
     findOper fid =
-      fromJust $
-        find
+      fromJust
+        $ find
           (maybe False (\fx -> Just fid == (fx ^. fixityId)) . (^. S.nameFixity))
           opers
 
@@ -2383,8 +2382,8 @@ makeExpressionTable (ExpressionAtoms atoms _) = [recordUpdate] : [appOpExplicit]
       where
         mkOperator :: ScopedIden -> Maybe (Precedence, P.Operator Parse Expression)
         mkOperator iden
-          | Just Fixity {..} <- _nameFixity = Just $
-              case _fixityArity of
+          | Just Fixity {..} <- _nameFixity = Just
+              $ case _fixityArity of
                 Unary u -> (_fixityPrecedence, P.Postfix (unaryApp <$> parseSymbolId _nameId))
                   where
                     unaryApp :: ScopedIden -> Expression -> Expression
@@ -2429,8 +2428,8 @@ makeExpressionTable (ExpressionAtoms atoms _) = [recordUpdate] : [appOpExplicit]
       where
         app :: Expression -> Expression -> Expression
         app f x =
-          ExpressionApplication $
-            Application
+          ExpressionApplication
+            $ Application
               { _applicationFunction = f,
                 _applicationParameter = x
               }
@@ -2443,23 +2442,27 @@ makeExpressionTable (ExpressionAtoms atoms _) = [recordUpdate] : [appOpExplicit]
         getArrow = \case
           AtomFunArrow r -> return r
           _ -> Nothing
+
         nonDepFun :: KeywordRef -> Expression -> Expression -> Expression
-        nonDepFun _funKw a b =
+        nonDepFun _funKw l r =
           ExpressionFunction
             Function
               { _funParameters = param,
-                _funReturn = b,
+                _funReturn = r,
                 _funKw
               }
           where
             param =
-              FunctionParameters
-                { _paramNames = [],
-                  _paramDelims = Irrelevant Nothing,
-                  _paramColon = Irrelevant Nothing,
-                  _paramImplicit = Explicit,
-                  _paramType = a
-                }
+              let (l', explicitOrInstance) = case l of
+                    ExpressionDoubleBraces i -> (i ^. withLocParam, ImplicitInstance)
+                    _ -> (l, Explicit)
+               in FunctionParameters
+                    { _paramNames = [],
+                      _paramDelims = Irrelevant Nothing,
+                      _paramColon = Irrelevant Nothing,
+                      _paramImplicit = explicitOrInstance,
+                      _paramType = l'
+                    }
 
 parseExpressionAtoms ::
   forall r.
@@ -2496,21 +2499,21 @@ mkExpressionParser table = embed @Parse pExpression
 
 parseTerm :: (Members '[Embed Parse] r) => Sem r Expression
 parseTerm =
-  embed @Parse $
-    parseUniverse
-      <|> parseNoInfixIdentifier
-      <|> parseParens
-      <|> parseHole
-      <|> parseFunction
-      <|> parseLambda
-      <|> parseCase
-      <|> parseList
-      <|> parseLiteral
-      <|> parseLet
-      <|> parseIterator
-      <|> parseDoubleBraces
-      <|> parseBraces
-      <|> parseNamedApplication
+  embed @Parse
+    $ parseUniverse
+    <|> parseNoInfixIdentifier
+    <|> parseParens
+    <|> parseHole
+    <|> parseFunction
+    <|> parseLambda
+    <|> parseCase
+    <|> parseList
+    <|> parseLiteral
+    <|> parseLet
+    <|> parseIterator
+    <|> parseDoubleBraces
+    <|> parseBraces
+    <|> parseNamedApplication
   where
     parseHole :: Parse Expression
     parseHole = ExpressionHole <$> P.token lit mempty
@@ -2701,21 +2704,22 @@ parsePatternTerm ::
   (Members '[Embed ParsePat] r) =>
   Sem r PatternArg
 parsePatternTerm = do
-  embed @ParsePat $
-    parseNoInfixConstructor
-      <|> parseVariable
-      <|> parseDoubleBraces
-      <|> parseParens
-      <|> parseBraces
-      <|> parseWildcard
-      <|> parseEmpty
-      <|> parseAt
-      <|> parseList
-      <|> parseRecord
+  embed @ParsePat
+    $ parseNoInfixConstructor
+    <|> parseVariable
+    <|> parseDoubleBraces
+    <|> parseParens
+    <|> parseBraces
+    <|> parseWildcard
+    <|> parseEmpty
+    <|> parseAt
+    <|> parseList
+    <|> parseRecord
   where
     parseNoInfixConstructor :: ParsePat PatternArg
     parseNoInfixConstructor =
-      explicitP . PatternConstructor
+      explicitP
+        . PatternConstructor
         <$> P.token constructorNoFixity mempty
       where
         constructorNoFixity :: PatternAtom 'Scoped -> Maybe ScopedIden

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -2722,8 +2722,7 @@ parsePatternTerm = do
   where
     parseNoInfixConstructor :: ParsePat PatternArg
     parseNoInfixConstructor =
-      explicitP
-        . PatternConstructor
+      explicitP . PatternConstructor
         <$> P.token constructorNoFixity mempty
       where
         constructorNoFixity :: PatternAtom 'Scoped -> Maybe ScopedIden

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -14,7 +14,7 @@ import Juvix.Compiler.Internal.Translation.FromConcrete.NamedArguments.Error
 data ScoperError
   = ErrInfixParser InfixError
   | ErrAppLeftImplicit AppLeftImplicit
-  | ErrAppLeftImplicitInstance AppLeftImplicitInstance
+  | ErrDanglingDoubleBrace DanglingDoubleBrace
   | ErrInfixPattern InfixErrorP
   | ErrMultipleDeclarations MultipleDeclarations
   | ErrImportCycle ImportCycle
@@ -54,7 +54,7 @@ instance ToGenericError ScoperError where
     ErrCaseBranchImplicitPattern e -> genericError e
     ErrInfixParser e -> genericError e
     ErrAppLeftImplicit e -> genericError e
-    ErrAppLeftImplicitInstance e -> genericError e
+    ErrDanglingDoubleBrace e -> genericError e
     ErrInfixPattern e -> genericError e
     ErrMultipleDeclarations e -> genericError e
     ErrImportCycle e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -14,6 +14,7 @@ import Juvix.Compiler.Internal.Translation.FromConcrete.NamedArguments.Error
 data ScoperError
   = ErrInfixParser InfixError
   | ErrAppLeftImplicit AppLeftImplicit
+  | ErrAppLeftImplicitInstance AppLeftImplicitInstance
   | ErrInfixPattern InfixErrorP
   | ErrMultipleDeclarations MultipleDeclarations
   | ErrImportCycle ImportCycle
@@ -53,6 +54,7 @@ instance ToGenericError ScoperError where
     ErrCaseBranchImplicitPattern e -> genericError e
     ErrInfixParser e -> genericError e
     ErrAppLeftImplicit e -> genericError e
+    ErrAppLeftImplicitInstance e -> genericError e
     ErrInfixPattern e -> genericError e
     ErrMultipleDeclarations e -> genericError e
     ErrImportCycle e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -313,7 +313,7 @@ instance ToGenericError AppLeftImplicit where
                 <> "It needs to be the argument of a function expecting an implicit argument."
 
 newtype DanglingDoubleBrace = DanglingDoubleBrace
-  { _danglingDoubleBrace :: WithLoc Expression
+  { _danglingDoubleBrace :: DoubleBracesExpression 'Scoped
   }
   deriving stock (Show)
 
@@ -331,7 +331,7 @@ instance ToGenericError DanglingDoubleBrace where
             }
         where
           opts' = fromGenericOptions opts
-          expr = ExpressionDoubleBraces (e ^. danglingDoubleBrace)
+          expr = e ^. danglingDoubleBrace
           i = getLoc expr
           msg =
             "The expression"

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -331,10 +331,11 @@ instance ToGenericError DanglingDoubleBrace where
             }
         where
           opts' = fromGenericOptions opts
-          i = getLoc (e ^. danglingDoubleBrace)
+          expr = ExpressionDoubleBraces (e ^. danglingDoubleBrace)
+          i = getLoc expr
           msg =
             "The expression"
-              <+> ppCode opts' (e ^. danglingDoubleBrace)
+              <+> ppCode opts' expr
               <+> "cannot appear by itself."
                 <> line
                 <> "It needs to be on the left of a function arrow."

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -312,6 +312,33 @@ instance ToGenericError AppLeftImplicit where
                 <> line
                 <> "It needs to be the argument of a function expecting an implicit argument."
 
+newtype AppLeftImplicitInstance = AppLeftImplicitInstance
+  { _appLeftImplicitInstance :: WithLoc Expression
+  }
+  deriving stock (Show)
+
+makeLenses ''AppLeftImplicitInstance
+
+instance ToGenericError AppLeftImplicitInstance where
+  genericError e = ask >>= generr
+    where
+      generr opts =
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = prettyError msg,
+              _genericErrorIntervals = [i]
+            }
+        where
+          opts' = fromGenericOptions opts
+          i = getLoc (e ^. appLeftImplicitInstance)
+          msg =
+            "The expression"
+              <+> ppCode opts' (e ^. appLeftImplicitInstance)
+              <+> "cannot appear by itself."
+                <> line
+                <> "It needs to be on the left of a function arrow."
+
 newtype ModuleNotInScope = ModuleNotInScope
   { _moduleNotInScopeName :: Name
   }

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -312,14 +312,14 @@ instance ToGenericError AppLeftImplicit where
                 <> line
                 <> "It needs to be the argument of a function expecting an implicit argument."
 
-newtype AppLeftImplicitInstance = AppLeftImplicitInstance
-  { _appLeftImplicitInstance :: WithLoc Expression
+newtype DanglingDoubleBrace = DanglingDoubleBrace
+  { _danglingDoubleBrace :: WithLoc Expression
   }
   deriving stock (Show)
 
-makeLenses ''AppLeftImplicitInstance
+makeLenses ''DanglingDoubleBrace
 
-instance ToGenericError AppLeftImplicitInstance where
+instance ToGenericError DanglingDoubleBrace where
   genericError e = ask >>= generr
     where
       generr opts =
@@ -331,10 +331,10 @@ instance ToGenericError AppLeftImplicitInstance where
             }
         where
           opts' = fromGenericOptions opts
-          i = getLoc (e ^. appLeftImplicitInstance)
+          i = getLoc (e ^. danglingDoubleBrace)
           msg =
             "The expression"
-              <+> ppCode opts' (e ^. appLeftImplicitInstance)
+              <+> ppCode opts' (e ^. danglingDoubleBrace)
               <+> "cannot appear by itself."
                 <> line
                 <> "It needs to be on the left of a function arrow."

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -1002,8 +1002,8 @@ functionParams = do
     (opn, impl) <- implicitOpen
     case impl of
       ImplicitInstance -> do
-        n <- optional pNameColon
-        return (opn, [fromMaybe (FunctionParameterUnnamed (getLoc opn)) n], impl, Irrelevant Nothing)
+        n <- pName <* kw kwColon
+        return (opn, [n], impl, Irrelevant Nothing)
       _ -> do
         n <- some pName
         c <- Irrelevant . Just <$> kw kwColon
@@ -1017,12 +1017,6 @@ functionParams = do
     pName =
       FunctionParameterName <$> symbol
         <|> FunctionParameterWildcard <$> kw kwWildcard
-
-    pNameColon :: ParsecS r (FunctionParameter 'Parsed)
-    pNameColon = P.try $ do
-      n <- pName
-      kw kwColon
-      return n
 
 functionOrDoubleBraces :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (Either (Function 'Parsed) (WithLoc (ExpressionAtoms 'Parsed)))
 functionOrDoubleBraces = do

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -926,6 +926,7 @@ functionDefinition _signBuiltin = P.label "<function definition>" $ do
               return (n, c)
         (ns, c) <- case impl of
           ImplicitInstance ->
+            -- FIXME this wildcard is wrong!
             first NonEmpty.singleton
               <$> ( parseArgumentNameColon
                       <|> return (ArgumentWildcard (Wildcard (getLoc opn)), Nothing)

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -888,7 +888,7 @@ goExpression = \case
       where
         (r, i) = case arg of
           ExpressionBraces b -> (b ^. withLocParam, Implicit)
-          ExpressionDoubleBraces b -> (b ^. withLocParam, ImplicitInstance)
+          ExpressionDoubleBraces b -> (b ^. doubleBracesExpression, ImplicitInstance)
           _ -> (arg, Explicit)
 
     goPostfix :: PostfixApplication -> Sem r Internal.Application

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -604,8 +604,8 @@ goInductive ty@InductiveDef {..} = do
   let inductiveName' = goSymbol _inductiveName
       constrRetType = Internal.foldExplicitApplication (Internal.toExpression inductiveName') (map (Internal.ExpressionIden . Internal.IdenVar . (^. Internal.inductiveParamName)) _inductiveParameters')
   _inductiveConstructors' <-
-    local (const _inductivePragmas')
-      $ mapM (goConstructorDef constrRetType) _inductiveConstructors
+    local (const _inductivePragmas') $
+      mapM (goConstructorDef constrRetType) _inductiveConstructors
   _inductiveExamples' <- goExamples _inductiveDoc
   let loc = getLoc _inductiveName
       indDef =
@@ -784,8 +784,8 @@ goExpression = \case
         mkArgs :: [Indexed Internal.VarName] -> Sem r [Internal.Expression]
         mkArgs vs = do
           fieldMap <- mkFieldmap
-          execOutputList
-            $ go (uncurry Indexed <$> IntMap.toAscList fieldMap) vs
+          execOutputList $
+            go (uncurry Indexed <$> IntMap.toAscList fieldMap) vs
           where
             go :: [Indexed (RecordUpdateField 'Scoped)] -> [Indexed Internal.VarName] -> Sem (Output Internal.Expression ': r) ()
             go fields = \case
@@ -911,8 +911,8 @@ goExpression = \case
       rngpats' <- mapM goPatternArg rngpats
       expr <- goExpression _iteratorBody
       let lam =
-            Internal.ExpressionLambda
-              $ Internal.Lambda
+            Internal.ExpressionLambda $
+              Internal.Lambda
                 { _lambdaClauses = Internal.LambdaClause (nonEmpty' (inipats' ++ rngpats')) expr :| [],
                   _lambdaType = Nothing
                 }
@@ -969,8 +969,8 @@ goFunction :: (Members '[Builtins, NameIdGen, Error ScoperError, Reader Pragmas]
 goFunction f = do
   headParam :| tailParams <- goFunctionParameters (f ^. funParameters)
   ret <- goExpression (f ^. funReturn)
-  return
-    $ Internal.Function
+  return $
+    Internal.Function
       { _functionLeft = headParam,
         _functionRight = foldr (\param acc -> Internal.ExpressionFunction $ Internal.Function param acc) ret tailParams
       }
@@ -991,8 +991,8 @@ goFunctionParameters FunctionParameters {..} = do
     . fromMaybe (pure (mkParam Nothing))
     . nonEmpty
     $ mkParam
-    . goFunctionParameter
-    <$> _paramNames
+      . goFunctionParameter
+      <$> _paramNames
   where
     goFunctionParameter :: FunctionParameter 'Scoped -> Maybe (SymbolType 'Scoped)
     goFunctionParameter = \case

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -744,7 +744,7 @@ goExpression = \case
   ExpressionLiteral l -> return (Internal.ExpressionLiteral (goLiteral l))
   ExpressionLambda l -> Internal.ExpressionLambda <$> goLambda l
   ExpressionBraces b -> throw (ErrAppLeftImplicit (AppLeftImplicit b))
-  ExpressionDoubleBraces b -> throw (ErrAppLeftImplicit (AppLeftImplicit b))
+  ExpressionDoubleBraces b -> throw (ErrAppLeftImplicitInstance (AppLeftImplicitInstance b))
   ExpressionLet l -> goLet l
   ExpressionList l -> goList l
   ExpressionUniverse uni -> return (Internal.ExpressionUniverse (goUniverse uni))

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -12,7 +12,6 @@ where
 
 import Data.HashMap.Strict qualified as HashMap
 import Data.IntMap.Strict qualified as IntMap
-import Data.List.NonEmpty qualified as NonEmpty
 import Juvix.Compiler.Builtins
 import Juvix.Compiler.Concrete.Data.NameSignature.Base
 import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
@@ -605,8 +604,8 @@ goInductive ty@InductiveDef {..} = do
   let inductiveName' = goSymbol _inductiveName
       constrRetType = Internal.foldExplicitApplication (Internal.toExpression inductiveName') (map (Internal.ExpressionIden . Internal.IdenVar . (^. Internal.inductiveParamName)) _inductiveParameters')
   _inductiveConstructors' <-
-    local (const _inductivePragmas') $
-      mapM (goConstructorDef constrRetType) _inductiveConstructors
+    local (const _inductivePragmas')
+      $ mapM (goConstructorDef constrRetType) _inductiveConstructors
   _inductiveExamples' <- goExamples _inductiveDoc
   let loc = getLoc _inductiveName
       indDef =
@@ -785,8 +784,8 @@ goExpression = \case
         mkArgs :: [Indexed Internal.VarName] -> Sem r [Internal.Expression]
         mkArgs vs = do
           fieldMap <- mkFieldmap
-          execOutputList $
-            go (uncurry Indexed <$> IntMap.toAscList fieldMap) vs
+          execOutputList
+            $ go (uncurry Indexed <$> IntMap.toAscList fieldMap) vs
           where
             go :: [Indexed (RecordUpdateField 'Scoped)] -> [Indexed Internal.VarName] -> Sem (Output Internal.Expression ': r) ()
             go fields = \case
@@ -912,8 +911,8 @@ goExpression = \case
       rngpats' <- mapM goPatternArg rngpats
       expr <- goExpression _iteratorBody
       let lam =
-            Internal.ExpressionLambda $
-              Internal.Lambda
+            Internal.ExpressionLambda
+              $ Internal.Lambda
                 { _lambdaClauses = Internal.LambdaClause (nonEmpty' (inipats' ++ rngpats')) expr :| [],
                   _lambdaType = Nothing
                 }
@@ -968,11 +967,13 @@ goUniverse u
 
 goFunction :: (Members '[Builtins, NameIdGen, Error ScoperError, Reader Pragmas] r) => Function 'Scoped -> Sem r Internal.Function
 goFunction f = do
-  params <- goFunctionParameters (f ^. funParameters)
+  headParam :| tailParams <- goFunctionParameters (f ^. funParameters)
   ret <- goExpression (f ^. funReturn)
-  return $
-    Internal.Function (head params) $
-      foldr (\param acc -> Internal.ExpressionFunction $ Internal.Function param acc) ret (NonEmpty.tail params)
+  return
+    $ Internal.Function
+      { _functionLeft = headParam,
+        _functionRight = foldr (\param acc -> Internal.ExpressionFunction $ Internal.Function param acc) ret tailParams
+      }
 
 goFunctionParameters ::
   (Members '[Builtins, NameIdGen, Error ScoperError, Reader Pragmas] r) =>
@@ -990,14 +991,13 @@ goFunctionParameters FunctionParameters {..} = do
     . fromMaybe (pure (mkParam Nothing))
     . nonEmpty
     $ mkParam
-      . goFunctionParameter
-      <$> _paramNames
+    . goFunctionParameter
+    <$> _paramNames
   where
     goFunctionParameter :: FunctionParameter 'Scoped -> Maybe (SymbolType 'Scoped)
     goFunctionParameter = \case
       FunctionParameterName n -> Just n
       FunctionParameterWildcard {} -> Nothing
-      FunctionParameterUnnamed {} -> Nothing
 
 mkConstructorApp :: Internal.ConstrName -> [Internal.PatternArg] -> Internal.ConstructorApp
 mkConstructorApp a b = Internal.ConstructorApp a b Nothing

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -744,7 +744,7 @@ goExpression = \case
   ExpressionLiteral l -> return (Internal.ExpressionLiteral (goLiteral l))
   ExpressionLambda l -> Internal.ExpressionLambda <$> goLambda l
   ExpressionBraces b -> throw (ErrAppLeftImplicit (AppLeftImplicit b))
-  ExpressionDoubleBraces b -> throw (ErrAppLeftImplicitInstance (AppLeftImplicitInstance b))
+  ExpressionDoubleBraces b -> throw (ErrDanglingDoubleBrace (DanglingDoubleBrace b))
   ExpressionLet l -> goLet l
   ExpressionList l -> goList l
   ExpressionUniverse uni -> return (Internal.ExpressionUniverse (goUniverse uni))

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -329,5 +329,12 @@ scoperErrorTests =
       $(mkRelFile "AliasCycle.juvix")
       $ \case
         ErrAliasCycle {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Dangling double brace"
+      $(mkRelDir "Internal")
+      $(mkRelFile "DanglingDoubleBrace.juvix")
+      $ \case
+        ErrAppLeftImplicitInstance {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -335,6 +335,6 @@ scoperErrorTests =
       $(mkRelDir "Internal")
       $(mkRelFile "DanglingDoubleBrace.juvix")
       $ \case
-        ErrAppLeftImplicitInstance {} -> Nothing
+        ErrDanglingDoubleBrace {} -> Nothing
         _ -> wrongError
   ]

--- a/tests/negative/Internal/DanglingDoubleBrace.juvix
+++ b/tests/negative/Internal/DanglingDoubleBrace.juvix
@@ -1,0 +1,3 @@
+module DanglingDoubleBrace;
+
+id {A} : A -> {{A}} := A;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -171,7 +171,6 @@ module Patterns;
     | (a, b, c, d) := a;
 end;
 
-
 module UnicodeStrings;
   a : String := "λ";
 end;
@@ -238,52 +237,52 @@ end;
 
 --- Traits
 module Traits;
+  import Stdlib.Prelude open hiding {Show; mkShow; show};
 
-import Stdlib.Prelude open hiding {Show; mkShow; show};
+  trait
+  type Show A :=
+    | mkShow {show : A → String};
 
-trait
-type Show A :=
-  mkShow {
-    show : A → String
-  };
+  instance
+  showStringI : Show String := mkShow (show := id);
 
-instance
-showStringI : Show String := mkShow (show := id);
+  instance
+  showBoolI : Show Bool :=
+    mkShow (show := λ {x := if x "true" "false"});
 
-instance
-showBoolI : Show Bool := mkShow (show := λ{x := if x "true" "false"});
+  instance
+  showNatI : Show Nat := mkShow (show := natToString);
 
-instance
-showNatI : Show Nat := mkShow (show := natToString);
+  showList {A} : {{Show A}} → List A → String
+    | nil := "nil"
+    | (h :: t) := Show.show h ++str " :: " ++str showList t;
 
-showList {A} : {{Show A}} → List A → String
-  | nil := "nil"
-  | (h :: t) := Show.show h ++str " :: " ++str showList t;
+  g : {A : Type} → {{Show A}} → Nat := 5;
 
-g : {A : Type} → {{Show A}} → Nat := 5;
+  instance
+  showListI {A} {{Show A}} : Show (List A) :=
+    mkShow (show := showList);
 
-instance
-showListI {A} {{Show A}} : Show (List A) := mkShow (show := showList);
+  showMaybe {A} {{Show A}} : Maybe A → String
+    | (just x) := "just (" ++str Show.show x ++str ")"
+    | nothing := "nothing";
 
-showMaybe {A} {{Show A}} : Maybe A → String
-  | (just x) := "just (" ++str Show.show x ++str ")"
-  | nothing := "nothing";
+  instance
+  showMaybeI {A} {{Show A}} : Show (Maybe A) :=
+    mkShow (show := showMaybe);
 
-instance
-showMaybeI {A} {{Show A}} : Show (Maybe A) := mkShow (show := showMaybe);
+  f {A} {{Show A}} : A → String
+    | x := Show.show x;
 
-f {A} {{Show A}} : A → String
-  | x := Show.show x;
+  f' {A} : {{Show A}} → A → String
+    | {{mkShow s}} x := s x;
 
-f' {A} : {{Show A}} → A → String
-  | {{mkShow s}} x := s x;
+  f'' {A} : {{Show A}} → A → String
+    | {{M}} x := Show.show {{M}} x;
 
-f'' {A} : {{Show A}} → A → String
-  | {{M}} x := Show.show {{M}} x;
+  f'3 {A} {{M : Show A}} : A → String := Show.show {{M}};
 
-f'3 {A} {{M : Show A}} : A → String := Show.show {{M}};
-
-f'4 {A} {{_ : Show A}} : A → String := Show.show;
+  f'4 {A} {{_ : Show A}} : A → String := Show.show;
 
 end;
 

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -10,7 +10,7 @@ hiding -- Hide some names
 {-- like this
 ,; -- don't want , here
 -- Bool either
-Bool; true; false};
+Bool; true; false; mkShow};
 
 import Stdlib.Data.Nat.Ord open;
 
@@ -171,7 +171,6 @@ module Patterns;
     | (a, b, c, d) := a;
 end;
 
-import Stdlib.Prelude open using {Nat as Natural};
 
 module UnicodeStrings;
   a : String := "λ";
@@ -235,6 +234,57 @@ module Comments;
   f; f};
 
   type list (A : Type) : Type := cons A (list A);
+end;
+
+--- Traits
+module Traits;
+
+import Stdlib.Prelude open hiding {Show; mkShow; show};
+
+trait
+type Show A :=
+  mkShow {
+    show : A → String
+  };
+
+instance
+showStringI : Show String := mkShow (show := id);
+
+instance
+showBoolI : Show Bool := mkShow (show := λ{x := if x "true" "false"});
+
+instance
+showNatI : Show Nat := mkShow (show := natToString);
+
+showList {A} : {{Show A}} → List A → String
+  | nil := "nil"
+  | (h :: t) := Show.show h ++str " :: " ++str showList t;
+
+g : {A : Type} → {{Show A}} → Nat := 5;
+
+instance
+showListI {A} {{Show A}} : Show (List A) := mkShow (show := showList);
+
+showMaybe {A} {{Show A}} : Maybe A → String
+  | (just x) := "just (" ++str Show.show x ++str ")"
+  | nothing := "nothing";
+
+instance
+showMaybeI {A} {{Show A}} : Show (Maybe A) := mkShow (show := showMaybe);
+
+f {A} {{Show A}} : A → String
+  | x := Show.show x;
+
+f' {A} : {{Show A}} → A → String
+  | {{mkShow s}} x := s x;
+
+f'' {A} : {{Show A}} → A → String
+  | {{M}} x := Show.show {{M}} x;
+
+f'3 {A} {{M : Show A}} : A → String := Show.show {{M}};
+
+f'4 {A} {{_ : Show A}} : A → String := Show.show;
+
 end;
 
 -- Comment at the end of a module

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -240,8 +240,7 @@ module Traits;
   import Stdlib.Prelude open hiding {Show; mkShow; show};
 
   trait
-  type Show A :=
-    | mkShow {show : A → String};
+  type Show A := mkShow {show : A → String};
 
   instance
   showStringI : Show String := mkShow (show := id);


### PR DESCRIPTION
This pr simplifies parsing by removing `FunctionParameterUnnamed`. It also removes ghost wildcards introduced during parsing.

It also introduces an error for double braced atoms `{{x}}` that are not on the left of an arrow `->`