### PR TITLE
Update juvix init to generate Package.juvix instead of juvix.yaml

### DIFF
--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -30,6 +30,7 @@ init = do
   pkg <- getPackage
   say ("creating " <> pack (toFilePath packageFilePath))
   embed (Utf8.writeFile @IO (toFilePath packageFilePath) (renderPackage pkg))
+  checkPackage
   say "you are all set"
   where
     renderPackage :: Package -> Text
@@ -43,6 +44,16 @@ checkNotInProject =
     err = do
       say "You are already in a Juvix project"
       embed exitFailure
+
+checkPackage :: forall r. (Members '[Embed IO] r) => Sem r ()
+checkPackage = do
+  cwd <- getCurrentDir
+  ep <- runError @JuvixError (readPackageIO' cwd DefaultBuildDir)
+  case ep of
+    Left {} -> do
+      say "Package.juvix is invalid. Please raise an issue at https://github.com/anoma/juvix/issues"
+      embed exitFailure
+    Right {} -> return ()
 
 getPackage :: forall r. (Members '[Embed IO] r) => Sem r Package
 getPackage = do

--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -1,7 +1,7 @@
 module Commands.Init where
 
 import Data.Text qualified as Text
-import Data.Text.IO.Utf8 qualified as Text
+import Data.Text.IO.Utf8 qualified as Utf8
 import Data.Versions
 import Juvix.Compiler.Concrete.Print (ppOutDefaultNoComments)
 import Juvix.Compiler.Pipeline.Package
@@ -29,7 +29,7 @@ init = do
   say "I will help you set it up"
   pkg <- getPackage
   say ("creating " <> pack (toFilePath packageFilePath))
-  embed (Text.writeFile @IO (toFilePath packageFilePath) (renderPackage pkg))
+  embed (Utf8.writeFile @IO (toFilePath packageFilePath) (renderPackage pkg))
   say "you are all set"
   where
     renderPackage :: Package -> Text

--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -48,7 +48,7 @@ checkNotInProject =
 checkPackage :: forall r. (Members '[Embed IO] r) => Sem r ()
 checkPackage = do
   cwd <- getCurrentDir
-  ep <- runError @JuvixError (readPackageIO' cwd DefaultBuildDir)
+  ep <- runError @JuvixError (loadPackageFileIO cwd DefaultBuildDir)
   case ep of
     Left {} -> do
       say "Package.juvix is invalid. Please raise an issue at https://github.com/anoma/juvix/issues"

--- a/src/Juvix/Compiler/Concrete/Gen.hs
+++ b/src/Juvix/Compiler/Concrete/Gen.hs
@@ -28,3 +28,86 @@ smallUniverseExpression = do
         { _expressionAtomsLoc = Irrelevant loc,
           _expressionAtoms = pure (AtomUniverse (smallUniverse loc))
         }
+
+symbol :: (Member (Reader Interval) r) => Text -> Sem r Symbol
+symbol t = do
+  l <- ask
+  return (WithLoc l t)
+
+expressionAtoms' :: (Member (Reader Interval) r) => NonEmpty (ExpressionAtom 'Parsed) -> Sem r (ExpressionAtoms 'Parsed)
+expressionAtoms' _expressionAtoms = do
+  _expressionAtomsLoc <- Irrelevant <$> ask
+  return ExpressionAtoms {..}
+
+namedArgument :: (Member (Reader Interval) r) => Text -> NonEmpty (ExpressionAtom 'Parsed) -> Sem r (NamedArgument 'Parsed)
+namedArgument n as = do
+  _namedArgValue <- expressionAtoms' as
+  _namedArgName <- symbol n
+  _namedArgAssignKw <- Irrelevant <$> kw kwAssign
+  return NamedArgument {..}
+
+literalString :: (Member (Reader Interval) r) => Text -> Sem r (ExpressionAtom s)
+literalString t = do
+  l <- ask
+  return (AtomLiteral (WithLoc l (LitString t)))
+
+identifier :: (Member (Reader Interval) r) => Text -> Sem r (ExpressionAtom 'Parsed)
+identifier = fmap (AtomIdentifier . NameUnqualified) . symbol
+
+braced :: (Member (Reader Interval) r) => NonEmpty (ExpressionAtom 'Parsed) -> Sem r (ExpressionAtom 'Parsed)
+braced a = do
+  l <- ask
+  AtomBraces . WithLoc l <$> expressionAtoms' a
+
+argumentBlock :: (Member (Reader Interval) r) => IsImplicit -> NonEmpty (NamedArgument 'Parsed) -> Sem r (ArgumentBlock 'Parsed)
+argumentBlock i as = do
+  parenL <- kw delimL
+  parenR <- kw delimR
+  return
+    ArgumentBlock
+      { _argBlockImplicit = i,
+        _argBlockDelims = Irrelevant (Just (parenL, parenR)),
+        _argBlockArgs = as
+      }
+  where
+    delimL :: Keyword
+    delimL = case i of
+      Explicit -> kwBracketL
+      Implicit -> delimBraceL
+      ImplicitInstance -> delimDoubleBraceL
+
+    delimR :: Keyword
+    delimR = case i of
+      Explicit -> kwBracketR
+      Implicit -> delimBraceR
+      ImplicitInstance -> delimDoubleBraceR
+
+namedApplication :: Name -> NonEmpty (ArgumentBlock 'Parsed) -> ExpressionAtom 'Parsed
+namedApplication n as =
+  AtomNamedApplication
+    NamedApplication
+      { _namedAppName = n,
+        _namedAppArgs = as
+      }
+
+literalInteger :: (Member (Reader Interval) r, Integral a) => a -> Sem r (ExpressionAtom 'Parsed)
+literalInteger a = do
+  l <- ask
+  return (AtomLiteral (WithLoc l (LitInteger (toInteger a))))
+
+mkList :: (Member (Reader Interval) r) => [NonEmpty (ExpressionAtom 'Parsed)] -> Sem r (ExpressionAtom 'Parsed)
+mkList as = do
+  items <- mapM expressionAtoms' as
+  parenR <- Irrelevant <$> kw kwBracketR
+  parenL <- Irrelevant <$> kw kwBracketL
+  return
+    ( AtomList
+        List
+          { _listItems = items,
+            _listBracketR = parenR,
+            _listBracketL = parenL
+          }
+    )
+
+functionDefExpression :: (Member (Reader Interval) r) => NonEmpty (ExpressionAtom 'Parsed) -> Sem r (FunctionDefBody 'Parsed)
+functionDefExpression exp = SigBodyExpression <$> expressionAtoms' exp

--- a/src/Juvix/Compiler/Concrete/Print.hs
+++ b/src/Juvix/Compiler/Concrete/Print.hs
@@ -11,6 +11,9 @@ import Juvix.Data.Effect.ExactPrint
 import Juvix.Data.PPOutput
 import Juvix.Prelude
 
+ppOutDefaultNoComments :: (PrettyPrint c) => c -> AnsiText
+ppOutDefaultNoComments = mkAnsiText . PPOutput . docNoComments defaultOptions
+
 ppOutDefault :: (HasLoc c, PrettyPrint c) => Comments -> c -> AnsiText
 ppOutDefault cs = mkAnsiText . PPOutput . doc defaultOptions cs
 

--- a/src/Juvix/Compiler/Pipeline/Package/Loader.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader.hs
@@ -1,31 +1,165 @@
 module Juvix.Compiler.Pipeline.Package.Loader where
 
 import Data.FileEmbed qualified as FE
+import Data.List.NonEmpty qualified as NEL
+import Data.Text qualified as T
 import Data.Versions
-import Juvix.Compiler.Core.Language
+import Juvix.Compiler.Concrete.Language
+import Juvix.Compiler.Concrete.Translation.FromSource
+import Juvix.Compiler.Concrete.Translation.FromSource.Lexer
+import Juvix.Compiler.Core.Language qualified as Core
 import Juvix.Compiler.Core.Language.Value
 import Juvix.Compiler.Pipeline.Package.Base
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Extra.Paths
 import Juvix.Extra.Strings qualified as Str
-import Language.Haskell.TH.Syntax
+import Juvix.Prelude
+import Language.Haskell.TH.Syntax hiding (Module)
+import System.FilePath qualified as FP
+
+data PackageDescriptionType = PackageDescriptionType
+  { _packageDescriptionTypePath :: Path Rel File,
+    _packageDescriptionTypeName :: Text,
+    _packageDescriptionTypeTransform :: Package -> FunctionDefBody 'Parsed,
+    _packageDescriptionTypeNeedsStdlibImport :: Package -> Bool
+  }
+
+makeLenses ''PackageDescriptionType
+
+v1PackageDescriptionType :: PackageDescriptionType
+v1PackageDescriptionType = PackageDescriptionType v1PackageDescriptionFile "Package" fromPackage needsStdlib
+  where
+    needsStdlib :: Package -> Bool
+    needsStdlib p =
+      let SemVer {..} = p ^. packageVersion
+       in isJust _svMeta || isJust _svPreRel
+
+    fromPackage :: Package -> FunctionDefBody 'Parsed
+    fromPackage p =
+      SigBodyExpression
+        ExpressionAtoms
+          { _expressionAtomsLoc = Irrelevant l,
+            _expressionAtoms =
+              AtomNamedApplication
+                NamedApplication
+                  { _namedAppName = NameUnqualified (mkSymbol "defaultPackage"),
+                    _namedAppArgs =
+                      ArgumentBlock
+                        { _argBlockImplicit = Implicit,
+                          _argBlockDelims = Irrelevant (Just (mkKeywordRef delimBraceL, mkKeywordRef delimBraceR)),
+                          _argBlockArgs = mkNamedArgs
+                        }
+                        :| []
+                  }
+                :| []
+          }
+      where
+        l :: Interval
+        l = singletonInterval (mkInitialLoc (p ^. packageFile))
+
+        mkSymbol :: Text -> Symbol
+        mkSymbol = WithLoc l
+
+        mkKeywordRef :: Keyword -> KeywordRef
+        mkKeywordRef k =
+          KeywordRef
+            { _keywordRefUnicode = Ascii,
+              _keywordRefKeyword = k,
+              _keywordRefInterval = l
+            }
+
+        mkNamedArgs :: NonEmpty (NamedArgument 'Parsed)
+        mkNamedArgs = mkNameArg :| [mkVersionArg]
+          where
+            mkNameArg :: NamedArgument 'Parsed
+            mkNameArg = mkNamedArg "name" ((mkLitText (p ^. packageName)) :| [])
+
+            mkLitText :: Text -> ExpressionAtom 'Parsed
+            mkLitText = AtomLiteral . WithLoc l . LitString
+
+            mkIdentifier :: Text -> ExpressionAtom 'Parsed
+            mkIdentifier = AtomIdentifier . NameUnqualified . mkSymbol
+
+            mkJustArg :: ExpressionAtom 'Parsed -> ExpressionAtom 'Parsed
+            mkJustArg a =
+              AtomBraces
+                ( WithLoc
+                    l
+                    ( ExpressionAtoms
+                        { _expressionAtomsLoc = Irrelevant l,
+                          _expressionAtoms = mkIdentifier "just" :| [a]
+                        }
+                    )
+                )
+
+            mkNothingArg :: ExpressionAtom 'Parsed
+            mkNothingArg = AtomBraces (WithLoc l (ExpressionAtoms {_expressionAtomsLoc = Irrelevant l, _expressionAtoms = mkIdentifier "nothing" :| []}))
+
+            mkVersionArg :: NamedArgument 'Parsed
+            mkVersionArg = mkNamedArg "version" ((mkIdentifier "mkVersion") :| args)
+              where
+                args :: [ExpressionAtom 'Parsed]
+                args = wordArgs <> optionalArgs
+
+                optionalArgs :: [ExpressionAtom 'Parsed]
+                optionalArgs = case (releaseArg, metaArg) of
+                  (Nothing, Nothing) -> []
+                  (Nothing, Just ma) -> mkNothingArg : [mkJustArg ma]
+                  (Just ra, Nothing) -> [mkJustArg ra]
+                  (Just ra, Just ma) -> mkJustArg ra : [mkJustArg ma]
+
+                mkWordArg :: Word -> ExpressionAtom 'Parsed
+                mkWordArg w = AtomLiteral (WithLoc l (LitInteger (toInteger w)))
+
+                wordArgs :: [ExpressionAtom 'Parsed]
+                wordArgs =
+                  let SemVer {..} = p ^. packageVersion
+                   in mkWordArg <$> [_svMajor, _svMinor, _svPatch]
+
+                releaseArg :: Maybe (ExpressionAtom 'Parsed)
+                releaseArg = let SemVer {..} = p ^. packageVersion in mkReleaseArg <$> _svPreRel
+                  where
+                    mkReleaseArg :: Release -> ExpressionAtom 'Parsed
+                    mkReleaseArg = mkLitText . prettyRelease
+
+                    prettyRelease :: Release -> Text
+                    prettyRelease (Release cs) = T.intercalate "." . map prettyChunk $ NEL.toList cs
+
+                    prettyChunk :: Chunk -> Text
+                    prettyChunk (Numeric n) = show n
+                    prettyChunk (Alphanum s) = s
+
+                metaArg :: Maybe (ExpressionAtom 'Parsed)
+                metaArg = let SemVer {..} = p ^. packageVersion in mkLitText <$> _svMeta
+
+            mkNamedArg :: Text -> NonEmpty (ExpressionAtom 'Parsed) -> NamedArgument 'Parsed
+            mkNamedArg n v =
+              NamedArgument
+                { _namedArgValue =
+                    ExpressionAtoms
+                      { _expressionAtomsLoc = Irrelevant l,
+                        _expressionAtoms = v
+                      },
+                  _namedArgName = mkSymbol n,
+                  _namedArgAssignKw = Irrelevant (mkKeywordRef kwAssign)
+                }
 
 -- | The names of the Package type name in every version of the PackageDescription module
-packageDescriptionTypes :: [(Path Rel File, Text)]
-packageDescriptionTypes = [(v1PackageDescriptionFile, "Package")]
+packageDescriptionTypes :: [PackageDescriptionType]
+packageDescriptionTypes = [v1PackageDescriptionType]
 
-acceptableTypes :: (Member Files r) => Sem r [TypeSpec]
-acceptableTypes = do
-  globalPackageDir <- globalPackageDescriptionRoot
-  return (go . first (globalPackageDir <//>) <$> packageDescriptionTypes)
+acceptableTypes :: forall r. (Member Files r) => Sem r [TypeSpec]
+acceptableTypes = mapM go packageDescriptionTypes
   where
-    go :: (Path Abs File, Text) -> TypeSpec
-    go (p, typeName) =
-      TypeSpec
-        { _typeSpecName = typeName,
-          _typeSpecFile = p
-        }
+    go :: PackageDescriptionType -> Sem r TypeSpec
+    go t = do
+      globalPackageDir <- globalPackageDescriptionRoot
+      return
+        TypeSpec
+          { _typeSpecName = t ^. packageDescriptionTypeName,
+            _typeSpecFile = globalPackageDir <//> (t ^. packageDescriptionTypePath)
+          }
 
 -- | Load a package file in the context of the PackageDescription module and the global package stdlib.
 loadPackage :: (Members '[Files, EvalFileEff, Error PackageLoaderError] r) => BuildDir -> Path Abs File -> Sem r Package
@@ -40,7 +174,7 @@ loadPackage buildDir packagePath = do
     -- This function also checks that the type of the identifier is among the
     -- expected types from the specific PackageDescription modules that are
     -- provided by the PathResolver.
-    getPackageNode :: forall r. (Members '[Files, EvalEff] r) => Sem r Node
+    getPackageNode :: forall r. (Members '[Files, EvalEff] r) => Sem r Core.Node
     getPackageNode = do
       n <- lookupIdentifier Str.package
       acceptableTypes >>= assertNodeType n
@@ -95,12 +229,12 @@ toPackage buildDir packagePath = \case
 
     toText :: Value -> Sem r Text
     toText = \case
-      ValueConstant (ConstString s) -> return s
+      ValueConstant (Core.ConstString s) -> return s
       _ -> err
 
     toInteger' :: Value -> Sem r Integer
     toInteger' = \case
-      ValueConstant (ConstInteger i) -> return i
+      ValueConstant (Core.ConstInteger i) -> return i
       _ -> err
 
     toWord :: Value -> Sem r Word
@@ -152,9 +286,83 @@ toPackage buildDir packagePath = \case
         p :: SomeBase Dir
         p = resolveBuildDir buildDir <///> relStdlibDir
 
+toConcrete :: PackageDescriptionType -> Package -> Module 'Parsed 'ModuleTop
+toConcrete t p = do
+  let _importModule :: TopModulePath = mkTopModulePath (fromJust (nonEmpty (mkSymbol . pack . FP.dropExtension <$> FP.splitDirectories (toFilePath (t ^. packageDescriptionTypePath)))))
+      retTy :: ExpressionAtoms 'Parsed =
+        ExpressionAtoms
+          { _expressionAtomsLoc = Irrelevant l,
+            _expressionAtoms = AtomIdentifier (NameUnqualified (mkSymbol (t ^. packageDescriptionTypeName))) :| []
+          }
+      stdlibImport :: [Statement 'Parsed]
+        | (t ^. packageDescriptionTypeNeedsStdlibImport) p = [mkStdlibImport]
+        | otherwise = []
+      _moduleBody :: [Statement 'Parsed] =
+        stdlibImport
+          <> [ mkImport _importModule,
+               StatementFunctionDef
+                 FunctionDef
+                   { _signTerminating = Nothing,
+                     _signRetType = Just retTy,
+                     _signPragmas = Nothing,
+                     _signName = mkSymbol Str.package,
+                     _signInstance = Nothing,
+                     _signDoc = Nothing,
+                     _signColonKw = Irrelevant (Just (mkKeywordRef kwColon)),
+                     _signCoercion = Nothing,
+                     _signBuiltin = Nothing,
+                     _signBody = (t ^. packageDescriptionTypeTransform) p,
+                     _signArgs = []
+                   }
+             ]
+   in Module
+        { _modulePath = mkTopModulePath (mkSymbol "Package" :| []),
+          _moduleKwEnd = (),
+          _moduleInductive = (),
+          _moduleDoc = Nothing,
+          _modulePragmas = Nothing,
+          _moduleKw = mkKeywordRef kwModule,
+          ..
+        }
+  where
+    mkImport :: TopModulePath -> Statement 'Parsed
+    mkImport _importModule =
+      StatementImport
+        Import
+          { _importOpen =
+              Just
+                OpenModuleParams
+                  { _openUsingHiding = Nothing,
+                    _openPublicKw = Irrelevant Nothing,
+                    _openPublic = NoPublic,
+                    _openModuleKw = mkKeywordRef kwOpen
+                  },
+            _importKw = mkKeywordRef kwImport,
+            _importAsName = Nothing,
+            ..
+          }
+
+    mkStdlibImport :: Statement 'Parsed
+    mkStdlibImport = mkImport (mkTopModulePath (mkSymbol "Stdlib" :| [mkSymbol "Prelude"]))
+
+    l :: Interval
+    l = singletonInterval (mkInitialLoc (p ^. packageFile))
+
+    mkSymbol :: Text -> Symbol
+    mkSymbol = WithLoc l
+
+    mkKeywordRef :: Keyword -> KeywordRef
+    mkKeywordRef k =
+      KeywordRef
+        { _keywordRefUnicode = Ascii,
+          _keywordRefKeyword = k,
+          _keywordRefInterval = l
+        }
+
 packageDescriptionDir' :: Path Abs Dir
 packageDescriptionDir' =
   $( FE.makeRelativeToProject (toFilePath packageDescriptionDir)
-       >>= runIO . parseAbsDir
+       >>= runIO
+         . parseAbsDir
        >>= lift
    )

--- a/src/Juvix/Compiler/Pipeline/Package/Loader.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader.hs
@@ -1,8 +1,10 @@
-module Juvix.Compiler.Pipeline.Package.Loader where
+module Juvix.Compiler.Pipeline.Package.Loader
+  ( module Juvix.Compiler.Pipeline.Package.Loader,
+    module Juvix.Compiler.Pipeline.Package.Loader.Versions,
+  )
+where
 
 import Data.FileEmbed qualified as FE
-import Data.List.NonEmpty qualified as NEL
-import Data.Text qualified as T
 import Data.Versions
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromSource
@@ -12,142 +14,12 @@ import Juvix.Compiler.Core.Language.Value
 import Juvix.Compiler.Pipeline.Package.Base
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
+import Juvix.Compiler.Pipeline.Package.Loader.Versions
 import Juvix.Extra.Paths
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
 import Language.Haskell.TH.Syntax hiding (Module)
 import System.FilePath qualified as FP
-
-data PackageDescriptionType = PackageDescriptionType
-  { _packageDescriptionTypePath :: Path Rel File,
-    _packageDescriptionTypeName :: Text,
-    _packageDescriptionTypeTransform :: Package -> FunctionDefBody 'Parsed,
-    _packageDescriptionTypeNeedsStdlibImport :: Package -> Bool
-  }
-
-makeLenses ''PackageDescriptionType
-
-v1PackageDescriptionType :: PackageDescriptionType
-v1PackageDescriptionType = PackageDescriptionType v1PackageDescriptionFile "Package" fromPackage needsStdlib
-  where
-    needsStdlib :: Package -> Bool
-    needsStdlib p =
-      let SemVer {..} = p ^. packageVersion
-       in isJust _svMeta || isJust _svPreRel
-
-    fromPackage :: Package -> FunctionDefBody 'Parsed
-    fromPackage p =
-      SigBodyExpression
-        ExpressionAtoms
-          { _expressionAtomsLoc = Irrelevant l,
-            _expressionAtoms =
-              AtomNamedApplication
-                NamedApplication
-                  { _namedAppName = NameUnqualified (mkSymbol "defaultPackage"),
-                    _namedAppArgs =
-                      ArgumentBlock
-                        { _argBlockImplicit = Implicit,
-                          _argBlockDelims = Irrelevant (Just (mkKeywordRef delimBraceL, mkKeywordRef delimBraceR)),
-                          _argBlockArgs = mkNamedArgs
-                        }
-                        :| []
-                  }
-                :| []
-          }
-      where
-        l :: Interval
-        l = singletonInterval (mkInitialLoc (p ^. packageFile))
-
-        mkSymbol :: Text -> Symbol
-        mkSymbol = WithLoc l
-
-        mkKeywordRef :: Keyword -> KeywordRef
-        mkKeywordRef k =
-          KeywordRef
-            { _keywordRefUnicode = Ascii,
-              _keywordRefKeyword = k,
-              _keywordRefInterval = l
-            }
-
-        mkNamedArgs :: NonEmpty (NamedArgument 'Parsed)
-        mkNamedArgs = mkNameArg :| [mkVersionArg]
-          where
-            mkNameArg :: NamedArgument 'Parsed
-            mkNameArg = mkNamedArg "name" ((mkLitText (p ^. packageName)) :| [])
-
-            mkLitText :: Text -> ExpressionAtom 'Parsed
-            mkLitText = AtomLiteral . WithLoc l . LitString
-
-            mkIdentifier :: Text -> ExpressionAtom 'Parsed
-            mkIdentifier = AtomIdentifier . NameUnqualified . mkSymbol
-
-            mkJustArg :: ExpressionAtom 'Parsed -> ExpressionAtom 'Parsed
-            mkJustArg a =
-              AtomBraces
-                ( WithLoc
-                    l
-                    ( ExpressionAtoms
-                        { _expressionAtomsLoc = Irrelevant l,
-                          _expressionAtoms = mkIdentifier "just" :| [a]
-                        }
-                    )
-                )
-
-            mkNothingArg :: ExpressionAtom 'Parsed
-            mkNothingArg = AtomBraces (WithLoc l (ExpressionAtoms {_expressionAtomsLoc = Irrelevant l, _expressionAtoms = mkIdentifier "nothing" :| []}))
-
-            mkVersionArg :: NamedArgument 'Parsed
-            mkVersionArg = mkNamedArg "version" ((mkIdentifier "mkVersion") :| args)
-              where
-                args :: [ExpressionAtom 'Parsed]
-                args = wordArgs <> optionalArgs
-
-                optionalArgs :: [ExpressionAtom 'Parsed]
-                optionalArgs = case (releaseArg, metaArg) of
-                  (Nothing, Nothing) -> []
-                  (Nothing, Just ma) -> mkNothingArg : [mkJustArg ma]
-                  (Just ra, Nothing) -> [mkJustArg ra]
-                  (Just ra, Just ma) -> mkJustArg ra : [mkJustArg ma]
-
-                mkWordArg :: Word -> ExpressionAtom 'Parsed
-                mkWordArg w = AtomLiteral (WithLoc l (LitInteger (toInteger w)))
-
-                wordArgs :: [ExpressionAtom 'Parsed]
-                wordArgs =
-                  let SemVer {..} = p ^. packageVersion
-                   in mkWordArg <$> [_svMajor, _svMinor, _svPatch]
-
-                releaseArg :: Maybe (ExpressionAtom 'Parsed)
-                releaseArg = let SemVer {..} = p ^. packageVersion in mkReleaseArg <$> _svPreRel
-                  where
-                    mkReleaseArg :: Release -> ExpressionAtom 'Parsed
-                    mkReleaseArg = mkLitText . prettyRelease
-
-                    prettyRelease :: Release -> Text
-                    prettyRelease (Release cs) = T.intercalate "." . map prettyChunk $ NEL.toList cs
-
-                    prettyChunk :: Chunk -> Text
-                    prettyChunk (Numeric n) = show n
-                    prettyChunk (Alphanum s) = s
-
-                metaArg :: Maybe (ExpressionAtom 'Parsed)
-                metaArg = let SemVer {..} = p ^. packageVersion in mkLitText <$> _svMeta
-
-            mkNamedArg :: Text -> NonEmpty (ExpressionAtom 'Parsed) -> NamedArgument 'Parsed
-            mkNamedArg n v =
-              NamedArgument
-                { _namedArgValue =
-                    ExpressionAtoms
-                      { _expressionAtomsLoc = Irrelevant l,
-                        _expressionAtoms = v
-                      },
-                  _namedArgName = mkSymbol n,
-                  _namedArgAssignKw = Irrelevant (mkKeywordRef kwAssign)
-                }
-
--- | The names of the Package type name in every version of the PackageDescription module
-packageDescriptionTypes :: [PackageDescriptionType]
-packageDescriptionTypes = [v1PackageDescriptionType]
 
 acceptableTypes :: forall r. (Member Files r) => Sem r [TypeSpec]
 acceptableTypes = mapM go packageDescriptionTypes

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/Versions.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/Versions.hs
@@ -1,0 +1,154 @@
+module Juvix.Compiler.Pipeline.Package.Loader.Versions where
+
+import Data.List.NonEmpty qualified as NEL
+import Data.Text qualified as T
+import Data.Versions
+import Juvix.Compiler.Concrete.Language
+import Juvix.Compiler.Concrete.Translation.FromSource.Lexer
+import Juvix.Compiler.Pipeline.Package.Base
+import Juvix.Extra.Paths
+import Juvix.Prelude
+
+data PackageDescriptionType = PackageDescriptionType
+  { _packageDescriptionTypePath :: Path Rel File,
+    _packageDescriptionTypeName :: Text,
+    _packageDescriptionTypeTransform :: Package -> FunctionDefBody 'Parsed,
+    _packageDescriptionTypeNeedsStdlibImport :: Package -> Bool
+  }
+
+makeLenses ''PackageDescriptionType
+
+-- | The names of the Package type name in every version of the PackageDescription module
+packageDescriptionTypes :: [PackageDescriptionType]
+packageDescriptionTypes = [v1PackageDescriptionType]
+
+v1PackageDescriptionType :: PackageDescriptionType
+v1PackageDescriptionType = PackageDescriptionType v1PackageDescriptionFile "Package" fromPackage needsStdlib
+  where
+    needsStdlib :: Package -> Bool
+    needsStdlib p =
+      let SemVer {..} = p ^. packageVersion
+       in isJust _svMeta || isJust _svPreRel
+
+    -- Supports the subset of Package fields that are customizable with `juvix init`
+    fromPackage :: Package -> FunctionDefBody 'Parsed
+    fromPackage p =
+      SigBodyExpression
+        ExpressionAtoms
+          { _expressionAtomsLoc = Irrelevant l,
+            _expressionAtoms =
+              AtomNamedApplication
+                NamedApplication
+                  { _namedAppName = NameUnqualified (mkSymbol "defaultPackage"),
+                    _namedAppArgs =
+                      ArgumentBlock
+                        { _argBlockImplicit = Implicit,
+                          _argBlockDelims = Irrelevant (Just (mkKeywordRef delimBraceL, mkKeywordRef delimBraceR)),
+                          _argBlockArgs = mkNamedArgs
+                        }
+                        :| []
+                  }
+                :| []
+          }
+      where
+        l :: Interval
+        l = singletonInterval (mkInitialLoc (p ^. packageFile))
+
+        mkSymbol :: Text -> Symbol
+        mkSymbol = WithLoc l
+
+        mkKeywordRef :: Keyword -> KeywordRef
+        mkKeywordRef k =
+          KeywordRef
+            { _keywordRefUnicode = Ascii,
+              _keywordRefKeyword = k,
+              _keywordRefInterval = l
+            }
+
+        mkNamedArgs :: NonEmpty (NamedArgument 'Parsed)
+        mkNamedArgs = mkNameArg :| [mkVersionArg]
+          where
+            mkNameArg :: NamedArgument 'Parsed
+            mkNameArg = mkNamedArg "name" (mkLitText (p ^. packageName) :| [])
+
+            mkLitText :: Text -> ExpressionAtom 'Parsed
+            mkLitText = AtomLiteral . WithLoc l . LitString
+
+            mkIdentifier :: Text -> ExpressionAtom 'Parsed
+            mkIdentifier = AtomIdentifier . NameUnqualified . mkSymbol
+
+            mkJust :: ExpressionAtom 'Parsed -> NonEmpty (ExpressionAtom 'Parsed)
+            mkJust a = mkIdentifier "just" :| [a]
+
+            mkJustArg :: ExpressionAtom 'Parsed -> ExpressionAtom 'Parsed
+            mkJustArg a =
+              AtomBraces
+                ( WithLoc
+                    l
+                    ( ExpressionAtoms
+                        { _expressionAtomsLoc = Irrelevant l,
+                          _expressionAtoms = mkJust a
+                        }
+                    )
+                )
+
+            mkNothingArg :: ExpressionAtom 'Parsed
+            mkNothingArg =
+              AtomBraces
+                ( WithLoc
+                    l
+                    ( ExpressionAtoms
+                        { _expressionAtomsLoc = Irrelevant l,
+                          _expressionAtoms = mkIdentifier "nothing" :| []
+                        }
+                    )
+                )
+
+            mkVersionArg :: NamedArgument 'Parsed
+            mkVersionArg = mkNamedArg "version" ((mkIdentifier "mkVersion") :| args)
+              where
+                args :: [ExpressionAtom 'Parsed]
+                args = wordArgs <> optionalArgs
+
+                optionalArgs :: [ExpressionAtom 'Parsed]
+                optionalArgs = case (releaseArg, metaArg) of
+                  (Nothing, Nothing) -> []
+                  (Nothing, Just ma) -> mkNothingArg : [mkJustArg ma]
+                  (Just ra, Nothing) -> [mkJustArg ra]
+                  (Just ra, Just ma) -> mkJustArg ra : [mkJustArg ma]
+
+                mkWordArg :: Word -> ExpressionAtom 'Parsed
+                mkWordArg w = AtomLiteral (WithLoc l (LitInteger (toInteger w)))
+
+                wordArgs :: [ExpressionAtom 'Parsed]
+                wordArgs =
+                  let SemVer {..} = p ^. packageVersion
+                   in mkWordArg <$> [_svMajor, _svMinor, _svPatch]
+
+                releaseArg :: Maybe (ExpressionAtom 'Parsed)
+                releaseArg = let SemVer {..} = p ^. packageVersion in mkReleaseArg <$> _svPreRel
+                  where
+                    mkReleaseArg :: Release -> ExpressionAtom 'Parsed
+                    mkReleaseArg = mkLitText . prettyRelease
+
+                    prettyRelease :: Release -> Text
+                    prettyRelease (Release cs) = T.intercalate "." . map prettyChunk $ NEL.toList cs
+
+                    prettyChunk :: Chunk -> Text
+                    prettyChunk (Numeric n) = show n
+                    prettyChunk (Alphanum s) = s
+
+                metaArg :: Maybe (ExpressionAtom 'Parsed)
+                metaArg = let SemVer {..} = p ^. packageVersion in mkLitText <$> _svMeta
+
+            mkNamedArg :: Text -> NonEmpty (ExpressionAtom 'Parsed) -> NamedArgument 'Parsed
+            mkNamedArg n v =
+              NamedArgument
+                { _namedArgValue =
+                    ExpressionAtoms
+                      { _expressionAtomsLoc = Irrelevant l,
+                        _expressionAtoms = v
+                      },
+                  _namedArgName = mkSymbol n,
+                  _namedArgAssignKw = Irrelevant (mkKeywordRef kwAssign)
+                }

--- a/src/Juvix/Prelude/Prepath.hs
+++ b/src/Juvix/Prelude/Prepath.hs
@@ -7,6 +7,7 @@ module Juvix.Prelude.Prepath
     prepathToAbsFile,
     prepathToFilePath,
     preFileFromAbs,
+    unsafePrepathToFilePath,
   )
 where
 
@@ -124,3 +125,6 @@ fromPreFileOrDir cwd fp = do
 
 preFileFromAbs :: Path Abs File -> Prepath File
 preFileFromAbs = mkPrepath . toFilePath
+
+unsafePrepathToFilePath :: Prepath a -> FilePath
+unsafePrepathToFilePath (Prepath p) = p

--- a/tests/smoke/Commands/init.smoke.yaml
+++ b/tests/smoke/Commands/init.smoke.yaml
@@ -10,12 +10,11 @@ tests:
         trap 'rm -rf -- "$temp"' EXIT
         cd $temp
         echo -e 'abc\n\n\n' | juvix init
-        cat juvix.yaml
+        juvix typecheck Package.juvix
     stdout:
-      contains:
-        "name: abc"
+      contains: type checks
     exit-status: 0
-  - name: init-does-not-contain-file-field
+  - name: init-name
     command:
       shell:
         - bash
@@ -23,12 +22,33 @@ tests:
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
         cd $temp
-        echo -e 'abc\n\n\n' | juvix init
-        cat juvix.yaml
+        echo -e 'packagename\n\n\n' | juvix init
+        juvix repl Package.juvix
     stdout:
-      matches:
-        regex: |-
-          ^((?!file:).)*$
-        options:
-          - dot-all
+      contains: '"packagename"'
+    stdin: Package.name package
+    exit-status: 0
+  - name: init-version
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        cd $temp
+        echo -e 'packagename\n1.2.3-prerel+meta\n\n' | juvix init
+        juvix repl Package.juvix
+    stdout:
+      contains: |
+        Package> 1
+        Package> 2
+        Package> 3
+        Package> just "prerel"
+        Package> just "meta"
+    stdin: |
+      SemVer.major (Package.version package)
+      SemVer.minor (Package.version package)
+      SemVer.patch (Package.version package)
+      SemVer.release (Package.version package)
+      SemVer.meta (Package.version package)
     exit-status: 0


### PR DESCRIPTION
`juvix init` now generates a `Package.juvix` file in the current directory instead of a `juvix.yaml` file. It uses the prompts from the user to fill in the name and version options.

### Validity check

After the file is generated, the Juvix project in the current directory is loaded to check that the generated file is valid.

### Version support

Each version of the PackageDescription module must have a corresponding [PackageDescriptionType](https://github.com/anoma/juvix/blob/c39c27000c99e6053dce83a34fca7c9f66b6c605/src/Juvix/Compiler/Pipeline/Package/Loader/Versions.hs#L12) which defines:

* The path relative to `include/package` that the file exists at (e.g `PackageDescription/V1.juvix`)
* The name of the Package type in the file (e.g `Package`)
* A function that translates a Package type into a Concrete function definition that represents the code that is generated in the `Package.juvix`
* A function that returns a Bool that determines if the generated function definition depends on the standard library. (i.e that the standard library needs to be imported by Package.juvix).

The last point is necessary because in the V1 spec, the `SemVer` type uses `Maybe` to encode the release and meta components of the of the version:

```
package : Package :=
  defaultPackage
    {name := "dd";
     version := mkVersion 1 2 3 {just "prerel"} {just "meta"}};
```

So if the user specifies a release or meta component in their version - then the standard library needs to be imported to provide the `just` constructor. If the user only specifies major, minor and patch components then the standard library does not need to be imported.

* Closes https://github.com/anoma/juvix/issues/2485