### PR TITLE
Add `juvix dependencies update` command

### DIFF
--- a/app/Commands/Dependencies.hs
+++ b/app/Commands/Dependencies.hs
@@ -1,0 +1,13 @@
+module Commands.Dependencies
+  ( module Commands.Dependencies,
+    module Commands.Dependencies.Options,
+  )
+where
+
+import Commands.Base
+import Commands.Dependencies.Options
+import Commands.Dependencies.Update qualified as Update
+
+runCommand :: (Members '[Embed IO, App] r) => DependenciesCommand -> Sem r ()
+runCommand = \case
+  Update -> Update.runCommand

--- a/app/Commands/Dependencies/Options.hs
+++ b/app/Commands/Dependencies/Options.hs
@@ -14,4 +14,4 @@ commandUpdate =
   command "update" $
     info
       (pure Update)
-      (progDesc "Fetch package dependencies and update the lockfile")
+      (progDesc "Fetch package dependencies and update the lock file")

--- a/app/Commands/Dependencies/Options.hs
+++ b/app/Commands/Dependencies/Options.hs
@@ -1,0 +1,17 @@
+module Commands.Dependencies.Options where
+
+import CommonOptions
+
+data DependenciesCommand
+  = Update
+  deriving stock (Data)
+
+parseDependenciesCommand :: Parser DependenciesCommand
+parseDependenciesCommand = hsubparser commandUpdate
+
+commandUpdate :: Mod CommandFields DependenciesCommand
+commandUpdate =
+  command "update" $
+    info
+      (pure Update)
+      (progDesc "Fetch package dependencies and update the lockfile")

--- a/app/Commands/Dependencies/Update.hs
+++ b/app/Commands/Dependencies/Update.hs
@@ -1,0 +1,6 @@
+module Commands.Dependencies.Update where
+
+import Commands.Base
+
+runCommand :: (Members '[Embed IO, App] r) => Sem r ()
+runCommand = runPipelineNoFile (upToSetup (set dependenciesConfigForceUpdateLockfile True defaultDependenciesConfig))

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -154,7 +154,7 @@ loadDefaultPrelude = whenJustM defaultPreludeEntryPoint $ \e -> do
     . runGitProcess
     . runError @DependencyError
     . runPathResolver root
-    $ entrySetup
+    $ entrySetup defaultDependenciesConfig
   loadEntryPoint e
 
 getReplEntryPoint :: (Roots -> a -> GlobalOptions -> IO EntryPoint) -> a -> Repl EntryPoint

--- a/app/TopCommand.hs
+++ b/app/TopCommand.hs
@@ -3,6 +3,7 @@ module TopCommand where
 import Commands.Base hiding (Format)
 import Commands.Clean qualified as Clean
 import Commands.Compile qualified as Compile
+import Commands.Dependencies qualified as Dependencies
 import Commands.Dev qualified as Dev
 import Commands.Doctor qualified as Doctor
 import Commands.Eval qualified as Eval
@@ -38,3 +39,4 @@ runTopCommand = \case
   Html opts -> Html.runCommand opts
   JuvixRepl opts -> Repl.runCommand opts
   JuvixFormat opts -> runFilesIO (Format.runCommand opts)
+  Dependencies opts -> Dependencies.runCommand opts

--- a/app/TopCommand/Options.hs
+++ b/app/TopCommand/Options.hs
@@ -1,6 +1,7 @@
 module TopCommand.Options where
 
 import Commands.Compile.Options
+import Commands.Dependencies.Options qualified as Dependencies
 import Commands.Dev.Options qualified as Dev
 import Commands.Doctor.Options
 import Commands.Eval.Options
@@ -27,6 +28,7 @@ data TopCommand
   | Init
   | JuvixRepl ReplOptions
   | JuvixFormat FormatOptions
+  | Dependencies Dependencies.DependenciesCommand
   deriving stock (Data)
 
 topCommandInputPath :: TopCommand -> IO (Maybe (SomePath Abs))
@@ -90,12 +92,13 @@ parseUtility =
     ( mconcat
         [ commandGroup "Utility commands:",
           metavar "UTILITY_CMD",
-          commandDoctor,
           commandInit,
-          commandDev,
           commandRepl,
           commandFormat,
-          commandClean
+          commandClean,
+          commandDependencies,
+          commandDoctor,
+          commandDev
         ]
     )
   where
@@ -148,6 +151,12 @@ parseUtility =
       command
         "clean"
         (info (pure Clean) (progDesc "Delete build artifacts"))
+
+    commandDependencies :: Mod CommandFields TopCommand
+    commandDependencies =
+      command
+        "dependencies"
+        (info (Dependencies <$> Dependencies.parseDependenciesCommand) (progDesc "Subcommands related to dependencies"))
 
 commandCheck :: Mod CommandFields TopCommand
 commandCheck =

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -242,14 +242,11 @@ registerDependencies' conf = do
   if
       | isGlobal -> do
           glob <- globalRoot
-          let globDep = mkPathDependency (toFilePath glob)
-              globalPackageFile = mkPackageFilePath glob
-          void (addDependency' (Just e) (mkPackageDependencyInfo globalPackageFile globDep))
+          void (addRootDependency conf e glob)
       | otherwise -> do
-          let pf = mkPackageFilePath (e ^. entryPointRoot)
-          rootDep <- addDependency' (Just e) (mkPackageDependencyInfo pf (mkPathDependency (toFilePath (e ^. entryPointRoot))))
+          lockfile <- addRootDependency conf e (e ^. entryPointRoot)
           root <- asks (^. envRoot)
-          whenM shouldWriteLockfile (writeLockfile root (Lockfile (rootDep ^. lockfileDependencyDependencies)))
+          whenM shouldWriteLockfile (writeLockfile root lockfile)
   where
     shouldWriteLockfile :: Sem r Bool
     shouldWriteLockfile = do
@@ -258,20 +255,34 @@ registerDependencies' conf = do
       depsShouldWriteLockfile <- gets (^. resolverShouldWriteLockfile)
       return (conf ^. dependenciesConfigForceUpdateLockfile || not lockfileExists && depsShouldWriteLockfile)
 
-addDependency' ::
+addRootDependency ::
+  forall r.
   (Members '[State ResolverState, Reader ResolverEnv, Files, Error Text, Error DependencyError, GitClone] r) =>
-  Maybe EntryPoint ->
-  PackageDependencyInfo ->
-  Sem r LockfileDependency
-addDependency' me = addDependencyHelper me
+  DependenciesConfig ->
+  EntryPoint ->
+  Path Abs Dir ->
+  Sem r Lockfile
+addRootDependency conf e root = do
+  let pf = mkPackageFilePath root
+      d = mkPackageDependencyInfo pf (mkPathDependency (toFilePath root))
+  resolvedDependency <- resolveDependency d
+  checkShouldWriteLockfile resolvedDependency
+  let p = resolvedDependency ^. resolvedDependencyPath
+  withEnvRoot p $ do
+    pkg <- mkPackage (Just e) p
+    let resolvedPkg :: Package
+          | conf ^. dependenciesConfigForceUpdateLockfile = unsetPackageLockfile pkg
+          | otherwise = pkg
+    deps <- addDependency' resolvedPkg (Just e) resolvedDependency
+    return Lockfile {_lockfileDependencies = deps ^. lockfileDependencyDependencies}
 
-addDependencyHelper ::
+addDependency ::
   forall r.
   (Members '[State ResolverState, Reader ResolverEnv, Files, Error Text, Error DependencyError, GitClone] r) =>
   Maybe EntryPoint ->
   PackageDependencyInfo ->
   Sem r LockfileDependency
-addDependencyHelper me d = do
+addDependency me d = do
   resolvedDependency <- resolveDependency d
   checkShouldWriteLockfile resolvedDependency
   let p = resolvedDependency ^. resolvedDependencyPath
@@ -280,39 +291,49 @@ addDependencyHelper me d = do
     Just cachedDep -> return cachedDep
     Nothing -> withEnvRoot p $ do
       pkg <- mkPackage me p
-      selectPackageLockfile pkg $ do
-        pkgInfo <- mkPackageInfo me p pkg
-        forM_ (pkgInfo ^. packageRelativeFiles) $ \f -> do
-          modify' (over resolverFiles (HashMap.insertWith (<>) f (pure pkgInfo)))
-        let packagePath = pkgInfo ^. packagePackage . packageFile
-        subDeps <-
-          forM
-            (pkgInfo ^. packagePackage . packageDependencies)
-            (\dep -> selectDependencyLockfile dep (addDependency' Nothing (mkPackageDependencyInfo packagePath dep)))
-        let dep =
-              LockfileDependency
-                { _lockfileDependencyDependency = resolvedDependency ^. resolvedDependencyDependency,
-                  _lockfileDependencyDependencies = subDeps
-                }
-        modify'
-          ( set
-              (resolverCache . at p)
-              ( Just
-                  ( ResolverCacheItem
-                      { _resolverCacheItemPackage = pkgInfo,
-                        _resolverCacheItemDependency = dep
-                      }
-                  )
+      addDependency' pkg me resolvedDependency
+
+addDependency' ::
+  forall r.
+  (Members '[State ResolverState, Reader ResolverEnv, Files, Error Text, Error DependencyError, GitClone] r) =>
+  Package ->
+  Maybe EntryPoint ->
+  ResolvedDependency ->
+  Sem r LockfileDependency
+addDependency' pkg me resolvedDependency = do
+  selectPackageLockfile pkg $ do
+    pkgInfo <- mkPackageInfo me (resolvedDependency ^. resolvedDependencyPath) pkg
+    forM_ (pkgInfo ^. packageRelativeFiles) $ \f -> do
+      modify' (over resolverFiles (HashMap.insertWith (<>) f (pure pkgInfo)))
+    let packagePath = pkgInfo ^. packagePackage . packageFile
+    subDeps <-
+      forM
+        (pkgInfo ^. packagePackage . packageDependencies)
+        (\dep -> selectDependencyLockfile dep (addDependency Nothing (mkPackageDependencyInfo packagePath dep)))
+    let dep =
+          LockfileDependency
+            { _lockfileDependencyDependency = resolvedDependency ^. resolvedDependencyDependency,
+              _lockfileDependencyDependencies = subDeps
+            }
+    modify'
+      ( set
+          (resolverCache . at (resolvedDependency ^. resolvedDependencyPath))
+          ( Just
+              ( ResolverCacheItem
+                  { _resolverCacheItemPackage = pkgInfo,
+                    _resolverCacheItemDependency = dep
+                  }
               )
           )
-        return dep
+      )
+    return dep
   where
     selectPackageLockfile :: Package -> Sem r a -> Sem r a
-    selectPackageLockfile pkg action = do
+    selectPackageLockfile p action = do
       currentLockfile <- asks (^. envLockfileInfo)
       case currentLockfile of
         Just _ -> action
-        Nothing -> case (pkg ^. packageLockfile) of
+        Nothing -> case (p ^. packageLockfile) of
           Just lf -> withLockfile lf action
           Nothing -> action
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/DependenciesConfig.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/DependenciesConfig.hs
@@ -7,6 +7,6 @@ newtype DependenciesConfig = DependenciesConfig
   }
 
 defaultDependenciesConfig :: DependenciesConfig
-defaultDependenciesConfig = DependenciesConfig {_dependenciesConfigForceUpdateLockfile = True}
+defaultDependenciesConfig = DependenciesConfig {_dependenciesConfigForceUpdateLockfile = False}
 
 makeLenses ''DependenciesConfig

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/DependenciesConfig.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/DependenciesConfig.hs
@@ -1,0 +1,12 @@
+module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig where
+
+import Juvix.Prelude.Base
+
+newtype DependenciesConfig = DependenciesConfig
+  { _dependenciesConfigForceUpdateLockfile :: Bool
+  }
+
+defaultDependenciesConfig :: DependenciesConfig
+defaultDependenciesConfig = DependenciesConfig {_dependenciesConfigForceUpdateLockfile = True}
+
+makeLenses ''DependenciesConfig

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -80,7 +80,7 @@ instance PrettyCodeAnn MissingLockfileDependency where
       <+> lockfilePath
         <> line
         <> "Try running"
-        <+> code "juvix dependencies update"
+      <+> code "juvix dependencies update"
     where
       lockfilePath :: Doc CodeAnn
       lockfilePath = pretty (e ^. missingLockfileDependencyPath)

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -88,7 +88,7 @@ instance PrettyCodeAnn MissingLockfileDependency where
       dependencyId :: Doc CodeAnn
       dependencyId = case e ^. missingLockfileDependencyDependency of
         DependencyGit g -> pretty @Text (g ^. gitDependencyName)
-        DependencyPath p -> pretty @Text (show (p ^. pathDependencyPath))
+        DependencyPath p -> pretty @Text (pack (p ^. pathDependencyPath . prepath))
 
 data PathResolverError
   = ErrDependencyConflict DependencyConflict

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -79,8 +79,8 @@ instance PrettyCodeAnn MissingLockfileDependency where
       <+> "is declared in the package's juvix.yaml but is not declared in the lockfile:"
       <+> lockfilePath
         <> line
-        <> "Try running"
-      <+> code "juvix dependencies update"
+        <> "Try running the following command:" <> line
+        <> code "juvix dependencies update"
     where
       lockfilePath :: Doc CodeAnn
       lockfilePath = pretty (e ^. missingLockfileDependencyPath)

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -79,7 +79,8 @@ instance PrettyCodeAnn MissingLockfileDependency where
       <+> "is declared in the package's juvix.yaml but is not declared in the lockfile:"
       <+> lockfilePath
         <> line
-        <> "Try running the following command:" <> line
+        <> "Try running the following command:"
+        <> line
         <> code "juvix dependencies update"
     where
       lockfilePath :: Doc CodeAnn

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -79,9 +79,8 @@ instance PrettyCodeAnn MissingLockfileDependency where
       <+> "is declared in the package's juvix.yaml but is not declared in the lockfile:"
       <+> lockfilePath
         <> line
-        <> "Try removing"
-      <+> lockfilePath
-      <+> "and then run Juvix again."
+        <> "Try running"
+        <+> code "juvix dependencies update"
     where
       lockfilePath :: Doc CodeAnn
       lockfilePath = pretty (e ^. missingLockfileDependencyPath)

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -3,6 +3,7 @@ module Juvix.Compiler.Pipeline
     module Juvix.Compiler.Pipeline.EntryPoint,
     module Juvix.Compiler.Pipeline.Artifacts,
     module Juvix.Compiler.Pipeline.Root,
+    module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig,
   )
 where
 
@@ -22,6 +23,7 @@ import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromParsed qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver qualified as PathResolver
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context qualified as Scoped
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as P
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
@@ -49,10 +51,16 @@ type TopPipelineEff = '[PathResolver, Error DependencyError, GitClone, Error Git
 -- Workflows
 --------------------------------------------------------------------------------
 
+upToSetup ::
+  (Members '[Reader EntryPoint, Files, GitClone, PathResolver] r) =>
+  DependenciesConfig ->
+  Sem r ()
+upToSetup = entrySetup
+
 upToParsing ::
   (Members '[HighlightBuilder, Reader EntryPoint, Files, Error JuvixError, NameIdGen, GitClone, PathResolver] r) =>
   Sem r Parser.ParserResult
-upToParsing = entrySetup >> ask >>= Parser.fromSource
+upToParsing = upToSetup defaultDependenciesConfig >> ask >>= Parser.fromSource
 
 upToScoping ::
   (Members '[HighlightBuilder, Reader EntryPoint, Files, NameIdGen, Error JuvixError, GitClone, PathResolver] r) =>

--- a/src/Juvix/Compiler/Pipeline/Package.hs
+++ b/src/Juvix/Compiler/Pipeline/Package.hs
@@ -21,6 +21,7 @@ module Juvix.Compiler.Pipeline.Package
     readGlobalPackage,
     mkPackageFilePath,
     packageLockfile,
+    unsetPackageLockfile,
   )
 where
 
@@ -190,6 +191,9 @@ processPackage _packageFile buildDir lockfile pkg = do
       where
         base :: SomeBase Dir = resolveBuildDir buildDir <///> relStdlibDir
         stdlib = mkPathDependency (fromSomeDir base)
+
+unsetPackageLockfile :: Package -> Package
+unsetPackageLockfile = set packageLockfile Nothing
 
 defaultStdlibDep :: BuildDir -> Dependency
 defaultStdlibDep buildDir = mkPathDependency (fromSomeDir (resolveBuildDir buildDir <///> relStdlibDir))

--- a/src/Juvix/Compiler/Pipeline/Setup.hs
+++ b/src/Juvix/Compiler/Pipeline/Setup.hs
@@ -7,5 +7,6 @@ import Juvix.Prelude
 
 entrySetup ::
   (Members '[Reader EntryPoint, Files, GitClone, PathResolver] r) =>
+  DependenciesConfig ->
   Sem r ()
 entrySetup = registerDependencies

--- a/test/Format.hs
+++ b/test/Format.hs
@@ -47,7 +47,7 @@ testDescr PosTest {..} =
             <$> runIO'
               entryPoint
               ( do
-                  void entrySetup
+                  void (entrySetup defaultDependenciesConfig)
                   Concrete.fromParsed p
               )
 

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -69,7 +69,7 @@ testDescr PosTest {..} = helper renderCodeNew
                   runIO'
                     entryPoint
                     ( do
-                        void entrySetup
+                        void (entrySetup defaultDependenciesConfig)
                         Concrete.fromParsed p
                     )
 

--- a/tests/smoke/Commands/compile-dependencies.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies.smoke.yaml
@@ -441,6 +441,98 @@ tests:
       contains: Hello from dep
     exit-status: 0
 
+  - name: git-dependencies-uses-generated-lockfile-update
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+
+        # create dependency
+        mkdir $temp/dep
+        cd $temp/dep
+        git init
+
+        cat <<-EOF > HelloDep.juvix
+        module HelloDep;
+        import Stdlib.Prelude open;
+        main : IO := printStringLn "Hello from dep";
+        EOF
+        touch juvix.yaml
+
+        git add -A
+        git commit -m "commit1"
+
+        dep1hash1=$(git rev-parse HEAD)
+
+        # update dependency
+        cd $temp/dep
+        cat <<-EOF > HelloDep.juvix
+        module HelloDep;
+        import Stdlib.Prelude open;
+        main : IO := printStringLn "Hello from commit 2";
+        EOF
+
+        git add -A
+        git commit -m "commit2"
+
+        dep1hash2=$(git rev-parse HEAD)
+
+        # create project that uses dependency
+        mkdir $temp/base
+        cd $temp/base
+
+        cat <<-EOF > juvix.yaml
+        name: HelloWorld
+        main: HelloWorld.juvix
+        dependencies:
+          - .juvix-build/stdlib
+          - git:
+              url: $temp/dep
+              name: dep1
+              ref: $dep1hash1
+        version: 0.1.0
+        EOF
+
+        cat <<-EOF > HelloWorld.juvix
+        -- HelloWorld.juvix
+        module HelloWorld;
+
+        import Stdlib.Prelude open;
+        import HelloDep;
+
+        main : IO := HelloDep.main;
+        EOF
+
+        # compile project and generate the lockfile
+        # that uses $dep1hash1
+        juvix compile HelloWorld.juvix
+
+        cd $temp/base
+
+        cat <<-EOF > juvix.yaml
+        name: HelloWorld
+        main: HelloWorld.juvix
+        dependencies:
+          - .juvix-build/stdlib
+          - git:
+              url: $temp/dep
+              name: dep1
+              ref: $dep1hash2
+        version: 0.1.0
+        EOF
+
+        # update the lockfile
+        juvix dependencies update
+
+        # compile should now use $dep1hash2
+        juvix compile HelloWorld.juvix
+        ./HelloWorld
+    stdout:
+      contains: Hello from commit 2
+    exit-status: 0
+
   - name: git-dependencies-nested-lockfile
     command:
       shell:


### PR DESCRIPTION
This PR adds a new command `juvix dependencies update` that fetches all dependencies in a project and updates the project lock file.

Currently the only way to update the lock file is to delete it and generate a new one.

## CLI Docs

```
juvix dependencies --help
Usage: juvix dependencies COMMAND

  Subcommands related to dependencies

Available options:
  -h,--help                Show this help text

Available commands:
  update                   Fetch package dependencies and update the lock file
```

## Example

A project containing the following `juvix.yaml`

```yaml
dependencies:
  - .juvix-build/stdlib/
  - git:
      url: https://github.com/anoma/juvix-test
      ref: v0.6.0
      name: test
main: Example.juvix
name: example
version: 1.0.0
```

compile to generate the lockfile: `juvix compile`

```yaml
# This file was autogenerated by Juvix version 0.5.1.
# Do not edit this file manually.

dependencies:
- path: .juvix-build/stdlib/
  dependencies: []
- git:
    name: test
    ref: a94c61749678ff57556ee6e4cb1f8fbbddbc4ab1
    url: https://github.com/anoma/juvix-test
  dependencies:
  - git:
      name: stdlib
      ref: 4facf14d9b2d06b81ce1be1882aa9050f768cb45
      url: https://github.com/anoma/juvix-stdlib
    dependencies: []
```

Now update the test dependency version:

```yaml
- .juvix-build/stdlib/
- git:
   url: https://github.com/anoma/juvix-test
   ref: v0.6.1
   name: test
main: Example.juvix
name: example
version: 1.0.0
```

And run `juvix dependencies update`

Now the lockfile has updated to the hash of v0.6.1:

```yaml
# This file was autogenerated by Juvix version 0.5.1.
# Do not edit this file manually.

dependencies:
- path: .juvix-build/stdlib/
  dependencies: []
- git:
    name: test
    ref: a7ac74cac0db92e0b5e349f279d797c3788cdfdd
    url: https://github.com/anoma/juvix-test
  dependencies:
  - git:
      name: stdlib
      ref: 4facf14d9b2d06b81ce1be1882aa9050f768cb45
      url: https://github.com/anoma/juvix-stdlib
    dependencies: []
```


