### PR TITLE
Use with-utf8 to manage setting a compatible terminal locale

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,11 +7,12 @@ import CommonOptions
 import Data.String.Interpolate (i)
 import GlobalOptions
 import Juvix.Compiler.Pipeline.Root
+import Main.Utf8 (withUtf8)
 import TopCommand
 import TopCommand.Options
 
 main :: IO ()
-main = do
+main = withUtf8 $ do
   let parserPreferences = prefs showHelpOnEmpty
   invokeDir <- getCurrentDir
   (_runAppIOArgsGlobalOptions, cli) <- customExecParser parserPreferences descr

--- a/package.yaml
+++ b/package.yaml
@@ -88,6 +88,7 @@ dependencies:
   - unordered-containers == 0.2.*
   - utf8-string == 1.0.*
   - versions == 6.0.*
+  - with-utf8 == 1.0.*
   - xdg-basedir == 0.2.*
   - yaml == 0.11.*
 


### PR DESCRIPTION
See: https://serokell.io/blog/haskell-with-utf8 for motivation for this library.

This is an attempt to fix:
* https://github.com/anoma/juvix/issues/2430