### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 <img align="right" width="300" height="300" alt="Juvix Mascot" src="../assets/images/tara-smiling.svg" />
 </a>
 
+## [0.5.1](https://github.com/anoma/juvix/tree/v0.5.1)
+
+[Full Changelog](https://github.com/anoma/juvix/compare/v0.5.0...v0.5.1)
+
+**Merged pull requests:**
+
+- Fix bug in isTrait [\#2368](https://github.com/anoma/juvix/pull/2368) ([lukaszcz](https://github.com/lukaszcz))
+
 ## [v0.5.0](https://github.com/anoma/juvix/tree/v0.5.0)
 
 [Full Changelog](https://github.com/anoma/juvix/compare/v0.4.3...v0.5.0)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: juvix
-version: 0.5.0
+version: 0.5.1
 license: GPL-3.0-only
 license-file: LICENSE.md
 copyright: (c) 2022- Heliax AG.

--- a/tests/smoke/Commands/version-help-doctor.smoke.yaml
+++ b/tests/smoke/Commands/version-help-doctor.smoke.yaml
@@ -7,7 +7,7 @@ tests:
     stdout:
       matches:
         regex: |-
-          ^Juvix version 0.5.0-([a-f0-9]{7}).*
+          ^Juvix version 0.5.1-([a-f0-9]{7}).*
 
   - name: cli-numeric-version
     command:


### PR DESCRIPTION
Juvix 0.5.1 is a bug fix release that contains just https://github.com/anoma/juvix/pull/2368

- [x] Package version
- [x] Smoke test
- [x] Changelog