### PR TITLE
Use system locale independent readFile and writeFile APIs from with-utf8

### DIFF
--- a/app/Commands/Dev/Asm/Compile.hs
+++ b/app/Commands/Dev/Asm/Compile.hs
@@ -19,7 +19,7 @@ runCommand opts = do
           { _entryPointTarget = tgt,
             _entryPointDebug = opts ^. compileDebug
           }
-  s <- embed (readFile (toFilePath file))
+  s <- readFile (toFilePath file)
   case Asm.runParser (toFilePath file) s of
     Left err -> exitJuvixError (JuvixError err)
     Right tab -> do

--- a/app/Commands/Dev/Asm/Run.hs
+++ b/app/Commands/Dev/Asm/Run.hs
@@ -8,7 +8,7 @@ import Juvix.Compiler.Asm.Translation.FromSource qualified as Asm
 runCommand :: forall r. (Members '[Embed IO, App] r) => AsmRunOptions -> Sem r ()
 runCommand opts = do
   afile :: Path Abs File <- fromAppPathFile file
-  s <- embed (readFile (toFilePath afile))
+  s <- readFile (toFilePath afile)
   case Asm.runParser (toFilePath afile) s of
     Left err -> exitJuvixError (JuvixError err)
     Right tab -> runAsm (not (opts ^. asmRunNoValidate)) tab

--- a/app/Commands/Dev/Asm/Validate.hs
+++ b/app/Commands/Dev/Asm/Validate.hs
@@ -9,7 +9,7 @@ import Juvix.Compiler.Asm.Translation.FromSource qualified as Asm
 runCommand :: forall r. (Members '[Embed IO, App] r) => AsmValidateOptions -> Sem r ()
 runCommand opts = do
   afile :: Path Abs File <- fromAppPathFile file
-  s <- embed (readFile (toFilePath afile))
+  s <- readFile (toFilePath afile)
   case Asm.runParser (toFilePath afile) s of
     Left err -> exitJuvixError (JuvixError err)
     Right tab -> do

--- a/app/Commands/Dev/Core/Asm.hs
+++ b/app/Commands/Dev/Core/Asm.hs
@@ -11,7 +11,7 @@ runCommand :: forall r a. (Members '[Embed IO, App] r, CanonicalProjection a Cor
 runCommand opts = do
   gopts <- askGlobalOptions
   inputFile :: Path Abs File <- fromAppPathFile sinputFile
-  s' <- embed (readFile $ toFilePath inputFile)
+  s' <- readFile $ toFilePath inputFile
   tab <- getRight (mapLeft JuvixError (Core.runParserMain inputFile Core.emptyInfoTable s'))
   r <- runReader (project @GlobalOptions @Core.CoreOptions gopts) $ runError @JuvixError $ Core.toStripped' tab
   tab' <- Asm.fromCore . Stripped.fromCore <$> getRight r

--- a/app/Commands/Dev/Core/Compile.hs
+++ b/app/Commands/Dev/Core/Compile.hs
@@ -9,7 +9,7 @@ import Juvix.Compiler.Core.Translation.FromSource qualified as Core
 runCommand :: forall r. (Members '[Embed IO, App] r) => CompileOptions -> Sem r ()
 runCommand opts = do
   file <- getFile
-  s <- embed (readFile (toFilePath file))
+  s <- readFile (toFilePath file)
   tab <- getRight (mapLeft JuvixError (Core.runParserMain file Core.emptyInfoTable s))
   let arg = PipelineArg opts file tab
   case opts ^. compileTarget of

--- a/app/Commands/Dev/Core/Eval.hs
+++ b/app/Commands/Dev/Core/Eval.hs
@@ -9,7 +9,7 @@ import Juvix.Compiler.Core.Translation.FromSource qualified as Core
 runCommand :: forall r. (Members '[Embed IO, App] r) => CoreEvalOptions -> Sem r ()
 runCommand opts = do
   f :: Path Abs File <- fromAppPathFile b
-  s <- embed (readFile (toFilePath f))
+  s <- readFile (toFilePath f)
   case Core.runParser f Core.emptyInfoTable s of
     Left err -> exitJuvixError (JuvixError err)
     Right (tab, Just node) -> do evalAndPrint opts tab node

--- a/app/Commands/Dev/Core/Normalize.hs
+++ b/app/Commands/Dev/Core/Normalize.hs
@@ -9,7 +9,7 @@ import Juvix.Compiler.Core.Translation.FromSource qualified as Core
 runCommand :: forall r. (Members '[Embed IO, App] r) => CoreNormalizeOptions -> Sem r ()
 runCommand opts = do
   f :: Path Abs File <- fromAppPathFile b
-  s <- embed (readFile (toFilePath f))
+  s <- readFile (toFilePath f)
   case Core.runParser f Core.emptyInfoTable s of
     Left err -> exitJuvixError (JuvixError err)
     Right (tab, Just node) -> do normalizeAndPrint opts tab node

--- a/app/Commands/Dev/Core/Read.hs
+++ b/app/Commands/Dev/Core/Read.hs
@@ -22,7 +22,7 @@ runCommand ::
 runCommand opts = do
   gopts <- askGlobalOptions
   inputFile :: Path Abs File <- fromAppPathFile sinputFile
-  s' <- embed . readFile . toFilePath $ inputFile
+  s' <- readFile . toFilePath $ inputFile
   tab <- getRight (mapLeft JuvixError (Core.runParserMain inputFile Core.emptyInfoTable s'))
   let r = run $ runReader (project @GlobalOptions @Core.CoreOptions gopts) $ runError @JuvixError $ Core.applyTransformations (project opts ^. coreReadTransformations) tab
   tab0 <- getRight $ mapLeft JuvixError r

--- a/app/Commands/Dev/Core/Repl.hs
+++ b/app/Commands/Dev/Core/Repl.hs
@@ -74,7 +74,7 @@ runRepl opts tab = do
           Right (tab', Nothing) ->
             runRepl opts tab'
       ':' : 'l' : ' ' : f -> do
-        s' <- embed (readFile f)
+        s' <- readFile f
         sf <- someBaseToAbs' (someFile f)
         case Core.runParser sf Core.emptyInfoTable s' of
           Left err -> do

--- a/app/Commands/Dev/Core/Strip.hs
+++ b/app/Commands/Dev/Core/Strip.hs
@@ -12,7 +12,7 @@ runCommand :: forall r a. (Members '[Embed IO, App] r, CanonicalProjection a Cor
 runCommand opts = do
   gopts <- askGlobalOptions
   inputFile :: Path Abs File <- fromAppPathFile sinputFile
-  s' <- embed (readFile $ toFilePath inputFile)
+  s' <- readFile $ toFilePath inputFile
   (tab, _) <- getRight (mapLeft JuvixError (Core.runParser inputFile Core.emptyInfoTable s'))
   let r =
         run $

--- a/app/Commands/Dev/Geb/Check.hs
+++ b/app/Commands/Dev/Geb/Check.hs
@@ -14,7 +14,7 @@ runCommand opts = do
   let b :: AppPath File
       b = opts ^. gebInferOptionsInputFile
   f :: Path Abs File <- fromAppPathFile b
-  content :: Text <- embed (readFile (toFilePath f))
+  content :: Text <- readFile (toFilePath f)
   case Geb.runParser f content of
     Right (Geb.ExpressionMorphism morph) -> do
       case Geb.inferObject' morph of

--- a/app/Commands/Dev/Geb/Eval.hs
+++ b/app/Commands/Dev/Geb/Eval.hs
@@ -19,7 +19,7 @@ runCommand opts = do
   let b :: AppPath File
       b = project opts ^. gebEvalOptionsInputFile
   f :: Path Abs File <- fromAppPathFile b
-  content :: Text <- embed (readFile (toFilePath f))
+  content :: Text <- readFile (toFilePath f)
   case Geb.runParser f content of
     Left err -> exitJuvixError (JuvixError err)
     Right gebTerm -> do

--- a/app/Commands/Dev/Geb/Infer.hs
+++ b/app/Commands/Dev/Geb/Infer.hs
@@ -13,7 +13,7 @@ runCommand opts = do
   let b :: AppPath File
       b = opts ^. gebInferOptionsInputFile
   f :: Path Abs File <- fromAppPathFile b
-  content :: Text <- embed (readFile (toFilePath f))
+  content :: Text <- readFile (toFilePath f)
   case Geb.runParser f content of
     Right (Geb.ExpressionMorphism gebTerm) ->
       case Geb.inferObject' gebTerm of

--- a/app/Commands/Dev/Geb/Read.hs
+++ b/app/Commands/Dev/Geb/Read.hs
@@ -14,7 +14,7 @@ runCommand opts = do
   let b :: AppPath File
       b = opts ^. gebReadOptionsInputFile
   f :: Path Abs File <- fromAppPathFile b
-  content :: Text <- embed (readFile (toFilePath f))
+  content :: Text <- readFile (toFilePath f)
   case Geb.runParser f content of
     Left err -> exitJuvixError (JuvixError err)
     Right gebTerm -> do

--- a/package.yaml
+++ b/package.yaml
@@ -88,6 +88,7 @@ dependencies:
   - unordered-containers == 0.2.*
   - utf8-string == 1.0.*
   - versions == 6.0.*
+  - with-utf8 == 1.0.*
   - xdg-basedir == 0.2.*
   - yaml == 0.11.*
 

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -42,6 +42,7 @@ module Juvix.Prelude.Base
     module Data.String,
     module Data.Text.Encoding,
     module Data.Text.IO,
+    module Data.Text.IO.Utf8,
     module Data.Traversable,
     module Data.Tuple.Extra,
     module Data.Typeable,
@@ -144,7 +145,8 @@ import Data.String
 import Data.Text (Text, pack, strip, unpack)
 import Data.Text qualified as Text
 import Data.Text.Encoding
-import Data.Text.IO
+import Data.Text.IO hiding (appendFile, readFile, writeFile)
+import Data.Text.IO.Utf8
 import Data.Traversable
 import Data.Tuple.Extra hiding (both)
 import Data.Type.Equality (type (~))


### PR DESCRIPTION
The problem with readFile and writeFile from text [Data.Text.IO](https://hackage.haskell.org/package/text-2.0.2/docs/Data-Text-IO.html) is that they use the system locale to determine the text encoding format.

Our assumption is that all Juvix source files are UTF-8 encoded.

I cannot reproduce the issue with using the old APIs on my machine, it can be reproduced on Arch linux. I'm not sure how to write a specific test for this.

* Closes https://github.com/anoma/juvix/issues/2472