### PR TITLE
Add dependent defaults for the new typechecker

### DIFF
--- a/src/Juvix/Compiler/Internal/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Internal/Data/InfoTable.hs
@@ -4,6 +4,7 @@ module Juvix.Compiler.Internal.Data.InfoTable
     extendWithReplExpression,
     lookupConstructor,
     lookupConstructorArgTypes,
+    lookupFunctionMaybe,
     lookupFunction,
     lookupConstructorReturnType,
     lookupInductive,
@@ -169,7 +170,7 @@ lookupConstructor f = do
         $ "impossible: "
           <> ppTrace f
           <> " is not in the InfoTable\n"
-          <> "The registered constructors are: "
+          <> "\nThe registered constructors are: "
           <> ppTrace (HashMap.keys tbl)
 
 lookupConstructorArgTypes :: (Member (Reader InfoTable) r) => Name -> Sem r ([InductiveParameter], [Expression])
@@ -188,13 +189,16 @@ lookupInductive f = do
         $ "impossible: "
           <> ppTrace f
           <> " is not in the InfoTable\n"
-          <> "The registered inductives are: "
+          <> "\nThe registered inductives are: "
           <> ppTrace (HashMap.keys tbl)
+
+lookupFunctionMaybe :: forall r. (Member (Reader InfoTable) r) => Name -> Sem r (Maybe FunctionInfo)
+lookupFunctionMaybe f = HashMap.lookup f <$> asks (^. infoFunctions)
 
 lookupFunction :: forall r. (Member (Reader InfoTable) r) => Name -> Sem r FunctionInfo
 lookupFunction f = do
   err <- impossibleErr
-  HashMap.lookupDefault err f <$> asks (^. infoFunctions)
+  fromMaybe err <$> lookupFunctionMaybe f
   where
     impossibleErr :: Sem r a
     impossibleErr = do
@@ -205,7 +209,7 @@ lookupFunction f = do
           <> ppTrace f
           <> " is not in the InfoTable\n"
           <> ppTrace (getLoc f)
-          <> "The registered functions are: "
+          <> "\nThe registered functions are: "
           <> ppTrace (HashMap.keys tbl)
 
 lookupAxiom :: (Member (Reader InfoTable) r) => Name -> Sem r AxiomInfo

