### PR TITLE
Numeric, ordering and equality traits

### DIFF
--- a/examples/demo/Demo.juvix
+++ b/examples/demo/Demo.juvix
@@ -2,9 +2,6 @@ module Demo;
 
 -- standard library prelude
 import Stdlib.Prelude open;
--- for comparisons on natural numbers
-import Stdlib.Data.Nat.Ord open;
--- for Ordering
 
 even : Nat → Bool
   | zero := true

--- a/examples/demo/Demo.juvix
+++ b/examples/demo/Demo.juvix
@@ -32,13 +32,13 @@ preorder : {A : Type} → Tree A → List A
   | (node x l r) := x :: nil ++ preorder l ++ preorder r;
 
 terminating
-sort : {A : Type} → (A → A → Ordering) → List A → List A
-  | _ nil := nil
-  | _ xs@(_ :: nil) := xs
-  | {A} cmp xs :=
+sort {A} {{Ord A}} : List A → List A
+  | nil := nil
+  | xs@(_ :: nil) := xs
+  | xs :=
     uncurry
-      (merge {{mkOrd cmp}})
-      (both (sort cmp) (splitAt (div (length xs) 2) xs));
+      merge
+      (both sort (splitAt (div (length xs) 2) xs));
 
 printNatListLn : List Nat → IO
   | nil := printStringLn "nil"
@@ -48,6 +48,6 @@ printNatListLn : List Nat → IO
 main : IO :=
   printStringLn "Hello!"
     >> printNatListLn (preorder (mirror tree))
-    >> printNatListLn (sort compare (preorder (mirror tree)))
+    >> printNatListLn (sort (preorder (mirror tree)))
     >> printNatLn (log2 3)
     >> printNatLn (log2 130);

--- a/examples/midsquare/MidSquareHash.juvix
+++ b/examples/midsquare/MidSquareHash.juvix
@@ -5,7 +5,6 @@
 module MidSquareHash;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 --- `pow N` is 2 ^ N
 pow : Nat -> Nat

--- a/examples/midsquare/MidSquareHashUnrolled.juvix
+++ b/examples/midsquare/MidSquareHashUnrolled.juvix
@@ -6,7 +6,6 @@
 module MidSquareHashUnrolled;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 --- `powN` is 2 ^ N
 pow0 : Nat := 1;

--- a/examples/milestone/Bank/Bank.juvix
+++ b/examples/milestone/Bank/Bank.juvix
@@ -6,8 +6,6 @@ module Bank;
 import Stdlib.Prelude open;
 import Stdlib.Debug.Fail open;
 
-import Stdlib.Data.Nat.Ord open;
-
 import Stdlib.Data.Nat as Nat;
 
 Address : Type := Nat;

--- a/examples/milestone/Collatz/Collatz.juvix
+++ b/examples/milestone/Collatz/Collatz.juvix
@@ -1,7 +1,6 @@
 module Collatz;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 collatzNext (n : Nat) : Nat :=
   if (mod n 2 == 0) (div n 2) (3 * n + 1);

--- a/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
+++ b/examples/milestone/TicTacToe/CLI/TicTacToe.juvix
@@ -5,7 +5,6 @@
 --- The module Logic.Game contains the game logic.
 module CLI.TicTacToe;
 
-import Stdlib.Data.Nat.Ord open;
 import Stdlib.Prelude open;
 import Logic.Game open;
 

--- a/examples/milestone/TicTacToe/Logic/Extra.juvix
+++ b/examples/milestone/TicTacToe/Logic/Extra.juvix
@@ -1,7 +1,6 @@
 --- Some generic helper definitions.
 module Logic.Extra;
 
-import Stdlib.Data.Nat.Ord open;
 import Stdlib.Prelude open;
 
 --- Concatenates a list of strings

--- a/examples/milestone/TicTacToe/Logic/Game.juvix
+++ b/examples/milestone/TicTacToe/Logic/Game.juvix
@@ -4,7 +4,6 @@
 --- diagonal row is the winner. It is a solved game, with a forced draw assuming best play from both players.
 module Logic.Game;
 
-import Stdlib.Data.Nat.Ord open;
 import Stdlib.Prelude open;
 import Logic.Extra open public;
 import Logic.Board open public;

--- a/examples/milestone/TicTacToe/Logic/Square.juvix
+++ b/examples/milestone/TicTacToe/Logic/Square.juvix
@@ -2,7 +2,6 @@ module Logic.Square;
 
 import Stdlib.Prelude open;
 import Logic.Symbol open;
