### PR TITLE
Fix formatting for all Juvix files in tests folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <a href="https://github.com/anoma/juvix"><img align="right" width="300" alt="Tara the Juvix mascot" src="https://github.com/anoma/juvix/raw/main/assets/images/tara-smiling.svg" /></a>
 
-
 <table>
 <tr>
 <th> CI Status </th>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Juvix
 
-<a href="https://github.com/anoma/juvix"><img align="right" width="300" alt="Tara the Juvix mascot" src="https://github.com/anoma/juvix/raw/main/assets/images/tara-smiling.svg" /></a>
+<a href="https://github.com/anoma/juvix"><img align="right" width="300" alt="Tara the Juvix mascot" src="https://raw.githubusercontent.com/anoma/juvix/main/assets/images/tara-smiling.svg" /></a>
 
 <table>
 <tr>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Juvix
 
-<a href="https://github.com/anoma/juvix"><img align="right" width="300" alt="Tara the Juvix mascot" src="https://raw.githubusercontent.com/anoma/juvix/main/assets/images/tara-smiling.svg" /></a>
+<a href="https://github.com/anoma/juvix"><img align="right" width="300" alt="Tara the Juvix mascot" src="https://github.com/anoma/juvix/raw/main/assets/images/tara-smiling.svg" /></a>
+
 
 <table>
 <tr>

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -1028,7 +1028,6 @@ instance PrettyPrint PatternArg where
       Implicit -> braces . asPatternInfo $ pat'
 
 instance PrettyPrint Text where
