### PR TITLE
Reinstate the project .hlint.yaml

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,89 @@
+# Based on HLint configuration file from https://github.com/ndmitchell/hlint
+
+- arguments: [--color]
+
+# ------------------------------------------------------------------------------
+# RESTRICTIONS
+# ------------------------------------------------------------------------------
+
+- extensions:
+    - default: false
+    - name:
+        - ApplicativeDo
+        - DataKinds
+        - DerivingStrategies
+        - GADTs
+        - ImportQualifiedPost
+        - LambdaCase
+        - NoImplicitPrelude
+        - OverloadedStrings
+        - QuantifiedConstraints
+        - QuasiQuotes
+        - RecordWildCards
+        - StandaloneKindSignatures
+        - TemplateHaskell
+        - TypeFamilyDependencies
+        - UndecidableInstances
+        - UnicodeSyntax
+        - GeneralizedNewtypeDeriving
+
+- flags:
+    - default: false
+    - name:
+        - -Wall
+        - -Wcompat
+        - -Wderiving-defaults
+        - -Widentities
+        - -Wincomplete-patterns
+        - -Wincomplete-record-updates
+        - -Wincomplete-uni-patterns
+        - -Wmissing-deriving-strategies
+        - -Wredundant-constraints
+        - -O2 -flate-specialise -fspecialise-aggressively
+
+- modules:
+    # if you import Data.Set qualified, it must be as 'Set'
+    - { name: [Data.Set, Data.HashSet], as: Set }
+    - { name: [Data.Map, Data.HashMap.Strict, Data.HashMap.Lazy], as: Map }
+  # - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+
+- functions:
+    - { name: Data.List.NonEmpty.nub, within: [] }
+    - { name: Data.List.NonEmpty.nubBy, within: [] }
+
+# ------------------------------------------------------------------------------
+# OTHER HINTS
+# ------------------------------------------------------------------------------
+
+# - warn: {name: Use explicit module export list}
+
+# ------------------------------------------------------------------------------
+# HINTS
+# ------------------------------------------------------------------------------
+
+- error: { lhs: idea Warning, rhs: warn }
+- error: { lhs: idea Suggestion, rhs: suggest }
+- error: { lhs: ideaN Warning, rhs: warnN }
+- error: { lhs: ideaN Suggestion, rhs: suggestN }
+
+- error: { lhs: occNameString (occName (unLoc x)), rhs: rdrNameStr x }
+- error: { lhs: occNameString (occName x), rhs: occNameStr x }
+- error:
+    {
+      lhs: noLoc (HsVar noExtField (noLoc (mkRdrUnqual (mkVarOcc x)))),
+      rhs: strToVar x,
+    }
+
+# ------------------------------------------------------------------------------
+# IGNORES
+# ------------------------------------------------------------------------------
+
+- ignore: { name: Use let, within: [Test.All] }
+- ignore: { name: Use String }
+- ignore: { name: Avoid restricted qualification }
+- ignore: { name: Redundant multi-way if }
+- ignore: { name: Redundant bracket }
+- ignore: { name: Eta reduce }
+- ignore: { name: Avoid restricted alias }
+- ignore: { name: Use tuple-section }
+- ignore: { name: Use map with tuple-section }


### PR DESCRIPTION
.hlint.yaml was removed in:

* https://github.com/anoma/juvix/pull/2398

however it's useful to keep it because it is used by Haskell tooling (emacs haskell-mode and vscode haskell extension).