-import Stdlib.Data.Nat.Ord open;
 import Logic.Extra open;
 
 --- A square is each of the holes in a board
@@ -26,7 +25,7 @@ showSquare : Square → String
 replace (player : Symbol) (k : Nat) : Square → Square
   | (empty n) :=
     if
-      (n Stdlib.Data.Nat.Ord.== k)
+      (n == k)
       (occupied player)
       (empty n)
   | s := s;

--- a/examples/milestone/TicTacToe/Logic/Square.juvix
+++ b/examples/milestone/TicTacToe/Logic/Square.juvix
@@ -23,9 +23,5 @@ showSquare : Square → String
   | (occupied s) := " " ++str showSymbol s ++str " ";
 
 replace (player : Symbol) (k : Nat) : Square → Square
-  | (empty n) :=
-    if
-      (n == k)
-      (occupied player)
-      (empty n)
+  | (empty n) := if (n == k) (occupied player) (empty n)
   | s := s;

--- a/examples/milestone/Tutorial/Tutorial.juvix
+++ b/examples/milestone/Tutorial/Tutorial.juvix
@@ -5,7 +5,5 @@ module Tutorial;
 
 -- import the standard library prelude and bring it into scope
 import Stdlib.Prelude open;
--- bring comparison operators on Nat into scope
-import Stdlib.Data.Nat.Ord open;
 
 main : IO := printStringLn "Hello world!";

--- a/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Translation/FromCore.hs
@@ -58,7 +58,7 @@ fromCore :: Core.InfoTable -> (Morphism, Object)
 fromCore tab = case tab ^. Core.infoMain of
   Just sym ->
     let node = Core.lookupIdentifierNode tab sym
-        syms = reverse $ filter (/= sym) $ Core.createIdentDependencyInfo tab ^. Core.depInfoTopSort
+        syms = reverse $ filter (/= sym) $ Core.createCallGraph tab ^. Core.depInfoTopSort
         idents = map (Core.lookupIdentifierInfo tab) syms
         morph = run . runReader emptyEnv $ goIdents node idents
         obj = convertType $ Info.getNodeType node

--- a/src/Juvix/Compiler/Core/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId.hs
@@ -26,6 +26,7 @@ data TransformationId
   | LambdaFolding
   | LetHoisting
   | Inlining
+  | MandatoryInlining
   | FoldTypeSynonyms
   | CaseCallLifting
   | SimplifyIfs
@@ -82,7 +83,7 @@ toStrippedTransformations =
   toEvalTransformations ++ [CheckExec, LambdaLetRecLifting, TopEtaExpand, OptPhaseExec, MoveApps, RemoveTypeArgs]
 
 toGebTransformations :: [TransformationId]
-toGebTransformations = toEvalTransformations ++ [FilterUnreachable, LetRecLifting, OptPhaseGeb, CheckGeb, UnrollRecursion, FoldTypeSynonyms, ComputeTypeInfo]
+toGebTransformations = toEvalTransformations ++ [FilterUnreachable, CheckGeb, LetRecLifting, OptPhaseGeb, UnrollRecursion, FoldTypeSynonyms, ComputeTypeInfo]
 
 pipeline :: PipelineId -> [TransformationId]
 pipeline = \case

--- a/src/Juvix/Compiler/Core/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId.hs
@@ -76,7 +76,7 @@ toNormalizeTransformations :: [TransformationId]
 toNormalizeTransformations = toEvalTransformations ++ [LetRecLifting, LetFolding, UnrollRecursion]
 
 toVampIRTransformations :: [TransformationId]
-toVampIRTransformations = toEvalTransformations ++ [CheckVampIR, LetRecLifting, OptPhaseVampIR, UnrollRecursion, Normalize, LetHoisting]
+toVampIRTransformations = toEvalTransformations ++ [FilterUnreachable, CheckVampIR, LetRecLifting, OptPhaseVampIR, UnrollRecursion, Normalize, LetHoisting]
 
 toStrippedTransformations :: [TransformationId]
 toStrippedTransformations =

--- a/src/Juvix/Compiler/Core/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId.hs
@@ -82,7 +82,7 @@ toStrippedTransformations =
   toEvalTransformations ++ [CheckExec, LambdaLetRecLifting, TopEtaExpand, OptPhaseExec, MoveApps, RemoveTypeArgs]
 
 toGebTransformations :: [TransformationId]
