### PR TITLE
Version the PackageDescription module

### DIFF
--- a/include/package/PackageDescription/V1.juvix
+++ b/include/package/PackageDescription/V1.juvix
@@ -1,4 +1,4 @@
-module PackageDescription;
+module PackageDescription.V1;
 
 import Stdlib.Prelude open;
 

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff.hs
@@ -13,7 +13,7 @@ makeLenses ''TypeSpec
 data EvalEff m a where
   Eval' :: Node -> EvalEff m Value
   LookupIdentifier :: Text -> EvalEff m Node
-  -- | Assert that the Node has a type given by one of the ;TypeSpec;s
+  -- | Assert that the Node has a type given by one of the 'TypeSpec's
   AssertNodeType :: (Foldable f) => Node -> f TypeSpec -> EvalEff m ()
 
 makeSem ''EvalEff

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff.hs
@@ -13,7 +13,8 @@ makeLenses ''TypeSpec
 data EvalEff m a where
   Eval' :: Node -> EvalEff m Value
   LookupIdentifier :: Text -> EvalEff m Node
-  AssertNodeType :: Node -> TypeSpec -> EvalEff m ()
+  -- | Assert that the Node has a type given by one of the ;TypeSpec;s
+  AssertNodeType :: (Foldable f) => Node -> f TypeSpec -> EvalEff m ()
 
 makeSem ''EvalEff
 

--- a/src/Juvix/Extra/Paths/Base.hs
+++ b/src/Juvix/Extra/Paths/Base.hs
@@ -38,11 +38,8 @@ juvixLockfile = $(mkRelFile "juvix.lock.yaml")
 packageDescriptionDir :: Path Rel Dir
 packageDescriptionDir = $(mkRelDir "include/package")
 
-packageDescriptionFile :: Path Rel File
-packageDescriptionFile = packageDescriptionDir <//> packageDescriptionFilename
-
-packageDescriptionFilename :: Path Rel File
-packageDescriptionFilename = $(mkRelFile "PackageDescription.juvix")
+v1PackageDescriptionFile :: Path Rel File
+v1PackageDescriptionFile = $(mkRelFile "PackageDescription/V1.juvix")
 
 packageFilePath :: Path Rel File
 packageFilePath = $(mkRelFile "Package.juvix")

--- a/tests/negative/Package/PackageJuvixDuplicateDependencies/Package.juvix
+++ b/tests/negative/Package/PackageJuvixDuplicateDependencies/Package.juvix
@@ -1,7 +1,7 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Package := defaultPackage {name := "abc"; version := mkVersion 0 0 1 ; dependencies := [ github "org" "repo" "ref1" ; github "org" "repo" "ref2" ]};
 

--- a/tests/negative/Package/PackageJuvixNoPackageSymbol/Package.juvix
+++ b/tests/negative/Package/PackageJuvixNoPackageSymbol/Package.juvix
@@ -1,6 +1,6 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 abc : Nat := 1;

--- a/tests/negative/Package/PackageJuvixPackageSymbolWrongType1/Package.juvix
+++ b/tests/negative/Package/PackageJuvixPackageSymbolWrongType1/Package.juvix
@@ -1,6 +1,6 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Nat := 1;

--- a/tests/positive/PackageLoader/PackageJuvix/Package.juvix
+++ b/tests/positive/PackageLoader/PackageJuvix/Package.juvix
@@ -1,7 +1,7 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Package :=
   defaultPackage {name := "package-juvix"};

--- a/tests/positive/PackageLoader/PackageJuvixAndYaml/Package.juvix
+++ b/tests/positive/PackageLoader/PackageJuvixAndYaml/Package.juvix
@@ -1,7 +1,7 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Package :=
   defaultPackage {name := "package-juvix"};

--- a/tests/positive/PackageLoader/PackageJuvixEmptyDependencies/Package.juvix
+++ b/tests/positive/PackageLoader/PackageJuvixEmptyDependencies/Package.juvix
@@ -1,7 +1,7 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Package :=
   defaultPackage {name := "package-juvix"; dependencies := []};

--- a/tests/positive/PackageLoader/PackageJuvixNoDependencies/Package.juvix
+++ b/tests/positive/PackageLoader/PackageJuvixNoDependencies/Package.juvix
@@ -1,7 +1,7 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Package :=
   defaultPackage {name := "package-juvix"};

--- a/tests/positive/PackageLoader/PackageJuvixUsesLockfile/Package.juvix
+++ b/tests/positive/PackageLoader/PackageJuvixUsesLockfile/Package.juvix
@@ -1,7 +1,7 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Package :=
   defaultPackage

--- a/tests/positive/package/Package.juvix
+++ b/tests/positive/package/Package.juvix
@@ -1,7 +1,7 @@
 module Package;
 
 import Stdlib.Prelude open;
-import PackageDescription open;
+import PackageDescription.V1 open;
 
 package : Package :=
   defaultPackage

--- a/tests/smoke/Commands/compile-dependencies-package-juvix.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies-package-juvix.smoke.yaml
@@ -35,7 +35,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -101,7 +101,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -171,7 +171,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -218,7 +218,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -280,7 +280,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -305,7 +305,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -417,7 +417,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -463,7 +463,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -528,7 +528,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -561,7 +561,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -636,7 +636,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -674,7 +674,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -738,7 +738,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -822,7 +822,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -860,7 +860,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -911,7 +911,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -958,7 +958,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -1005,7 +1005,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -1074,7 +1074,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -1127,7 +1127,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage
@@ -1192,7 +1192,7 @@ tests:
         module Package;
 
         import Stdlib.Prelude open;
-        import PackageDescription open;
+        import PackageDescription.V1 open;
 
         package : Package :=
           defaultPackage


### PR DESCRIPTION
This PR adds a version number to the module name of the `PackageDescription` module. This allows us to change the Package file format in a backwards compatible way in the future.

Now the simplest Package.juvix file looks like:

```
module Package;

import PackageDescription.V1 open;

package : Package := defaultPackage;
```

## Adding new versions

The idea is that new versions of the PackageDescription format will be
added as files of the form:
include/package/PackageDescription/Vx.juvix

The correspondence between a version of the PackageDescription file and the package type name is recorded in [`packageDescriptionTypes`](https://github.com/anoma/juvix/blob/9ba869d836f9f4a6bf678bee65838594fbd8613a/src/Juvix/Compiler/Pipeline/Package/Loader.hs#L15).

The `package` identifier type must come from **one** of the versions
of the PackageDescription module.

* Closes https://github.com/anoma/juvix/issues/2452