### PR TITLE
Update Lisp File Printer

### DIFF
--- a/src/Juvix/Compiler/Backend/Geb/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Backend/Geb/Pretty/Base.hs
@@ -29,7 +29,11 @@ docLisp opts packageName entryName morph _ =
     <> line
     <> indent' "(:shadowing-import-from :geb.spec #:case)"
     <> line
-    <> indent' "(:use #:common-lisp #:geb.lambda.spec #:geb))"
+    <> indent' "(:shadowing-import-from :geb.lambda.trans #:int)"
+    <> line
+    <> indent' "(:use #:common-lisp #:geb.lambda.spec #:geb)"
+    <> line
+    <> indent' "(:export :*entry*))"
     <> line
     <> line
     <> "(in-package :"


### PR DESCRIPTION
Updates the compiled Lisp files for Geb usage by adding exports of the int type as well as exporting the main entry parameter.