### PR TITLE
runtime Makefile: Do not resolve variables when writing a dependency file

### DIFF
--- a/runtime/Makefile.generic
+++ b/runtime/Makefile.generic
@@ -240,23 +240,23 @@ $(CLEXSOURCES) : $(BUILDDIR)%.c : %.lex
 
 $(CDEPENDS) : $(BUILDDIR)%.d : %.c
 	$(CC) $(CDEPFLAGS) -MM -MT $(patsubst %.c,$(BUILDDIR)%.o,$<) $< > $@
-	printf "\t$(CC) -c $(CFLAGS) -o $(patsubst %.c,$(BUILDDIR)%.o,$<) $<\n" >> $@
+	printf "\t\$$(CC) -c \$$(CFLAGS) -o $(patsubst %.c,$(BUILDDIR)%.o,$<) $<\n" >> $@
 
 $(CYLDEPENDS) : $(BUILDDIR)%.d : $(BUILDDIR)%.c
 	$(CC) $(CDEPFLAGS) -MM -MT $(patsubst %.c,%.o,$<) $< > $@
-	printf "\t$(CC) -c $(CFLAGS) -o $(patsubst %.c,%.o,$<) $<\n" >> $@
+	printf "\t\$$(CC) -c \$$(CFLAGS) -o $(patsubst %.c,%.o,$<) $<\n" >> $@
 
 $(CPPDEPENDS) : $(BUILDDIR)%.d : %.cpp
 	$(CXX) $(CXXDEPFLAGS) -MM -MT $(patsubst %.cpp,$(BUILDDIR)%.o,$<) $< > $@
-	printf "\t$(CXX) -c $(CXXFLAGS) -o $(patsubst %.cpp,$(BUILDDIR)%.o,$<) $<\n" >> $@
+	printf "\t\$$(CXX) -c \$$(CXXFLAGS) -o $(patsubst %.cpp,$(BUILDDIR)%.o,$<) $<\n" >> $@
 
 $(CXXDEPENDS) : $(BUILDDIR)%.d : %.cxx
 	$(CXX) $(CXXDEPFLAGS) -MM -MT $(patsubst %.cxx,$(BUILDDIR)%.o,$<) $< > $@
-	printf "\t$(CXX) -c $(CXXFLAGS) -o $(patsubst %.cxx,$(BUILDDIR)%.o,$<) $<\n" >> $@
+	printf "\t\$$(CXX) -c \$$(CXXFLAGS) -o $(patsubst %.cxx,$(BUILDDIR)%.o,$<) $<\n" >> $@
 
 $(CCDEPENDS) : $(BUILDDIR)%.d : %.cc
 	$(CXX) $(CXXDEPFLAGS) -MM -MT $(patsubst %.cc,$(BUILDDIR)%.o,$<) $< > $@
-	printf "\t$(CXX) -c $(CXXFLAGS) -o $(patsubst %.cc,$(BUILDDIR)%.o,$<) $<\n" >> $@
+	printf "\t\$$(CXX) -c \$$(CXXFLAGS) -o $(patsubst %.cc,$(BUILDDIR)%.o,$<) $<\n" >> $@
 
 $(CPROGRAMS) : % : $(ALLOBJECTS)
 	$(CCLD) -o $@ $@.o $(OBJECTS) $(CCLDFLAGS)


### PR DESCRIPTION
This is an attempt to fix a confusing situation where a user:

1. Builds the runtime with clang that does not support wasm32-wasi
2. Attempts to rebuild the runtime by passing the CC parameter pointing to another installation of clang that does support wasm32-wasi.

In step 1. the runtime Makefile generates dependencies files which contain the resolved value of `$(CC)`. When the user passes the correct `CC` variable to the Makefile in step 2., the dependencies files are not regenerated, the old value of `CC` is used in the build and the build continues to fail.

In this PR we change the dependency file generation so that the variables like `$(CC)` are written into the dependency file verbatim. They are resolved when they are run in step 2. using the new value of the CC parameter.

* Closes https://github.com/anoma/juvix/issues/2537