--- a/src/Juvix/Compiler/Internal/Extra/Base.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Base.hs
@@ -405,6 +405,7 @@ foldApplication f args = case nonEmpty args of
 unfoldApplication' :: Application -> (Expression, NonEmpty ApplicationArg)
 unfoldApplication' (Application l' r' i') = second (|: (ApplicationArg i' r')) (unfoldExpressionApp l')
 
+-- TODO make it tail recursive
 unfoldExpressionApp :: Expression -> (Expression, [ApplicationArg])
 unfoldExpressionApp = \case
   ExpressionApplication (Application l r i) ->

--- a/src/Juvix/Compiler/Internal/Extra/Base.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Base.hs
@@ -126,11 +126,12 @@ instance HasExpressions SimpleLambda where
 instance HasExpressions FunctionParameter where
   leafExpressions f FunctionParameter {..} = do
     ty' <- leafExpressions f _paramType
-    pure FunctionParameter {
-      _paramType = ty',
-      _paramName,
-      _paramImplicit
-                           }
+    pure
+      FunctionParameter
+        { _paramType = ty',
+          _paramName,
+          _paramImplicit
+        }
 
 instance HasExpressions Function where
   leafExpressions f (Function l r) = do
@@ -306,10 +307,10 @@ inductiveTypeVarsAssoc def l
     vars :: [VarName]
     vars = def ^.. inductiveParameters . each . inductiveParamName
 
-substitutionApp :: forall r expr. (Member NameIdGen r, HasExpressions expr) => (Maybe Name, Expression) -> expr -> Sem r expr
+substitutionApp :: (Maybe Name, Expression) -> Subs
 substitutionApp (mv, ty) = case mv of
-  Nothing -> return
-  Just v -> substitutionE (HashMap.singleton v ty)
+  Nothing -> mempty
+  Just v -> HashMap.singleton v ty
 
 localsToSubsE :: LocalVars -> Subs
 localsToSubsE l = ExpressionIden . IdenVar <$> l ^. localTyMap

--- a/src/Juvix/Compiler/Internal/Extra/Base.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Base.hs
@@ -124,9 +124,13 @@ instance HasExpressions SimpleLambda where
     pure (SimpleLambda bi' b')
 
 instance HasExpressions FunctionParameter where
-  leafExpressions f (FunctionParameter m i e) = do
-    e' <- leafExpressions f e
-    pure (FunctionParameter m i e')
+  leafExpressions f FunctionParameter {..} = do
+    ty' <- leafExpressions f _paramType
+    pure FunctionParameter {
+      _paramType = ty',
+      _paramName,
+      _paramImplicit
+                           }
 
 instance HasExpressions Function where
   leafExpressions f (Function l r) = do

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -391,7 +391,7 @@ instance HasAtomicity SimpleLambda where
   atomicity = const Atom
 
 instance HasAtomicity Let where
-  atomicity l = atomicity (l ^. letExpression)
+  atomicity = const (Aggregate letFixity)
 
 instance HasAtomicity Literal where
   atomicity = \case

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -778,10 +778,7 @@ goExpression = \case
         cls <- goArgs appargs
         let args :: [Internal.Name] = appargs ^.. each . namedArgumentNewFunDef . signName . to goSymbol
             -- changes the kind from Variable to Function
-            updateKind :: Internal.Subs =
-              HashMap.fromList
-                [ (s, Internal.toExpression s') | s <- args, let s' = Internal.IdenFunction (set Internal.nameKind KNameFunction s)
-                ]
+            updateKind :: Internal.Subs = Internal.subsKind args KNameFunction
             napp' =
               Concrete.NamedApplication
                 { _namedAppName = napp ^. namedApplicationNewName,
@@ -841,10 +838,7 @@ goExpression = \case
     goDesugaredNamedApplication :: DesugaredNamedApplication -> Sem r Internal.Expression
     goDesugaredNamedApplication a = do
       let fun = goScopedIden (a ^. dnamedAppIdentifier)
-          updateKind :: Internal.Subs =
-            HashMap.fromList
-              [ (s, Internal.ExpressionIden s') | s <- a ^.. dnamedAppArgs . each . argName . to goSymbol, let s' = Internal.IdenFunction (set Internal.nameKind KNameFunction s)
-              ]
+          updateKind :: Internal.Subs = Internal.subsKind (a ^.. dnamedAppArgs . each . argName . to goSymbol) KNameFunction
           mkAppArg :: Arg -> Internal.ApplicationArg
           mkAppArg arg =
             Internal.ApplicationArg

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Checker.hs
@@ -915,7 +915,7 @@ inferExpression' hint e = case e of
                         <> ppTrace (Application l r iapp)
                     )
                 )
-              ty <- substitutionApp (paraName, r') funR
+              ty <- substitutionE (substitutionApp (paraName, r')) funR
               return
                 TypedExpression
                   { _typedExpression =

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
@@ -56,6 +56,7 @@ data AppBuilderArg = AppBuilderArg
 
 data AppBuilder = AppBuilder
   { _appBuilder :: Expression,
+    _appBuilderCheckedArgs :: [InsertedArg],
     _appBuilderType :: BuilderType,
     _appBuilderArgs :: [AppBuilderArg]
   }
@@ -1044,6 +1045,7 @@ holesHelper mhint expr = do
       iniBuilder =
         AppBuilder
           { _appBuilder = fTy ^. typedExpression,
+            _appBuilderCheckedArgs = [],
             _appBuilderType = iniBuilderType,
             _appBuilderArgs = map iniArg args
           }
@@ -1055,6 +1057,38 @@ holesHelper mhint expr = do
         _typedExpression = st' ^. appBuilder
       }
   where
+    mkFinalExpression :: Expression -> [InsertedArg] -> Sem r Expression
+    mkFinalExpression f args =
+      case nonEmpty  args of
+        Nothing -> return f
+        Just args'
+          | not hasADefault -> return (foldApplication f (map (^. insertedArg) args))
+          | otherwise  -> do
+            let mkClause :: InsertedArg -> Sem r PreLetStatement
+                mkClause InsertedArg {..} = do
+                      -- TODO put actual type instead of hole?
+                      let arg = _insertedArg
+                          nm = _insertedArgName
+                      ty <- mkFreshHole (getLoc arg)
+                      return (PreLetFunctionDef (simpleFunDef nm ty (arg ^. appArg)))
+                mkAppArg :: InsertedArg -> ApplicationArg
+                mkAppArg InsertedArg {..} =
+                      ApplicationArg
+                        { _appArgIsImplicit = _insertedArg ^. appArgIsImplicit,
+                          _appArg = toExpression _insertedArgName
+                        }
+                app = foldApplication f (map mkAppArg args)
+            clauses :: NonEmpty LetClause <- nonEmpty' . mkLetClauses <$> mapM mkClause args'
+            letexpr <- substitutionE (renameKind KNameFunction (map (^. insertedArgName) args)) $
+                    ExpressionLet
+                      Let
+                        { _letClauses = clauses,
+                          _letExpression = app
+                        }
+            clone letexpr
+        where
+         hasADefault = any (^. insertedArgDefault) args
+
     mkFinalBuilderType :: BuilderType -> Expression
     mkFinalBuilderType = \case
       BuilderTypeNoDefaults e -> e
@@ -1248,6 +1282,8 @@ holesHelper mhint expr = do
                             _functionDefaultRight = r'
                           }
                     )
+              -- FIXME add arg' to appBuilderCheckedArgs
+              -- TODO we need to update the FunctionsTable if necessary!
               applyArg :: Expression -> Expression
               applyArg l =
                 ExpressionApplication

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
@@ -22,7 +22,7 @@ newtype InsertedArgsStack = InsertedArgsStack
 -- checker.
 data InsertedArg = InsertedArg
   { _insertedImplicit :: IsImplicit,
-    _insertedFunction :: FunctionDef,
+    _insertedValue :: Expression,
     -- | True if this corresponds to an automatically inserted default argument.
     -- False if it is an inserted hole or an argument present in the source code.
     _insertedArgDefault :: Bool

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew/Arity.hs
@@ -1,6 +1,5 @@
 module Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.CheckerNew.Arity where
 
-import Juvix.Compiler.Internal.Extra.Base
 import Juvix.Compiler.Internal.Language
 import Juvix.Prelude
 import Juvix.Prelude.Pretty
@@ -22,8 +21,8 @@ newtype InsertedArgsStack = InsertedArgsStack
 -- | Helper type used during insertion of default arguments in the arity
 -- checker.
 data InsertedArg = InsertedArg
-  { _insertedArgName :: Name,
-    _insertedArg :: ApplicationArg,
+  { _insertedImplicit :: IsImplicit,
+    _insertedFunction :: FunctionDef,
     -- | True if this corresponds to an automatically inserted default argument.
     -- False if it is an inserted hole or an argument present in the source code.
     _insertedArgDefault :: Bool

--- a/src/Juvix/Data/Fixity.hs
+++ b/src/Juvix/Data/Fixity.hs
@@ -71,11 +71,19 @@ isBinary f = case f ^. fixityArity of
 isUnary :: Fixity -> Bool
 isUnary = not . isBinary
 
+letFixity :: Fixity
+letFixity =
+  Fixity
+    { _fixityPrecedence = PrecArrow,
+      _fixityArity = OpBinary AssocRight,
+      _fixityId = Nothing
+    }
+
 appFixity :: Fixity
 appFixity =
   Fixity
     { _fixityPrecedence = PrecApp,
-      _fixityArity = (OpBinary AssocLeft),
+      _fixityArity = OpBinary AssocLeft,
       _fixityId = Nothing
     }
 
@@ -83,7 +91,7 @@ funFixity :: Fixity
 funFixity =
   Fixity
     { _fixityPrecedence = PrecArrow,
-      _fixityArity = (OpBinary AssocRight),
+      _fixityArity = OpBinary AssocRight,
       _fixityId = Nothing
     }
 
@@ -91,7 +99,7 @@ updateFixity :: Fixity
 updateFixity =
   Fixity
     { _fixityPrecedence = PrecUpdate,
-      _fixityArity = (OpUnary AssocPostfix),
+      _fixityArity = OpUnary AssocPostfix,
       _fixityId = Nothing
     }
 

--- a/test/Compilation/PositiveNew.hs
+++ b/test/Compilation/PositiveNew.hs
@@ -50,9 +50,7 @@ extraTests =
 ignored :: HashSet String
 ignored =
   HashSet.fromList
-    [ "Test070: Nested default values and named arguments",
-      "Test071: Named application (Ord instance with default cmp)",
-      "Test046: Polymorphic type arguments",
+    [ "Test046: Polymorphic type arguments",
       -- TODO allow lambda branches of different number of patterns
       "Test027: Church numerals"
     ]

--- a/test/Typecheck/PositiveNew.hs
+++ b/test/Typecheck/PositiveNew.hs
@@ -43,8 +43,6 @@ extraTests = []
 ignored :: HashSet String
 ignored =
   HashSet.fromList
-    [ "Test070: Nested default values and named arguments",
-      "Test071: Named application (Ord instance with default cmp)",
-      -- This test does not pass with the new hole insertion algorithm
+    [ -- This test does not pass with the new hole insertion algorithm
       "Test046: Polymorphic type arguments"
     ]


### PR DESCRIPTION
This pr adds support for default values that depend on previous arguments. For instance, see [test071](https://github.com/anoma/juvix/blob/ca7d0fa06d7fca30c8d9abe87dfb2afc1b9bd8c9/tests/Compilation/positive/test071.juvix).
- After #2540 is implemented, we'll be able to remove the old type checker (including the aritychecker).