### PR TITLE
Update file walker to use Package.juvix to detect a Juvix package

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/PathResolver.hs
@@ -63,7 +63,7 @@ mkPackageInfo mpackageEntry _packageRoot pkg = do
   return PackageInfo {..}
   where
     juvixAccum :: Path Abs Dir -> [Path Rel Dir] -> [Path Rel File] -> [Path Abs File] -> Sem r ([Path Abs File], Recurse Rel)
-    juvixAccum cd _ files acc = return (newJuvixFiles <> acc, RecurseFilter (\hasJuvixYaml d -> not hasJuvixYaml && not (isHiddenDirectory d)))
+    juvixAccum cd _ files acc = return (newJuvixFiles <> acc, RecurseFilter (\hasJuvixPackage d -> not hasJuvixPackage && not (isHiddenDirectory d)))
       where
         newJuvixFiles :: [Path Abs File]
         newJuvixFiles = [cd <//> f | f <- files, isJuvixFile f]

--- a/src/Juvix/Data/Effect/Files.hs
+++ b/src/Juvix/Data/Effect/Files.hs
@@ -57,8 +57,14 @@ walkDirRel handler topdir = do
             where
               filterSubdirs :: Path Rel Dir -> Sem (State (HashSet Uid) ': r) Bool
               filterSubdirs d = do
-                hasJuvixYaml <- fileExists' (topdir <//> curdir <//> d <//> juvixYamlFile)
-                return (fi hasJuvixYaml d)
+                hasJuvixPackage <-
+                  orM
+                    ( fileExists' . (rootDir <//>) <$> [juvixYamlFile, packageFilePath]
+                    )
+                return (fi hasJuvixPackage d)
+                where
+                  rootDir :: Path Abs Dir
+                  rootDir = topdir <//> curdir <//> d
 
       checkLoop :: Path Abs Dir -> Sem (State (HashSet Uid) ': r) Bool
       checkLoop dir = do

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -90,7 +90,7 @@ formatProject p = do
     handler cd _ files res = do
       let juvixFiles = [cd <//> f | f <- files, isJuvixFile f]
       subRes <- mconcat <$> mapM format juvixFiles
-      return (res <> subRes, RecurseFilter (\hasJuvixYaml d -> not hasJuvixYaml && not (isHiddenDirectory d)))
+      return (res <> subRes, RecurseFilter (\hasJuvixPackage d -> not hasJuvixPackage && not (isHiddenDirectory d)))
 
 formatPath ::
   (Members '[Reader Text, ScopeEff] r) =>

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -194,6 +194,26 @@ tests:
     stdout: ''
     exit-status: 0
 
+  - name: format-ignore-subproject-project-juvix
+    command:
+      shell:
+        - bash
+      script: |
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        pushd $temp > /dev/null
+        juvix init -n
+        popd > /dev/null
+        cp positive/Format.juvix $temp
+        mkdir $temp/sub
+        pushd $temp/sub > /dev/null
+        juvix init -n
+        popd > /dev/null
+        cp positive/Format.juvix $temp/sub
+        juvix format $temp
+    stdout: ''
+    exit-status: 0
+
   - name: format-dir-containing-unformatted-check-no-stdout
     command:
       shell:


### PR DESCRIPTION
The file walker `RecurseFilter` indictates if the the walker recurses into
a directory which contains a Juvix project.

Previously the file walker would detect juvix.yaml. It now detects both
juvix.yaml and Package.juvix.

* Part of https://github.com/anoma/juvix/issues/2487