### PR TITLE
Add non-dependent default values to the new typechecking algorithm

### DIFF
--- a/src/Juvix/Compiler/Internal/Extra/Base.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Base.hs
@@ -292,7 +292,7 @@ inductiveTypeVarsAssoc def l
     vars :: [VarName]
     vars = def ^.. inductiveParameters . each . inductiveParamName
 
-substitutionApp :: forall r. (Member NameIdGen r) => (Maybe Name, Expression) -> Expression -> Sem r Expression
+substitutionApp :: forall r expr. (Member NameIdGen r, HasExpressions expr) => (Maybe Name, Expression) -> expr -> Sem r expr
 substitutionApp (mv, ty) = case mv of
   Nothing -> return
   Just v -> substitutionE (HashMap.singleton v ty)
@@ -300,7 +300,7 @@ substitutionApp (mv, ty) = case mv of
 localsToSubsE :: LocalVars -> Subs
 localsToSubsE l = ExpressionIden . IdenVar <$> l ^. localTyMap
 
-substitutionE :: forall r. (Member NameIdGen r) => Subs -> Expression -> Sem r Expression
+substitutionE :: forall r expr. (Member NameIdGen r, HasExpressions expr) => Subs -> expr -> Sem r expr
 substitutionE m = leafExpressions goLeaf
   where
     goLeaf :: Expression -> Sem r Expression

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -331,6 +331,16 @@ instance PrettyCode Module where
 instance PrettyCode Interval where
   ppCode = return . annotate AnnCode . pretty
 
+instance PrettyCode New.ArgId where
+  ppCode a = case a ^. New.argIdName . unIrrelevant of
+    Nothing -> do
+      f' <- ppCode (a ^. New.argIdFunctionName)
+      return (ordinal (a ^. New.argIdIx) <+> "argument of" <+> f')
+    Just n -> do
+      n' <- ppCode n
+      loc' <- ppCode (getLoc n)
+      return (n' <+> "at" <+> loc')
+
 instance PrettyCode New.ArityParameter where
   ppCode = return . pretty
 

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
@@ -1149,12 +1149,14 @@ holesHelper mhint expr = do
           restExprAri <- typeArity restExprTy
           let preImplicits :: Arity -> [IsImplicit]
               preImplicits = takeWhile isImplicitOrInstance . map (^. arityParameterImplicit) . unfoldArity
-              preRestAriExpr = preImplicits restExprAri
+              preImplicitsTypeRest = preImplicits restExprAri
               preAriHint = preImplicits ariHint
+              preImplicitsInType = length (takeWhile isImplicitOrInstance
+                                             (map fst defaults ++ preImplicitsTypeRest))
           loc <- getLoc <$> gets (^. appBuilder)
-          let numberOfExtraHoles = length preRestAriExpr + length defaults - length preAriHint
+          let numberOfExtraHoles =  preImplicitsInType - length preAriHint
               toBeInserted :: [(IsImplicit, Maybe (ArgId, Expression))] =
-                take numberOfExtraHoles (defaults <> (map (,Nothing) preRestAriExpr))
+                take numberOfExtraHoles (defaults <> (map (,Nothing) preImplicitsTypeRest))
               mkHoleArg :: (IsImplicit, Maybe (ArgId, Expression)) -> Sem r' AppBuilderArg
               mkHoleArg (i, mdef) = do
                 (_appArg, _appBuilderArgIsDefault) <- case i of

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
@@ -1089,7 +1089,8 @@ holesHelper mhint expr = do
                 _functionDefaultDefault =
                   let uid =
                         ArgId
-                          { _argIdDefinitionLoc = getLoc f,
+                          { _argIdDefinitionLoc = Irrelevant (getLoc f),
+                            _argIdName = Irrelevant (a ^. argInfoName),
                             _argIdFunctionName,
                             _argIdIx
                           }

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
@@ -56,7 +56,6 @@ data AppBuilderArg = AppBuilderArg
 
 data AppBuilder = AppBuilder
   { _appBuilder :: Expression,
-    _appBuilderCheckedArgs :: [InsertedArg],
     _appBuilderType :: BuilderType,
     _appBuilderArgs :: [AppBuilderArg]
   }
@@ -1033,7 +1032,6 @@ holesHelper mhint expr = do
       iniBuilder =
         AppBuilder
           { _appBuilder = fTy ^. typedExpression,
-            _appBuilderCheckedArgs = [],
             _appBuilderType = iniBuilderType,
             _appBuilderArgs = map iniArg args
           }
@@ -1049,38 +1047,6 @@ holesHelper mhint expr = do
         _typedExpression = st' ^. appBuilder
       }
   where
-    mkFinalExpression :: Expression -> [InsertedArg] -> Sem r Expression
-    mkFinalExpression f args =
-      case nonEmpty  args of
-        Nothing -> return f
-        Just args'
-          | not hasADefault -> return (foldApplication f (map (^. insertedArg) args))
-          | otherwise  -> do
-            let mkClause :: InsertedArg -> Sem r PreLetStatement
-                mkClause InsertedArg {..} = do
-                      -- TODO put actual type instead of hole?
-                      let arg = _insertedArg
-                          nm = _insertedArgName
-                      ty <- mkFreshHole (getLoc arg)
-                      return (PreLetFunctionDef (simpleFunDef nm ty (arg ^. appArg)))
-                mkAppArg :: InsertedArg -> ApplicationArg
-                mkAppArg InsertedArg {..} =
-                      ApplicationArg
-                        { _appArgIsImplicit = _insertedArg ^. appArgIsImplicit,
-                          _appArg = toExpression _insertedArgName
-                        }
-                app = foldApplication f (map mkAppArg args)
-            clauses :: NonEmpty LetClause <- nonEmpty' . mkLetClauses <$> mapM mkClause args'
-            letexpr <- substitutionE (renameKind KNameFunction (map (^. insertedArgName) args)) $
-                    ExpressionLet
-                      Let
-                        { _letClauses = clauses,
-                          _letExpression = app
-                        }
-            clone letexpr
-        where
-         hasADefault = any (^. insertedArgDefault) args
-
     mkFinalBuilderType :: BuilderType -> Expression
     mkFinalBuilderType = \case
       BuilderTypeNoDefaults e -> e
@@ -1269,8 +1235,6 @@ holesHelper mhint expr = do
                             _functionDefaultRight = r'
                           }
                     )