-toGebTransformations = toEvalTransformations ++ [FilterUnreachable, CheckGeb, LetRecLifting, OptPhaseGeb, UnrollRecursion, FoldTypeSynonyms, ComputeTypeInfo]
+toGebTransformations = toEvalTransformations ++ [FilterUnreachable, LetRecLifting, OptPhaseGeb, CheckGeb, UnrollRecursion, FoldTypeSynonyms, ComputeTypeInfo]
 
 pipeline :: PipelineId -> [TransformationId]
 pipeline = \case

--- a/src/Juvix/Compiler/Core/Data/TransformationId/Parser.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId/Parser.hs
@@ -86,6 +86,7 @@ transformationText = \case
   LambdaFolding -> strLambdaFolding
   LetHoisting -> strLetHoisting
   Inlining -> strInlining
+  MandatoryInlining -> strMandatoryInlining
   FoldTypeSynonyms -> strFoldTypeSynonyms
   CaseCallLifting -> strCaseCallLifting
   SimplifyIfs -> strSimplifyIfs
@@ -190,6 +191,9 @@ strLambdaFolding = "lambda-folding"
 
 strInlining :: Text
 strInlining = "inlining"
+
+strMandatoryInlining :: Text
+strMandatoryInlining = "mandatory-inlining"
 
 strFoldTypeSynonyms :: Text
 strFoldTypeSynonyms = "fold-type-synonyms"

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -89,7 +89,7 @@ geval opts herr ctx env0 = eval' env0
           Closure env' (NLam (Lambda i' bi b)) ->
             let !v = eval' env r in evalBody i' bi env' v b
           lv
-            | opts ^. evalOptionsNormalize ->
+            | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
                 let !v = eval' env r in goNormApp i lv v
             | otherwise ->
                 evalError "invalid application" (mkApp i lv (substEnv env r))
@@ -106,7 +106,7 @@ geval opts herr ctx env0 = eval' env0
           NCtr (Constr _ tag args) ->
             branch n env args tag def bs
           v'
