### PR TITLE
Fix the global 'package' package so that modules within it can be type-checked independently

### DIFF
--- a/include/package/Package.juvix
+++ b/include/package/Package.juvix
@@ -1,0 +1,5 @@
+module Package;
+
+import PackageDescription.Basic open;
+
+package : Package := basicPackage;

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/PathResolver.hs
@@ -49,16 +49,16 @@ runPackagePathResolver rootPath sem = do
               { _rootInfoPath = globalStdlib,
                 _rootInfoKind = RootKindPackage
               }
-      | relPath `HashSet.member` pkgFiles =
-          Just $
-            RootInfo
-              { _rootInfoPath = globalPackageDir,
-                _rootInfoKind = RootKindPackage
-              }
       | relPath == packageFilePath =
           Just $
             RootInfo
               { _rootInfoPath = rootPath,
+                _rootInfoKind = RootKindPackage
+              }
+      | relPath `HashSet.member` pkgFiles =
+          Just $
+            RootInfo
+              { _rootInfoPath = globalPackageDir,
                 _rootInfoKind = RootKindPackage
               }
       | otherwise = Nothing

--- a/tests/smoke/Commands/typecheck.smoke.yaml
+++ b/tests/smoke/Commands/typecheck.smoke.yaml
@@ -55,6 +55,28 @@ tests:
       equals: "Well done! It type checks\n"
     exit-status: 0
 
+  - name: typecheck-package-description
+    command:
+      shell:
+        - bash
+      script: |
+        base=$PWD
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        configDir=$temp/config
+        projDir=$temp/projDir
+        mkdir $configDir
+        export XDG_CONFIG_HOME="$configDir"
+        mkdir $projDir
+        cd $projDir
+        # side-effect: initializes the global project / the package package
+        globalPackageDir=$(juvix dev root)
+        packagePackageDir="$(dirname $globalPackageDir)"/package
+        juvix typecheck "$packagePackageDir/PackageDescription/V1.juvix"
+    stdout:
+      equals: "Well done! It type checks\n"
+    exit-status: 0
+
   - name: typecheck-stdin
     command:
       - juvix


### PR DESCRIPTION
This PR adds a Package.juvix file to the global 'package' package (that is the package containing the `PackageDescription.{Basic, V1}` modules.

This means that users can now go-to-definition on Package.juvix types and identifiers and navigate to fully highlighted `PackageDescription.{Basic, V1}` modules.

* Closes https://github.com/anoma/juvix/issues/2525