### PR TITLE
Add nodes with no edges to the dependency graph

### DIFF
--- a/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
@@ -56,6 +56,17 @@ addStartNode n = modify (HashSet.insert n)
 addEdgeMay :: (Member (State DependencyGraph) r) => Maybe Name -> Name -> Sem r ()
 addEdgeMay mn1 n2 = whenJust mn1 $ \n1 -> addEdge n1 n2
 
+addNode :: (Member (State DependencyGraph) r) => Name -> Sem r ()
+addNode n =
+  modify
+    ( HashMap.alter
+        ( \case
+            Just x -> Just x
+            Nothing -> Just (mempty :: HashSet Name)
+        )
+        n
+    )
+
 addEdge :: (Member (State DependencyGraph) r) => Name -> Name -> Sem r ()
 addEdge n1 n2 =
   modify
@@ -179,6 +190,7 @@ goFunctionDefHelper ::
   FunctionDef ->
   Sem r ()
 goFunctionDefHelper f = do
+  addNode (f ^. funDefName)
   checkStartNode (f ^. funDefName)
   when (f ^. funDefInstance) $
     goInstance f

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -244,8 +244,12 @@ instance PrettyCode FunctionDef where
         <?+> funDefName'
           <+> kwColon
           <+> funDefType'
-            <> line
+            <> hardline
             <> vsep (toList clauses')
+
+instance PrettyCode PreLetStatement where
+  ppCode = \case
+    PreLetFunctionDef f -> ppCode f
 
 instance PrettyCode FunctionClause where
   ppCode c = do

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -113,7 +113,9 @@ buildLetMutualBlocks ss = nonEmpty' . mapMaybe nameToPreStatement $ scomponents
   where
     -- TODO buildDependencyInfoLet is repeating too much work when there are big nested lets
     depInfo = buildDependencyInfoLet ss
+
     scomponents :: [SCC Internal.Name] = buildSCCs depInfo
+
     statementsByName :: HashMap Internal.Name Internal.PreLetStatement
     statementsByName = HashMap.fromList (map mkAssoc (toList ss))
       where

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -288,6 +288,10 @@ tests =
     posTest
       "Instance import"
       $(mkRelDir "InstanceImport")
+      $(mkRelFile "Main.juvix"),
+    posTest
+      "Hole as numeric type"
+      $(mkRelDir "issue2373")
       $(mkRelFile "Main.juvix")
   ]
     <> [ compilationTest t | t <- Compilation.tests

--- a/tests/positive/issue2373/Main.juvix
+++ b/tests/positive/issue2373/Main.juvix
@@ -1,0 +1,8 @@
+module Main;
+
+import Stdlib.Data.Nat open;
+
+main : Nat :=
+  let
+    x : _ := 0;
+  in x;

--- a/tests/positive/issue2373/Main.juvix
+++ b/tests/positive/issue2373/Main.juvix
@@ -1,8 +1,10 @@
 module Main;
 
 import Stdlib.Data.Nat open;
+import Stdlib.Data.Bool open;
 
 main : Nat :=
   let
+    y : Nat := 0;
     x : _ := 0;
   in x;

--- a/tests/positive/issue2373/juvix.yaml
+++ b/tests/positive/issue2373/juvix.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- .juvix-build/stdlib/
+name: issue2373
+version: 0.0.0


### PR DESCRIPTION
- Closes #2373 

Consider this:
```
let 
 x : _ := 0
in ...
```
When translating the let to internal, we build the dependency graph and then use that to group definitions in mutually recursive blocks. Since `x` has no edge, it was not being added to the dependency graph, so it was not being translated to Internal, thus crashing later during inference.