### PR TITLE
Format long list literals by splitting using pre-comma multiline

### DIFF
--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -266,8 +266,8 @@ instance (SingI s) => PrettyPrint (List s) where
   ppCode List {..} = do
     let l = ppCode _listBracketL
         r = ppCode _listBracketR
-        e = hsepSemicolon (map ppExpressionType _listItems)
-    l <> e <> r
+        es = vcatPreSemicolon (map ppExpressionType _listItems)
+    grouped (align (l <> spaceOrEmpty <> es <> lineOrEmpty <> r))
 
 instance (SingI s) => PrettyPrint (NamedArgument s) where
   ppCode NamedArgument {..} = do

--- a/src/Juvix/Data/Effect/ExactPrint.hs
+++ b/src/Juvix/Data/Effect/ExactPrint.hs
@@ -68,6 +68,9 @@ doubleBraces = enclose (enqueue C.kwDoubleBraceL) (noLoc C.kwDoubleBraceR)
 lineOrEmpty :: (Members '[ExactPrint] r) => Sem r ()
 lineOrEmpty = noLoc P.line'
 
+spaceOrEmpty :: (Members '[ExactPrint] r) => Sem r ()
+spaceOrEmpty = noLoc P.spaceOrEmpty
+
 grouped :: (Members '[ExactPrint] r) => Sem r () -> Sem r ()
 grouped = region P.group
 
@@ -109,6 +112,9 @@ sepSemicolon = grouped . vsepSemicolon
 
 vsepSemicolon :: (Members '[ExactPrint] r, Foldable l) => l (Sem r ()) -> Sem r ()
 vsepSemicolon = sequenceWith (semicolon <> line)
+
+vcatPreSemicolon :: (Members '[ExactPrint] r, Foldable l) => l (Sem r ()) -> Sem r ()
+vcatPreSemicolon = sequenceWith (lineOrEmpty <> semicolon <> space)
 
 hsepSemicolon :: (Members '[ExactPrint] r, Foldable l) => l (Sem r ()) -> Sem r ()
 hsepSemicolon = sequenceWith (semicolon <> space)

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -10,7 +10,6 @@ import Data.Text qualified as Text
 import Juvix.Prelude.Base
 import Prettyprinter hiding (concatWith, defaultLayoutOptions, hsep, sep, vsep)
 import Prettyprinter qualified as PP
-import Prettyprinter.Internal.Type
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import Prettyprinter.Render.Terminal qualified as Ansi
 import Prettyprinter.Render.Text qualified as Text
@@ -168,7 +167,7 @@ hang' :: Doc ann -> Doc ann
 hang' = hang 2
 
 spaceOrEmpty :: Doc ann
-spaceOrEmpty = FlatAlt (Char ' ') mempty
+spaceOrEmpty = flatAlt (pretty ' ') mempty
 
 oneLineOrNext :: Doc ann -> Doc ann
 oneLineOrNext x = PP.group (flatAlt (line <> indent' x) (space <> x))

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -10,6 +10,7 @@ import Data.Text qualified as Text
 import Juvix.Prelude.Base
 import Prettyprinter hiding (concatWith, defaultLayoutOptions, hsep, sep, vsep)
 import Prettyprinter qualified as PP
+import Prettyprinter.Internal.Type
 import Prettyprinter.Render.Terminal (AnsiStyle)
 import Prettyprinter.Render.Terminal qualified as Ansi
 import Prettyprinter.Render.Text qualified as Text
@@ -165,6 +166,9 @@ indent' = indent 2
 
 hang' :: Doc ann -> Doc ann
 hang' = hang 2
+
+spaceOrEmpty :: Doc ann
+spaceOrEmpty = FlatAlt (Char ' ') mempty
 
 oneLineOrNext :: Doc ann -> Doc ann
 oneLineOrNext x = PP.group (flatAlt (line <> indent' x) (space <> x))

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -356,14 +356,14 @@ l1 : List Int :=
 
 l2 : List Int := [1; 2; 3];
 
-l3 : List Int :=
+l3 : List (List Int) :=
   [ [1; 2; 3]
   ; longLongLongListArg
   ; longLongLongListArg
   ; longLongLongListArg
   ];
 
-l4 : List Int :=
+l4 : List (List Int) :=
   [ [1; 2; 3]
   ; longLongLongListArg
   ; [ longLongLongListArg

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -341,4 +341,37 @@ module OperatorRecord;
     in n + m * m;
 end;
 
+longLongLongArg : Int := 0;
+
+longLongLongListArg : List Int := [];
+
+l1 : List Int :=
+  [ 1
+  ; 2
+  ; longLongLongArg
+  ; longLongLongArg
+  ; longLongLongArg
+  ; longLongLongArg
+  ];
+
+l2 : List Int := [1; 2; 3];
+
+l3 : List Int :=
+  [ [1; 2; 3]
+  ; longLongLongListArg
+  ; longLongLongListArg
+  ; longLongLongListArg
+  ];
+
+l4 : List Int :=
+  [ [1; 2; 3]
+  ; longLongLongListArg
+  ; [ longLongLongListArg
+    ; longLongLongListArg
+    ; longLongLongListArg
+    ; longLongLongListArg
+    ]
+  ; longLongLongListArg
+  ];
+
 -- Comment at the end of a module

--- a/tests/positive/package/Package.juvix
+++ b/tests/positive/package/Package.juvix
@@ -7,10 +7,9 @@ package : Package :=
   defaultPackage
     {name := "foo";
      version := mkVersion 0 1 0;
-     dependencies := [github
-       "anoma"
-       "juvix-stdlib"
-       "adf58a7180b361a022fb53c22ad9e5274ebf6f66"; github
-       "anoma"
-       "juvix-containers"
-       "v0.7.1"]};
+     dependencies := [ github
+                       "anoma"
+                       "juvix-stdlib"
+                       "adf58a7180b361a022fb53c22ad9e5274ebf6f66"
+                     ; github "anoma" "juvix-containers" "v0.7.1"
+                     ]};


### PR DESCRIPTION
### Example of nested list formatting using the new method:

```
l : List (List Int) :=
  [ [1; 2; 3]
  ; longLongLongListArg
  ; [ longLongLongListArg
    ; longLongLongListArg
    ; longLongLongListArg
    ; longLongLongListArg
    ]
  ; longLongLongListArg
  ];
```

* Closes https://github.com/anoma/juvix/issues/2466