-  ppCode :: (Members '[ExactPrint, Reader Options] r) => Text -> Sem r ()
   ppCode = noLoc . pretty
 
 ppUnkindedSymbol :: (Members '[Reader Options, ExactPrint] r) => WithLoc Text -> Sem r ()

--- a/tests/negative/265/M.juvix
+++ b/tests/negative/265/M.juvix
@@ -5,7 +5,7 @@ type Bool :=
   | false : Bool;
 
 type Pair (A : Type) (B : Type) :=
-  | mkPair : A → B → Pair A B;
+  mkPair : A → B → Pair A B;
 
 f : _ → _
   | (mkPair false true) := true

--- a/tests/negative/Internal/AmbiguousInstances.juvix
+++ b/tests/negative/Internal/AmbiguousInstances.juvix
@@ -5,10 +5,10 @@ type Unit := unit;
 type Box A B := box A B;
 
 trait
-type T A := mkT { pp : A → A };
+type T A := mkT {pp : A → A};
 
 instance
-unitT : T Unit := mkT (pp := λ{_ := unit});
+unitT : T Unit := mkT (pp := λ {_ := unit});
 
 ppBox {A B} {{T A}} : Box A B → Box A B
   | (box x y) := box (T.pp x) y;
@@ -17,6 +17,6 @@ instance
 boxT {A} {{T A}} : T (Box A Unit) := mkT (pp := ppBox);
 
 instance
-boxTUnit {B} : T (Box Unit B) := mkT (pp := λ{x := x});
+boxTUnit {B} : T (Box Unit B) := mkT (pp := λ {x := x});
 
 main : Box Unit Unit := T.pp (box unit unit);

--- a/tests/negative/Internal/ExpectedExplicitArgument.juvix
+++ b/tests/negative/Internal/ExpectedExplicitArgument.juvix
@@ -1,7 +1,6 @@
 module ExpectedExplicitArgument;
 
-type T (A : Type) :=
-  | c : A → T A;
+type T (A : Type) := c : A → T A;
 
 f : {A : Type} → A → T A
   | {A} a := c {A} {a};

--- a/tests/negative/Internal/ExpectedExplicitPattern.juvix
+++ b/tests/negative/Internal/ExpectedExplicitPattern.juvix
@@ -1,7 +1,6 @@
 module ExpectedExplicitPattern;
 
-type T (A : Type) :=
-  | c : A → T A;
+type T (A : Type) := c : A → T A;
 
 f : {A : Type} → T A → A
   | {_} {c a} := a;

--- a/tests/negative/Internal/ExpectedFunctionType.juvix
+++ b/tests/negative/Internal/ExpectedFunctionType.juvix
@@ -1,10 +1,8 @@
 module ExpectedFunctionType;
 
-type Pair (A : Type) :=
-  | mkPair : A → A → Pair A;
+type Pair (A : Type) := mkPair : A → A → Pair A;
 
-type B :=
-  | b : B;
+type B := b : B;
 
 f : Pair B → Pair B
   | (mkPair a b) := a b;

--- a/tests/negative/Internal/ExplicitInstanceArgument.juvix
+++ b/tests/negative/Internal/ExplicitInstanceArgument.juvix
@@ -5,12 +5,12 @@ type Unit := unit;
 type Box A := box A;
 
 trait
-type T A := mkT { pp : A → A };
+type T A := mkT {pp : A → A};
 
 instance
-unitT : T Unit := mkT (pp := λ{_ := unit});
+unitT : T Unit := mkT (pp := λ {_ := unit});
 
 instance
-boxT {A} (x : Box A) : T (Box A) := mkT (pp := \{_ := x});
+boxT {A} (x : Box A) : T (Box A) := mkT (pp := \ {_ := x});
 
 main : Box Unit := T.pp (box unit);

--- a/tests/negative/Internal/FunctionApplied.juvix
+++ b/tests/negative/Internal/FunctionApplied.juvix
@@ -1,7 +1,6 @@
 module FunctionApplied;
 
-type T (A : Type) :=
-  | c : A → T A;
+type T (A : Type) := c : A → T A;
 
 f : {A : Type} → A → T A
   | {A} a := c {(A → A) A} a;

--- a/tests/negative/Internal/FunctionPattern.juvix
+++ b/tests/negative/Internal/FunctionPattern.juvix
@@ -1,7 +1,6 @@
 module FunctionPattern;
 
-type T :=
-  | A : T;
+type T := A : T;
 
 f : (T → T) → T
   | A := A;

--- a/tests/negative/Internal/InstanceTermination.juvix
+++ b/tests/negative/Internal/InstanceTermination.juvix
@@ -5,9 +5,9 @@ type Unit := unit;
 type Box A := box A;
 
 trait
-type T A := mkT { pp : A → A };
+type T A := mkT {pp : A → A};
 
 instance
-boxT {A} : {{T (Box A)}} → T (Box A) := mkT (λ{x := x});
+boxT {A} : {{T (Box A)}} → T (Box A) := mkT λ {x := x};
 
 main : Box Unit := T.pp (box unit);

--- a/tests/negative/Internal/LhsTooManyPatterns.juvix
+++ b/tests/negative/Internal/LhsTooManyPatterns.juvix
@@ -1,7 +1,6 @@
 module LhsTooManyPatterns;
 
-type T :=
-  | A : T;
+type T := A : T;
 
 f : T → T
   | A x := A;

--- a/tests/negative/Internal/MultiWrongType.juvix
+++ b/tests/negative/Internal/MultiWrongType.juvix
@@ -1,10 +1,8 @@
 module MultiWrongType;
 
-type A :=
-  | a : A;
+type A := a : A;
 
-type B :=
-  | b : B;
+type B := b : B;
 
 f : A := b;
 

--- a/tests/negative/Internal/NoInstance.juvix
+++ b/tests/negative/Internal/NoInstance.juvix
@@ -5,6 +5,6 @@ type Unit := unit;
 type Box A := box A;
 
 trait
-type T A := mkT { pp : A → A };
+type T A := mkT {pp : A → A};
 
 main : Box Unit := T.pp (box unit);

--- a/tests/negative/Internal/NotATrait.juvix
+++ b/tests/negative/Internal/NotATrait.juvix
@@ -1,5 +1,7 @@
 module NotATrait;
 
-type Maybe A := just A | nothing;
+type Maybe A :=
+  | just A
+  | nothing;
 
 f {A} {{Maybe A}} : Maybe A := nothing;

--- a/tests/negative/Internal/PatternConstructor.juvix
+++ b/tests/negative/Internal/PatternConstructor.juvix
@@ -1,10 +1,8 @@
 module PatternConstructor;
 
-type A :=
-  | a : A;
+type A := a : A;
 
-type B :=
-  | b : B;
+type B := b : B;
 
 f : A → B
   | b := b;

--- a/tests/negative/Internal/Positivity/E1.juvix
+++ b/tests/negative/Internal/Positivity/E1.juvix
@@ -2,6 +2,5 @@ module E1;
 
 axiom B : Type;
 
-type X :=
-  | c : (X -> B) -> X;
+type X := c : (X -> B) -> X;
 

--- a/tests/negative/Internal/Positivity/E10.juvix
+++ b/tests/negative/Internal/Positivity/E10.juvix
@@ -1,10 +1,8 @@
 module E10;
 
-type T0 (A : Type) :=
-  | t : (A -> T0 A) -> T0 A;
+type T0 (A : Type) := t : (A -> T0 A) -> T0 A;
 
 alias : Type -> Type := T0;
 
-type T1 :=
-  | c : alias T1 -> T1;
+type T1 := c : alias T1 -> T1;
 

--- a/tests/negative/Internal/Positivity/E11.juvix
+++ b/tests/negative/Internal/Positivity/E11.juvix
@@ -1,11 +1,9 @@
 module E11;
 
-type T0 (A : Type) :=
-  | t : (A -> T0 A) -> T0 _;
+type T0 (A : Type) := t : (A -> T0 A) -> T0 _;
 
 alias : Type -> Type -> Type
   | A B := A -> B;
 
-type T1 :=
-  | c : alias T1 T1 -> _;
+type T1 := c : alias T1 T1 -> _;
 

--- a/tests/negative/Internal/Positivity/E2.juvix
+++ b/tests/negative/Internal/Positivity/E2.juvix
@@ -2,6 +2,5 @@ module E2;
 
 import NegParam open;
 
-type D :=
-  | d : T D -> D;
+type D := d : T D -> D;
 

--- a/tests/negative/Internal/Positivity/E3.juvix
+++ b/tests/negative/Internal/Positivity/E3.juvix
@@ -2,6 +2,5 @@ module E3;
 
 axiom B : Type;
 
-type X :=
-  | c : B -> (X -> B) -> X;
+type X := c : B -> (X -> B) -> X;
 

--- a/tests/negative/Internal/Positivity/E4.juvix
+++ b/tests/negative/Internal/Positivity/E4.juvix
@@ -4,6 +4,5 @@ type Tree (A : Type) :=
   | leaf : Tree A
   | node : (A -> Tree A) -> Tree A;
 
-type Bad :=
-  | bad : Tree Bad -> Bad;
+type Bad := bad : Tree Bad -> Bad;
 

--- a/tests/negative/Internal/Positivity/E5.juvix
+++ b/tests/negative/Internal/Positivity/E5.juvix
@@ -1,13 +1,10 @@
 module E5;
 
-type T0 (A : Type) :=
-  | c0 : (A -> T0 A) -> T0 A;
+type T0 (A : Type) := c0 : (A -> T0 A) -> T0 A;
 
 axiom B : Type;
 
-type T1 (A : Type) :=
-  | c1 : (B -> T0 A) -> T1 A;
+type T1 (A : Type) := c1 : (B -> T0 A) -> T1 A;
 
-type T2 :=
-  | c2 : (B -> B -> T1 T2) -> T2;
+type T2 := c2 : (B -> B -> T1 T2) -> T2;
 

--- a/tests/negative/Internal/Positivity/E6.juvix
+++ b/tests/negative/Internal/Positivity/E6.juvix
@@ -2,6 +2,5 @@ module E6;
 
 axiom A : Type;
 
-type T (A : Type) :=
-  | c : (A -> A -> T A -> A) -> T A;
+type T (A : Type) := c : (A -> A -> T A -> A) -> T A;
 

--- a/tests/negative/Internal/Positivity/E7.juvix
+++ b/tests/negative/Internal/Positivity/E7.juvix
@@ -1,8 +1,6 @@
 module E7;
 
-type T0 (A : Type) (B : Type) :=
-  | c0 : (B -> A) -> T0 A B;
+type T0 (A : Type) (B : Type) := c0 : (B -> A) -> T0 A B;
 
-type T1 (A : Type) :=
-  | c1 : (A -> T0 A (T1 A)) -> T1 A;
+type T1 (A : Type) := c1 : (A -> T0 A (T1 A)) -> T1 A;
 

--- a/tests/negative/Internal/Positivity/E8.juvix
+++ b/tests/negative/Internal/Positivity/E8.juvix
@@ -1,4 +1,3 @@
 module E8;
 
-type B (A : Type) :=
-  | b : (A -> B (B A -> A)) -> B A;
+type B (A : Type) := b : (A -> B (B A -> A)) -> B A;

--- a/tests/negative/Internal/Positivity/E9.juvix
+++ b/tests/negative/Internal/Positivity/E9.juvix
@@ -1,8 +1,6 @@
 module E9;
 
-type B :=
-  | b : B;
+type B := b : B;
 
-type T :=
-  | c : ((B → T) -> T) -> T;
+type T := c : ((B → T) -> T) -> T;
 

--- a/tests/negative/Internal/Positivity/NegParam.juvix
+++ b/tests/negative/Internal/Positivity/NegParam.juvix
@@ -1,4 +1,3 @@
 module NegParam;
 
-type T (A : Type) :=
-  | c : (A -> T A) -> T A;
+type T (A : Type) := c : (A -> T A) -> T A;

--- a/tests/negative/Internal/SubsumedInstance.juvix
+++ b/tests/negative/Internal/SubsumedInstance.juvix
@@ -5,10 +5,10 @@ type Unit := unit;
 type Box A := box A;
 
 trait
-type T A := mkT { pp : A → A };
+type T A := mkT {pp : A → A};
 
 instance
-unitT : T Unit := mkT (pp := λ{_ := unit});
+unitT : T Unit := mkT (pp := λ {_ := unit});
 
 ppBox {A} {{T A}} : Box A → Box A
   | (box x) := box (T.pp x);
@@ -17,6 +17,6 @@ instance
 boxT {A} {{T A}} : T (Box A) := mkT (pp := ppBox);
 
 instance
-boxTUnit : T (Box Unit) := mkT (pp := λ{x := x});
+boxTUnit : T (Box Unit) := mkT (pp := λ {x := x});
 
 main : Box Unit := T.pp (box unit);

--- a/tests/negative/Internal/TargetNotATrait.juvix
+++ b/tests/negative/Internal/TargetNotATrait.juvix
@@ -1,6 +1,8 @@
 module TargetNotATrait;
 
-type Maybe A := just A | nothing;
+type Maybe A :=
+  | just A
+  | nothing;
 
 instance
 inst {A} : Maybe A := nothing;

--- a/tests/negative/Internal/TooManyArguments.juvix
+++ b/tests/negative/Internal/TooManyArguments.juvix
@@ -1,7 +1,6 @@
 module TooManyArguments;
 
-type T (A : Type) :=
-  | c : A → T A;
+type T (A : Type) := c : A → T A;
 
 f : {A : Type} → A → T A
   | {A} a := c {A} a a {a};

--- a/tests/negative/Internal/UnsolvedMeta.juvix
+++ b/tests/negative/Internal/UnsolvedMeta.juvix
@@ -1,7 +1,6 @@
 module UnsolvedMeta;
 
-type Proxy (A : Type) :=
-  | x : Proxy A;
+type Proxy (A : Type) := x : Proxy A;
 
 t : Proxy _ := x;
 

--- a/tests/negative/Internal/WrongConstructorArity.juvix
+++ b/tests/negative/Internal/WrongConstructorArity.juvix
@@ -1,7 +1,6 @@
 module WrongConstructorArity;
 
-type T :=
-  | A : T → T;
+type T := A : T → T;
 
 f : T → T
   | (A i x) := i;

--- a/tests/negative/Internal/WrongReturnType.juvix
+++ b/tests/negative/Internal/WrongReturnType.juvix
@@ -2,6 +2,5 @@ module WrongReturnType;
 
 axiom B : Type;
 
-type A :=
-  | c : B;
+type A := c : B;
 

--- a/tests/negative/Internal/WrongReturnTypeParameters.juvix
+++ b/tests/negative/Internal/WrongReturnTypeParameters.juvix
@@ -1,5 +1,4 @@
 module WrongReturnTypeParameters;
 
-type A (B : Type) :=
-  | c : A B B;
+type A (B : Type) := c : A B B;
 

--- a/tests/negative/Internal/WrongReturnTypeTooFewArguments.juvix
+++ b/tests/negative/Internal/WrongReturnTypeTooFewArguments.juvix
@@ -1,5 +1,4 @@
 module WrongReturnTypeTooFewArguments;
 
-type A (B : Type) :=
-  | c : A;
+type A (B : Type) := c : A;
 

--- a/tests/negative/Internal/WrongReturnTypeTooManyArguments.juvix
+++ b/tests/negative/Internal/WrongReturnTypeTooManyArguments.juvix
@@ -1,5 +1,4 @@
 module WrongReturnTypeTooManyArguments;
 
-type A (B : Type) :=
-  | c : A B B;
+type A (B : Type) := c : A B B;
 

--- a/tests/negative/Internal/WrongType.juvix
+++ b/tests/negative/Internal/WrongType.juvix
@@ -1,9 +1,7 @@
 module WrongType;
 
-type A :=
-  | a : A;
+type A := a : A;
 
-type B :=
-  | b : B;
+type B := b : B;
 
 f : A := b;

--- a/tests/negative/Internal/issue2293.juvix
+++ b/tests/negative/Internal/issue2293.juvix
@@ -1,6 +1,8 @@
 module issue2293;
 
-type List A := nil | cons A (List A);
+type List A :=
+  | nil
+  | cons A (List A);
 
 map {A B} (f : A → B) : List A → List B
   | nil := nil

--- a/tests/negative/RepeatedFieldPattern.juvix
+++ b/tests/negative/RepeatedFieldPattern.juvix
@@ -1,13 +1,12 @@
 module RepeatedFieldPattern;
 
-type T :=
-  | t;
+type T := t;
 
 type R :=
-  | mkR {
-      a : T;
-      b : T
-    };
+  mkR {
+    a : T;
+    b : T
+  };
 
 f : R -> T
   | mkR@{a := x; a := y} := x;

--- a/tests/negative/Termination/Axiom.juvix
+++ b/tests/negative/Termination/Axiom.juvix
@@ -1,5 +1,5 @@
 module Axiom;
 
 axiom A : let
-    x : Type := x;
-  in x;
+            x : Type := x;
+          in x;

--- a/tests/negative/Termination/Data/Nat.juvix
+++ b/tests/negative/Termination/Data/Nat.juvix
@@ -23,11 +23,11 @@ import Data.Bool;
 open Data.Bool;
 
 even : ℕ → Bool
-
+  
   | zero := true
   | (suc n) := odd n;
 
 odd : ℕ → Bool
-
+  
   | zero := false
   | (suc n) := even n;

--- a/tests/negative/Termination/Data/QuickSort.juvix
+++ b/tests/negative/Termination/Data/QuickSort.juvix
@@ -13,10 +13,7 @@ type List (A : Type) :=
 filter : {A : Type} → (A → Bool) → List A → List A
   | f nil := nil
   | f (cons h hs) :=
-    ite
-      (f h)
-      (cons h (filter f hs))
-      (filter f hs);
+    ite (f h) (cons h (filter f hs)) (filter f hs);
 
 concat : {A : Type} → List A → List A → List A
   | nil ys := ys

--- a/tests/negative/issue1337/DoubleBraces.juvix
+++ b/tests/negative/issue1337/DoubleBraces.juvix
@@ -4,6 +4,4 @@ type Nat :=
   | O : Nat
   | S : Nat -> Nat;
 
-fun (n : Nat) : Nat :=
-  case n
-    | S {{y}} := O;
+fun (n : Nat) : Nat := case n of {S {{y}} := O};

--- a/tests/negative/issue1344/M.juvix
+++ b/tests/negative/issue1344/M.juvix
@@ -2,8 +2,7 @@ module M;
 
 import Other;
 
-type Unit :=
-  | t : Unit;
+type Unit := t : Unit;
 
 u : Other.Unit := t;
 

--- a/tests/negative/issue1344/Other.juvix
+++ b/tests/negative/issue1344/Other.juvix
@@ -1,5 +1,4 @@
 module Other;
 
-type Unit :=
-  | t : Unit;
+type Unit := t : Unit;
 

--- a/tests/negative/issue1344/U.juvix
+++ b/tests/negative/issue1344/U.juvix
@@ -1,5 +1,4 @@
 module U;
 
-type Unit :=
-  | t : Unit;
+type Unit := t : Unit;
 

--- a/tests/positive/265/M.juvix
+++ b/tests/positive/265/M.juvix
@@ -5,7 +5,7 @@ type Bool :=
   | false : Bool;
 
 type Pair (A : Type) (B : Type) :=
-  | mkPair : A → B → Pair A B;
+  mkPair : A → B → Pair A B;
 
 f : _ → _
   | (mkPair false true) := true

--- a/tests/positive/272/M.juvix
+++ b/tests/positive/272/M.juvix
@@ -4,8 +4,7 @@ type Bool :=
   | true : Bool
   | false : Bool;
 
-type T :=
-  | t : T;
+type T := t : T;
 
 type Nat :=
   | zero : Nat
@@ -16,7 +15,7 @@ f : _
   | true _ := false;
 
 type Pair (A : Type) (B : Type) :=
-  | mkPair : A → B → Pair A B;
+  mkPair : A → B → Pair A B;
 
 g : _
   | (mkPair (mkPair zero false) true) := mkPair false zero;

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -20,9 +20,10 @@ not2 (b : Boolean) : Boolean :=
   let
     syntax alias yes := ⊤;
     syntax alias no := ⊥;
-  in case b
-    | no := yes
-    | yes := no;
+  in case b of {
+       | no := yes
+       | yes := no
+     };
 
 module ExportAlias;
   syntax alias Binary := Bool;
@@ -46,8 +47,7 @@ or3 (a b c : Binary) : Binary := or (or a b) c;
 
 or3' (a b c : Binary) : Binary := (a ||| b) ||| c;
 
-type Pair :=
-  | mkPair Binary Binary;
+type Pair := mkPair Binary Binary;
 
 syntax operator , pair;
 syntax alias , := mkPair;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -12,366 +12,378 @@ hiding -- Hide some names
 -- Bool either
 Bool; true; false; mkShow; module Show};
 
--- Lorem ipsum dolor sit amet, consectetur adipiscing elit
-terminating
--- Comment between terminating and type sig
-go : Nat → Nat → Nat
-  | n s :=
-    if
-      (s < n)
-      (go (sub n 1) s)
-      (go n (sub s n) + go (sub n 1) s);
-
-module {- local module -}
-M;
-  syntax -- syntax in local modules
-  operator , pair;
-  axiom , : String → String → String;
-end;
-
--- case with single branch
-case1 (n : Nat) : Nat := case n of {x := zero};
-
--- case with multiple branches
-case2 (n : Nat) : Nat :=
-  case n of {
-    | zero := zero
-    | _ := zero
-  };
-
--- case on nested case
-case3 (n : Nat) : Nat :=
-  case case n of {_ := zero} of {
-    | zero := zero
-    | _ := zero
-  };
-
--- case on nested case expression
-case4 (n : Nat) : Nat :=
-  case n of {
-    | zero := case n of {x := zero}
-    | _ := zero
-  };
-
--- -- case with application subject
-case5 (n : Nat) : Nat := case id n of {x := zero};
-
--- qualified commas
-t4 : String := "a" M., "b" M., "c" M., "d";
-
-open M;
-
--- mix qualified and unqualified commas
-t5 : String := "a" M., "b" M., "c", "d";
-
--- comma chain fits in a line
-t2 : String := "a", "b", "c", "d";
-
--- comma chain does not fit in a line
-t3 : String :=
-  "a"
-    , "b"
-    , "c"
-    , "d"
-    , "e"
-    , "f"
-    , "g"
-    , "h"
-    , "i"
-    , "j"
-    , "k"
-    , "1234";
-
--- escaping in String literals
-e1 : String := "\"\n";
-
-syntax fixity l1 := binary {assoc := left; below := [pair]};
-syntax fixity r3 := binary {assoc := right; above := [pair]};
-syntax fixity l6 := binary {assoc := left; above := [r3]};
-syntax fixity r6 := binary {assoc := right; same := l6};
-syntax fixity l7 := binary {assoc := left; above := [l6]};
-
-syntax operator +l7 l7;
-axiom +l7 : String → String → String;
-
-syntax operator +r3 r3;
-axiom +r3 : String → String → String;
-
-syntax operator +l1 l1;
-axiom +l1 : String → String → String;
-
-syntax operator +l6 l6;
-axiom +l6 : String → String → String;
-
-syntax operator +r6 r6;
-axiom +r6 : String → String → String;
-
--- nesting of chains
-t : String :=
-  "Hellooooooooo"
-    +l1 "Hellooooooooo"
-    +l1 "Hellooooooooo"
-        +l6 "Hellooooooooo"
-        +l6 ("Hellooooooooo"
-          +r6 "Hellooooooooo"
-          +r6 "Hellooooooooo")
-        +l6 "Hellooooooooo"
-        +l6 "Hellooooooooo"
-          +l7 "Hellooooooooo"
-          +l7 "Hellooooooooo"
-          +l7 "Hellooooooooo"
-      , "hi"
-      , "hi";
-
--- function with single wildcard parameter
-g : (_ : Type) -> Nat
-  | _ := 1;
-
--- grouping of type arguments
-exampleFunction1
-  : {A : Type}
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> Nat
-  | _ _ _ _ _ _ _ := 1;
-
-axiom undefined : {A : Type} -> A;
-
--- 200 in the body is idented with respect to the start of the chain
--- (at {A : Type})
-exampleFunction2
-  : {A : Type}
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> List A
-    -> Nat :=
-  λ {_ _ _ _ _ _ _ :=
-    undefined
-      -- comment after first
-      + undefined
-      -- comment after second
-      + undefined
-      + undefined
-      + undefined
-      + undefined
-      + undefined
-      + undefined
-      + undefined
-      + undefined
-      + undefined};
-
-positive
-type T0 (A : Type) := c0 : (A -> T0 A) -> T0 A;
-
--- Single Lambda clause
-idLambda : {A : Type} -> A -> A := λ {x := x};
-
--- Lambda clauses
-f : Nat -> Nat :=
-  \ {
-    -- comment before lambda pipe
-    | zero :=
-      let
-        foo : Nat := 1;
-      in foo
-    | _ -- comment before lambda :=
-    := 1
-  };
-
-module Patterns;
-  syntax operator × functor;
-  syntax operator , pair;
-  type × (A : Type) (B : Type) := , : A → B → A × B;
-
-  f : Nat × Nat × Nat × Nat -> Nat
-    | (a, b, c, d) := a;
-end;
-
-module UnicodeStrings;
-  a : String := "λ";
-end;
-
-module Comments;
-  axiom a1 : Type;
-  -- attached to a1
-
-  -- attached to a2
-  axiom a2 : Type;
-
-  -- attached to nothing
-
-  axiom a3 -- comment before axiom :
-  : Type;
-
-  num
-    -- comment before type sig :
-    : -- comment after type sig :
-    Nat :=
-    -- comment before clause :=
-    -- comment after clause :=
-    123;
-
-  -- attached to nothing
-  -- attached to nothing 2
-
-  -- attached to nothing 3
-
-  axiom a4 : -- before open pi brace
-    {-- after open pi brace
-    a -- before pi :
-    : Type}
-    -> Type;
-
-  id2 : {A : Type} -> A -> Nat -> A
-    | -- before patternarg braces
-    {A} a -- before open patternarg parens
-    (suc b) :=
-      idLambda
-        -- before implicit app
-        {-- inside implicit arg
-        A}
-        -- before closing implicit arg
-        a;
-
-  type color : Type :=
-    -- comment before pipe
-    | black : color
-    | white : color
-    | red : color
-    -- comment before pipe
-    | blue : color;
-
-  axiom a5 : Type;
-
-  open Patterns -- before using
-  using -- before brace
-  {-- before first f
-  f; f};
-
-  type list (A : Type) : Type := cons A (list A);
-end;
-
-module EmptyRecords;
-  import Stdlib.Data.Bool.Base open;
-
-  type T := mkT {};
-
-  x : T := mkT@{};
-
-  isZero : Nat -> Bool
-    | zero := true
-    | suc@{} := false;
-end;
-
---- Traits
-module Traits;
-  import Stdlib.Prelude open hiding {Show; mkShow; module Show};
-
-  trait
-  type Show A := mkShow {show : A → String};
-
-  instance
-  showStringI : Show String := mkShow (show := id);
-
-  instance
-  showBoolI : Show Bool :=
-    mkShow (show := λ {x := if x "true" "false"});
-
-  instance
-  showNatI : Show Nat := mkShow (show := natToString);
-
-  showList {A} : {{Show A}} → List A → String
-    | nil := "nil"
-    | (h :: t) := Show.show h ++str " :: " ++str showList t;
-
-  g : {A : Type} → {{Show A}} → Nat := 5;
-
-  instance
-  showListI {A} {{Show A}} : Show (List A) :=
-    mkShow (show := showList);
-
-  showMaybe {A} {{Show A}} : Maybe A → String
-    | (just x) := "just (" ++str Show.show x ++str ")"
-    | nothing := "nothing";
-
-  instance
-  showMaybeI {A} {{Show A}} : Show (Maybe A) :=
-    mkShow (show := showMaybe);
-
-  f {A} {{Show A}} : A → String
-    | x := Show.show x;
-
-  f' {A} : {{Show A}} → A → String
-    | {{mkShow s}} x := s x;
-
-  f'' {A} : {{Show A}} → A → String
-    | {{M}} x := Show.show {{M}} x;
-
-  f'3 {A} {{M : Show A}} : A → String := Show.show {{M}};
-
-  f'4 {A} {{_ : Show A}} : A → String := Show.show;
-
-end;
-
-module OperatorRecord;
-  trait
-  type Natural A :=
-    myNatural {
-      syntax operator + additive;
-      + : A -> A -> A;
-
-      syntax operator * multiplicative;
-      * : A -> A -> A
-    };
-
-  open Natural;
-
-  calc {A : Type} {{Natural A}} (n m : A) : A :=
-    let
-      open Natural;
-    in n + m * m;
-end;
-
-longLongLongArg : Int := 0;
-
-longLongLongListArg : List Int := [];
-
-l1 : List Int :=
-  [ 1
-  ; 2
-  ; longLongLongArg
-  ; longLongLongArg
-  ; longLongLongArg
-  ; longLongLongArg
-  ];
-
-l2 : List Int := [1; 2; 3];
-
-l3 : List (List Int) :=
-  [ [1; 2; 3]
-  ; longLongLongListArg
-  ; longLongLongListArg
-  ; longLongLongListArg
-  ];
-
-l4 : List (List Int) :=
-  [ [1; 2; 3]
-  ; longLongLongListArg
-  ; [ longLongLongListArg
-    ; longLongLongListArg
-    ; longLongLongListArg
-    ; longLongLongListArg
-    ]
-  ; longLongLongListArg
-  ];
+-- -- Lorem ipsum dolor sit amet, consectetur adipiscing elit
+-- terminating
+-- -- Comment between terminating and type sig
+-- go : Nat → Nat → Nat
+--   | n s :=
+--     if
+--       (s < n)
+--       (go (sub n 1) s)
+--       (go n (sub s n) + go (sub n 1) s);
+
+-- module {- local module -}
+-- M;
+--   syntax -- syntax in local modules
+--   operator , pair;
+--   axiom , : String → String → String;
+-- end;
+
+-- -- case with single branch
+-- case1 (n : Nat) : Nat := case n of {x := zero};
+
+-- -- case with multiple branches
+-- case2 (n : Nat) : Nat :=
+--   case n of {
+--     | zero := zero
+--     | _ := zero
+--   };
+
+-- -- case on nested case
+-- case3 (n : Nat) : Nat :=
+--   case case n of {_ := zero} of {
+--     | zero := zero
+--     | _ := zero
+--   };
+
+-- -- case on nested case expression
+-- case4 (n : Nat) : Nat :=
+--   case n of {
+--     | zero := case n of {x := zero}
+--     | _ := zero
+--   };
+
+-- -- -- case with application subject
+-- case5 (n : Nat) : Nat := case id n of {x := zero};
+
+-- -- qualified commas
+-- t4 : String := "a" M., "b" M., "c" M., "d";
+
+-- open M;
+
+-- -- mix qualified and unqualified commas
+-- t5 : String := "a" M., "b" M., "c", "d";
+
+-- -- comma chain fits in a line
+-- t2 : String := "a", "b", "c", "d";
+
+-- -- comma chain does not fit in a line
+-- t3 : String :=
+--   "a"
+--     , "b"
+--     , "c"
+--     , "d"
+--     , "e"
+--     , "f"
+--     , "g"
+--     , "h"
+--     , "i"
+--     , "j"
+--     , "k"
+--     , "1234";
+
+-- -- escaping in String literals
+-- e1 : String := "\"\n";
+
+-- syntax fixity l1 := binary {assoc := left; below := [pair]};
+-- syntax fixity r3 := binary {assoc := right; above := [pair]};
+-- syntax fixity l6 := binary {assoc := left; above := [r3]};
+-- syntax fixity r6 := binary {assoc := right; same := l6};
+-- syntax fixity l7 := binary {assoc := left; above := [l6]};
+
+-- syntax operator +l7 l7;
+-- axiom +l7 : String → String → String;
+
+-- syntax operator +r3 r3;
+-- axiom +r3 : String → String → String;
+
+-- syntax operator +l1 l1;
+-- axiom +l1 : String → String → String;
+
+-- syntax operator +l6 l6;
+-- axiom +l6 : String → String → String;
+
+-- syntax operator +r6 r6;
+-- axiom +r6 : String → String → String;
+
+-- -- nesting of chains
+-- t : String :=
+--   "Hellooooooooo"
+--     +l1 "Hellooooooooo"
+--     +l1 "Hellooooooooo"
+--         +l6 "Hellooooooooo"
+--         +l6 ("Hellooooooooo"
+--           +r6 "Hellooooooooo"
+--           +r6 "Hellooooooooo")
+--         +l6 "Hellooooooooo"
+--         +l6 "Hellooooooooo"
+--           +l7 "Hellooooooooo"
+--           +l7 "Hellooooooooo"
+--           +l7 "Hellooooooooo"
+--       , "hi"
+--       , "hi";
+
+-- -- function with single wildcard parameter
+-- g : (_ : Type) -> Nat
+--   | _ := 1;
+
+-- -- grouping of type arguments
+-- exampleFunction1
+--   : {A : Type}
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> Nat
+--   | _ _ _ _ _ _ _ := 1;
+
+-- axiom undefined : {A : Type} -> A;
+
+-- -- 200 in the body is idented with respect to the start of the chain
+-- -- (at {A : Type})
+-- exampleFunction2
+--   : {A : Type}
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> List A
+--     -> Nat :=
+--   λ {_ _ _ _ _ _ _ :=
+--     undefined
+--       -- comment after first
+--       + undefined
+--       -- comment after second
+--       + undefined
+--       + undefined
+--       + undefined
+--       + undefined
+--       + undefined
+--       + undefined
+--       + undefined
+--       + undefined
+--       + undefined};
+
+-- positive
+-- type T0 (A : Type) := c0 : (A -> T0 A) -> T0 A;
+
+-- -- Single Lambda clause
+-- idLambda : {A : Type} -> A -> A := λ {x := x};
+
+-- -- Lambda clauses
+-- f : Nat -> Nat :=
+--   \ {
+--     -- comment before lambda pipe
+--     | zero :=
+--       let
+--         foo : Nat := 1;
+--       in foo
+--     | _ -- comment before lambda :=
+--     := 1
+--   };
+
+-- module Patterns;
+--   syntax operator × functor;
+--   syntax operator , pair;
+--   type × (A : Type) (B : Type) := , : A → B → A × B;
+
+--   f : Nat × Nat × Nat × Nat -> Nat
+--     | (a, b, c, d) := a;
+-- end;
+
+-- module UnicodeStrings;
+--   a : String := "λ";
+-- end;
+
+-- module Comments;
+--   axiom a1 : Type;
+--   -- attached to a1
+
+--   -- attached to a2
+--   axiom a2 : Type;
+
+--   -- attached to nothing
+
+--   axiom a3 -- comment before axiom :
+--   : Type;
+
+--   num
+--     -- comment before type sig :
+--     : -- comment after type sig :
+--     Nat :=
+--     -- comment before clause :=
+--     -- comment after clause :=
+--     123;
+
+--   -- attached to nothing
+--   -- attached to nothing 2
+
+--   -- attached to nothing 3
+
+--   axiom a4 : -- before open pi brace
+--     {-- after open pi brace
+--     a -- before pi :
+--     : Type}
+--     -> Type;
+
+--   id2 : {A : Type} -> A -> Nat -> A
+--     | -- before patternarg braces
+--     {A} a -- before open patternarg parens
+--     (suc b) :=
+--       idLambda
+--         -- before implicit app
+--         {-- inside implicit arg
+--         A}
+--         -- before closing implicit arg
+--         a;
+
+--   type color : Type :=
+--     -- comment before pipe
+--     | black : color
+--     | white : color
+--     | red : color
+--     -- comment before pipe
+--     | blue : color;
+
+--   axiom a5 : Type;
+
+--   open Patterns -- before using
+--   using -- before brace
+--   {-- before first f
+--   f; f};
+
+--   type list (A : Type) : Type := cons A (list A);
+-- end;
+
+-- module EmptyRecords;
+--   import Stdlib.Data.Bool.Base open;
+
+--   type T := mkT {};
+
+--   x : T := mkT@{};
+
+--   isZero : Nat -> Bool
+--     | zero := true
+--     | suc@{} := false;
+-- end;
+
+-- --- Traits
+-- module Traits;
+--   import Stdlib.Prelude open hiding {Show; mkShow; module Show};
+
+--   trait
+--   type Show A := mkShow {show : A → String};
+
+--   instance
+--   showStringI : Show String := mkShow (show := id);
+
+--   instance
+--   showBoolI : Show Bool :=
+--     mkShow (show := λ {x := if x "true" "false"});
+
+--   instance
+--   showNatI : Show Nat := mkShow (show := natToString);
+
+--   showList {A} : {{Show A}} → List A → String
+--     | nil := "nil"
+--     | (h :: t) := Show.show h ++str " :: " ++str showList t;
+
+--   g : {A : Type} → {{Show A}} → Nat := 5;
+
+--   instance
+--   showListI {A} {{Show A}} : Show (List A) :=
+--     mkShow (show := showList);
+
+--   showMaybe {A} {{Show A}} : Maybe A → String
+--     | (just x) := "just (" ++str Show.show x ++str ")"
+--     | nothing := "nothing";
+
+--   instance
+--   showMaybeI {A} {{Show A}} : Show (Maybe A) :=
+--     mkShow (show := showMaybe);
+
+--   f {A} {{Show A}} : A → String
+--     | x := Show.show x;
+
+--   f' {A} : {{Show A}} → A → String
+--     | {{mkShow s}} x := s x;
+
+--   f'' {A} : {{Show A}} → A → String
+--     | {{M}} x := Show.show {{M}} x;
+
+--   f'3 {A} {{M : Show A}} : A → String := Show.show {{M}};
+
+--   f'4 {A} {{_ : Show A}} : A → String := Show.show;
+
+-- end;
+
+-- module OperatorRecord;
+--   trait
+--   type Natural A :=
+--     myNatural {
+--       syntax operator + additive;
+--       + : A -> A -> A;
+
+--       syntax operator * multiplicative;
+--       * : A -> A -> A
+--     };
+
+--   open Natural;
+
+--   calc {A : Type} {{Natural A}} (n m : A) : A :=
+--     let
+--       open Natural;
+--     in n + m * m;
+-- end;
+
+-- longLongLongArg : Int := 0;
+
+-- longLongLongListArg : List Int := [];
+
+-- l1 : List Int :=
+--   [ 1
+--   ; 2
+--   ; longLongLongArg
+--   ; longLongLongArg
+--   ; longLongLongArg
+--   ; longLongLongArg
+--   ];
+
+-- l2 : List Int := [1; 2; 3];
+
+-- l3 : List (List Int) :=
+--   [ [1; 2; 3]
+--   ; longLongLongListArg
+--   ; longLongLongListArg
+--   ; longLongLongListArg
+--   ];
+
+-- l4 : List (List Int) :=
+--   [ [1; 2; 3]
+--   ; longLongLongListArg
+--   ; [ longLongLongListArg
+--     ; longLongLongListArg
+--     ; longLongLongListArg
+--     ; longLongLongListArg
+--     ]
+--   ; longLongLongListArg
+--   ];
 
 -- Comment at the end of a module
+
+-- Format as-pattern interacting with implicit args.
+
+implicitWithInnerParens : {_ : Nat} -> Nat
+  | {A@(suc B@(suc x))} := x
+  | {B@(suc x)} := B
+  | {_} := zero;
+
+i2479' : {_ : Nat} -> Nat
+  | {suc (suc x)} := x
+  | {suc x} := x
+  | {_} := zero;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -387,15 +387,3 @@ i2479' : {_ : Nat} -> Nat
   | {_} := zero;
 
 -- Comment at the end of a module
-
--- Format as-pattern interacting with implicit args.
-
-implicitWithInnerParens : {_ : Nat} -> Nat
-  | {A@(suc B@(suc x))} := x
-  | {B@(suc x)} := B
-  | {_} := zero;
-
-i2479' : {_ : Nat} -> Nat
-  | {suc (suc x)} := x
-  | {suc x} := x
-  | {_} := zero;

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -12,367 +12,367 @@ hiding -- Hide some names
 -- Bool either
 Bool; true; false; mkShow; module Show};
 
