### PR TITLE
Refactor EntryPoint, Package, Pipeline, Root packages 

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -5,7 +5,7 @@ import Data.ByteString qualified as ByteString
 import GlobalOptions
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
-import Juvix.Compiler.Pipeline
+import Juvix.Compiler.Pipeline.Run
 import Juvix.Data.Error qualified as Error
 import Juvix.Extra.Paths.Base
 import Juvix.Prelude.Pretty hiding

--- a/app/Commands/Dev/Highlight.hs
+++ b/app/Commands/Dev/Highlight.hs
@@ -3,6 +3,7 @@ module Commands.Dev.Highlight where
 import Commands.Base
 import Commands.Dev.Highlight.Options
 import Juvix.Compiler.Concrete.Data.Highlight qualified as Highlight
+import Juvix.Compiler.Pipeline.Run
 
 runCommand :: (Members '[Embed IO, App] r) => HighlightOptions -> Sem r ()
 runCommand HighlightOptions {..} = do

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -32,6 +32,7 @@ import Juvix.Compiler.Core.Transformation.DisambiguateNames (disambiguateNames)
 import Juvix.Compiler.Internal.Language qualified as Internal
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Pipeline.Repl
+import Juvix.Compiler.Pipeline.Run
 import Juvix.Compiler.Pipeline.Setup (entrySetup)
 import Juvix.Data.Effect.Git
 import Juvix.Data.Effect.Process

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -1,5 +1,5 @@
 module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
-  ( module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Base,
+  ( module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Paths,
     module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error,
     module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.PackageInfo,
     module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig,
@@ -24,10 +24,10 @@ import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
 import Data.Text qualified as T
 import Juvix.Compiler.Concrete.Data.Name
-import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Base
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.PackageInfo
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Paths
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Lockfile
 import Juvix.Compiler.Pipeline.Package

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -30,6 +30,7 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Erro
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.PackageInfo
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Lockfile
+import Juvix.Compiler.Pipeline.Package
 import Juvix.Data.Effect.Git
 import Juvix.Extra.Paths
 import Juvix.Extra.Stdlib (ensureStdlib)

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Base.hs
@@ -1,0 +1,23 @@
+module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Base
+  ( module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Base,
+    module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig,
+  )
+where
+
+import Juvix.Compiler.Concrete.Data.Name
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error
+import Juvix.Prelude
+
+data PathResolver m a where
+  RegisterDependencies :: DependenciesConfig -> PathResolver m ()
+  ExpectedModulePath :: Path Abs File -> TopModulePath -> PathResolver m (Maybe (Path Abs File))
+  WithPath ::
+    TopModulePath ->
+    (Either PathResolverError (Path Abs Dir, Path Rel File) -> m x) ->
+    PathResolver m x
+
+makeSem ''PathResolver
+
+withPathFile :: (Members '[PathResolver] r) => TopModulePath -> (Either PathResolverError (Path Abs File) -> Sem r a) -> Sem r a
+withPathFile m f = withPath m (f . mapRight (uncurry (<//>)))

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Data.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Data.hs
@@ -1,0 +1,57 @@
+module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Data where
+
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.PackageInfo
+import Juvix.Compiler.Pipeline.Lockfile
+import Juvix.Compiler.Pipeline.Package.Base
+import Juvix.Prelude
+
+data ResolverEnv = ResolverEnv
+  { _envRoot :: Path Abs Dir,
+    -- | The path of the input file *if* we are using the global project
+    _envSingleFile :: Maybe (Path Abs File),
+    _envLockfileInfo :: Maybe LockfileInfo
+  }
+
+data ResolverCacheItem = ResolverCacheItem
+  { _resolverCacheItemPackage :: PackageInfo,
+    _resolverCacheItemDependency :: LockfileDependency
+  }
+  deriving stock (Show)
+
+data ResolverState = ResolverState
+  { -- | juvix files indexed by relative path
+    _resolverFiles :: HashMap (Path Rel File) (NonEmpty PackageInfo),
+    -- | PackageInfos indexed by root
+    _resolverCache :: HashMap (Path Abs Dir) ResolverCacheItem,
+    _resolverShouldWriteLockfile :: Bool
+  }
+  deriving stock (Show)
+
+data ResolvedDependency = ResolvedDependency
+  { _resolvedDependencyPath :: Path Abs Dir,
+    _resolvedDependencyDependency :: Dependency
+  }
+
+makeLenses ''ResolverState
+makeLenses ''ResolverEnv
+makeLenses ''ResolvedDependency
+makeLenses ''ResolverCacheItem
+
+iniResolverState :: ResolverState
+iniResolverState =
+  ResolverState
+    { _resolverCache = mempty,
+      _resolverFiles = mempty,
+      _resolverShouldWriteLockfile = False
+    }
+
+checkShouldWriteLockfile :: (Member (State ResolverState) r) => ResolvedDependency -> Sem r ()
+checkShouldWriteLockfile d = case d ^. resolvedDependencyDependency of
+  DependencyGit {} -> modify' (set resolverShouldWriteLockfile True)
+  DependencyPath {} -> return ()
+
+withEnvRoot :: (Members '[Reader ResolverEnv] r) => Path Abs Dir -> Sem r a -> Sem r a
+withEnvRoot root' = local (set envRoot root')
+
+withLockfile :: (Members '[Reader ResolverEnv] r) => LockfileInfo -> Sem r a -> Sem r a
+withLockfile f = local (set envLockfileInfo (Just f))

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -3,7 +3,7 @@ module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Erro
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.PackageInfo
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Paths
-import Juvix.Compiler.Pipeline.Package
+import Juvix.Compiler.Pipeline.Package.Base
 import Juvix.Data.CodeAnn
 import Juvix.Data.Effect.Git
 import Juvix.Prelude

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Error.hs
@@ -1,8 +1,8 @@
 module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error where
 
 import Juvix.Compiler.Concrete.Language
-import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Base
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.PackageInfo
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Paths
 import Juvix.Compiler.Pipeline.Package
 import Juvix.Data.CodeAnn
 import Juvix.Data.Effect.Git

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Paths.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver/Paths.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Base where
+module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Paths where
 
 import Juvix.Compiler.Concrete.Data.Name
 import Juvix.Prelude

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -34,6 +34,7 @@ import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.D
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context qualified as Typed
 import Juvix.Compiler.Pipeline.Artifacts
+import Juvix.Compiler.Pipeline.Artifacts.PathResolver
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Loader.PathResolver
 import Juvix.Compiler.Pipeline.Root

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -17,26 +17,17 @@ import Juvix.Compiler.Backend.Geb qualified as Geb
 import Juvix.Compiler.Backend.VampIR.Translation qualified as VampIR
 import Juvix.Compiler.Builtins
 import Juvix.Compiler.Concrete.Data.Highlight.Input
-import Juvix.Compiler.Concrete.Data.ParsedInfoTableBuilder.BuilderState qualified as Concrete
-import Juvix.Compiler.Concrete.Data.Scope
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromParsed qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
-import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver qualified as PathResolver
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.DependenciesConfig
-import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context qualified as Scoped
-import Juvix.Compiler.Concrete.Translation.FromSource qualified as P
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
 import Juvix.Compiler.Core qualified as Core
 import Juvix.Compiler.Core.Translation.Stripped.FromCore qualified as Stripped
 import Juvix.Compiler.Internal qualified as Internal
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking.Data.Context qualified as Arity
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context qualified as Typed
 import Juvix.Compiler.Pipeline.Artifacts
-import Juvix.Compiler.Pipeline.Artifacts.PathResolver
 import Juvix.Compiler.Pipeline.EntryPoint
-import Juvix.Compiler.Pipeline.Loader.PathResolver
 import Juvix.Compiler.Pipeline.Root
 import Juvix.Compiler.Pipeline.Setup
 import Juvix.Compiler.Reg.Data.InfoTable qualified as Reg
@@ -165,164 +156,3 @@ regToMiniC' tab = do
 
 coreToVampIR' :: (Members '[Error JuvixError, Reader Core.CoreOptions] r) => Core.InfoTable -> Sem r VampIR.Result
 coreToVampIR' = Core.toVampIR' >=> return . VampIR.fromCore' False
-
---------------------------------------------------------------------------------
--- Run pipeline
---------------------------------------------------------------------------------
-
--- | It returns `ResolverState` so that we can retrieve the `juvix.yaml` files,
--- which we require for `Scope` tests.
-runIOEither :: forall a. EntryPoint -> Sem PipelineEff a -> IO (Either JuvixError (ResolverState, a))
-runIOEither entry = fmap snd . runIOEitherHelper entry
-
-runIOEitherTermination :: forall a. EntryPoint -> Sem (Termination ': PipelineEff) a -> IO (Either JuvixError (ResolverState, a))
-runIOEitherTermination entry = fmap snd . runIOEitherHelper entry . evalTermination iniTerminationState
-
-runPipelineHighlight :: forall a. EntryPoint -> Sem PipelineEff a -> IO HighlightInput
-runPipelineHighlight entry = fmap fst . runIOEitherHelper entry
-
-runIOEitherHelper :: forall a. EntryPoint -> Sem PipelineEff a -> IO (HighlightInput, (Either JuvixError (ResolverState, a)))
-runIOEitherHelper entry = do
-  let hasInternet = not (entry ^. entryPointOffline)
-      runPathResolver'
-        | mainIsPackageFile = runPackagePathResolver' (entry ^. entryPointResolverRoot)
-        | otherwise = runPathResolverPipe
-  runM
-    . evalInternet hasInternet
-    . runHighlightBuilder
-    . runJuvixError
-    . evalTopBuiltins
-    . evalTopNameIdGen
-    . runFilesIO
-    . runReader entry
-    . runLogIO
-    . runProcessIO
-    . mapError (JuvixError @GitProcessError)
-    . runGitProcess
-    . mapError (JuvixError @DependencyError)
-    . runPathResolver'
-  where
-    mainIsPackageFile :: Bool
-    mainIsPackageFile = case entry ^? entryPointModulePaths . _head of
-      Just p -> p == mkPackagePath (entry ^. entryPointResolverRoot)
-      Nothing -> False
-
-runIO :: GenericOptions -> EntryPoint -> Sem PipelineEff a -> IO (ResolverState, a)
-runIO opts entry = runIOEither entry >=> mayThrow
-  where
-    mayThrow :: Either JuvixError r -> IO r
-    mayThrow = \case
-      Left err -> runM . runReader opts $ printErrorAnsiSafe err >> embed exitFailure
-      Right r -> return r
-
-runIO' :: EntryPoint -> Sem PipelineEff a -> IO (ResolverState, a)
-runIO' = runIO defaultGenericOptions
-
-corePipelineIO' :: EntryPoint -> IO Artifacts
-corePipelineIO' = corePipelineIO defaultGenericOptions
-
-corePipelineIO :: GenericOptions -> EntryPoint -> IO Artifacts
-corePipelineIO opts entry = corePipelineIOEither entry >>= mayThrow
-  where
-    mayThrow :: Either JuvixError r -> IO r
-    mayThrow = \case
-      Left err -> runM . runReader opts $ printErrorAnsiSafe err >> embed exitFailure
-      Right r -> return r
-
-corePipelineIOEither ::
-  EntryPoint ->
-  IO (Either JuvixError Artifacts)
-corePipelineIOEither entry = do
-  let hasInternet = not (entry ^. entryPointOffline)
-  eith <-
-    runM
-      . evalInternet hasInternet
-      . ignoreHighlightBuilder
-      . runError
-      . runState initialArtifacts
-      . runBuiltinsArtifacts
-      . runNameIdGenArtifacts
-      . runFilesIO
-      . runReader entry
-      . runLogIO
-      . mapError (JuvixError @GitProcessError)
-      . runProcessIO
-      . runGitProcess
-      . mapError (JuvixError @DependencyError)
-      . runPathResolverArtifacts
-      $ upToCore
-  return $ case eith of
-    Left err -> Left err
-    Right (art, coreRes) ->
-      let typedResult :: Internal.InternalTypedResult
-          typedResult =
-            coreRes
-              ^. Core.coreResultInternalTypedResult
-
-          typesTable :: Typed.TypesTable
-          typesTable = typedResult ^. Typed.resultIdenTypes
-
-          functionsTable :: Typed.FunctionsTable
-          functionsTable = typedResult ^. Typed.resultFunctions
-
-          typedTable :: Internal.InfoTable
-          typedTable = typedResult ^. Typed.resultInfoTable
-
-          internalResult :: Internal.InternalResult
-          internalResult =
-            typedResult
-              ^. Typed.resultInternalArityResult
-                . Arity.resultInternalResult
-
-          coreTable :: Core.InfoTable
-          coreTable = coreRes ^. Core.coreResultTable
-
-          scopedResult :: Scoped.ScoperResult
-          scopedResult =
-            internalResult
-              ^. Internal.resultScoper
-
-          parserResult :: P.ParserResult
-          parserResult = scopedResult ^. Scoped.resultParserResult
-
-          resultScoperTable :: Scoped.InfoTable
-          resultScoperTable = scopedResult ^. Scoped.resultScoperTable
-
-          mainModuleScope_ :: Scope
-          mainModuleScope_ = Scoped.mainModuleSope scopedResult
-       in Right $
-            Artifacts
-              { _artifactMainModuleScope = Just mainModuleScope_,
-                _artifactParsing = parserResult ^. P.resultBuilderState,
-                _artifactInternalModuleCache = internalResult ^. Internal.resultModulesCache,
-                _artifactInternalTypedTable = typedTable,
-                _artifactTerminationState = typedResult ^. Typed.resultTermination,
-                _artifactCoreTable = coreTable,
-                _artifactScopeTable = resultScoperTable,
-                _artifactScopeExports = scopedResult ^. Scoped.resultExports,
-                _artifactTypes = typesTable,
-                _artifactFunctions = functionsTable,
-                _artifactScoperState = scopedResult ^. Scoped.resultScoperState,
-                _artifactResolver = art ^. artifactResolver,
-                _artifactBuiltins = art ^. artifactBuiltins,
-                _artifactNameIdState = art ^. artifactNameIdState
-              }
-  where
-    initialArtifacts :: Artifacts
-    initialArtifacts =
-      Artifacts
-        { _artifactParsing = Concrete.iniState,
-          _artifactMainModuleScope = Nothing,
-          _artifactInternalTypedTable = mempty,
-          _artifactTypes = mempty,
-          _artifactTerminationState = iniTerminationState,
-          _artifactResolver = PathResolver.iniResolverState,
-          _artifactNameIdState = allNameIds,
-          _artifactFunctions = mempty,
-          _artifactCoreTable = Core.emptyInfoTable,
-          _artifactScopeTable = Scoped.emptyInfoTable,
-          _artifactBuiltins = iniBuiltins,
-          _artifactScopeExports = mempty,
-          _artifactInternalModuleCache = Internal.ModulesCache mempty,
-          _artifactScoperState = Scoper.iniScoperState
-        }

--- a/src/Juvix/Compiler/Pipeline/Artifacts/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Artifacts/Base.hs
@@ -1,0 +1,39 @@
+module Juvix.Compiler.Pipeline.Artifacts.Base where
+
+import Juvix.Compiler.Builtins
+import Juvix.Compiler.Concrete.Data.InfoTable qualified as Scoped
+import Juvix.Compiler.Concrete.Data.ParsedInfoTableBuilder (BuilderState)
+import Juvix.Compiler.Concrete.Data.Scope
+import Juvix.Compiler.Concrete.Data.Scope qualified as Scoped
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Data
+import Juvix.Compiler.Core.Data.InfoTableBuilder qualified as Core
+import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context
+import Juvix.Prelude
+
+-- | `Artifacts` contains enough information so that the pipeline can be
+-- restarted while preserving existing state.
+data Artifacts = Artifacts
+  { _artifactParsing :: BuilderState,
+    -- Scoping
+    _artifactResolver :: ResolverState,
+    _artifactBuiltins :: BuiltinsState,
+    _artifactNameIdState :: Stream NameId,
+    _artifactScopeTable :: Scoped.InfoTable,
+    _artifactScopeExports :: HashSet NameId,
+    _artifactMainModuleScope :: Maybe Scope,
+    _artifactScoperState :: Scoped.ScoperState,
+    -- Concrete -> Internal
+    _artifactInternalModuleCache :: Internal.ModulesCache,
+    _artifactTerminationState :: TerminationState,
+    -- Typechecking
+    _artifactTypes :: TypesTable,
+    _artifactFunctions :: FunctionsTable,
+    -- | This includes the InfoTable from all type checked modules
+    _artifactInternalTypedTable :: Internal.InfoTable,
+    -- Core
+    _artifactCoreTable :: Core.InfoTable
+  }
+
+makeLenses ''Artifacts

--- a/src/Juvix/Compiler/Pipeline/Artifacts/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Artifacts/PathResolver.hs
@@ -1,0 +1,10 @@
+module Juvix.Compiler.Pipeline.Artifacts.PathResolver where
+
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
+import Juvix.Compiler.Pipeline.Artifacts
+import Juvix.Compiler.Pipeline.EntryPoint
+import Juvix.Data.Effect.Git
+import Juvix.Prelude
+
+runPathResolverArtifacts :: (Members '[Files, Reader EntryPoint, State Artifacts, Error DependencyError, GitClone] r) => Sem (PathResolver ': r) a -> Sem r a
+runPathResolverArtifacts = runStateLikeArtifacts runPathResolverPipe' artifactResolver

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -1,11 +1,11 @@
 module Juvix.Compiler.Pipeline.EntryPoint
   ( module Juvix.Compiler.Pipeline.EntryPoint,
-    module Juvix.Compiler.Pipeline.Package,
+    module Juvix.Compiler.Pipeline.Package.Base,
   )
 where
 
 import Juvix.Compiler.Backend
-import Juvix.Compiler.Pipeline.Package
+import Juvix.Compiler.Pipeline.Package.Base
 import Juvix.Compiler.Pipeline.Root
 import Juvix.Extra.Paths
 import Juvix.Prelude
@@ -44,18 +44,6 @@ data EntryPoint = EntryPoint
   deriving stock (Eq, Show)
 
 makeLenses ''EntryPoint
-
-defaultEntryPointCwdIO :: Path Abs File -> IO EntryPoint
-defaultEntryPointCwdIO mainFile = do
-  cwd <- getCurrentDir
-  roots <- findRootAndChangeDir (Just (parent mainFile)) Nothing cwd
-  return (defaultEntryPoint roots mainFile)
-
-defaultEntryPointNoFileCwdIO :: IO EntryPoint
-defaultEntryPointNoFileCwdIO = do
-  cwd <- getCurrentDir
-  roots <- findRootAndChangeDir Nothing Nothing cwd
-  return (defaultEntryPointNoFile roots)
 
 defaultEntryPoint :: Roots -> Path Abs File -> EntryPoint
 defaultEntryPoint roots mainFile =

--- a/src/Juvix/Compiler/Pipeline/EntryPoint/IO.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint/IO.hs
@@ -1,0 +1,17 @@
+module Juvix.Compiler.Pipeline.EntryPoint.IO where
+
+import Juvix.Compiler.Pipeline.EntryPoint
+import Juvix.Compiler.Pipeline.Root
+import Juvix.Prelude
+
+defaultEntryPointCwdIO :: Path Abs File -> IO EntryPoint
+defaultEntryPointCwdIO mainFile = do
+  cwd <- getCurrentDir
+  roots <- findRootAndChangeDir (Just (parent mainFile)) Nothing cwd
+  return (defaultEntryPoint roots mainFile)
+
+defaultEntryPointNoFileCwdIO :: IO EntryPoint
+defaultEntryPointNoFileCwdIO = do
+  cwd <- getCurrentDir
+  roots <- findRootAndChangeDir Nothing Nothing cwd
+  return (defaultEntryPointNoFile roots)

--- a/src/Juvix/Compiler/Pipeline/Package.hs
+++ b/src/Juvix/Compiler/Pipeline/Package.hs
@@ -1,154 +1,20 @@
 module Juvix.Compiler.Pipeline.Package
-  ( module Juvix.Compiler.Pipeline.Package.Dependency,
-    BuildDir (..),
-    RawPackage,
-    Package,
-    Package' (..),
-    defaultVersion,
-    defaultStdlibDep,
-    packageName,
-    packageBuildDir,
-    packageVersion,
-    packageDependencies,
-    packageMain,
-    packageFile,
-    rawPackage,
+  ( module Juvix.Compiler.Pipeline.Package.Base,
     readPackage,
     readPackageIO,
     readGlobalPackageIO,
-    globalPackage,
-    emptyPackage,
     readGlobalPackage,
-    mkPackageFilePath,
-    packageLockfile,
-    unsetPackageLockfile,
-    mkPackagePath,
   )
 where
 
-import Data.Aeson (genericToEncoding, genericToJSON)
-import Data.Aeson.BetterErrors
-import Data.Aeson.TH
 import Data.ByteString qualified as ByteString
 import Data.HashSet qualified as HashSet
-import Data.Kind qualified as GHC
 import Data.Versions
 import Data.Yaml
 import Juvix.Compiler.Pipeline.Lockfile
-import Juvix.Compiler.Pipeline.Package.Dependency
+import Juvix.Compiler.Pipeline.Package.Base
 import Juvix.Extra.Paths
 import Juvix.Prelude
-import Lens.Micro.Platform qualified as Lens
-
-type NameType :: IsProcessed -> GHC.Type
-type family NameType s = res | res -> s where
-  NameType 'Raw = Maybe Text
-  NameType 'Processed = Text
-
-type VersionType :: IsProcessed -> GHC.Type
-type family VersionType s = res | res -> s where
-  VersionType 'Raw = Maybe Text
-  VersionType 'Processed = SemVer
-
-type DependenciesType :: IsProcessed -> GHC.Type
-type family DependenciesType s = res | res -> s where
-  DependenciesType 'Raw = Maybe [Dependency]
-  DependenciesType 'Processed = [Dependency]
-
-type PackageFileType :: IsProcessed -> GHC.Type
-type family PackageFileType s = res | res -> s where
-  PackageFileType 'Raw = Maybe ()
-  PackageFileType 'Processed = Path Abs File
-
-type PackageLockfileType :: IsProcessed -> GHC.Type
-type family PackageLockfileType s = res | res -> s where
-  PackageLockfileType 'Raw = Maybe ()
-  PackageLockfileType 'Processed = Maybe LockfileInfo
-
-data Package' (s :: IsProcessed) = Package
-  { _packageName :: NameType s,
-    _packageVersion :: VersionType s,
-    _packageDependencies :: DependenciesType s,
-    _packageBuildDir :: Maybe (SomeBase Dir),
-    _packageMain :: Maybe (Prepath File),
-    _packageFile :: PackageFileType s,
-    _packageLockfile :: PackageLockfileType s
-  }
-  deriving stock (Generic)
-
-makeLenses ''Package'
-
-type Package = Package' 'Processed
-
-type RawPackage = Package' 'Raw
-
-deriving stock instance Eq RawPackage
-
-deriving stock instance Eq Package
-
-deriving stock instance Show RawPackage
-
-deriving stock instance Show Package
-
-rawPackageOptions :: Options
-rawPackageOptions =
-  defaultOptions
-    { fieldLabelModifier = over Lens._head toLower . dropPrefix "_package",
-      rejectUnknownFields = True,
-      omitNothingFields = True
-    }
-
-instance ToJSON RawPackage where
-  toJSON = genericToJSON rawPackageOptions
-  toEncoding = genericToEncoding rawPackageOptions
-
-instance FromJSON RawPackage where
-  parseJSON = toAesonParser' (fromMaybe err <$> p)
-    where
-      p :: Parse' (Maybe RawPackage)
-      p = perhaps $ do
-        _packageName <- keyMay "name" asText
-        _packageVersion <- keyMay "version" asText
-        _packageDependencies <- keyMay "dependencies" fromAesonParser
-        _packageBuildDir <- keyMay "build-dir" fromAesonParser
-        _packageMain <- keyMay "main" fromAesonParser
-        return Package {_packageFile = Nothing, _packageLockfile = Nothing, ..}
-      err :: a
-      err = error "Failed to parse juvix.yaml"
-
-data BuildDir
-  = DefaultBuildDir
-  | CustomBuildDir (SomeBase Dir)
-
-resolveBuildDir :: BuildDir -> SomeBase Dir
-resolveBuildDir = \case
-  DefaultBuildDir -> Rel (relBuildDir)
-  CustomBuildDir d -> d
-
--- | This is used when juvix.yaml exists but it is empty
-emptyPackage :: BuildDir -> Path Abs File -> Package
-emptyPackage buildDir yamlPath =
-  Package
-    { _packageName = defaultPackageName,
-      _packageVersion = defaultVersion,
-      _packageDependencies = [defaultStdlibDep buildDir],
-      _packageMain = Nothing,
-      _packageBuildDir = Nothing,
-      _packageFile = yamlPath,
-      _packageLockfile = Nothing
-    }
-
-rawPackage :: Package -> RawPackage
-rawPackage pkg =
-  Package
-    { _packageName = Just (pkg ^. packageName),
-      _packageVersion = Just (prettySemVer (pkg ^. packageVersion)),
-      _packageDependencies = Just (pkg ^. packageDependencies),
-      _packageBuildDir = pkg ^. packageBuildDir,
-      _packageMain = pkg ^. packageMain,
-      _packageFile = Nothing,
-      _packageLockfile = Nothing
-    }
 
 processPackage :: forall r. (Members '[Error Text] r) => Path Abs File -> BuildDir -> Maybe LockfileInfo -> RawPackage -> Sem r Package
 processPackage _packageFile buildDir lockfile pkg = do
@@ -192,36 +58,6 @@ processPackage _packageFile buildDir lockfile pkg = do
       where
         base :: SomeBase Dir = resolveBuildDir buildDir <///> relStdlibDir
         stdlib = mkPathDependency (fromSomeDir base)
-
-unsetPackageLockfile :: Package -> Package
-unsetPackageLockfile = set packageLockfile Nothing
-
-defaultStdlibDep :: BuildDir -> Dependency
-defaultStdlibDep buildDir = mkPathDependency (fromSomeDir (resolveBuildDir buildDir <///> relStdlibDir))
-
-defaultPackageName :: Text
-defaultPackageName = "my-project"
-
-defaultVersion :: SemVer
-defaultVersion = SemVer 0 0 0 Nothing Nothing
-
-globalPackage :: RawPackage
-globalPackage =
-  Package
-    { _packageDependencies = Just [defaultStdlibDep DefaultBuildDir],
-      _packageName = Just "global-juvix-package",
-      _packageVersion = Just (prettySemVer defaultVersion),
-      _packageMain = Nothing,
-      _packageBuildDir = Nothing,
-      _packageFile = Nothing,
-      _packageLockfile = Nothing
-    }
-
-mkPackageFilePath :: Path Abs Dir -> Path Abs File
-mkPackageFilePath = (<//> juvixYamlFile)
-
-mkPackagePath :: Path Abs Dir -> Path Abs File
-mkPackagePath = (<//> packageFilePath)
 
 -- | Given some directory d it tries to read the file d/juvix.yaml and parse its contents
 readPackage ::

--- a/src/Juvix/Compiler/Pipeline/Package/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Base.hs
@@ -1,0 +1,155 @@
+module Juvix.Compiler.Pipeline.Package.Base
+  ( module Juvix.Compiler.Pipeline.Package.Base,
+    module Juvix.Compiler.Pipeline.Package.Dependency,
+  )
+where
+
+import Data.Aeson
+import Data.Aeson.BetterErrors
+import Data.Kind qualified as GHC
+import Data.Versions
+import Juvix.Compiler.Pipeline.Lockfile
+import Juvix.Compiler.Pipeline.Package.Dependency
+import Juvix.Extra.Paths
+import Juvix.Prelude
+import Lens.Micro.Platform qualified as Lens
+
+data BuildDir
+  = DefaultBuildDir
+  | CustomBuildDir (SomeBase Dir)
+
+type NameType :: IsProcessed -> GHC.Type
+type family NameType s = res | res -> s where
+  NameType 'Raw = Maybe Text
+  NameType 'Processed = Text
+
+type VersionType :: IsProcessed -> GHC.Type
+type family VersionType s = res | res -> s where
+  VersionType 'Raw = Maybe Text
+  VersionType 'Processed = SemVer
+
+type DependenciesType :: IsProcessed -> GHC.Type
+type family DependenciesType s = res | res -> s where
+  DependenciesType 'Raw = Maybe [Dependency]
+  DependenciesType 'Processed = [Dependency]
+
+type PackageFileType :: IsProcessed -> GHC.Type
+type family PackageFileType s = res | res -> s where
+  PackageFileType 'Raw = Maybe ()
+  PackageFileType 'Processed = Path Abs File
+
+type PackageLockfileType :: IsProcessed -> GHC.Type
+type family PackageLockfileType s = res | res -> s where
+  PackageLockfileType 'Raw = Maybe ()
+  PackageLockfileType 'Processed = Maybe LockfileInfo
+
+data Package' (s :: IsProcessed) = Package
+  { _packageName :: NameType s,
+    _packageVersion :: VersionType s,
+    _packageDependencies :: DependenciesType s,
+    _packageBuildDir :: Maybe (SomeBase Dir),
+    _packageMain :: Maybe (Prepath File),
+    _packageFile :: PackageFileType s,
+    _packageLockfile :: PackageLockfileType s
+  }
+  deriving stock (Generic)
+
+makeLenses ''Package'
+
+type Package = Package' 'Processed
+
+type RawPackage = Package' 'Raw
+
+deriving stock instance Eq RawPackage
+
+deriving stock instance Eq Package
+
+deriving stock instance Show RawPackage
+
+deriving stock instance Show Package
+
+rawPackageOptions :: Options
+rawPackageOptions =
+  defaultOptions
+    { fieldLabelModifier = over Lens._head toLower . dropPrefix "_package",
+      rejectUnknownFields = True,
+      omitNothingFields = True
+    }
+
+instance ToJSON RawPackage where
+  toJSON = genericToJSON rawPackageOptions
+  toEncoding = genericToEncoding rawPackageOptions
+
+instance FromJSON RawPackage where
+  parseJSON = toAesonParser' (fromMaybe err <$> p)
+    where
+      p :: Parse' (Maybe RawPackage)
+      p = perhaps $ do
+        _packageName <- keyMay "name" asText
+        _packageVersion <- keyMay "version" asText
+        _packageDependencies <- keyMay "dependencies" fromAesonParser
+        _packageBuildDir <- keyMay "build-dir" fromAesonParser
+        _packageMain <- keyMay "main" fromAesonParser
+        return Package {_packageFile = Nothing, _packageLockfile = Nothing, ..}
+      err :: a
+      err = error "Failed to parse juvix.yaml"
+
+resolveBuildDir :: BuildDir -> SomeBase Dir
+resolveBuildDir = \case
+  DefaultBuildDir -> Rel (relBuildDir)
+  CustomBuildDir d -> d
+
+-- | This is used when juvix.yaml exists but it is empty
+emptyPackage :: BuildDir -> Path Abs File -> Package
+emptyPackage buildDir yamlPath =
+  Package
+    { _packageName = defaultPackageName,
+      _packageVersion = defaultVersion,
+      _packageDependencies = [defaultStdlibDep buildDir],
+      _packageMain = Nothing,
+      _packageBuildDir = Nothing,
+      _packageFile = yamlPath,
+      _packageLockfile = Nothing
+    }
+
+rawPackage :: Package -> RawPackage
+rawPackage pkg =
+  Package
+    { _packageName = Just (pkg ^. packageName),
+      _packageVersion = Just (prettySemVer (pkg ^. packageVersion)),
+      _packageDependencies = Just (pkg ^. packageDependencies),
+      _packageBuildDir = pkg ^. packageBuildDir,
+      _packageMain = pkg ^. packageMain,
+      _packageFile = Nothing,
+      _packageLockfile = Nothing
+    }
+
+defaultVersion :: SemVer
+defaultVersion = SemVer 0 0 0 Nothing Nothing
+
+unsetPackageLockfile :: Package -> Package
+unsetPackageLockfile = set packageLockfile Nothing
+
+defaultStdlibDep :: BuildDir -> Dependency
+defaultStdlibDep buildDir = mkPathDependency (fromSomeDir (resolveBuildDir buildDir <///> relStdlibDir))
+
+defaultPackageName :: Text
+defaultPackageName = "my-project"
+
+globalPackage :: RawPackage
+globalPackage =
+  Package
+    { _packageDependencies = Just [defaultStdlibDep DefaultBuildDir],
+      _packageName = Just "global-juvix-package",
+      _packageVersion = Just (prettySemVer defaultVersion),
+      _packageMain = Nothing,
+      _packageBuildDir = Nothing,
+      _packageFile = Nothing,
+      _packageLockfile = Nothing
+    }
+
+mkPackageFilePath :: Path Abs Dir -> Path Abs File
+mkPackageFilePath = (<//> juvixYamlFile)
+
+mkPackagePath :: Path Abs Dir -> Path Abs File
+mkPackagePath = (<//> packageFilePath)

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/PathResolver.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Pipeline.Loader.PathResolver where
+module Juvix.Compiler.Pipeline.Package.Loader.PathResolver where
 
 import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Concrete hiding (Symbol)

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -13,6 +13,7 @@ import Juvix.Compiler.Internal qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as FromConcrete
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Pipeline.Artifacts
+import Juvix.Compiler.Pipeline.Artifacts.PathResolver
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Data.Effect.Git.Process
 import Juvix.Data.Effect.Git.Process.Error

--- a/src/Juvix/Compiler/Pipeline/Root.hs
+++ b/src/Juvix/Compiler/Pipeline/Root.hs
@@ -1,20 +1,14 @@
-module Juvix.Compiler.Pipeline.Root where
+module Juvix.Compiler.Pipeline.Root
+  ( module Juvix.Compiler.Pipeline.Root,
+    module Juvix.Compiler.Pipeline.Root.Base,
+  )
+where
 
 import Control.Exception qualified as IO
 import Juvix.Compiler.Pipeline.Package
+import Juvix.Compiler.Pipeline.Root.Base
 import Juvix.Extra.Paths qualified as Paths
 import Juvix.Prelude
-
-data Roots = Roots
-  { _rootsRootDir :: Path Abs Dir,
-    _rootsPackage :: Package,
-    _rootsPackageGlobal :: Bool,
-    _rootsBuildDir :: Path Abs Dir,
-    _rootsInvokeDir :: Path Abs Dir
-  }
-  deriving stock (Show)
-
-makeLenses ''Roots
 
 findRootAndChangeDir ::
   Maybe (Path Abs Dir) ->

--- a/src/Juvix/Compiler/Pipeline/Root/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Root/Base.hs
@@ -1,0 +1,15 @@
+module Juvix.Compiler.Pipeline.Root.Base where
+
+import Juvix.Compiler.Pipeline.Package.Base
+import Juvix.Prelude
+
+data Roots = Roots
+  { _rootsRootDir :: Path Abs Dir,
+    _rootsPackage :: Package,
+    _rootsPackageGlobal :: Bool,
+    _rootsBuildDir :: Path Abs Dir,
+    _rootsInvokeDir :: Path Abs Dir
+  }
+  deriving stock (Show)
+
+makeLenses ''Roots

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -20,7 +20,7 @@ import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking qualified as Typed
 import Juvix.Compiler.Pipeline
 import Juvix.Compiler.Pipeline.Artifacts.PathResolver
-import Juvix.Compiler.Pipeline.Loader.PathResolver
+import Juvix.Compiler.Pipeline.Package.Loader.PathResolver
 import Juvix.Data.Effect.Git
 import Juvix.Data.Effect.Process
 import Juvix.Prelude

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -1,0 +1,185 @@
+module Juvix.Compiler.Pipeline.Run
+  ( module Juvix.Compiler.Pipeline.Run,
+    module Juvix.Compiler.Pipeline,
+  )
+where
+
+import Juvix.Compiler.Builtins
+import Juvix.Compiler.Concrete.Data.Highlight
+import Juvix.Compiler.Concrete.Data.ParsedInfoTableBuilder.BuilderState qualified as Concrete
+import Juvix.Compiler.Concrete.Data.Scope
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoped
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
+import Juvix.Compiler.Concrete.Translation.FromSource qualified as P
+import Juvix.Compiler.Core.Data.InfoTable qualified as Core
+import Juvix.Compiler.Core.Translation.FromInternal.Data qualified as Core
+import Juvix.Compiler.Internal.Translation qualified as Internal
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.ArityChecking qualified as Arity
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking qualified as Typed
+import Juvix.Compiler.Pipeline
+import Juvix.Compiler.Pipeline.Artifacts.PathResolver
+import Juvix.Compiler.Pipeline.Loader.PathResolver
+import Juvix.Data.Effect.Git
+import Juvix.Data.Effect.Process
+import Juvix.Prelude
+
+-- | It returns `ResolverState` so that we can retrieve the `juvix.yaml` files,
+-- which we require for `Scope` tests.
+runIOEither :: forall a. EntryPoint -> Sem PipelineEff a -> IO (Either JuvixError (ResolverState, a))
+runIOEither entry = fmap snd . runIOEitherHelper entry
+
+runIOEitherTermination :: forall a. EntryPoint -> Sem (Termination ': PipelineEff) a -> IO (Either JuvixError (ResolverState, a))
+runIOEitherTermination entry = fmap snd . runIOEitherHelper entry . evalTermination iniTerminationState
+
+runPipelineHighlight :: forall a. EntryPoint -> Sem PipelineEff a -> IO HighlightInput
+runPipelineHighlight entry = fmap fst . runIOEitherHelper entry
+
+runIOEitherHelper :: forall a. EntryPoint -> Sem PipelineEff a -> IO (HighlightInput, (Either JuvixError (ResolverState, a)))
+runIOEitherHelper entry = do
+  let hasInternet = not (entry ^. entryPointOffline)
+      runPathResolver'
+        | mainIsPackageFile = runPackagePathResolver' (entry ^. entryPointResolverRoot)
+        | otherwise = runPathResolverPipe
+  runM
+    . evalInternet hasInternet
+    . runHighlightBuilder
+    . runJuvixError
+    . evalTopBuiltins
+    . evalTopNameIdGen
+    . runFilesIO
+    . runReader entry
+    . runLogIO
+    . runProcessIO
+    . mapError (JuvixError @GitProcessError)
+    . runGitProcess
+    . mapError (JuvixError @DependencyError)
+    . runPathResolver'
+  where
+    mainIsPackageFile :: Bool
+    mainIsPackageFile = case entry ^? entryPointModulePaths . _head of
+      Just p -> p == mkPackagePath (entry ^. entryPointResolverRoot)
+      Nothing -> False
+
+runIO :: GenericOptions -> EntryPoint -> Sem PipelineEff a -> IO (ResolverState, a)
+runIO opts entry = runIOEither entry >=> mayThrow
+  where
+    mayThrow :: Either JuvixError r -> IO r
+    mayThrow = \case
+      Left err -> runM . runReader opts $ printErrorAnsiSafe err >> embed exitFailure
+      Right r -> return r
+
+runIO' :: EntryPoint -> Sem PipelineEff a -> IO (ResolverState, a)
+runIO' = runIO defaultGenericOptions
+
+corePipelineIO' :: EntryPoint -> IO Artifacts
+corePipelineIO' = corePipelineIO defaultGenericOptions
+
+corePipelineIO :: GenericOptions -> EntryPoint -> IO Artifacts
+corePipelineIO opts entry = corePipelineIOEither entry >>= mayThrow
+  where
+    mayThrow :: Either JuvixError r -> IO r
+    mayThrow = \case
+      Left err -> runM . runReader opts $ printErrorAnsiSafe err >> embed exitFailure
+      Right r -> return r
+
+corePipelineIOEither ::
+  EntryPoint ->
+  IO (Either JuvixError Artifacts)
+corePipelineIOEither entry = do
+  let hasInternet = not (entry ^. entryPointOffline)
+  eith <-
+    runFinal
+      . resourceToIOFinal
+      . embedToFinal @IO
+      . evalInternet hasInternet
+      . ignoreHighlightBuilder
+      . runError
+      . runState initialArtifacts
+      . runBuiltinsArtifacts
+      . runNameIdGenArtifacts
+      . runFilesIO
+      . runReader entry
+      . runLogIO
+      . mapError (JuvixError @GitProcessError)
+      . runProcessIO
+      . runGitProcess
+      . mapError (JuvixError @DependencyError)
+      . runPathResolverArtifacts
+      $ upToCore
+  return $ case eith of
+    Left err -> Left err
+    Right (art, coreRes) ->
+      let typedResult :: Internal.InternalTypedResult
+          typedResult =
+            coreRes
+              ^. Core.coreResultInternalTypedResult
+
+          typesTable :: Typed.TypesTable
+          typesTable = typedResult ^. Typed.resultIdenTypes
+
+          functionsTable :: Typed.FunctionsTable
+          functionsTable = typedResult ^. Typed.resultFunctions
+
+          typedTable :: Internal.InfoTable
+          typedTable = typedResult ^. Typed.resultInfoTable
+
+          internalResult :: Internal.InternalResult
+          internalResult =
+            typedResult
+              ^. Typed.resultInternalArityResult
+                . Arity.resultInternalResult
+
+          coreTable :: Core.InfoTable
+          coreTable = coreRes ^. Core.coreResultTable
+
+          scopedResult :: Scoped.ScoperResult
+          scopedResult =
+            internalResult
+              ^. Internal.resultScoper
+
+          parserResult :: P.ParserResult
+          parserResult = scopedResult ^. Scoped.resultParserResult
+
+          resultScoperTable :: Scoped.InfoTable
+          resultScoperTable = scopedResult ^. Scoped.resultScoperTable
+
+          mainModuleScope_ :: Scope
+          mainModuleScope_ = Scoped.mainModuleSope scopedResult
+       in Right $
+            Artifacts
+              { _artifactMainModuleScope = Just mainModuleScope_,
+                _artifactParsing = parserResult ^. P.resultBuilderState,
+                _artifactInternalModuleCache = internalResult ^. Internal.resultModulesCache,
+                _artifactInternalTypedTable = typedTable,
+                _artifactTerminationState = typedResult ^. Typed.resultTermination,
+                _artifactCoreTable = coreTable,
+                _artifactScopeTable = resultScoperTable,
+                _artifactScopeExports = scopedResult ^. Scoped.resultExports,
+                _artifactTypes = typesTable,
+                _artifactFunctions = functionsTable,
+                _artifactScoperState = scopedResult ^. Scoped.resultScoperState,
+                _artifactResolver = art ^. artifactResolver,
+                _artifactBuiltins = art ^. artifactBuiltins,
+                _artifactNameIdState = art ^. artifactNameIdState
+              }
+  where
+    initialArtifacts :: Artifacts
+    initialArtifacts =
+      Artifacts
+        { _artifactParsing = Concrete.iniState,
+          _artifactMainModuleScope = Nothing,
+          _artifactInternalTypedTable = mempty,
+          _artifactTypes = mempty,
+          _artifactTerminationState = iniTerminationState,
+          _artifactResolver = iniResolverState,
+          _artifactNameIdState = allNameIds,
+          _artifactFunctions = mempty,
+          _artifactCoreTable = Core.emptyInfoTable,
+          _artifactScopeTable = Scoped.emptyInfoTable,
+          _artifactBuiltins = iniBuiltins,
+          _artifactScopeExports = mempty,
+          _artifactInternalModuleCache = Internal.ModulesCache mempty,
+          _artifactScoperState = Scoper.iniScoperState
+        }

--- a/test/Base.hs
+++ b/test/Base.hs
@@ -5,14 +5,16 @@ module Base
     module Base,
     module Juvix.Extra.Paths,
     module Juvix.Prelude.Env,
-    module Juvix.Compiler.Pipeline,
+    module Juvix.Compiler.Pipeline.Run,
+    module Juvix.Compiler.Pipeline.EntryPoint.IO,
   )
 where
 
 import Control.Monad.Extra as Monad
 import Data.Algorithm.Diff
 import Data.Algorithm.DiffOutput
-import Juvix.Compiler.Pipeline
+import Juvix.Compiler.Pipeline.EntryPoint.IO
+import Juvix.Compiler.Pipeline.Run
 import Juvix.Extra.Paths
 import Juvix.Prelude hiding (assert)
 import Juvix.Prelude.Env

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -10,7 +10,7 @@ import Juvix.Compiler.Concrete.Print qualified as P
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
-import Juvix.Compiler.Pipeline.Loader.PathResolver
+import Juvix.Compiler.Pipeline.Package.Loader.PathResolver
 import Juvix.Compiler.Pipeline.Setup
 import Juvix.Data.Effect.Git
 import Juvix.Data.Effect.Process


### PR DESCRIPTION
Depends on:
*  https://github.com/anoma/juvix/pull/2451

This PR is part of a series implementing:
* https://github.com/anoma/juvix/issues/2336

In attempt to make the main PR:
* https://github.com/anoma/juvix/pull/2434
easier to review.

Changes in this PR refactor EntryPoint, Package, Pipeline, Root, splitting out the types into Base modules so that they can be imported and used in subsequent PRs with fewer dependencies to avoid package cycles.