### PR TITLE
Add `Partial` trait

### DIFF
--- a/examples/milestone/Bank/Bank.juvix
+++ b/examples/milestone/Bank/Bank.juvix
@@ -88,7 +88,7 @@ calculateInterest : Nat -> Nat -> Nat -> Nat
 
 --- Asserts some ;Bool; condition.
 assert : {A : Type} -> Bool -> A -> A
-  | c a := if c a (fail "assertion failed");
+  | c a := if c a (failwith "assertion failed");
 
 --- Returns a new ;Token;. Arguments are:
 ---

--- a/examples/milestone/TicTacToe/Logic/Board.juvix
+++ b/examples/milestone/TicTacToe/Logic/Board.juvix
@@ -18,7 +18,7 @@ possibleMoves : List Square → List Nat
 --- ;true; if all the ;Square;s in the list are equal
 full : List Square → Bool
   | (a :: b :: c :: nil) := ==Square a b && ==Square b c
-  | _ := fail "full";
+  | _ := failwith "full";
 
 diagonals : List (List Square) → List (List Square)
   | ((a1 :: _ :: b1 :: nil)
@@ -26,7 +26,7 @@ diagonals : List (List Square) → List (List Square)
     :: (b2 :: _ :: a2 :: nil)
     :: nil) :=
     (a1 :: c :: a2 :: nil) :: (b1 :: c :: b2 :: nil) :: nil
-  | _ := fail "diagonals";
+  | _ := failwith "diagonals";
 
 columns : List (List Square) → List (List Square) :=
   transpose;

--- a/tests/Compilation/positive/test007.juvix
+++ b/tests/Compilation/positive/test007.juvix
@@ -10,8 +10,8 @@ map' {A B} (f : A → B) : List A → List B :=
   };
 
 terminating
-map'' {A B} (f : A → B) (x : List A) : List B :=
-  if (null x) nil (f (head x) :: map'' f (tail x));
+map'' {A B} {{Partial}} (f : A → B) (x : List A) : List B :=
+  if (null x) nil (f (phead x) :: map'' f (tail x));
 
 lst : List Nat := 0 :: 1 :: nil;
 
@@ -26,9 +26,9 @@ printNatListLn (lst : List Nat) : IO :=
 main : IO :=
   printBoolLn (null lst)
     >> printBoolLn (null (nil {Nat}))
-    >> printNatLn (head lst)
+    >> printNatLn (head 1 lst)
     >> printNatListLn (tail lst)
-    >> printNatLn (head (tail lst))
+    >> printNatLn (head 0 (tail lst))
     >> printNatListLn (map ((+) 1) lst)
     >> printNatListLn (map' ((+) 1) lst)
-    >> printNatListLn (map'' ((+) 1) lst);
+    >> printNatListLn (runPartial (λ{{{_}} := map'' ((+) 1) lst}));

--- a/tests/Compilation/positive/test026.juvix
+++ b/tests/Compilation/positive/test026.juvix
@@ -12,8 +12,8 @@ qfst : {A : Type} → Queue A → List A
 qsnd : {A : Type} → Queue A → List A
   | (queue _ x) := x;
 
-front : {A : Type} → Queue A → A
-  | q := head (qfst q);
+front {{Partial}} : {A : Type} → Queue A → A
+  | q := phead (qfst q);
 
 pop_front : {A : Type} → Queue A → Queue A
   | {A} q :=
@@ -41,11 +41,13 @@ is_empty : {A : Type} → Queue A → Bool
 empty : {A : Type} → Queue A := queue nil nil;
 
 terminating
-g : List Nat → Queue Nat → List Nat
+g {{Partial}} : List Nat → Queue Nat → List Nat
   | acc q :=
     if (is_empty q) acc (g (front q :: acc) (pop_front q));
 
-f : Nat → Queue Nat → List Nat
+-- TODO: remove `terminating` after fixing https://github.com/anoma/juvix/issues/2414
+terminating
+f {{Partial}} : Nat → Queue Nat → List Nat
   | zero q := g nil q
   | n@(suc n') q := f n' (push_back q n);
 
@@ -54,6 +56,6 @@ printListNatLn : List Nat → IO
   | (h :: t) :=
     printNat h >> printString " :: " >> printListNatLn t;
 
-main : IO := printListNatLn (f 100 empty);
+main : IO := printListNatLn (runPartial (λ {{{_}} := f 100 empty}));
 -- list of numbers from 1 to 100
 

--- a/tests/benchmark/prime/juvix/prime.juvix
+++ b/tests/benchmark/prime/juvix/prime.juvix
@@ -9,17 +9,15 @@ checkDivisible : Nat → List Nat → Bool
   | p (h :: t) := if (mod p h == 0) true (checkDivisible p t);
 
 terminating
-go : Nat → Nat → List Nat → Nat
-  | n p lst :=
+go (n p : Nat) (lst : List Nat) : Nat :=
     if
       (n == 0)
-      (head lst)
+      (head 0 lst)
       (if
         (checkDivisible p lst)
         (go n (p + 1) lst)
         (go (sub n 1) (p + 1) (p :: lst)));
 
-prime : Nat → Nat
-  | n := go n 2 nil;
+prime (n : Nat) : Nat := go n 2 nil;
 
 main : IO := printNatLn (prime 16384);


### PR DESCRIPTION
Adds a Partial trait to the standard library, similar to the one in PureScript:

https://book.purescript.org/chapter6.html#nullary-type-classes

This enables using partial functions in an encapsulated manner and without depending on the Debug module.

Adds a trait:

```
trait
type Partial := mkPartial {
   fail : {A : Type} -> String -> A
};

runPartial {A} (f : {{Partial}} -> A) : A := f {{mkPartial Debug.failwith}};
```
