### PR TITLE
Use a versioned documentation link in the doctor output

### DIFF
--- a/app/Commands/Doctor.hs
+++ b/app/Commands/Doctor.hs
@@ -57,7 +57,7 @@ documentedMessage w = uncurry DocumentedMessage (first (baseUrl <>) warningInfo)
       NoWasmer -> ("could-not-find-the-wasmer-command", "Could not find the wasmer command")
 
     baseUrl :: Text
-    baseUrl = "https://docs.juvix.org/dev/reference/tooling/doctor/#"
+    baseUrl = "https://docs.juvix.org/" <> V.versionDoc <> "/reference/tooling/doctor/#"
 
 heading :: (Member Log r) => Text -> Sem r ()
 heading = log . ("> " <>)


### PR DESCRIPTION
Previously the doctor help links would point to the Juvix documentation dev URLs.

Now the doctor help links point to the version of the documentation corresponding to the compiler version.

```
$ juvix doctor
> Checking for clang...
> Checking clang version...
> Checking for wasm-ld...
> Checking that clang supports wasm32...
> Checking that clang supports wasm32-wasi...
> Checking that WASI_SYSROOT_PATH is set...
  ! Environment variable WASI_SYSROOT_PATH is missing
  ! https://docs.juvix.org/0.5.2/reference/tooling/doctor/#environment-variable-wasi_sysroot_path-is-not-set
> Checking for wasmer...
> Checking latest Juvix release on Github...
```

Spotted by @agureev 