### PR TITLE
Avoid serialization of _packageFile field in juvix.yaml

### DIFF
--- a/src/Juvix/Compiler/Pipeline/Package.hs
+++ b/src/Juvix/Compiler/Pipeline/Package.hs
@@ -53,7 +53,7 @@ type family DependenciesType s = res | res -> s where
 
 type PackageFileType :: IsProcessed -> GHC.Type
 type family PackageFileType s = res | res -> s where
-  PackageFileType 'Raw = ()
+  PackageFileType 'Raw = Maybe ()
   PackageFileType 'Processed = Path Abs File
 
 data Package' (s :: IsProcessed) = Package
@@ -102,8 +102,7 @@ instance FromJSON RawPackage where
         _packageDependencies <- keyMay "dependencies" fromAesonParser
         _packageBuildDir <- keyMay "build-dir" fromAesonParser
         _packageMain <- keyMay "main" fromAesonParser
-        let _packageFile = ()
-        return Package {..}
+        return Package {_packageFile = Nothing, ..}
       err :: a
       err = error "Failed to parse juvix.yaml"
 
@@ -136,7 +135,7 @@ rawPackage pkg =
       _packageDependencies = Just (pkg ^. packageDependencies),
       _packageBuildDir = pkg ^. packageBuildDir,
       _packageMain = pkg ^. packageMain,
-      _packageFile = ()
+      _packageFile = Nothing
     }
 
 processPackage :: forall r. (Members '[Error Text] r) => Path Abs File -> BuildDir -> RawPackage -> Sem r Package
@@ -194,7 +193,7 @@ globalPackage =
       _packageVersion = Just (prettySemVer defaultVersion),
       _packageMain = Nothing,
       _packageBuildDir = Nothing,
-      _packageFile = ()
+      _packageFile = Nothing
     }
 
 mkPackageFilePath :: Path Abs Dir -> Path Abs File

--- a/tests/smoke/Commands/init.smoke.yaml
+++ b/tests/smoke/Commands/init.smoke.yaml
@@ -6,14 +6,29 @@ tests:
       shell:
         - bash
       script: |
-        mkdir tmp
-        cd tmp
-        juvix init
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        cd $temp
+        echo -e 'abc\n\n\n' | juvix init
         cat juvix.yaml
-        cd ..
-        rm -rf tmp
     stdout:
       contains:
-        "name: tmp"
-    stdin: "\n\n"
+        "name: abc"
+    exit-status: 0
+  - name: init-does-not-contain-file-field
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        cd $temp
+        echo -e 'abc\n\n\n' | juvix init
+        cat juvix.yaml
+    stdout:
+      matches:
+        regex: |-
+          ^((?!file:).)*$
+        options:
+          - dot-all
     exit-status: 0


### PR DESCRIPTION
The _packageFile field of the Package record is used internally to track
the package file path and is used in error messages. It is not intended
to be present in the juvix.yaml file.

To express this the PackageFileType family with the Raw index is set to
`()`. However `()` is serialized to an empty array by Aeson, so the
`file: []` field was added to juvix.yaml.

NB: From aeson 2.2, fields with type `()` are ommitted when the
`omitNothingFields` flag is set to True, as it is for the package ToJSON
instance.

The solution in this PR is to set `PackageFileType 'Raw` to `Maybe ()`. The
`omitNothingFields` flag then omits this field from the serialized
package object.


* Closes https://github.com/anoma/juvix/issues/2380