### PR TITLE
Add constructor wildcards

### DIFF
--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -587,7 +587,7 @@ deriving stock instance Ord (RhsAdt 'Scoped)
 
 data RhsRecord (s :: Stage) = RhsRecord
   { _rhsRecordDelim :: Irrelevant (KeywordRef, KeywordRef),
-    _rhsRecordFields :: NonEmpty (RecordField s)
+    _rhsRecordFields :: [RecordField s]
   }
 
 deriving stock instance Show (RhsRecord 'Parsed)
@@ -1524,7 +1524,7 @@ data RecordUpdateExtra = RecordUpdateExtra
 
 data RecordCreationExtra = RecordCreationExtra
   { -- | Implicitly bound fields sorted by index
-    _recordCreationExtraVars :: NonEmpty S.Symbol,
+    _recordCreationExtraVars :: [S.Symbol],
     _recordCreationExtraSignature :: RecordNameSignature
   }
   deriving stock (Show)
@@ -1539,7 +1539,7 @@ data RecordUpdate (s :: Stage) = RecordUpdate
     _recordUpdateDelims :: Irrelevant (KeywordRef, KeywordRef),
     _recordUpdateTypeName :: IdentifierType s,
     _recordUpdateExtra :: Irrelevant (RecordUpdateExtraType s),
-    _recordUpdateFields :: NonEmpty (RecordUpdateField s)
+    _recordUpdateFields :: [RecordUpdateField s]
   }
 
 deriving stock instance Show (RecordUpdate 'Parsed)
@@ -1581,7 +1581,7 @@ deriving stock instance Ord (NamedApplication 'Scoped)
 data RecordCreation (s :: Stage) = RecordCreation
   { _recordCreationConstructor :: IdentifierType s,
     _recordCreationAtKw :: Irrelevant KeywordRef,
-    _recordCreationFields :: NonEmpty (RecordDefineField s),
+    _recordCreationFields :: [RecordDefineField s],
     _recordCreationExtra :: Irrelevant (RecordCreationExtraType s)
   }
 
@@ -2069,11 +2069,12 @@ instance (SingI s) => HasLoc (RecordUpdateField s) where
 instance (SingI s) => HasLoc (RecordDefineField s) where
   getLoc f = getLoc (f ^. fieldDefineFunDef)
 
-instance (SingI s) => HasLoc (RecordUpdate s) where
-  getLoc r = getLoc (r ^. recordUpdateAtKw) <> getLocSpan (r ^. recordUpdateFields)
+instance HasLoc (RecordUpdate s) where
+  getLoc r = getLoc (r ^. recordUpdateAtKw) <> getLoc (r ^. recordUpdateDelims . unIrrelevant . _2)
 
+-- TODO add delims
 instance (SingI s) => HasLoc (RecordCreation s) where
-  getLoc RecordCreation {..} = getLocIdentifierType _recordCreationConstructor <> getLocSpan _recordCreationFields
+  getLoc RecordCreation {..} = getLocIdentifierType _recordCreationConstructor
 
 instance HasLoc RecordUpdateApp where
   getLoc r = getLoc (r ^. recordAppExpression) <> getLoc (r ^. recordAppUpdate)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -300,7 +300,7 @@ instance (SingI s) => PrettyPrint (RecordUpdate s) where
   ppCode RecordUpdate {..} = do
     let Irrelevant (l, r) = _recordUpdateDelims
         fields'
-          | null (_recordUpdateFields ^. _tail1) = ppCode (_recordUpdateFields ^. _head1)
+          | [f] <- _recordUpdateFields = ppCode f
           | otherwise =
               line
                 <> indent
@@ -1112,7 +1112,7 @@ instance (SingI s) => PrettyPrint (RhsRecord s) where
   ppCode RhsRecord {..} = do
     let Irrelevant (l, r) = _rhsRecordDelim
         fields'
-          | null (_rhsRecordFields ^. _tail1) = ppCode (_rhsRecordFields ^. _head1)
+          | [f] <- _rhsRecordFields = ppCode f
           | otherwise =
               hardline
                 <> indent

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -155,7 +155,7 @@ instance PrettyPrint PatternBinding where
   ppCode PatternBinding {..} = do
     let n' = ppSymbolType _patternBindingName
         p' = ppCode _patternBindingPattern
-    n' <> ppCode Kw.kwAt <> p'
+    n' <> ppCode _patternBindingAtKw <> p'
 
 instance (SingI s) => PrettyPrint (ListPattern s) where
   ppCode ListPattern {..} = do
@@ -186,10 +186,19 @@ instance PrettyPrint NameSignature where
     | null _nameSignatureArgs = noLoc (pretty @Text "<empty name signature>")
     | otherwise = hsep . map ppCode $ _nameSignatureArgs
 
+instance (SingI s) => PrettyPrint (WildcardConstructor s) where
+  ppCode WildcardConstructor {..} = do
+    let (l, r) = _wildcardConstructorDelims ^. unIrrelevant
+    ppIdentifierType _wildcardConstructor
+      <> ppCode _wildcardConstructorAtKw
+      <> ppCode l
+      <> ppCode r
+
 instance (SingI s) => PrettyPrint (PatternAtom s) where
   ppCode = \case
     PatternAtomIden n -> ppPatternAtomIdenType n
     PatternAtomWildcard w -> ppCode w
+    PatternAtomWildcardConstructor w -> ppCode w
     PatternAtomList l -> ppCode l
     PatternAtomEmpty {} -> parens (return ())
     PatternAtomParens p -> parens (ppPatternParensType p)
@@ -279,12 +288,14 @@ instance (SingI s) => PrettyPrint (NamedApplication s) where
 
 instance (SingI s) => PrettyPrint (RecordCreation s) where
   ppCode RecordCreation {..} = do
-    let fields' =
-          blockIndent
-            ( sequenceWith
-                (semicolon >> line)
-                (ppCode <$> _recordCreationFields)
-            )
+    let fields'
+          | null _recordCreationFields = mempty
+          | otherwise =
+              blockIndent
+                ( sequenceWith
+                    (semicolon >> line)
+                    (ppCode <$> _recordCreationFields)
+                )
     ppIdentifierType _recordCreationConstructor
       <> ppCode _recordCreationAtKw
       <> braces fields'
@@ -974,6 +985,7 @@ instance PrettyPrint Pattern where
           r' = ppRightExpression appFixity r
       l' <+> r'
     PatternWildcard w -> ppCode w
+    PatternWildcardConstructor w -> ppCode w
     PatternList w -> ppCode w
     PatternEmpty {} -> parens (return ())
     PatternConstructor constr -> ppCode constr
@@ -1112,6 +1124,7 @@ instance (SingI s) => PrettyPrint (RhsRecord s) where
   ppCode RhsRecord {..} = do
     let Irrelevant (l, r) = _rhsRecordDelim
         fields'
+          | [] <- _rhsRecordFields = mempty
           | [f] <- _rhsRecordFields = ppCode f
           | otherwise =
               hardline

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -668,7 +668,7 @@ recordUpdate = do
   _recordUpdateAtKw <- Irrelevant <$> kw kwAt
   _recordUpdateTypeName <- name
   l <- kw delimBraceL
-  _recordUpdateFields <- P.sepEndBy1 recordUpdateField semicolon
+  _recordUpdateFields <- P.sepEndBy recordUpdateField semicolon
   r <- kw delimBraceR
   let _recordUpdateDelims = Irrelevant (l, r)
       _recordUpdateExtra = Irrelevant ()
@@ -843,7 +843,7 @@ recordCreation = P.label "<record creation>" $ do
     a <- Irrelevant <$> kw kwAt
     lbrace
     return (n, a)
-  defs <- P.sepEndBy1 (functionDefinition True False Nothing) semicolon
+  defs <- P.sepEndBy (functionDefinition True False Nothing) semicolon
   rbrace
   let _recordCreationFields = fmap mkField defs
       _recordCreationExtra = Irrelevant ()
@@ -1268,7 +1268,7 @@ rhsAdt = P.label "<constructor arguments>" $ do
 rhsRecord :: (Members '[InfoTableBuilder, PragmasStash, JudocStash, NameIdGen] r) => ParsecS r (RhsRecord 'Parsed)
 rhsRecord = P.label "<constructor record>" $ do
   l <- kw delimBraceL
-  _rhsRecordFields <- P.sepEndBy1 recordField semicolon
+  _rhsRecordFields <- P.sepEndBy recordField semicolon
   r <- kw delimBraceR
   let _rhsRecordDelim = Irrelevant (l, r)
   return RhsRecord {..}

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -716,6 +716,7 @@ fromPatternArg pa = case pa ^. Internal.patternArgName of
 
     fromPattern :: Maybe (Name, Type) -> Internal.Pattern -> Sem r Pattern
     fromPattern asPat = \case
+      Internal.PatternWildcardConstructor {} -> impossible
       Internal.PatternVariable n -> do
         ty <- getPatternType n
         varsNum <- (^. indexTableVarsNum) <$> get
@@ -832,6 +833,7 @@ addPatternVariableNames p lvl vars =
     getPatternVars = \case
       Internal.PatternVariable n -> [Just n]
       Internal.PatternConstructorApp {} -> impossible
+      Internal.PatternWildcardConstructor {} -> impossible
 
 goIden ::
   forall r.

--- a/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
@@ -207,8 +207,12 @@ goConstructorDef indName c = do
 goPattern :: forall r. (Member (State DependencyGraph) r) => Maybe Name -> PatternArg -> Sem r ()
 goPattern n p = case p ^. patternArgPattern of
   PatternVariable {} -> return ()
+  PatternWildcardConstructor c -> goWildcardConstructor c
   PatternConstructorApp a -> goApp a
   where
+    goWildcardConstructor :: WildcardConstructor -> Sem r ()
+    goWildcardConstructor w = addEdgeMay n (w ^. wildcardConstructor)
+
     goApp :: ConstructorApp -> Sem r ()
     goApp (ConstructorApp ctr ps _) = do
       addEdgeMay n ctr

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -225,9 +225,15 @@ instance PrettyCode ConstructorApp where
       Nothing -> return $ hsep (constr' : params')
       Just ty' -> return $ parens (hsep (constr' : params') <+> kwColon <+> ty')
 
+instance PrettyCode WildcardConstructor where
+  ppCode p = do
+    constr' <- ppCode (p ^. wildcardConstructor)
+    return $ constr' <> kwAt <> braces mempty
+
 instance PrettyCode Pattern where
   ppCode p = case p of
     PatternVariable v -> ppCode v
+    PatternWildcardConstructor v -> ppCode v
     PatternConstructorApp a -> ppCode a
 
 instance PrettyCode BuiltinFunction where

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -1048,8 +1048,8 @@ goPatternApplication a = uncurry mkConstructorApp <$> viewApp (PatternApplicatio
 
 goWildcardConstructor ::
   WildcardConstructor 'Scoped ->
-  Internal.ConstructorApp
-goWildcardConstructor a = mkConstructorApp (goScopedIden (a ^. wildcardConstructor)) []
+  Internal.WildcardConstructor
+goWildcardConstructor a = Internal.WildcardConstructor (goScopedIden (a ^. wildcardConstructor))
 
 goPatternConstructor ::
   (Members '[Builtins, NameIdGen, Error ScoperError] r) =>
@@ -1110,7 +1110,7 @@ goPattern p = case p of
   PatternVariable a -> return $ Internal.PatternVariable (goSymbol a)
   PatternList a -> goListPattern a
   PatternConstructor c -> Internal.PatternConstructorApp <$> goPatternConstructor c
-  PatternWildcardConstructor c -> return (Internal.PatternConstructorApp (goWildcardConstructor c))
+  PatternWildcardConstructor c -> return (Internal.PatternWildcardConstructor (goWildcardConstructor c))
   PatternApplication a -> Internal.PatternConstructorApp <$> goPatternApplication a
   PatternInfixApplication a -> Internal.PatternConstructorApp <$> goInfixPatternApplication a
   PatternPostfixApplication a -> Internal.PatternConstructorApp <$> goPostfixPatternApplication a

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -455,6 +455,7 @@ checkPattern = go
       whenJust name (\n -> addVar n ty argTy)
       pat' <- case pat of
         PatternVariable v -> addVar v ty argTy $> pat
+        PatternWildcardConstructor {} -> impossible
         PatternConstructorApp a -> do
           s <- checkSaturatedInductive ty
           info <- lookupConstructor (a ^. constrAppConstructor)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Inference.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Inference.hs
@@ -406,6 +406,8 @@ matchPatterns (PatternArg impl1 name1 pat1) (PatternArg impl2 name2 pat2) =
       (PatternConstructorApp c1, PatternConstructorApp c2) -> goConstructor c1 c2
       (PatternVariable {}, _) -> err
       (_, PatternVariable {}) -> err
+      (PatternWildcardConstructor {}, _) -> impossible
+      (_, PatternWildcardConstructor {}) -> impossible
     goConstructor :: ConstructorApp -> ConstructorApp -> Sem r Bool
     goConstructor (ConstructorApp c1 args1 _) (ConstructorApp c2 args2 _)
       | c1 /= c2 = err

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -262,6 +262,18 @@ module Comments;
   type list (A : Type) : Type := cons A (list A);
 end;
 
+module EmptyRecords;
+  import Stdlib.Data.Bool.Base open;
+
+  type T := mkT {};
+
+  x : T := mkT@{};
+
+  isZero : Nat -> Bool
+    | zero := true
+    | suc@{} := false;
+end;
+
 --- Traits
 module Traits;
   import Stdlib.Prelude open hiding {Show; mkShow; module Show};


### PR DESCRIPTION
- Closes #2402.

Changes:
1. Allow the definition of empty record types.
2. Introduce the _constructor wildcard_ pattern. That is, a pattern of the form `constr@{}` that matches the constructor `constr` regardless of its number of arguments.