--- -- Lorem ipsum dolor sit amet, consectetur adipiscing elit
--- terminating
--- -- Comment between terminating and type sig
--- go : Nat → Nat → Nat
---   | n s :=
---     if
---       (s < n)
---       (go (sub n 1) s)
---       (go n (sub s n) + go (sub n 1) s);
-
--- module {- local module -}
--- M;
---   syntax -- syntax in local modules
---   operator , pair;
---   axiom , : String → String → String;
--- end;
-
--- -- case with single branch
--- case1 (n : Nat) : Nat := case n of {x := zero};
-
--- -- case with multiple branches
--- case2 (n : Nat) : Nat :=
---   case n of {
---     | zero := zero
---     | _ := zero
---   };
-
--- -- case on nested case
--- case3 (n : Nat) : Nat :=
---   case case n of {_ := zero} of {
---     | zero := zero
---     | _ := zero
---   };
-
--- -- case on nested case expression
--- case4 (n : Nat) : Nat :=
---   case n of {
---     | zero := case n of {x := zero}
---     | _ := zero
---   };
-
--- -- -- case with application subject
--- case5 (n : Nat) : Nat := case id n of {x := zero};
-
--- -- qualified commas
--- t4 : String := "a" M., "b" M., "c" M., "d";
-
--- open M;
-
--- -- mix qualified and unqualified commas
--- t5 : String := "a" M., "b" M., "c", "d";
-
--- -- comma chain fits in a line
--- t2 : String := "a", "b", "c", "d";
-
--- -- comma chain does not fit in a line
--- t3 : String :=
---   "a"
---     , "b"
---     , "c"
---     , "d"
---     , "e"
---     , "f"
---     , "g"
---     , "h"
---     , "i"
---     , "j"
---     , "k"
---     , "1234";
-
--- -- escaping in String literals
--- e1 : String := "\"\n";
-
--- syntax fixity l1 := binary {assoc := left; below := [pair]};
--- syntax fixity r3 := binary {assoc := right; above := [pair]};
--- syntax fixity l6 := binary {assoc := left; above := [r3]};
--- syntax fixity r6 := binary {assoc := right; same := l6};
--- syntax fixity l7 := binary {assoc := left; above := [l6]};
-
--- syntax operator +l7 l7;
--- axiom +l7 : String → String → String;
-
--- syntax operator +r3 r3;
--- axiom +r3 : String → String → String;
-
--- syntax operator +l1 l1;
--- axiom +l1 : String → String → String;
-
--- syntax operator +l6 l6;
--- axiom +l6 : String → String → String;
-
--- syntax operator +r6 r6;
--- axiom +r6 : String → String → String;
-
--- -- nesting of chains
--- t : String :=
---   "Hellooooooooo"
---     +l1 "Hellooooooooo"
---     +l1 "Hellooooooooo"
---         +l6 "Hellooooooooo"
---         +l6 ("Hellooooooooo"
---           +r6 "Hellooooooooo"
---           +r6 "Hellooooooooo")
---         +l6 "Hellooooooooo"
---         +l6 "Hellooooooooo"
---           +l7 "Hellooooooooo"
---           +l7 "Hellooooooooo"
---           +l7 "Hellooooooooo"
---       , "hi"
---       , "hi";
-
--- -- function with single wildcard parameter
--- g : (_ : Type) -> Nat
---   | _ := 1;
-
--- -- grouping of type arguments
--- exampleFunction1
---   : {A : Type}
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> Nat
---   | _ _ _ _ _ _ _ := 1;
-
--- axiom undefined : {A : Type} -> A;
-
--- -- 200 in the body is idented with respect to the start of the chain
--- -- (at {A : Type})
--- exampleFunction2
---   : {A : Type}
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> List A
---     -> Nat :=
---   λ {_ _ _ _ _ _ _ :=
---     undefined
---       -- comment after first
---       + undefined
---       -- comment after second
---       + undefined
---       + undefined
---       + undefined
---       + undefined
---       + undefined
---       + undefined
---       + undefined
---       + undefined
---       + undefined};
-
--- positive
--- type T0 (A : Type) := c0 : (A -> T0 A) -> T0 A;
-
--- -- Single Lambda clause
--- idLambda : {A : Type} -> A -> A := λ {x := x};
-
--- -- Lambda clauses
--- f : Nat -> Nat :=
---   \ {
---     -- comment before lambda pipe
---     | zero :=
---       let
---         foo : Nat := 1;
---       in foo
---     | _ -- comment before lambda :=
---     := 1
---   };
-
--- module Patterns;
---   syntax operator × functor;
---   syntax operator , pair;
---   type × (A : Type) (B : Type) := , : A → B → A × B;
-
---   f : Nat × Nat × Nat × Nat -> Nat
---     | (a, b, c, d) := a;
--- end;
-
--- module UnicodeStrings;
---   a : String := "λ";
--- end;
-
--- module Comments;
---   axiom a1 : Type;
---   -- attached to a1
-
---   -- attached to a2
---   axiom a2 : Type;
-
---   -- attached to nothing
-
---   axiom a3 -- comment before axiom :
---   : Type;
-
---   num
---     -- comment before type sig :
---     : -- comment after type sig :
---     Nat :=
---     -- comment before clause :=
---     -- comment after clause :=
---     123;
-
---   -- attached to nothing
---   -- attached to nothing 2
-
---   -- attached to nothing 3
-
---   axiom a4 : -- before open pi brace
---     {-- after open pi brace
---     a -- before pi :
---     : Type}
---     -> Type;
-
---   id2 : {A : Type} -> A -> Nat -> A
---     | -- before patternarg braces
---     {A} a -- before open patternarg parens
---     (suc b) :=
---       idLambda
---         -- before implicit app
---         {-- inside implicit arg
---         A}
---         -- before closing implicit arg
---         a;
-
---   type color : Type :=
---     -- comment before pipe
---     | black : color
---     | white : color
---     | red : color
---     -- comment before pipe
---     | blue : color;
-
---   axiom a5 : Type;
-
---   open Patterns -- before using
---   using -- before brace
---   {-- before first f
---   f; f};
-
---   type list (A : Type) : Type := cons A (list A);
--- end;
-
--- module EmptyRecords;
---   import Stdlib.Data.Bool.Base open;
-
---   type T := mkT {};
-
---   x : T := mkT@{};
-
---   isZero : Nat -> Bool
---     | zero := true
---     | suc@{} := false;
--- end;
-
--- --- Traits
--- module Traits;
---   import Stdlib.Prelude open hiding {Show; mkShow; module Show};
-
---   trait
---   type Show A := mkShow {show : A → String};
-
---   instance
---   showStringI : Show String := mkShow (show := id);
-
---   instance
---   showBoolI : Show Bool :=
---     mkShow (show := λ {x := if x "true" "false"});
-
---   instance
---   showNatI : Show Nat := mkShow (show := natToString);
-
---   showList {A} : {{Show A}} → List A → String
---     | nil := "nil"
---     | (h :: t) := Show.show h ++str " :: " ++str showList t;
-
---   g : {A : Type} → {{Show A}} → Nat := 5;
-
---   instance
---   showListI {A} {{Show A}} : Show (List A) :=
---     mkShow (show := showList);
-
---   showMaybe {A} {{Show A}} : Maybe A → String
---     | (just x) := "just (" ++str Show.show x ++str ")"
---     | nothing := "nothing";
-
---   instance
---   showMaybeI {A} {{Show A}} : Show (Maybe A) :=
---     mkShow (show := showMaybe);
-
---   f {A} {{Show A}} : A → String
---     | x := Show.show x;
-
---   f' {A} : {{Show A}} → A → String
---     | {{mkShow s}} x := s x;
-
---   f'' {A} : {{Show A}} → A → String
---     | {{M}} x := Show.show {{M}} x;
-
---   f'3 {A} {{M : Show A}} : A → String := Show.show {{M}};
-
---   f'4 {A} {{_ : Show A}} : A → String := Show.show;
-
--- end;
-
--- module OperatorRecord;
---   trait
---   type Natural A :=
---     myNatural {
---       syntax operator + additive;
---       + : A -> A -> A;
-
---       syntax operator * multiplicative;
---       * : A -> A -> A
---     };
-
---   open Natural;
-
---   calc {A : Type} {{Natural A}} (n m : A) : A :=
---     let
---       open Natural;
---     in n + m * m;
--- end;
-
--- longLongLongArg : Int := 0;
-
--- longLongLongListArg : List Int := [];
-
--- l1 : List Int :=
---   [ 1
---   ; 2
---   ; longLongLongArg
---   ; longLongLongArg
---   ; longLongLongArg
---   ; longLongLongArg
---   ];
-
--- l2 : List Int := [1; 2; 3];
-
--- l3 : List (List Int) :=
---   [ [1; 2; 3]
---   ; longLongLongListArg
---   ; longLongLongListArg
---   ; longLongLongListArg
---   ];
-
--- l4 : List (List Int) :=
---   [ [1; 2; 3]
---   ; longLongLongListArg
---   ; [ longLongLongListArg
---     ; longLongLongListArg
---     ; longLongLongListArg
---     ; longLongLongListArg
---     ]
---   ; longLongLongListArg
---   ];
+-- Lorem ipsum dolor sit amet, consectetur adipiscing elit
+terminating
+-- Comment between terminating and type sig
+go : Nat → Nat → Nat
+  | n s :=
+    if
+      (s < n)
+      (go (sub n 1) s)
+      (go n (sub s n) + go (sub n 1) s);
+
+module {- local module -}
+M;
+  syntax -- syntax in local modules
+  operator , pair;
+  axiom , : String → String → String;
+end;
+
+-- case with single branch
+case1 (n : Nat) : Nat := case n of {x := zero};
+
+-- case with multiple branches
+case2 (n : Nat) : Nat :=
+  case n of {
+    | zero := zero
+    | _ := zero
+  };
+
+-- case on nested case
+case3 (n : Nat) : Nat :=
+  case case n of {_ := zero} of {
+    | zero := zero
+    | _ := zero
+  };
+
+-- case on nested case expression
+case4 (n : Nat) : Nat :=
+  case n of {
+    | zero := case n of {x := zero}
+    | _ := zero
+  };
+
+-- -- case with application subject
+case5 (n : Nat) : Nat := case id n of {x := zero};
+
+-- qualified commas
+t4 : String := "a" M., "b" M., "c" M., "d";
+
+open M;
+
+-- mix qualified and unqualified commas
+t5 : String := "a" M., "b" M., "c", "d";
+
+-- comma chain fits in a line
+t2 : String := "a", "b", "c", "d";
+
+-- comma chain does not fit in a line
+t3 : String :=
+  "a"
+    , "b"
+    , "c"
+    , "d"
+    , "e"
+    , "f"
+    , "g"
+    , "h"
+    , "i"
+    , "j"
+    , "k"
+    , "1234";
+
+-- escaping in String literals
+e1 : String := "\"\n";
+
+syntax fixity l1 := binary {assoc := left; below := [pair]};
+syntax fixity r3 := binary {assoc := right; above := [pair]};
+syntax fixity l6 := binary {assoc := left; above := [r3]};
+syntax fixity r6 := binary {assoc := right; same := l6};
+syntax fixity l7 := binary {assoc := left; above := [l6]};
+
+syntax operator +l7 l7;
+axiom +l7 : String → String → String;
+
+syntax operator +r3 r3;
+axiom +r3 : String → String → String;
+
+syntax operator +l1 l1;
+axiom +l1 : String → String → String;
+
+syntax operator +l6 l6;
+axiom +l6 : String → String → String;
+
+syntax operator +r6 r6;
+axiom +r6 : String → String → String;
+
+-- nesting of chains
+t : String :=
+  "Hellooooooooo"
+    +l1 "Hellooooooooo"
+    +l1 "Hellooooooooo"
+        +l6 "Hellooooooooo"
+        +l6 ("Hellooooooooo"
+          +r6 "Hellooooooooo"
+          +r6 "Hellooooooooo")
+        +l6 "Hellooooooooo"
+        +l6 "Hellooooooooo"
+          +l7 "Hellooooooooo"
+          +l7 "Hellooooooooo"
+          +l7 "Hellooooooooo"
+      , "hi"
+      , "hi";
+
+-- function with single wildcard parameter
+g : (_ : Type) -> Nat
+  | _ := 1;
+
+-- grouping of type arguments
+exampleFunction1
+  : {A : Type}
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> Nat
+  | _ _ _ _ _ _ _ := 1;
+
+axiom undefined : {A : Type} -> A;
+
+-- 200 in the body is idented with respect to the start of the chain
+-- (at {A : Type})
+exampleFunction2
+  : {A : Type}
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> List A
+    -> Nat :=
+  λ {_ _ _ _ _ _ _ :=
+    undefined
+      -- comment after first
+      + undefined
+      -- comment after second
+      + undefined
+      + undefined
+      + undefined
+      + undefined
+      + undefined
+      + undefined
+      + undefined
+      + undefined
+      + undefined};
+
+positive
+type T0 (A : Type) := c0 : (A -> T0 A) -> T0 A;
+
+-- Single Lambda clause
+idLambda : {A : Type} -> A -> A := λ {x := x};
+
+-- Lambda clauses
+f : Nat -> Nat :=
+  \ {
+    -- comment before lambda pipe
+    | zero :=
+      let
+        foo : Nat := 1;
+      in foo
+    | _ -- comment before lambda :=
+    := 1
+  };
+
+module Patterns;
+  syntax operator × functor;
+  syntax operator , pair;
+  type × (A : Type) (B : Type) := , : A → B → A × B;
+
+  f : Nat × Nat × Nat × Nat -> Nat
+    | (a, b, c, d) := a;
+end;
+
+module UnicodeStrings;
+  a : String := "λ";
+end;
+
+module Comments;
+  axiom a1 : Type;
+  -- attached to a1
+
+  -- attached to a2
+  axiom a2 : Type;
+
+  -- attached to nothing
+
+  axiom a3 -- comment before axiom :
+  : Type;
+
+  num
+    -- comment before type sig :
+    : -- comment after type sig :
+    Nat :=
+    -- comment before clause :=
+    -- comment after clause :=
+    123;
+
+  -- attached to nothing
+  -- attached to nothing 2
+
+  -- attached to nothing 3
+
+  axiom a4 : -- before open pi brace
+    {-- after open pi brace
+    a -- before pi :
+    : Type}
+    -> Type;
+
+  id2 : {A : Type} -> A -> Nat -> A
+    | -- before patternarg braces
+    {A} a -- before open patternarg parens
+    (suc b) :=
+      idLambda
+        -- before implicit app
+        {-- inside implicit arg
+        A}
+        -- before closing implicit arg
+        a;
+
+  type color : Type :=
+    -- comment before pipe
+    | black : color
+    | white : color
+    | red : color
+    -- comment before pipe
+    | blue : color;
+
+  axiom a5 : Type;
+
+  open Patterns -- before using
+  using -- before brace
+  {-- before first f
+  f; f};
+
+  type list (A : Type) : Type := cons A (list A);
+end;
+
+module EmptyRecords;
+  import Stdlib.Data.Bool.Base open;
+
+  type T := mkT {};
+
+  x : T := mkT@{};
+
+  isZero : Nat -> Bool
+    | zero := true
+    | suc@{} := false;
+end;
+
+--- Traits
+module Traits;
+  import Stdlib.Prelude open hiding {Show; mkShow; module Show};
+
+  trait
+  type Show A := mkShow {show : A → String};
+
+  instance
+  showStringI : Show String := mkShow (show := id);
+
+  instance
+  showBoolI : Show Bool :=
+    mkShow (show := λ {x := if x "true" "false"});
+
+  instance
+  showNatI : Show Nat := mkShow (show := natToString);
+
+  showList {A} : {{Show A}} → List A → String
+    | nil := "nil"
+    | (h :: t) := Show.show h ++str " :: " ++str showList t;
+
+  g : {A : Type} → {{Show A}} → Nat := 5;
+
+  instance
+  showListI {A} {{Show A}} : Show (List A) :=
+    mkShow (show := showList);
+
+  showMaybe {A} {{Show A}} : Maybe A → String
+    | (just x) := "just (" ++str Show.show x ++str ")"
+    | nothing := "nothing";
+
+  instance
+  showMaybeI {A} {{Show A}} : Show (Maybe A) :=
+    mkShow (show := showMaybe);
+
+  f {A} {{Show A}} : A → String
+    | x := Show.show x;
+
+  f' {A} : {{Show A}} → A → String
+    | {{mkShow s}} x := s x;
+
+  f'' {A} : {{Show A}} → A → String
+    | {{M}} x := Show.show {{M}} x;
+
+  f'3 {A} {{M : Show A}} : A → String := Show.show {{M}};
+
+  f'4 {A} {{_ : Show A}} : A → String := Show.show;
+
+end;
+
+module OperatorRecord;
+  trait
+  type Natural A :=
+    myNatural {
+      syntax operator + additive;
+      + : A -> A -> A;
+
+      syntax operator * multiplicative;
+      * : A -> A -> A
+    };
+
+  open Natural;
+
+  calc {A : Type} {{Natural A}} (n m : A) : A :=
+    let
+      open Natural;
+    in n + m * m;
+end;
+
+longLongLongArg : Int := 0;
+
+longLongLongListArg : List Int := [];
+
+l1 : List Int :=
+  [ 1
+  ; 2
+  ; longLongLongArg
+  ; longLongLongArg
+  ; longLongLongArg
+  ; longLongLongArg
+  ];
+
+l2 : List Int := [1; 2; 3];
+
+l3 : List (List Int) :=
+  [ [1; 2; 3]
+  ; longLongLongListArg
+  ; longLongLongListArg
+  ; longLongLongListArg
+  ];
+
+l4 : List (List Int) :=
+  [ [1; 2; 3]
+  ; longLongLongListArg
+  ; [ longLongLongListArg
+    ; longLongLongListArg
+    ; longLongLongListArg
+    ; longLongLongListArg
+    ]
+  ; longLongLongListArg
+  ];
 
 -- Comment at the end of a module
 

