### PR TITLE
Add -n/--non-interactive option to juvix init

### DIFF
--- a/app/Commands/Init/Options.hs
+++ b/app/Commands/Init/Options.hs
@@ -1,0 +1,19 @@
+module Commands.Init.Options where
+
+import CommonOptions
+
+newtype InitOptions = InitOptions
+  {_initOptionsNonInteractive :: Bool}
+  deriving stock (Data)
+
+makeLenses ''InitOptions
+
+parseInitOptions :: Parser InitOptions
+parseInitOptions = do
+  _initOptionsNonInteractive <-
+    switch
+      ( long "non-interactive"
+          <> short 'n'
+          <> help "Run non-interactively. Generates a default Package.juvix"
+      )
+  pure InitOptions {..}

--- a/app/TopCommand.hs
+++ b/app/TopCommand.hs
@@ -30,7 +30,7 @@ runTopCommand = \case
   DisplayNumericVersion -> embed runDisplayNumericVersion
   DisplayHelp -> embed showHelpText
   Doctor opts -> runLogIO (Doctor.runCommand opts)
-  Init -> runLogIO Init.init
+  Init opts -> runLogIO (Init.init opts)
   Dev opts -> Dev.runCommand opts
   Typecheck opts -> Typecheck.runCommand opts
   Compile opts -> Compile.runCommand opts

--- a/app/TopCommand/Options.hs
+++ b/app/TopCommand/Options.hs
@@ -8,6 +8,7 @@ import Commands.Doctor.Options
 import Commands.Eval.Options
 import Commands.Format.Options
 import Commands.Html.Options
+import Commands.Init.Options
 import Commands.Repl.Options
 import Commands.Typecheck.Options
 import CommonOptions hiding (Doc)
@@ -26,7 +27,7 @@ data TopCommand
   | Html HtmlOptions
   | Dev Dev.DevCommand
   | Doctor DoctorOptions
-  | Init
+  | Init InitOptions
   | JuvixRepl ReplOptions
   | JuvixFormat FormatOptions
   | Dependencies Dependencies.DependenciesCommand
@@ -108,7 +109,7 @@ parseUtility =
       command
         "init"
         ( info
-            (pure Init)
+            (Init <$> parseInitOptions)
             (progDesc "Interactively initialize a Juvix project in the current directory")
         )
     commandDoctor :: Mod CommandFields TopCommand

--- a/tests/smoke/Commands/init.smoke.yaml
+++ b/tests/smoke/Commands/init.smoke.yaml
@@ -14,6 +14,21 @@ tests:
     stdout:
       contains: type checks
     exit-status: 0
+  - name: init-non-interactive-name
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        mkdir "$temp/packagename"
+        cd "$temp/packagename"
+        juvix init -n
+        juvix repl Package.juvix
+    stdout:
+      contains: '"packagename"'
+    stdin: Package.name package
+    exit-status: 0
   - name: init-name
     command:
       shell:


### PR DESCRIPTION
When moving to Package.juvix, the package configuration file cannot be empty. So it's convenient to have a quick way to create a Package.juvix file (previously you could run `touch juvix.yaml`.

This PR adds the `-n / --non-interactive` option to `juvix init`. This will create a default `Package.juvix`, using the name of the current directory to populate the package name.

Similarly for the interactive version of juvix init, if the name of the current directory is not a valid Juvix module then a fallback name is used instead.

For example:
```
$ mkdir /tmp/new-package
$ cd /tmp/new-package
$ juvix init -n
$ cat Package.juvix
module Package;

import PackageDescription.V1 open;

package : Package :=
  defaultPackage
    {name := "new-package";
     version := mkVersion 0 0 0;
     dependencies := [defaultStdlib]};
```

* Part of https://github.com/anoma/juvix/issues/2487