### PR TITLE
Remove package.yaml entry for PNG assets

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,6 @@ extra-source-files:
   - assets/css/*.css
   - assets/js/*.js
   - assets/images/*.svg
-  - assets/images/*.png
   - juvix-stdlib/juvix.yaml
   - juvix-stdlib/**/*.juvix
   - runtime/include/**/*.h


### PR DESCRIPTION
The project's PNG assets were removed in https://github.com/anoma/juvix/pull/2398

Stack gives a warning `Specified pattern "assets/images/*.png" for extra-source-files does not match any files` because of the unused package.yaml extra-source-files

This PR fixes the extra-source-files