--- a/tests/positive/IdInType.juvix
+++ b/tests/positive/IdInType.juvix
@@ -1,7 +1,6 @@
 module IdInType;
 
-type Unit :=
-  | unit : Unit;
+type Unit := unit : Unit;
 
 id : {a : Type} -> a -> a
   | a := a;

--- a/tests/positive/ImportShadow/Nat.juvix
+++ b/tests/positive/ImportShadow/Nat.juvix
@@ -10,6 +10,7 @@ type Nat :=
 
 is-zero : Nat → Bool
   | n :=
-    case n
+    case n of {
       | zero := true
-      | suc _ := false;
+      | suc _ := false
+    };

--- a/tests/positive/InstanceImport/Main.juvix
+++ b/tests/positive/InstanceImport/Main.juvix
@@ -3,10 +3,11 @@ module Main;
 import M open;
 import M open;
 
-type Bool := true | false;
+type Bool :=
+  | true
+  | false;
 
 instance
 boolI : T Bool := mkT λ {x := x};
 
-main : Bool := case T.pp unit
-  | unit := T.pp true;
+main : Bool := case T.pp unit of {unit := T.pp true};

--- a/tests/positive/Internal/AsPattern.juvix
+++ b/tests/positive/Internal/AsPattern.juvix
@@ -44,7 +44,7 @@ lambda : Nat → Nat → Nat
     };
 
 a : {A : Type} → A × Nat → Nat
