### PR TITLE
Do not call `git fetch` on git dependency if ref already exists in clone

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -121,11 +121,8 @@ getDependencyPath i = case i ^. packageDepdendencyInfoDependency of
     r <- rootBuildDir <$> asks (^. envRoot)
     let cloneDir = r <//> relDependenciesDir <//> relDir (T.unpack (g ^. gitDependencyName))
         cloneArgs = CloneArgs {_cloneArgsCloneDir = cloneDir, _cloneArgsRepoUrl = g ^. gitDependencyUrl}
-        errorHandler' = errorHandler cloneDir
-    scoped @CloneArgs @Git cloneArgs $ do
-      fetch errorHandler'
-      checkout errorHandler' (g ^. gitDependencyRef)
-      return cloneDir
+    scoped @CloneArgs @Git cloneArgs $
+      fetchOnNoSuchRefAndRetry (errorHandler cloneDir) (`checkout` (g ^. gitDependencyRef)) >> return cloneDir
     where
       errorHandler :: Path Abs Dir -> GitError -> Sem (Git ': r) a
       errorHandler p c =

--- a/src/Juvix/Data/Effect/Git/Base.hs
+++ b/src/Juvix/Data/Effect/Git/Base.hs
@@ -22,8 +22,20 @@ data GitError
 data Git m a where
   Fetch :: (GitError -> m ()) -> Git m ()
   Checkout :: (GitError -> m ()) -> GitRef -> Git m ()
-  HeadRef :: (GitError -> m GitRef) -> Git m GitRef
+  NormalizeRef :: (GitError -> m GitRef) -> GitRef -> Git m GitRef
 
 makeSem ''Git
 
 type GitClone = Scoped CloneArgs Git
+
+headRef :: (Member Git r) => (GitError -> Sem r GitRef) -> Sem r GitRef
+headRef h = normalizeRef h "HEAD"
+
+-- | If an action fails because a ref does not exist in the clone, first do a fetch and then retry.
+fetchOnNoSuchRefAndRetry :: forall r a. (Member Git r) => (GitError -> Sem r a) -> ((GitError -> Sem r a) -> Sem r a) -> Sem r a
+fetchOnNoSuchRefAndRetry handler action = action retryHandler
+  where
+    retryHandler :: GitError -> Sem r a
+    retryHandler = \case
+      NoSuchRef _ -> fetch (void . handler) >> action handler
+      e -> handler e

--- a/tests/smoke/Commands/compile-dependencies.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies.smoke.yaml
@@ -561,3 +561,67 @@ tests:
     stdout:
       contains: duplicate
     exit-status: 1
+
+  - name: git-dependencies-no-fetch-if-ref-exists-in-clone
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+
+        # create dependency
+        mkdir $temp/dep
+        cd $temp/dep
+        git init
+
+        cat <<-EOF > HelloDep.juvix
+        module HelloDep;
+        import Stdlib.Prelude open;
+        main : IO := printStringLn "Hello from dep";
+        EOF
+        touch juvix.yaml
+
+        git add -A
+        git commit -m "commit1"
+
+        dep1hash=$(git rev-parse HEAD)
+
+        # create project that uses dependency
+        mkdir $temp/base
+        cd $temp/base
+
+        cat <<-EOF > juvix.yaml
+        name: HelloWorld
+        main: HelloWorld.juvix
+        dependencies:
+          - .juvix-build/stdlib
+          - git:
+              url: $temp/dep
+              name: dep1
+              ref: $dep1hash
+        version: 0.1.0
+        EOF
+
+        cat <<-EOF > HelloWorld.juvix
+        -- HelloWorld.juvix
+        module HelloWorld;
+
+        import Stdlib.Prelude open;
+        import HelloDep;
+
+        main : IO := HelloDep.main;
+        EOF
+
+        # compile project
+        juvix compile HelloWorld.juvix
+
+        # delete the dependency to check that it's not required
+        rm -rf $temp/dep
+
+        # compile project
+        juvix compile HelloWorld.juvix
+    stderr: ""
+    stdout:
+      contains: cloning
+    exit-status: 0


### PR DESCRIPTION
During path resolution, `git fetch` is called on every git dependency clone. It's desirable to reduce the number of `git fetch` calls because it makes a network call.

This PR changes the git dependency resolution to only call `git fetch` if the existing clone does not already contain the specified ref.