### PR TITLE
Cache .hie directory in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: main/.hie
-          key: ${{ runner.os }}-stack-hie-${{ hashFiles('main/**/*.hs') }}-${{ hashFiles('main/package.yaml', 'main/stack.yaml') }}
+          key: ${{ runner.os }}-stack-hie
 
       - name: Stack setup
         id: stack
@@ -278,7 +278,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: main/.hie
-          key: ${{ runner.os }}-stack-hie-${{ hashFiles('main/**/*.hs') }}-${{ hashFiles('main/package.yaml', 'main/stack.yaml') }}
+          key: ${{ runner.os }}-stack-hie
 
       - name: Stack setup
         id: stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,20 @@ jobs:
           cd main
           make runtime
 
+      # We use the options:
+      #   - -fhide-source-paths
+      #   - -fwrite-ide-info -hiedir=.hie
+      # in package.yaml.
+      #
+      # If a previously available .hie directory is missing then GHC will rebuild the whole project.
+      # with reason: HIE file is missing. So we need to cache it.
+      - name: Cache .hie
+        id: cache-hie
+        uses: actions/cache@v3
+        with:
+          path: main/.hie
+          key: ${{ runner.os }}-stack-hie-${{ hashFiles('main/**/*.hs') }}-${{ hashFiles('main/package.yaml', 'main/stack.yaml') }}
+
       - name: Stack setup
         id: stack
         uses: freckle/stack-action@v4
@@ -251,6 +265,20 @@ jobs:
         run: |
           cd main
           make CC=$CC LIBTOOL=$LIBTOOL runtime
+
+      # We use the options:
+      #   - -fhide-source-paths
+      #   - -fwrite-ide-info -hiedir=.hie
+      # in package.yaml.
+      #
+      # If a previously available .hie directory is missing then GHC will rebuild the whole project.
+      # with reason: HIE file is missing. So we need to cache it.
+      - name: Cache .hie
+        id: cache-hie
+        uses: actions/cache@v3
+        with:
+          path: main/.hie
+          key: ${{ runner.os }}-stack-hie-${{ hashFiles('main/**/*.hs') }}-${{ hashFiles('main/package.yaml', 'main/stack.yaml') }}
 
       - name: Stack setup
         id: stack


### PR DESCRIPTION
We use the options in `package.yaml`.

```
         - -fhide-source-paths
         - -fwrite-ide-info -hiedir=.hie
```
If a previously available .hie directory is missing then GHC will rebuild the whole project with reason: `[HIE file is missing]`. So we need to cache it to take advantage of incremental builds.