-              -- FIXME add arg' to appBuilderCheckedArgs
-              -- TODO we need to update the FunctionsTable if necessary!
               applyArg :: Expression -> Expression
               applyArg l =
                 ExpressionApplication

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
@@ -1151,10 +1151,14 @@ holesHelper mhint expr = do
               preImplicits = takeWhile isImplicitOrInstance . map (^. arityParameterImplicit) . unfoldArity
               preImplicitsTypeRest = preImplicits restExprAri
               preAriHint = preImplicits ariHint
-              preImplicitsInType = length (takeWhile isImplicitOrInstance
-                                             (map fst defaults ++ preImplicitsTypeRest))
+              preImplicitsInType =
+                length
+                  ( takeWhile
+                      isImplicitOrInstance
+                      (map fst defaults ++ preImplicitsTypeRest)
+                  )
           loc <- getLoc <$> gets (^. appBuilder)
-          let numberOfExtraHoles =  preImplicitsInType - length preAriHint
+          let numberOfExtraHoles = preImplicitsInType - length preAriHint
               toBeInserted :: [(IsImplicit, Maybe (ArgId, Expression))] =
                 take numberOfExtraHoles (defaults <> (map (,Nothing) preImplicitsTypeRest))
               mkHoleArg :: (IsImplicit, Maybe (ArgId, Expression)) -> Sem r' AppBuilderArg

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
@@ -6,6 +6,7 @@ import Juvix.Prelude.Pretty
 
 data ArgId = ArgId
   { _argIdFunctionName :: Name,
+    _argIdDefinitionLoc :: Interval,
     _argIdIx :: Int
   }
   deriving stock (Eq, Ord)
@@ -25,9 +26,6 @@ data InsertedArg = InsertedArg
     -- False if it is an inserted hole or an argument present in the source code.
     _insertedArgDefault :: Bool
   }
-
--- pattern ArityParam :: IsImplicit -> ArityParameter
--- pattern ArityParam impl <- ArityParameter {_arityParameterImplicit = impl}
 
 data Blocking
   = BlockingVar VarName
@@ -76,6 +74,9 @@ makeLenses ''FunctionArity
 makeLenses ''InsertedArg
 makeLenses ''ArityParameter
 makeLenses ''InsertedArgsStack
+
+instance HasLoc ArgId where
+  getLoc = (^. argIdDefinitionLoc)
 
 arityParameterName :: Lens' ArityParameter (Maybe Name)
 arityParameterName = arityParameterInfo . argInfoName

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
@@ -4,9 +4,15 @@ import Juvix.Compiler.Internal.Extra
 import Juvix.Prelude
 import Juvix.Prelude.Pretty
 
+data ArgId = ArgId
+  { _argIdFunctionName :: Name,
+    _argIdIx :: Int
+  }
+  deriving stock (Eq, Ord)
+
 -- | Used to detect of cycles of default arguments in the arity checker.
 newtype InsertedArgsStack = InsertedArgsStack