-  | A'@{_} p@(x, s@zero) := snd p + 1
+  | {A'@_} p@(x, s@zero) := snd p + 1
   | p@(x, s@_) := snd p + 1;
 
 b : {A : Type} → A × Nat → ({B : Type} → B → B) → A

--- a/tests/positive/Internal/AsPattern.juvix
+++ b/tests/positive/Internal/AsPattern.juvix
@@ -28,8 +28,7 @@ builtin nat-plus
 
 syntax operator × functor;
 syntax operator , pair;
-type × (A : Type) (B : Type) :=
-  | , : A → B → A × B;
+type × (A : Type) (B : Type) := , : A → B → A × B;
 
 fst : {A : Type} → {B : Type} → A × B → A
   | p@(a, _) := a;
@@ -45,7 +44,7 @@ lambda : Nat → Nat → Nat
     };
 
 a : {A : Type} → A × Nat → Nat
-  | {A'@_} p@(x, s@zero) := snd p + 1
+  | A'@{_} p@(x, s@zero) := snd p + 1
   | p@(x, s@_) := snd p + 1;
 
 b : {A : Type} → A × Nat → ({B : Type} → B → B) → A

--- a/tests/positive/Internal/Box.juvix
+++ b/tests/positive/Internal/Box.juvix
@@ -1,10 +1,8 @@
 module Box;
 
-type Box (A : Type) :=
-  | box : A → Box A;
+type Box (A : Type) := box : A → Box A;
 
-type T :=
-  | t : T;
+type T := t : T;
 
 b : Box _ := box t;
 

--- a/tests/positive/Internal/HoleInSignature.juvix
+++ b/tests/positive/Internal/HoleInSignature.juvix
@@ -1,7 +1,7 @@
 module HoleInSignature;
 
 type Pair (A : Type) (B : Type) :=
-  | mkPair : A → B → Pair A B;
+  mkPair : A → B → Pair A B;
 
 type Bool :=
   | true : Bool

--- a/tests/positive/Internal/Implicit.juvix
+++ b/tests/positive/Internal/Implicit.juvix
@@ -20,8 +20,7 @@ type Nat :=
 
 syntax operator × functor;
 syntax operator , pair;
-type × (A : Type) (B : Type) :=
-  | , : A → B → A × B;
+type × (A : Type) (B : Type) := , : A → B → A × B;
 
 uncurry
   : {A : Type}
@@ -80,8 +79,7 @@ upToTwo : _ := zero :: suc zero :: suc (suc zero) :: nil;
 p1 : Nat → Nat → Nat × Nat
   | a b := a, b;
 
-type Proxy (A : Type) :=
-  | proxy : Proxy A;
+type Proxy (A : Type) := proxy : Proxy A;
 
 t2' : {A : Type} → Proxy A := proxy;
 

--- a/tests/positive/Internal/Lambda.juvix
+++ b/tests/positive/Internal/Lambda.juvix
@@ -8,8 +8,7 @@ type Nat :=
 
 syntax operator × functor;
 syntax operator , pair;
-type × (A : Type) (B : Type) :=
-  | , : A → B → A × B;
+type × (A : Type) (B : Type) := , : A → B → A × B;
 
 syntax operator ∘ composition;
 
@@ -160,8 +159,7 @@ t
     → List A × List B :=
   id {({X : Type} → List X) → _} λ {f := f {_}, f {_}};
 
-type Box (A : Type) :=
-  | box : A → Box A;
+type Box (A : Type) := box : A → Box A;
 
 x : Box ((A : Type) → A → A) := box λ {A a := a};
 

--- a/tests/positive/Internal/LiteralInt.juvix
+++ b/tests/positive/Internal/LiteralInt.juvix
@@ -2,11 +2,9 @@ module LiteralInt;
 
 import Stdlib.Prelude open;
 
-type A :=
-  | a : A;
+type A := a : A;
 
-type B :=
-  | b : B;
+type B := b : B;
 
 f : Nat := 1;
 

--- a/tests/positive/Internal/LiteralString.juvix
+++ b/tests/positive/Internal/LiteralString.juvix
@@ -3,10 +3,8 @@ module LiteralString;
 builtin string
 axiom String : Type;
 
-type A :=
-  | a : A;
+type A := a : A;
 
-type B :=
-  | b : B;
+type B := b : B;
 
 f : String := "a";

--- a/tests/positive/Internal/Positivity/E5.juvix
+++ b/tests/positive/Internal/Positivity/E5.juvix
@@ -1,13 +1,10 @@
 module E5;
 
-type T0 (A : Type) :=
-  | c0 : (A -> T0 A) -> T0 A;
+type T0 (A : Type) := c0 : (A -> T0 A) -> T0 A;
 
 axiom B : Type;
 
-type T1 (A : Type) :=
-  | c1 : (B -> T0 A) -> T1 A;
+type T1 (A : Type) := c1 : (B -> T0 A) -> T1 A;
 
 positive
-type T2 :=
-  | c2 : (B -> B -> T1 T2) -> T2;
+type T2 := c2 : (B -> B -> T1 T2) -> T2;

--- a/tests/positive/Internal/Positivity/RoseTree.juvix
+++ b/tests/positive/Internal/Positivity/RoseTree.juvix
@@ -5,4 +5,4 @@ type List (A : Type) : Type :=
   | cons : A -> List A -> List A;
 
 type RoseTree (A : Type) : Type :=
-  | node : A -> List (RoseTree A) -> RoseTree A;
+  node : A -> List (RoseTree A) -> RoseTree A;

--- a/tests/positive/Internal/Simple.juvix
+++ b/tests/positive/Internal/Simple.juvix
@@ -1,7 +1,6 @@
 module Simple;
 
-type T :=
-  | tt : T;
+type T := tt : T;
 
 someT : T := tt;
 

--- a/tests/positive/Internal/Synonyms.juvix
+++ b/tests/positive/Internal/Synonyms.juvix
@@ -9,7 +9,7 @@ idTy (A : Type) : Type := A;
 idTy2 : typeToType
   | A := A;
 
-typeToType  : Type := Type -> Type;
+typeToType : Type := Type -> Type;
 
 Ty2 : idTy Type := Ty1;
 

--- a/tests/positive/LambdaCalculus.juvix
+++ b/tests/positive/LambdaCalculus.juvix
@@ -9,8 +9,6 @@ type Expr (V : Type) :=
   | lam : LambdaTy V -> Expr V
   | app : AppTy V -> Expr V;
 
-type Lambda (V : Type) :=
-  | mkLambda : Expr V -> Lambda V;
+type Lambda (V : Type) := mkLambda : Expr V -> Lambda V;
 
-type App (V : Type) :=
-  | mkApp : Expr V -> Expr V -> App V;
+type App (V : Type) := mkApp : Expr V -> Expr V -> App V;

--- a/tests/positive/LetShadow.juvix
+++ b/tests/positive/LetShadow.juvix
@@ -4,12 +4,12 @@ type Nat :=
   | zero : Nat
   | suc : Nat → Nat;
 
-type Unit :=
-  | unit : Unit;
+type Unit := unit : Unit;
 
 t : Nat :=
-  case unit
-    | x :=
+  case unit of {
+    x :=
       let
         x : Nat := suc zero;
-      in x;
+      in x
+  };

--- a/tests/positive/LocalSynonym.juvix
+++ b/tests/positive/LocalSynonym.juvix
@@ -1,7 +1,6 @@
 module LocalSynonym;
 
-type Unit :=
-  | unit : Unit;
+type Unit := unit : Unit;
 
 myUnit : Type := Unit;
 

--- a/tests/positive/MutualType.juvix
+++ b/tests/positive/MutualType.juvix
@@ -15,5 +15,4 @@ Forest : Type -> Type
   | A := List (Tree A);
 
 --- N-Ary tree.
-type Tree (A : Type) :=
-  | node : A -> Forest A -> Tree A;
+type Tree (A : Type) := node : A -> Forest A -> Tree A;

--- a/tests/positive/NamedArguments.juvix
+++ b/tests/positive/NamedArguments.juvix
@@ -16,8 +16,7 @@ axiom g : Type;
 
 axiom h : Type;
 
-type Unit :=
-  | unit : Unit;
+type Unit := unit : Unit;
 
 axiom fun1 : (a : Type) -> (b : Type) -> {c : Type} -> Type;
 
@@ -83,7 +82,7 @@ t6' : Type :=
 
 module FakeRecord;
   type Pair (A B : Type) :=
-    | mkPair : (fst : A) -> (snd : B) -> Pair A B;
+    mkPair : (fst : A) -> (snd : B) -> Pair A B;
 
   pp : Pair (B := Unit; A := Type) :=
     mkPair (snd := unit; fst := Type);

--- a/tests/positive/NestedPatterns.juvix
+++ b/tests/positive/NestedPatterns.juvix
@@ -2,14 +2,14 @@ module NestedPatterns;
 
 import Stdlib.Prelude open;
 
-type MyList (A : Type) :=
-  | myList : List A -> MyList A;
+type MyList (A : Type) := myList : List A -> MyList A;
 
 toList : {A : Type} -> MyList A -> List A
   | (myList xs) := xs;
 
 f : MyList Nat -> Nat
   | xs :=
-    case toList xs
+    case toList xs of {
       | suc n :: nil := n
-      | _ := zero;
+      | _ := zero
+    };

--- a/tests/positive/NoDependencies/Foo.juvix
+++ b/tests/positive/NoDependencies/Foo.juvix
@@ -1,4 +1,3 @@
 module Foo;
 
-type Bar :=
-  | bar : Bar;
+type Bar := bar : Bar;

--- a/tests/positive/Polymorphism.juvix
+++ b/tests/positive/Polymorphism.juvix
@@ -1,7 +1,7 @@
 module Polymorphism;
 
 type Pair (A : Type) (B : Type) :=
-  | mkPair : A → B → Pair A B;
+  mkPair : A → B → Pair A B;
 
 type Nat :=
   | zero : Nat

--- a/tests/positive/PolymorphismHoles.juvix
+++ b/tests/positive/PolymorphismHoles.juvix
@@ -1,7 +1,7 @@
 module PolymorphismHoles;
 
 type Pair (A : Type) (B : Type) :=
-  | mkPair : A → B → Pair A B;
+  mkPair : A → B → Pair A B;
 
 type Nat :=
   | zero : Nat

--- a/tests/positive/Projections.juvix
+++ b/tests/positive/Projections.juvix
@@ -4,21 +4,20 @@ type Maybe (A : Type) :=
   | nothing : Maybe A
   | just : A -> Maybe A;
 
-type T :=
-  | t : T;
+type T := t : T;
 
 module M;
   type RecA (A B : Type) :=
-    | mkRecA {
-        arg : Maybe (RecB B A);
-        arg2 : A
-      };
+    mkRecA {
+      arg : Maybe (RecB B A);
+      arg2 : A
+    };
 
   type RecB (A B : Type) :=
-    | mkRecB {
-        arg : RecA B A;
-        arg2 : T
-      };
+    mkRecB {
+      arg : RecA B A;
+      arg2 : T
+    };
 
   p1 : RecA T (Maybe T) :=
     mkRecA
@@ -40,10 +39,10 @@ p4 : T := arg2 p1;
 
 module M2;
   type Pair (A B : Type) :=
-    | mkPair {
-        fst : A;
-        snd : B
-      };
+    mkPair {
+      fst : A;
+      snd : B
+    };
 
   open Pair public;
 end;

--- a/tests/positive/Reachability/Data/Nat.juvix
+++ b/tests/positive/Reachability/Data/Nat.juvix
@@ -1,7 +1,7 @@
 module Data.Nat;
 
 syntax fixity add := binary {assoc := left};
-syntax fixity mul  := binary {assoc := left; above := [add]};
+syntax fixity mul := binary {assoc := left; above := [add]};
 
 type ℕ :=
   | zero : ℕ

--- a/tests/positive/Reachability/Data/Product.juvix
+++ b/tests/positive/Reachability/Data/Product.juvix
@@ -3,5 +3,4 @@ module Data.Product;
 syntax fixity prod := binary;
 
 syntax operator × prod;
-type × (a : Type) (b : Type) :=
-  | , : a → b → a × b;
+type × (a : Type) (b : Type) := , : a → b → a × b;

--- a/tests/positive/Reachability/N.juvix
+++ b/tests/positive/Reachability/N.juvix
@@ -6,5 +6,4 @@ import Stdlib.Prelude open hiding {Unit};
 test : {A : Type} -> A -> A
   | x := x;
 
-type Unit :=
-  | unit : Unit;
+type Unit := unit : Unit;

--- a/tests/positive/RecordPattern.juvix
+++ b/tests/positive/RecordPattern.juvix
@@ -1,10 +1,10 @@
 module RecordPattern;
 
 type Pair (A B : Type) :=
-  | mkPair {
-      fst : A;
-      snd : B
-    };
+  mkPair {
+    fst : A;
+    snd : B
+  };
 
 swap {A B : Type} : Pair A B -> Pair B A
   | mkPair@{fst := c1; snd := c2} := mkPair c2 c1;

--- a/tests/positive/Records2.juvix
+++ b/tests/positive/Records2.juvix
@@ -3,12 +3,12 @@ module Records2;
 import Stdlib.Data.Nat.Base open;
 
 type Pair (A B : Type) :=
-  | mkPair {
-      pfst : A;
-      psnd : B
-    };
+  mkPair {
+    pfst : A;
+    psnd : B
+  };
 
 main : Pair Nat Nat :=
   let
     p : Pair Nat Nat := mkPair 2 2;
-  in p @Pair{pfst := pfst + psnd};
+  in p@Pair{pfst := pfst + psnd};

--- a/tests/positive/StdlibImport/A.juvix
+++ b/tests/positive/StdlibImport/A.juvix
@@ -1,4 +1,3 @@
 module A;
 
-type Foo :=
-  | bar : Foo;
+type Foo := bar : Foo;

--- a/tests/positive/Termination/Data/Nat.juvix
+++ b/tests/positive/Termination/Data/Nat.juvix
@@ -23,11 +23,11 @@ import Data.Bool;
 open Data.Bool;
 
 even : ℕ → Bool
-
+  
   | zero := true
   | (suc n) := odd n;
 
 odd : ℕ → Bool
-
+  
   | zero := false
   | (suc n) := even n;

--- a/tests/positive/Traits.juvix
+++ b/tests/positive/Traits.juvix
@@ -5,7 +5,7 @@ type Unit := unit;
 type Box A := box A;
 
 trait
-type T A := mkT { pp : A → A };
+type T A := mkT {pp : A → A};
 
 ppBox {A} {{T A}} : Box A → Box A
   | (box x) := box (T.pp x);

--- a/tests/positive/TypeAlias.juvix
+++ b/tests/positive/TypeAlias.juvix
@@ -1,10 +1,8 @@
 module TypeAlias;
 
-type T :=
-  | t : T;
+type T := t : T;
 
-type T2 :=
-  | t2 : T2;
+type T2 := t2 : T2;
 
 alias : Type := T;
 
@@ -27,7 +25,7 @@ flip
   | f a b := f b a;
 
 type Pair (A : Type) (B : Type) :=
-  | mkPair : id T → id (id A) → B → Pair A B;
+  mkPair : id T → id (id A) → B → Pair A B;
 
 p : {A : Type} → A → Pair A A
   | a := mkPair t a a;

--- a/tests/positive/issue1333/M.juvix
+++ b/tests/positive/issue1333/M.juvix
@@ -1,4 +1,3 @@
 module M;
 
-type T (A : Type) :=
-  | c : T _;
+type T (A : Type) := c : T _;

--- a/tests/positive/issue1879/LetSynonym.juvix
+++ b/tests/positive/issue1879/LetSynonym.juvix
@@ -1,7 +1,6 @@
 module LetSynonym;
 
-type T :=
-  | t : T;
+type T := t : T;
 
 main : T :=
   let


### PR DESCRIPTION
In this PR, we ran the Juvix formatter so that we can now freely run `make format`, `make check`, or `make pre-commit` without any unexpected file changes.

This goes after:

- https://github.com/anoma/juvix/pull/2486