-            | opts ^. evalOptionsNormalize ->
+            | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
                 goNormCase env i sym v' bs def
             | otherwise ->
                 evalError "matching on non-data" (substEnv env (mkCase i sym v' bs def))
@@ -214,7 +214,7 @@ geval opts herr ctx env0 = eval' env0
                 (Just v1, Just v2) ->
                   toNode (v1 `op` v2)
                 _
-                  | opts ^. evalOptionsNormalize ->
+                  | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
                       mkBuiltinApp' opcode [vl, vr]
                   | otherwise ->
                       evalError "wrong operand type" n

--- a/src/Juvix/Compiler/Core/Transformation.hs
+++ b/src/Juvix/Compiler/Core/Transformation.hs
@@ -35,6 +35,7 @@ import Juvix.Compiler.Core.Transformation.Optimize.FilterUnreachable (filterUnre
 import Juvix.Compiler.Core.Transformation.Optimize.Inlining
 import Juvix.Compiler.Core.Transformation.Optimize.LambdaFolding
 import Juvix.Compiler.Core.Transformation.Optimize.LetFolding
+import Juvix.Compiler.Core.Transformation.Optimize.MandatoryInlining
 import Juvix.Compiler.Core.Transformation.Optimize.Phase.Eval qualified as Phase.Eval
 import Juvix.Compiler.Core.Transformation.Optimize.Phase.Exec qualified as Phase.Exec
 import Juvix.Compiler.Core.Transformation.Optimize.Phase.Geb qualified as Phase.Geb
@@ -74,6 +75,7 @@ applyTransformations ts tbl = foldM (flip appTrans) tbl ts
       LambdaFolding -> return . lambdaFolding
       LetHoisting -> return . letHoisting
       Inlining -> inlining
+      MandatoryInlining -> return . mandatoryInlining
       FoldTypeSynonyms -> return . foldTypeSynonyms
       CaseCallLifting -> return . caseCallLifting
       SimplifyIfs -> return . simplifyIfs

--- a/src/Juvix/Compiler/Core/Transformation/LetHoisting.hs
+++ b/src/Juvix/Compiler/Core/Transformation/LetHoisting.hs
@@ -1,4 +1,4 @@
--- Moves al let expressions at the top, just after the top lambdas. This
+-- Moves all let expressions at the top, just after the top lambdas. This
 -- transformation assumes:
 -- - There are no LetRecs, Lambdas (other than the ones at the top), nor Match.
 -- - Case nodes do not have binders.

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/FilterUnreachable.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/FilterUnreachable.hs
@@ -5,10 +5,13 @@ import Juvix.Compiler.Core.Data.IdentDependencyInfo
 import Juvix.Compiler.Core.Transformation.Base
 
 filterUnreachable :: InfoTable -> InfoTable
-filterUnreachable tab = pruneInfoTable $ over infoIdentifiers goFilter tab
+filterUnreachable tab =
+  pruneInfoTable $
+    over infoInductives goFilter $
+      over infoIdentifiers goFilter tab
   where
-    depInfo = createIdentDependencyInfo tab
+    depInfo = createSymbolDependencyInfo tab
 
-    goFilter :: HashMap Symbol IdentifierInfo -> HashMap Symbol IdentifierInfo
-    goFilter idents =
-      HashMap.filterWithKey (\sym _ -> isReachable depInfo sym) idents
+    goFilter :: HashMap Symbol a -> HashMap Symbol a
+    goFilter =
+      HashMap.filterWithKey (\sym _ -> isReachable depInfo sym)

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
@@ -48,6 +48,16 @@ convertNode inlineDepth recSyms tab = dmapL go
                   def = lookupIdentifierNode tab _identSymbol
               _ ->
                 node
+      NIdt Ident {..} ->
+        case pi of
+          Just InlineFullyApplied | argsNum == 0 -> def
+          Just (InlinePartiallyApplied 0) -> def
+          _ -> node
+        where
+          ii = lookupIdentifierInfo tab _identSymbol
+          pi = ii ^. identifierPragmas . pragmasInline
+          argsNum = ii ^. identifierArgsNum
+          def = lookupIdentifierNode tab _identSymbol
       -- inline zero-argument definitions automatically if inlining would result
       -- in case reduction
       NCase cs@Case {..} -> case _caseValue of

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
@@ -32,6 +32,8 @@ convertNode inlineDepth recSyms tab = dmapL go
                   Just (InlinePartiallyApplied k)
                     | length args >= k ->
                         mkApps def args
+                  Just InlineAlways ->
+                    mkApps def args
                   Just InlineNever ->
                     node
                   _
@@ -52,6 +54,7 @@ convertNode inlineDepth recSyms tab = dmapL go
         case pi of
           Just InlineFullyApplied | argsNum == 0 -> def
           Just (InlinePartiallyApplied 0) -> def
+          Just InlineAlways -> def
           _ -> node
         where
           ii = lookupIdentifierInfo tab _identSymbol

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/MandatoryInlining.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/MandatoryInlining.hs
@@ -1,0 +1,18 @@
+module Juvix.Compiler.Core.Transformation.Optimize.MandatoryInlining where
+
+import Juvix.Compiler.Core.Extra
+import Juvix.Compiler.Core.Transformation.Base
+
+convertNode :: InfoTable -> Node -> Node
+convertNode tab = dmap go
+  where
+    go :: Node -> Node
+    go node = case node of
+      NIdt Ident {..}
+        | Just InlineAlways <- lookupIdentifierInfo tab _identSymbol ^. identifierPragmas . pragmasInline ->
+            lookupIdentifierNode tab _identSymbol
+      _ ->
+        node
+
+mandatoryInlining :: InfoTable -> InfoTable
+mandatoryInlining tab = mapAllNodes (convertNode tab) tab

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/Eval.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/Eval.hs
@@ -1,11 +1,15 @@
 module Juvix.Compiler.Core.Transformation.Optimize.Phase.Eval where
 
-import Juvix.Compiler.Core.Options
 import Juvix.Compiler.Core.Transformation.Base
+import Juvix.Compiler.Core.Transformation.Optimize.CaseFolding
 import Juvix.Compiler.Core.Transformation.Optimize.LambdaFolding
 import Juvix.Compiler.Core.Transformation.Optimize.LetFolding
+import Juvix.Compiler.Core.Transformation.Optimize.MandatoryInlining
 
-optimize :: (Member (Reader CoreOptions) r) => InfoTable -> Sem r InfoTable
+optimize :: InfoTable -> Sem r InfoTable
 optimize =
-  withOptimizationLevel 1 $
-    return . letFolding . lambdaFolding
+  return
+    . caseFolding
+    . letFolding
+    . lambdaFolding
+    . mandatoryInlining

--- a/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
+++ b/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
@@ -13,7 +13,7 @@ unrollRecursion tab = do
   (mp, tab') <-
     runState @(HashMap Symbol Symbol) mempty $
       execInfoTableBuilder tab $
-        forM_ (buildSCCs (createIdentDependencyInfo tab)) goSCC
+        forM_ (buildSCCs (createCallGraph tab)) goSCC
   return $ mapIdentSymbols mp $ pruneInfoTable tab'
   where
     mapIdentSymbols :: HashMap Symbol Symbol -> InfoTable -> InfoTable

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -93,7 +93,7 @@ genFieldProjection _funDefName info fieldIx = do
         _funDefTerminating = False,
         _funDefInstance = False,
         _funDefBuiltin = Nothing,
-        _funDefPragmas = mempty,
+        _funDefPragmas = mempty {_pragmasInline = Just InlineAlways},
         _funDefBody = body',
         _funDefType = foldFunType (inductiveArgs ++ [saturatedTy]) retTy,
         ..

--- a/test/Core/Transformation/Unrolling.hs
+++ b/test/Core/Transformation/Unrolling.hs
@@ -44,5 +44,5 @@ liftTest _testEval =
 checkNoRecursion :: InfoTable -> Assertion
 checkNoRecursion tab =
   when
-    (isCyclic (createIdentDependencyInfo tab))
+    (isCyclic (createCallGraph tab))
     (assertFailure "recursion detected")

--- a/tests/Compilation/positive/test006.juvix
+++ b/tests/Compilation/positive/test006.juvix
@@ -2,7 +2,6 @@
 module test006;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 loop : Nat := loop;

--- a/tests/Compilation/positive/test012.juvix
+++ b/tests/Compilation/positive/test012.juvix
@@ -2,7 +2,6 @@
 module test012;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 type Tree :=
   | leaf : Tree

--- a/tests/Compilation/positive/test013.juvix
+++ b/tests/Compilation/positive/test013.juvix
@@ -2,7 +2,6 @@
 module test013;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 f : Nat → Nat → Nat
   | x :=

--- a/tests/Compilation/positive/test015.juvix
+++ b/tests/Compilation/positive/test015.juvix
@@ -2,7 +2,6 @@
 module test015;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 f : Nat → Nat → Nat

--- a/tests/Compilation/positive/test020.juvix
+++ b/tests/Compilation/positive/test020.juvix
@@ -2,7 +2,6 @@
 module test020;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 -- McCarthy's 91 function
 terminating

--- a/tests/Compilation/positive/test021.juvix
+++ b/tests/Compilation/positive/test021.juvix
@@ -2,7 +2,6 @@
 module test021;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 power' : Nat → Nat → Nat → Nat

--- a/tests/Compilation/positive/test022.juvix
+++ b/tests/Compilation/positive/test022.juvix
@@ -2,7 +2,6 @@
 module test022;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 gen : Nat → List Nat
   | zero := nil

--- a/tests/Compilation/positive/test023.juvix
+++ b/tests/Compilation/positive/test023.juvix
@@ -2,11 +2,10 @@
 module test023;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 f : Nat → Nat
-  
+
   | x := if (x < 1) 1 (2 * x + g (sub x 1));
 
 terminating

--- a/tests/Compilation/positive/test025.juvix
+++ b/tests/Compilation/positive/test025.juvix
@@ -2,7 +2,6 @@
 module test025;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 gcd : Nat → Nat → Nat

--- a/tests/Compilation/positive/test028.juvix
+++ b/tests/Compilation/positive/test028.juvix
@@ -2,7 +2,6 @@
 module test028;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 type Stream :=
   | cons : Nat → (Unit → Stream) → Stream;

--- a/tests/Compilation/positive/test032.juvix
+++ b/tests/Compilation/positive/test032.juvix
@@ -2,7 +2,6 @@
 module test032;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 split : {A : Type} → Nat → List A → List A × List A
   | zero xs := nil, xs

--- a/tests/Compilation/positive/test034.juvix
+++ b/tests/Compilation/positive/test034.juvix
@@ -2,7 +2,6 @@
 module test034;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 sum : Nat → Nat :=
   let

--- a/tests/Compilation/positive/test049.juvix
+++ b/tests/Compilation/positive/test049.juvix
@@ -1,9 +1,7 @@
 -- Builtin Int
 module test049;
 
-import Stdlib.Prelude open hiding {+; *; div; mod};
-import Stdlib.Data.Int.Ord open;
-import Stdlib.Data.Int open;
+import Stdlib.Prelude open;
 
 f : Int -> Nat
   | (negSuc n) := n
@@ -23,8 +21,8 @@ main : IO :=
     >> printBoolLn (-1 == -2)
     >> printBoolLn (-1 == -1)
     >> printBoolLn (1 == 1)
-    >> printBoolLn (-1 == 1)
-    >> printIntLn (-1 + 1)
+    >> printBoolLn (-1 == ofNat 1)
+    >> printIntLn (-1 + ofNat 1)
     >> printIntLn (negNat (suc zero))
     >> printIntLn
       (let
@@ -35,9 +33,9 @@ main : IO :=
       (let
         g : Int -> Int := neg;
       in g -1)
-    >> printIntLn (-2 * 2)
-    >> printIntLn (div 4 -2)
-    >> printIntLn (2 - 2)
+    >> printIntLn (-2 * ofNat 2)
+    >> printIntLn (div (ofNat 4) -2)
+    >> printIntLn (ofNat 2 - ofNat 2)
     >> printBoolLn (nonNeg 0)
     >> printBoolLn (nonNeg -1)
     >> printIntLn (mod -5 -2)
@@ -45,5 +43,5 @@ main : IO :=
     >> printBoolLn (0 <= 0)
     >> printBoolLn (0 < 1)
     >> printBoolLn (1 <= 0)
-    >> printIntLn (mod 5 -3)
-    >> printIntLn (div 5 -3);
+    >> printIntLn (mod (ofNat 5) -3)
+    >> printIntLn (div (ofNat 5) -3);

--- a/tests/Compilation/positive/test050.juvix
+++ b/tests/Compilation/positive/test050.juvix
@@ -1,13 +1,11 @@
 -- Pattern matching with integers
 module test050;
 
-import Stdlib.Prelude open hiding {+; *; div; mod};
-import Stdlib.Data.Int.Ord open;
-import Stdlib.Data.Int open;
+import Stdlib.Prelude open;
 
 f : Int -> Int
   | (negSuc zero) := ofNat 0
   | (negSuc m@(suc n)) := ofNat n + ofNat m
-  | (ofNat n) := neg (ofNat n - 7);
+  | (ofNat n) := neg (ofNat n - ofNat 7);
 
 main : Int := f -10 - f 1 + f -1;

--- a/tests/Geb/positive/Compilation/test010.juvix
+++ b/tests/Geb/positive/Compilation/test010.juvix
@@ -2,7 +2,6 @@
 module test010;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 f : Nat → Nat → Nat
   | x :=

--- a/tests/Geb/positive/Compilation/test012.juvix
+++ b/tests/Geb/positive/Compilation/test012.juvix
@@ -2,7 +2,6 @@
 module test012;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 pow0 : Nat := 1;
 

--- a/tests/Geb/positive/Compilation/test016.juvix
+++ b/tests/Geb/positive/Compilation/test016.juvix
@@ -2,7 +2,6 @@
 module test016;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 f : Nat → Nat → Nat

--- a/tests/Geb/positive/Compilation/test020.juvix
+++ b/tests/Geb/positive/Compilation/test020.juvix
@@ -2,7 +2,6 @@
 module test020;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 f91 : Nat → Nat

--- a/tests/Geb/positive/Compilation/test021.juvix
+++ b/tests/Geb/positive/Compilation/test021.juvix
@@ -2,7 +2,6 @@
 module test021;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 power' : Nat → Nat → Nat → Nat

--- a/tests/Geb/positive/Compilation/test022.juvix
+++ b/tests/Geb/positive/Compilation/test022.juvix
@@ -2,11 +2,9 @@
 module test022;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 f : Nat → Nat
-  
   | x := if (x < 1) 1 (2 * x + g (sub x 1));
 
 terminating

--- a/tests/Geb/positive/Compilation/test023.juvix
+++ b/tests/Geb/positive/Compilation/test023.juvix
@@ -2,7 +2,6 @@
 module test023;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 gcd : Nat → Nat → Nat

--- a/tests/Geb/positive/Compilation/test025.juvix
+++ b/tests/Geb/positive/Compilation/test025.juvix
@@ -2,7 +2,6 @@
 module test025;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 pow : Nat -> Nat
   | zero := 1

--- a/tests/Geb/positive/Compilation/test026.juvix
+++ b/tests/Geb/positive/Compilation/test026.juvix
@@ -2,7 +2,6 @@
 module test026;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 sum : Nat → Nat :=
   let

--- a/tests/Internal/Core/positive/test006.juvix
+++ b/tests/Internal/Core/positive/test006.juvix
@@ -1,7 +1,6 @@
 module test006;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 loop : Nat := loop;

--- a/tests/Internal/Core/positive/test011.juvix
+++ b/tests/Internal/Core/positive/test011.juvix
@@ -1,7 +1,6 @@
 module test011;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 fib' : Nat -> Nat -> Nat -> Nat
   | zero x _ := x

--- a/tests/Internal/positive/QuickSort.juvix
+++ b/tests/Internal/positive/QuickSort.juvix
@@ -39,6 +39,5 @@ four : Nat := suc three;
 
 main : List Nat :=
   uniq
-    compare
-    (quickSort compare (flatten (gen2 three four nil)));
-
+    Ord.cmp
+    (quickSort Ord.cmp (flatten (gen2 three four nil)));

--- a/tests/Internal/positive/QuickSort.juvix
+++ b/tests/Internal/positive/QuickSort.juvix
@@ -1,7 +1,6 @@
 module QuickSort;
 
 import Stdlib.Prelude open hiding {quickSort};
-import Stdlib.Data.Nat.Ord open;
 
 qsHelper : {A : Type} → A → List A × List A → List A
   | a (l, r) := l ++ (a :: nil) ++ r;

--- a/tests/VampIR/negative/test001.juvix
+++ b/tests/VampIR/negative/test001.juvix
@@ -1,7 +1,6 @@
 module test001;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 {-# argnames: [a, b
                 c] #-}

--- a/tests/VampIR/positive/Compilation/test001.juvix
+++ b/tests/VampIR/positive/Compilation/test001.juvix
@@ -2,7 +2,6 @@
 module test001;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 main : Nat -> Nat
   | x := if (x == 0) 1 0;

--- a/tests/VampIR/positive/Compilation/test002.juvix
+++ b/tests/VampIR/positive/Compilation/test002.juvix
@@ -2,7 +2,6 @@
 module test002;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 type optbool :=
   | Just : Bool -> optbool

--- a/tests/VampIR/positive/Compilation/test003.juvix
+++ b/tests/VampIR/positive/Compilation/test003.juvix
@@ -2,7 +2,6 @@
 module test003;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 type enum :=
   | opt0 : enum

--- a/tests/VampIR/positive/Compilation/test006.juvix
+++ b/tests/VampIR/positive/Compilation/test006.juvix
@@ -2,7 +2,6 @@
 module test006;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 type enum :=
   | opt0 : enum

--- a/tests/VampIR/positive/Compilation/test008.juvix
+++ b/tests/VampIR/positive/Compilation/test008.juvix
@@ -2,7 +2,6 @@
 module test008;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 f : Nat → Nat → Nat
   | x :=

--- a/tests/VampIR/positive/Compilation/test010.juvix
+++ b/tests/VampIR/positive/Compilation/test010.juvix
@@ -2,7 +2,6 @@
 module test010;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 pow0 : Nat := 1;
 

--- a/tests/VampIR/positive/Compilation/test017.juvix
+++ b/tests/VampIR/positive/Compilation/test017.juvix
@@ -2,7 +2,6 @@
 module test017;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 {-# unroll: 11 #-}
 terminating

--- a/tests/VampIR/positive/Compilation/test018.juvix
+++ b/tests/VampIR/positive/Compilation/test018.juvix
@@ -2,7 +2,6 @@
 module test018;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 pow : Nat -> Nat
   | zero := 1

--- a/tests/VampIR/positive/Compilation/test021.juvix
+++ b/tests/VampIR/positive/Compilation/test021.juvix
@@ -2,7 +2,6 @@
 module test021;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 power : Nat → Nat → Nat :=
   let

--- a/tests/VampIR/positive/Compilation/test022.juvix
+++ b/tests/VampIR/positive/Compilation/test022.juvix
@@ -2,7 +2,6 @@
 module test022;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 power : Nat → Nat → Nat :=
   let

--- a/tests/VampIR/positive/Compilation/test023.juvix
+++ b/tests/VampIR/positive/Compilation/test023.juvix
@@ -2,7 +2,6 @@
 module test023;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 main : Nat → Nat → Nat
   | x y :=

--- a/tests/benchmark/ackermann/juvix/ackermann.juvix
+++ b/tests/benchmark/ackermann/juvix/ackermann.juvix
@@ -2,7 +2,6 @@
 module ackermann;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 iter : {A : Type} → (A → A) → Nat → A → A
   | f zero := id

--- a/tests/benchmark/combinations/juvix/combinations.juvix
+++ b/tests/benchmark/combinations/juvix/combinations.juvix
@@ -2,7 +2,6 @@
 module combinations;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 terminating
 go : Nat → Nat → Nat

--- a/tests/benchmark/cps/juvix/cps.juvix
+++ b/tests/benchmark/cps/juvix/cps.juvix
@@ -2,7 +2,6 @@
 module cps;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 step : Nat → Nat → Nat → (Nat → Nat → Nat → Nat) → Nat
   | zero n _ _ := n

--- a/tests/benchmark/fibonacci/juvix/fibonacci.juvix
+++ b/tests/benchmark/fibonacci/juvix/fibonacci.juvix
@@ -2,7 +2,6 @@
 module fibonacci;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 go : Nat → Nat → Nat → Nat
   | zero n _ := n

--- a/tests/benchmark/fold/juvix/fold.juvix
+++ b/tests/benchmark/fold/juvix/fold.juvix
@@ -2,7 +2,6 @@
 module fold;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 plusMod : Nat → Nat → Nat
   | x y := mod (x + y) 268435456;

--- a/tests/benchmark/mapfold/juvix/mapfold.juvix
+++ b/tests/benchmark/mapfold/juvix/mapfold.juvix
@@ -2,7 +2,6 @@
 module mapfold;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 run : Nat → Nat → List Nat → Nat
   | zero acc lst := acc

--- a/tests/benchmark/maybe/juvix/maybe.juvix
+++ b/tests/benchmark/maybe/juvix/maybe.juvix
@@ -2,7 +2,6 @@
 module maybe;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 type Tree :=
   | leaf : Tree

--- a/tests/benchmark/mergesort/juvix/mergesort.juvix
+++ b/tests/benchmark/mergesort/juvix/mergesort.juvix
@@ -2,7 +2,6 @@
 module mergesort;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 split_go
   : {A : Type} → List A → List A → List A → List A × List A

--- a/tests/benchmark/prime/juvix/prime.juvix
+++ b/tests/benchmark/prime/juvix/prime.juvix
@@ -2,7 +2,6 @@
 module prime;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 checkDivisible : Nat → List Nat → Bool
   | p nil := false

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -12,8 +12,6 @@ hiding -- Hide some names
 -- Bool either
 Bool; true; false; mkShow; module Show};
 
-import Stdlib.Data.Nat.Ord open;
-
 -- Lorem ipsum dolor sit amet, consectetur adipiscing elit
 terminating
 -- Comment between terminating and type sig

--- a/tests/positive/issue1731/builtinTrace.juvix
+++ b/tests/positive/issue1731/builtinTrace.juvix
@@ -1,7 +1,6 @@
 module builtinTrace;
 
 import Stdlib.Prelude open;
-import Stdlib.Data.Nat.Ord open;
 
 builtin trace
 axiom trace : {A : Type} → A → A;

--- a/tests/smoke/Commands/dev/core.smoke.yaml
+++ b/tests/smoke/Commands/dev/core.smoke.yaml
@@ -62,6 +62,7 @@ tests:
       - dev
       - core
       - from-concrete
+      - -t eta-expand-apps
       - --normalize
     args:
       - positive/Internal/Norm.juvix

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -74,11 +74,7 @@ tests:
     stdin: ":def + (+) (((+)))"
     stdout:
       contains: |
-        --- Addition for ;Nat;s.
-        builtin nat-plus
-        + : Nat → Nat → Nat
-          | zero b := b
-          | (suc a) b := suc (a + b)
+        + {A} {{Natural A}} : A -> A -> A := Natural.+
     exit-status: 0
 
   - name: repl-def-infix
@@ -89,11 +85,7 @@ tests:
     stdin: ":def +"
     stdout:
       contains: |
-        --- Addition for ;Nat;s.
-        builtin nat-plus
-        + : Nat → Nat → Nat
-          | zero b := b
-          | (suc a) b := suc (a + b)
+        + {A} {{Natural A}} : A -> A -> A := Natural.+
     exit-status: 0
 
   - name: open
@@ -454,7 +446,7 @@ tests:
     command:
       - juvix
       - repl
-    stdin: "import Stdlib.Data.Int.Ord as Int open\n1 == 1"
+    stdin: "import Stdlib.Data.Int.Ord as Int open\n1 Int.== 1"
     stdout:
       contains: "true"
     exit-status: 0
@@ -463,9 +455,9 @@ tests:
     command:
       - juvix
       - repl
-    stdin: "import Stdlib.Data.Int.Ord open\n1 == 1"
+    stdin: "import Stdlib.Data.Int.Ord open\ncompare 1 1"
     stdout:
-      contains: "true"
+      contains: "EQ"
     exit-status: 0
 
   - name: infix-constructors


### PR DESCRIPTION
* Adapts to https://github.com/anoma/juvix-stdlib/pull/86
* Adds a pass in `toEvalTransformations` to automatically inline all record projection functions, regardless of the optimization level. This is necessary to ensure that arithmetic operations and comparisons on `Nat` or `Int` are always represented directly with the corresponding built-in Core functions. This is generally highly desirable and required for the Geb target.
* Adds the `inline: always` pragma which indicates that a function should always be inlined during the mandatory inlining phase, regardless of optimization level.