-  { _insertedArgsStack :: [Name]
+  { _insertedArgsStack :: [ArgId]
   }
   deriving newtype (Monoid, Semigroup)
 
@@ -65,6 +71,7 @@ instance Eq ArityParameter where
     (ari, impl) == (ari', impl')
 
 makeLenses ''UnfoldedArity
+makeLenses ''ArgId
 makeLenses ''FunctionArity
 makeLenses ''InsertedArg
 makeLenses ''ArityParameter

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
@@ -6,8 +6,9 @@ import Juvix.Prelude.Pretty
 
 data ArgId = ArgId
   { _argIdFunctionName :: Name,
-    _argIdDefinitionLoc :: Interval,
-    _argIdIx :: Int
+    _argIdIx :: Int,
+    _argIdDefinitionLoc :: Irrelevant Interval,
+    _argIdName :: Irrelevant (Maybe Name)
   }
   deriving stock (Eq, Ord)
 
@@ -76,7 +77,7 @@ makeLenses ''ArityParameter
 makeLenses ''InsertedArgsStack
 
 instance HasLoc ArgId where
-  getLoc = (^. argIdDefinitionLoc)
+  getLoc = (^. argIdDefinitionLoc . unIrrelevant)
 
 arityParameterName :: Lens' ArityParameter (Maybe Name)
 arityParameterName = arityParameterInfo . argInfoName

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
@@ -35,6 +35,7 @@ data TypeCheckerError
   | ErrExplicitInstanceArgument ExplicitInstanceArgument
   | ErrTraitNotTerminating TraitNotTerminating
   | ErrArityCheckerError ArityCheckerError
+  | ErrDefaultArgLoop DefaultArgLoop
 
 instance ToGenericError TypeCheckerError where
   genericError :: (Member (Reader GenericOptions) r) => TypeCheckerError -> Sem r GenericError
@@ -62,3 +63,4 @@ instance ToGenericError TypeCheckerError where
     ErrExplicitInstanceArgument e -> genericError e
     ErrTraitNotTerminating e -> genericError e
     ErrArityCheckerError e -> genericError e
+    ErrDefaultArgLoop e -> genericError e

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -629,9 +629,9 @@ newtype DefaultArgLoop = DefaultArgLoop
 makeLenses ''DefaultArgLoop
 
 instance ToGenericError DefaultArgLoop where
-  genericError e = ask >>= generr
+  genericError e = generr
     where
-      generr opts =
+      generr =
         return
           GenericError
             { _genericErrorLoc = i,
@@ -639,6 +639,5 @@ instance ToGenericError DefaultArgLoop where
               _genericErrorIntervals = [i]
             }
         where
-          opts' = fromGenericOptions opts
           i = getLoc (head (e ^. defaultArgLoop))
-          msg = "Inserting default arguments is looping"
+          msg :: Doc Ann = "Inserting default arguments is looping"

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -629,9 +629,9 @@ newtype DefaultArgLoop = DefaultArgLoop
 makeLenses ''DefaultArgLoop
 
 instance ToGenericError DefaultArgLoop where
-  genericError e = generr
+  genericError e = ask >>= generr
     where
-      generr =
+      generr opts =
         return
           GenericError
             { _genericErrorLoc = i,
@@ -639,5 +639,9 @@ instance ToGenericError DefaultArgLoop where
               _genericErrorIntervals = [i]
             }
         where
+          opts' = fromGenericOptions opts
           i = getLoc (head (e ^. defaultArgLoop))
-          msg :: Doc Ann = "Inserting default arguments is looping"
+          msg :: Doc Ann =
+            "Inserting default arguments caused a loop. The involved arguments are:"
+              <> line
+              <> itemize (ppCode opts' <$> e ^. defaultArgLoop)

--- a/test/Typecheck/PositiveNew.hs
+++ b/test/Typecheck/PositiveNew.hs
@@ -56,10 +56,7 @@ extraTests =
 ignored :: HashSet String
 ignored =
   HashSet.fromList
-    [ "Test066: Import function with a function call in default argument",
-      "Test068: Dependent default values inserted in the arity checker",
-      "Test069: Dependent default values for Ord trait",
-      "Test070: Nested default values and named arguments",
+    [ "Test070: Nested default values and named arguments",
       "Test071: Named application",
       -- This test does not pass with the new hole insertion algorithm
       "Test046: Polymorphic type arguments"


### PR DESCRIPTION
This pr adds default values (that don't depend on previous default values) under the new `--new-typechecker` flag.