### PR TITLE
Remove duplicated implicit pattern check from scoper

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1793,7 +1793,6 @@ checkCaseBranch ::
   Sem r (CaseBranch 'Scoped)
 checkCaseBranch CaseBranch {..} = withLocalScope $ do
   pattern' <- checkParsePatternAtoms _caseBranchPattern
-  checkNotImplicit pattern'
   expression' <- (checkParseExpressionAtoms _caseBranchExpression)
   return $
     CaseBranch
@@ -1801,12 +1800,6 @@ checkCaseBranch CaseBranch {..} = withLocalScope $ do
         _caseBranchExpression = expression',
         ..
       }
-  where
-    checkNotImplicit :: PatternArg -> Sem r ()
-    checkNotImplicit p =
-      when
-        (p ^. patternArgIsImplicit == Implicit)
-        (throw (ErrCaseBranchImplicitPattern (CaseBranchImplicitPattern p)))
 
 checkCase ::
   (Members '[Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r) =>

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -33,7 +33,6 @@ data ScoperError
   | ErrAliasBinderPattern AliasBinderPattern
   | ErrImplicitPatternLeftApplication ImplicitPatternLeftApplication
   | ErrConstructorExpectedLeftApplication ConstructorExpectedLeftApplication
-  | ErrCaseBranchImplicitPattern CaseBranchImplicitPattern
   | ErrModuleDoesNotExportSymbol ModuleDoesNotExportSymbol
   | ErrIteratorInitializer IteratorInitializer
   | ErrIteratorRange IteratorRange
@@ -51,7 +50,6 @@ data ScoperError
 
 instance ToGenericError ScoperError where
   genericError = \case
-    ErrCaseBranchImplicitPattern e -> genericError e
     ErrInfixParser e -> genericError e
     ErrAppLeftImplicit e -> genericError e
     ErrDanglingDoubleBrace e -> genericError e

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -609,26 +609,6 @@ instance ToGenericError ConstructorExpectedLeftApplication where
             "Constructor expected on the left of a pattern application:"
               <+> ppCode opts' pat
 
-newtype CaseBranchImplicitPattern = CaseBranchImplicitPattern
-  { _caseBranchImplicitPattern :: PatternArg
-  }
-  deriving stock (Show)
-
-instance ToGenericError CaseBranchImplicitPattern where
-  genericError :: (Member (Reader GenericOptions) r) => CaseBranchImplicitPattern -> Sem r GenericError
-  genericError CaseBranchImplicitPattern {..} = do
-    opts <- fromGenericOptions <$> ask
-    let msg = "The pattern" <+> ppCode opts _caseBranchImplicitPattern <+> "is not valid because implicit patterns are not allowed in case branches"
-    return
-      GenericError
-        { _genericErrorLoc = i,
-          _genericErrorMessage = mkAnsiText msg,
-          _genericErrorIntervals = [i]
-        }
-    where
-      i :: Interval
-      i = getLoc _caseBranchImplicitPattern
-
 data ModuleDoesNotExportSymbol = ModuleDoesNotExportSymbol
   { _moduleDoesNotExportSymbol :: Symbol,
     _moduleDoesNotExportModule :: ModuleRef

--- a/test/Typecheck/Negative.hs
+++ b/test/Typecheck/Negative.hs
@@ -98,6 +98,13 @@ tests =
         ErrArity (ErrWrongPatternIsImplicit {}) -> Nothing
         _ -> wrongError,
     NegTest
+      "Unexpected double braces in pattern"
+      $(mkRelDir "issue1337")
+      $(mkRelFile "DoubleBraces.juvix")
+      $ \case
+        ErrArity (ErrWrongPatternIsImplicit {}) -> Nothing
+        _ -> wrongError,
+    NegTest
       "Wrong return type name for a constructor of a simple data type"
       $(mkRelDir "Internal")
       $(mkRelFile "WrongReturnType.juvix")

--- a/tests/negative/issue1337/DoubleBraces.juvix
+++ b/tests/negative/issue1337/DoubleBraces.juvix
@@ -1,0 +1,9 @@
+module DoubleBraces;
+
+type Nat :=
+  | O : Nat
+  | S : Nat -> Nat;
+
+fun (n : Nat) : Nat :=
+  case n
+    | S {{y}} := O;


### PR DESCRIPTION
This PR removes the CaseBranchImplicit error from the scoper. This error is already handled in the arity/typechecker with a good error message:

 The arity checker error message for

```
   case b of {
      | {{true}} := false
```
is 

```
Expected an explicit pattern but found an implicit instance pattern: {{true}}
```

* Closes https://github.com/anoma/juvix/issues/2356