### PR TITLE
Read `Package` on demand and cache it

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -99,7 +99,6 @@ reAppIO args@RunAppIOArgs {..} =
     getMainFile' :: (Members '[SCache Package, Embed IO] r') => Maybe (AppPath File) -> Sem r' (Path Abs File)
     getMainFile' = \case
       Just p -> embed (prepathToAbsFile invDir (p ^. pathPath))
-      -- Nothing -> case pkg ^. packageMain of
       Nothing -> do
         pkg <- getPkg
         case pkg ^. packageMain of

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -9,7 +9,7 @@ import Juvix.Compiler.Core qualified as Core
 import Juvix.Compiler.Core.Pretty qualified as Core
 import Juvix.Compiler.Core.Transformation.DisambiguateNames qualified as Core
 
-runCommand :: (Members '[Embed IO, App] r) => CompileOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => CompileOptions -> Sem r ()
 runCommand opts@CompileOptions {..} = do
   inputFile <- getMainFile _compileInputFile
   Core.CoreResult {..} <- runPipeline (AppPath (preFileFromAbs inputFile) True) upToCore
@@ -27,7 +27,7 @@ runCommand opts@CompileOptions {..} = do
     TargetCore -> writeCoreFile arg
     TargetAsm -> Compile.runAsmPipeline arg
 
-writeCoreFile :: (Members '[Embed IO, App] r) => Compile.PipelineArg -> Sem r ()
+writeCoreFile :: (Members '[Embed IO, App, TaggedLock] r) => Compile.PipelineArg -> Sem r ()
 writeCoreFile pa@Compile.PipelineArg {..} = do
   entryPoint <- Compile.getEntry pa
   coreFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile

--- a/app/Commands/Dependencies.hs
+++ b/app/Commands/Dependencies.hs
@@ -8,6 +8,6 @@ import Commands.Base
 import Commands.Dependencies.Options
 import Commands.Dependencies.Update qualified as Update
 
-runCommand :: (Members '[Embed IO, App] r) => DependenciesCommand -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => DependenciesCommand -> Sem r ()
 runCommand = \case
   Update -> Update.runCommand

--- a/app/Commands/Dependencies/Update.hs
+++ b/app/Commands/Dependencies/Update.hs
@@ -2,5 +2,5 @@ module Commands.Dependencies.Update where
 
 import Commands.Base
 
-runCommand :: (Members '[Embed IO, App] r) => Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => Sem r ()
 runCommand = runPipelineNoFile (upToSetup (set dependenciesConfigForceUpdateLockfile True defaultDependenciesConfig))

--- a/app/Commands/Dev.hs
+++ b/app/Commands/Dev.hs
@@ -19,7 +19,7 @@ import Commands.Dev.Scope qualified as Scope
 import Commands.Dev.Termination qualified as Termination
 import Commands.Repl qualified as Repl
 
-runCommand :: (Members '[Embed IO, App] r) => DevCommand -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => DevCommand -> Sem r ()
 runCommand = \case
   Highlight opts -> Highlight.runCommand opts
   Parse opts -> Parse.runCommand opts

--- a/app/Commands/Dev/Asm.hs
+++ b/app/Commands/Dev/Asm.hs
@@ -6,7 +6,7 @@ import Commands.Dev.Asm.Options
 import Commands.Dev.Asm.Run as Run
 import Commands.Dev.Asm.Validate as Validate
 
-runCommand :: forall r. (Members '[Embed IO, App] r) => AsmCommand -> Sem r ()
+runCommand :: forall r. (Members '[Embed IO, App, TaggedLock] r) => AsmCommand -> Sem r ()
 runCommand = \case
   Run opts -> Run.runCommand opts
   Validate opts -> Validate.runCommand opts

--- a/app/Commands/Dev/Asm/Compile.hs
+++ b/app/Commands/Dev/Asm/Compile.hs
@@ -8,7 +8,7 @@ import Juvix.Compiler.Asm.Translation.FromSource qualified as Asm
 import Juvix.Compiler.Backend qualified as Backend
 import Juvix.Compiler.Backend.C qualified as C
 
-runCommand :: forall r. (Members '[Embed IO, App] r) => AsmCompileOptions -> Sem r ()
+runCommand :: forall r. (Members '[Embed IO, App, TaggedLock] r) => AsmCompileOptions -> Sem r ()
 runCommand opts = do
   file <- getFile
   ep <- getEntryPoint (AppPath (preFileFromAbs file) True)

--- a/app/Commands/Dev/Core.hs
+++ b/app/Commands/Dev/Core.hs
@@ -11,7 +11,7 @@ import Commands.Dev.Core.Read as Read
 import Commands.Dev.Core.Repl as Repl
 import Commands.Dev.Core.Strip as Strip
 
-runCommand :: forall r. (Members '[Embed IO, App] r) => CoreCommand -> Sem r ()
+runCommand :: forall r. (Members '[Embed IO, App, TaggedLock] r) => CoreCommand -> Sem r ()
 runCommand = \case
   Repl opts -> Repl.runCommand opts
   Eval opts -> Eval.runCommand opts

--- a/app/Commands/Dev/Core/Compile.hs
+++ b/app/Commands/Dev/Core/Compile.hs
@@ -6,7 +6,7 @@ import Commands.Dev.Core.Compile.Options
 import Juvix.Compiler.Core.Data.InfoTable qualified as Core
 import Juvix.Compiler.Core.Translation.FromSource qualified as Core
 
-runCommand :: forall r. (Members '[Embed IO, App] r) => CompileOptions -> Sem r ()
+runCommand :: forall r. (Members '[Embed IO, App, TaggedLock] r) => CompileOptions -> Sem r ()
 runCommand opts = do
   file <- getFile
   s <- readFile (toFilePath file)

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -18,7 +18,7 @@ data PipelineArg = PipelineArg
     _pipelineArgInfoTable :: Core.InfoTable
   }
 
-getEntry :: (Members '[Embed IO, App] r) => PipelineArg -> Sem r EntryPoint
+getEntry :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r EntryPoint
 getEntry PipelineArg {..} = do
   ep <- getEntryPoint (AppPath (preFileFromAbs _pipelineArgFile) True)
   return $
@@ -46,7 +46,7 @@ getEntry PipelineArg {..} = do
 
 runCPipeline ::
   forall r.
-  (Members '[Embed IO, App] r) =>
+  (Members '[Embed IO, App, TaggedLock] r) =>
   PipelineArg ->
   Sem r ()
 runCPipeline pa@PipelineArg {..} = do
@@ -69,7 +69,7 @@ runCPipeline pa@PipelineArg {..} = do
 
 runGebPipeline ::
   forall r.
-  (Members '[Embed IO, App] r) =>
+  (Members '[Embed IO, App, TaggedLock] r) =>
   PipelineArg ->
   Sem r ()
 runGebPipeline pa@PipelineArg {..} = do
@@ -89,7 +89,7 @@ runGebPipeline pa@PipelineArg {..} = do
 
 runVampIRPipeline ::
   forall r.
-  (Members '[Embed IO, App] r) =>
+  (Members '[Embed IO, App, TaggedLock] r) =>
   PipelineArg ->
   Sem r ()
 runVampIRPipeline pa@PipelineArg {..} = do
@@ -98,7 +98,7 @@ runVampIRPipeline pa@PipelineArg {..} = do
   VampIR.Result {..} <- getRight (run (runReader entryPoint (runError (coreToVampIR _pipelineArgInfoTable :: Sem '[Error JuvixError, Reader EntryPoint] VampIR.Result))))
   embed $ TIO.writeFile (toFilePath vampirFile) _resultCode
 
-runAsmPipeline :: (Members '[Embed IO, App] r) => PipelineArg -> Sem r ()
+runAsmPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runAsmPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa
   asmFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile

--- a/app/Commands/Dev/Core/FromConcrete.hs
+++ b/app/Commands/Dev/Core/FromConcrete.hs
@@ -10,7 +10,7 @@ import Juvix.Compiler.Core.Transformation qualified as Core
 import Juvix.Compiler.Core.Transformation.DisambiguateNames (disambiguateNames)
 import Juvix.Compiler.Core.Translation
 
-runCommand :: forall r. (Members '[Embed IO, App] r) => CoreFromConcreteOptions -> Sem r ()
+runCommand :: forall r. (Members '[Embed IO, TaggedLock, App] r) => CoreFromConcreteOptions -> Sem r ()
 runCommand localOpts = do
   gopts <- askGlobalOptions
   tab <- (^. coreResultTable) <$> runPipeline (localOpts ^. coreFromConcreteInputFile) upToCore

--- a/app/Commands/Dev/Geb/Repl.hs
+++ b/app/Commands/Dev/Geb/Repl.hs
@@ -43,7 +43,7 @@ runCommand replOpts = do
         gopts <- State.gets (^. replStateGlobalOptions)
         absInputFile :: Path Abs File <- replMakeAbsolute inputFile
         set entryPointTarget Backend.TargetGeb
-          <$> liftIO (entryPointFromGlobalOptions root absInputFile gopts)
+          <$> liftIO (runM (runTaggedLockPermissive (entryPointFromGlobalOptions root absInputFile gopts)))
   embed
     ( State.evalStateT
         (replAction replOpts getReplEntryPoint)

--- a/app/Commands/Dev/Highlight.hs
+++ b/app/Commands/Dev/Highlight.hs
@@ -5,7 +5,7 @@ import Commands.Dev.Highlight.Options
 import Juvix.Compiler.Concrete.Data.Highlight qualified as Highlight
 import Juvix.Compiler.Pipeline.Run
 
-runCommand :: (Members '[Embed IO, App] r) => HighlightOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => HighlightOptions -> Sem r ()
 runCommand HighlightOptions {..} = do
   entry <- getEntryPoint _highlightInputFile
   inputFile <- fromAppPathFile _highlightInputFile

--- a/app/Commands/Dev/Highlight.hs
+++ b/app/Commands/Dev/Highlight.hs
@@ -12,5 +12,5 @@ runCommand HighlightOptions {..} = do
   hinput <-
     Highlight.filterInput
       inputFile
-      <$> liftIO (runPipelineHighlight entry upToInternalTyped)
+      <$> runPipelineHighlight entry upToInternalTyped
   sayRaw (Highlight.highlight _highlightBackend hinput)

--- a/app/Commands/Dev/Internal.hs
+++ b/app/Commands/Dev/Internal.hs
@@ -6,7 +6,7 @@ import Commands.Dev.Internal.Pretty qualified as Pretty
 import Commands.Dev.Internal.Reachability qualified as Reachability
 import Commands.Dev.Internal.Typecheck qualified as Typecheck
 
-runCommand :: (Members '[Embed IO, App] r) => InternalCommand -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => InternalCommand -> Sem r ()
 runCommand = \case
   Pretty opts -> Pretty.runCommand opts
   TypeCheck opts -> Typecheck.runCommand opts

--- a/app/Commands/Dev/Internal/Pretty.hs
+++ b/app/Commands/Dev/Internal/Pretty.hs
@@ -5,7 +5,7 @@ import Commands.Dev.Internal.Pretty.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
 
-runCommand :: (Members '[Embed IO, App] r) => InternalPrettyOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => InternalPrettyOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
   intern <- head . (^. Internal.resultModules) <$> runPipelineTermination (opts ^. internalPrettyInputFile) upToInternal

--- a/app/Commands/Dev/Internal/Reachability.hs
+++ b/app/Commands/Dev/Internal/Reachability.hs
@@ -5,7 +5,7 @@ import Commands.Dev.Internal.Reachability.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
 
-runCommand :: (Members '[Embed IO, App] r) => InternalReachabilityOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => InternalReachabilityOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
   depInfo <- (^. Internal.resultDepInfo) <$> runPipelineTermination (opts ^. internalReachabilityInputFile) upToInternal

--- a/app/Commands/Dev/Internal/Typecheck.hs
+++ b/app/Commands/Dev/Internal/Typecheck.hs
@@ -5,7 +5,7 @@ import Commands.Dev.Internal.Typecheck.Options
 import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking qualified as InternalTyped
 
-runCommand :: (Members '[Embed IO, App] r) => InternalTypeOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => InternalTypeOptions -> Sem r ()
 runCommand localOpts = do
   globalOpts <- askGlobalOptions
   res <- runPipeline (localOpts ^. internalTypeInputFile) upToInternalTyped

--- a/app/Commands/Dev/Parse.hs
+++ b/app/Commands/Dev/Parse.hs
@@ -5,7 +5,7 @@ import Commands.Dev.Parse.Options
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
 import Text.Show.Pretty (ppShow)
 
-runCommand :: (Members '[Embed IO, App] r) => ParseOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => ParseOptions -> Sem r ()
 runCommand opts = do
   m <-
     head . (^. Parser.resultModules)

--- a/app/Commands/Dev/Scope.hs
+++ b/app/Commands/Dev/Scope.hs
@@ -7,7 +7,7 @@ import Juvix.Compiler.Concrete.Print qualified as Print
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
 import Juvix.Prelude.Pretty
 
-runCommand :: (Members '[Embed IO, App] r) => ScopeOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => ScopeOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
   res :: Scoper.ScoperResult <- runPipeline (opts ^. scopeInputFile) upToScoping

--- a/app/Commands/Dev/Termination.hs
+++ b/app/Commands/Dev/Termination.hs
@@ -5,7 +5,7 @@ import Commands.Dev.Termination.CallGraph qualified as CallGraph
 import Commands.Dev.Termination.Calls qualified as Calls
 import Commands.Dev.Termination.Options
 
-runCommand :: (Members '[Embed IO, App] r) => TerminationCommand -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => TerminationCommand -> Sem r ()
 runCommand = \case
   Calls opts -> Calls.runCommand opts
   CallGraph opts -> CallGraph.runCommand opts

--- a/app/Commands/Dev/Termination/CallGraph.hs
+++ b/app/Commands/Dev/Termination/CallGraph.hs
@@ -9,7 +9,7 @@ import Juvix.Compiler.Internal.Translation.FromConcrete.Data.Context qualified a
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination qualified as Termination
 import Juvix.Prelude.Pretty
 
-runCommand :: (Members '[Embed IO, App] r) => CallGraphOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => CallGraphOptions -> Sem r ()
 runCommand CallGraphOptions {..} = do
   globalOpts <- askGlobalOptions
   results <- runPipelineTermination _graphInputFile upToInternal

--- a/app/Commands/Dev/Termination/Calls.hs
+++ b/app/Commands/Dev/Termination/Calls.hs
@@ -6,7 +6,7 @@ import Juvix.Compiler.Internal.Pretty qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination qualified as Termination
 
-runCommand :: (Members '[Embed IO, App] r) => CallsOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => CallsOptions -> Sem r ()
 runCommand localOpts@CallsOptions {..} = do
   globalOpts <- askGlobalOptions
   results <- runPipelineTermination _callsInputFile upToInternal

--- a/app/Commands/Eval.hs
+++ b/app/Commands/Eval.hs
@@ -6,7 +6,7 @@ import Evaluator qualified as Eval
 import Juvix.Compiler.Core qualified as Core
 import Juvix.Extra.Strings qualified as Str
 
-runCommand :: (Members '[Embed IO, App] r) => EvalOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => EvalOptions -> Sem r ()
 runCommand opts@EvalOptions {..} = do
   gopts <- askGlobalOptions
   Core.CoreResult {..} <- runPipeline _evalInputFile upToCore

--- a/app/Commands/Extra/Package.hs
+++ b/app/Commands/Extra/Package.hs
@@ -6,9 +6,6 @@ import Juvix.Compiler.Pipeline.Package.Loader
 import Juvix.Extra.Paths
 import Juvix.Prelude
 
-currentPackageVersion :: PackageVersion
-currentPackageVersion = PackageVersion2
-
 renderPackage :: Package -> Text
 renderPackage = renderPackageVersion currentPackageVersion
 

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -45,7 +45,7 @@ targetFromOptions opts = do
                     "Use the --help option to display more usage information."
                   ]
 
-runCommand :: forall r. (Members '[Embed IO, App, Resource, Files] r) => FormatOptions -> Sem r ()
+runCommand :: forall r. (Members '[Embed IO, App, TaggedLock, Resource, Files] r) => FormatOptions -> Sem r ()
 runCommand opts = do
   target <- targetFromOptions opts
   runOutputSem (renderFormattedOutput target opts) $ runScopeFileApp $ do
@@ -96,7 +96,7 @@ renderFormattedOutput target opts fInfo = do
         InputPath p -> say (pack (toFilePath p))
         Silent -> return ()
 
-runScopeFileApp :: (Member App r) => Sem (ScopeEff ': r) a -> Sem r a
+runScopeFileApp :: (Members '[App, Embed IO, TaggedLock] r) => Sem (ScopeEff ': r) a -> Sem r a
 runScopeFileApp = interpret $ \case
   ScopeFile p -> do
     let appFile =

--- a/app/Commands/Html.hs
+++ b/app/Commands/Html.hs
@@ -13,7 +13,7 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Cont
 import Juvix.Extra.Process
 import System.Process qualified as Process
 
-runGenOnlySourceHtml :: (Members '[Embed IO, App] r) => HtmlOptions -> Sem r ()
+runGenOnlySourceHtml :: (Members '[Embed IO, TaggedLock, App] r) => HtmlOptions -> Sem r ()
 runGenOnlySourceHtml HtmlOptions {..} = do
   res <- runPipeline _htmlInputFile upToScoping
   let m = head (res ^. Scoper.resultModules)
@@ -37,7 +37,7 @@ runGenOnlySourceHtml HtmlOptions {..} = do
           _genSourceHtmlArgsTheme = _htmlTheme
         }
 
-runCommand :: (Members '[Embed IO, App] r) => HtmlOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => HtmlOptions -> Sem r ()
 runCommand HtmlOptions {..}
   | _htmlOnlySource = runGenOnlySourceHtml HtmlOptions {..}
   | otherwise = do

--- a/app/Commands/Markdown.hs
+++ b/app/Commands/Markdown.hs
@@ -12,7 +12,7 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified
 import Juvix.Extra.Assets (writeAssets)
 
 runCommand ::
-  (Members '[Embed IO, App] r) =>
+  (Members '[Embed IO, TaggedLock, App] r) =>
   MarkdownOptions ->
   Sem r ()
 runCommand opts = do

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -39,7 +39,6 @@ import Juvix.Compiler.Pipeline.Setup (entrySetup)
 import Juvix.Data.CodeAnn (Ann)
 import Juvix.Data.Effect.Git
 import Juvix.Data.Effect.Process
-import Juvix.Data.Effect.TaggedLock
 import Juvix.Data.Error.GenericError qualified as Error
 import Juvix.Data.NameKind
 import Juvix.Extra.Paths qualified as P
@@ -172,10 +171,10 @@ getReplEntryPoint f inputFile = do
   liftIO (set entryPointSymbolPruningMode KeepAll <$> f root inputFile gopts)
 
 getReplEntryPointFromPrepath :: Prepath File -> Repl EntryPoint
-getReplEntryPointFromPrepath = getReplEntryPoint entryPointFromGlobalOptionsPre
+getReplEntryPointFromPrepath = getReplEntryPoint (\r x -> runM . runTaggedLockPermissive . entryPointFromGlobalOptionsPre r x)
 
 getReplEntryPointFromPath :: Path Abs File -> Repl EntryPoint
-getReplEntryPointFromPath = getReplEntryPoint entryPointFromGlobalOptions
+getReplEntryPointFromPath = getReplEntryPoint (\r a -> runM . runTaggedLockPermissive . entryPointFromGlobalOptions r a)
 
 displayVersion :: String -> Repl ()
 displayVersion _ = liftIO (putStrLn versionTag)
@@ -495,9 +494,10 @@ printRoot _ = do
   r <- State.gets (^. replStateRoot . rootRootDir)
   liftIO $ putStrLn (pack (toFilePath r))
 
-runCommand :: (Members '[Embed IO, App] r) => ReplOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, App, TaggedLock] r) => ReplOptions -> Sem r ()
 runCommand opts = do
   root <- askRoot
+  pkg <- askPackage
   let replAction :: ReplS ()
       replAction = do
         evalReplOpts
@@ -515,7 +515,8 @@ runCommand opts = do
   let env =
         ReplEnv
           { _replRoot = root,
-            _replOptions = opts
+            _replOptions = opts,
+            _replPackage = pkg
           }
       iniState =
         ReplState
@@ -539,7 +540,7 @@ defaultPreludeEntryPoint = do
   root <- State.gets (^. replStateRoot)
   let buildRoot = root ^. rootRootDir
       buildDir = resolveAbsBuildDir buildRoot (root ^. rootBuildDir)
-      pkg = root ^. rootPackage
+  pkg <- Reader.asks (^. replPackage)
   mstdlibPath <- liftIO (runM (runFilesIO (packageStdlib buildRoot buildDir (pkg ^. packageDependencies))))
   case mstdlibPath of
     Just stdlibPath ->

--- a/app/Commands/Repl/Base.hs
+++ b/app/Commands/Repl/Base.hs
@@ -20,6 +20,7 @@ data ReplContext = ReplContext
 
 data ReplEnv = ReplEnv
   { _replRoot :: Root,
+    _replPackage :: Package,
     _replOptions :: ReplOptions
   }
 

--- a/app/Commands/Typecheck.hs
+++ b/app/Commands/Typecheck.hs
@@ -3,7 +3,7 @@ module Commands.Typecheck where
 import Commands.Base
 import Commands.Typecheck.Options
 
-runCommand :: (Members '[Embed IO, App] r) => TypecheckOptions -> Sem r ()
+runCommand :: (Members '[Embed IO, TaggedLock, App] r) => TypecheckOptions -> Sem r ()
 runCommand localOpts = do
   void (runPipeline (localOpts ^. typecheckInputFile) upToCoreTypecheck)
   say "Well done! It type checks"

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -1,5 +1,6 @@
 module GlobalOptions
   ( module GlobalOptions,
+    module Juvix.Data.Effect.TaggedLock,
   )
 where
 
@@ -7,6 +8,8 @@ import CommonOptions
 import Juvix.Compiler.Core.Options qualified as Core
 import Juvix.Compiler.Internal.Pretty.Options qualified as Internal
 import Juvix.Compiler.Pipeline
+import Juvix.Compiler.Pipeline.Package (readPackageRootIO)
+import Juvix.Data.Effect.TaggedLock
 import Juvix.Data.Error.GenericError qualified as E
 
 data GlobalOptions = GlobalOptions
@@ -139,16 +142,17 @@ parseBuildDir m = do
       )
   pure AppPath {_pathIsInput = False, ..}
 
-entryPointFromGlobalOptionsPre :: Root -> Prepath File -> GlobalOptions -> IO EntryPoint
+entryPointFromGlobalOptionsPre :: (Members '[TaggedLock, Embed IO] r) => Root -> Prepath File -> GlobalOptions -> Sem r EntryPoint
 entryPointFromGlobalOptionsPre root premainFile opts = do
-  mainFile <- prepathToAbsFile (root ^. rootInvokeDir) premainFile
+  mainFile <- liftIO (prepathToAbsFile (root ^. rootInvokeDir) premainFile)
   entryPointFromGlobalOptions root mainFile opts
 
-entryPointFromGlobalOptions :: Root -> Path Abs File -> GlobalOptions -> IO EntryPoint
+entryPointFromGlobalOptions :: (Members '[TaggedLock, Embed IO] r) => Root -> Path Abs File -> GlobalOptions -> Sem r EntryPoint
 entryPointFromGlobalOptions root mainFile opts = do
-  mabsBuildDir :: Maybe (Path Abs Dir) <- mapM (prepathToAbsDir cwd) optBuildDir
+  mabsBuildDir :: Maybe (Path Abs Dir) <- liftIO (mapM (prepathToAbsDir cwd) optBuildDir)
+  pkg <- readPackageRootIO root
   let def :: EntryPoint
-      def = defaultEntryPoint root mainFile
+      def = defaultEntryPoint pkg root mainFile
   return
     def
       { _entryPointNoTermination = opts ^. globalNoTermination,
@@ -165,11 +169,12 @@ entryPointFromGlobalOptions root mainFile opts = do
     optBuildDir = fmap (^. pathPath) (opts ^. globalBuildDir)
     cwd = root ^. rootInvokeDir
 
-entryPointFromGlobalOptionsNoFile :: Root -> GlobalOptions -> IO EntryPoint
+entryPointFromGlobalOptionsNoFile :: (Members '[Embed IO, TaggedLock] r, MonadIO (Sem r)) => Root -> GlobalOptions -> Sem r EntryPoint
 entryPointFromGlobalOptionsNoFile root opts = do
   mabsBuildDir :: Maybe (Path Abs Dir) <- mapM (prepathToAbsDir cwd) optBuildDir
+  pkg <- readPackageRootIO root
   let def :: EntryPoint
-      def = defaultEntryPointNoFile root
+      def = defaultEntryPointNoFile pkg root
   return
     def
       { _entryPointNoTermination = opts ^. globalNoTermination,

--- a/app/TopCommand.hs
+++ b/app/TopCommand.hs
@@ -25,7 +25,7 @@ showHelpText = do
       (msg, _) = renderFailure helpText progn
   putStrLn (pack msg)
 
-runTopCommand :: forall r. (Members '[Embed IO, App, Resource] r) => TopCommand -> Sem r ()
+runTopCommand :: forall r. (Members '[Embed IO, App, Resource, TaggedLock] r) => TopCommand -> Sem r ()
 runTopCommand = \case
   DisplayVersion -> embed runDisplayVersion
   DisplayNumericVersion -> embed runDisplayNumericVersion

--- a/package.yaml
+++ b/package.yaml
@@ -77,6 +77,7 @@ dependencies:
   - process == 1.6.*
   - safe == 0.3.*
   - singletons == 3.0.*
+  - singletons-base == 3.1.*
   - singletons-th == 3.1.*
   - Stream == 0.4.*
   - string-interpolate == 0.3.*

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -7,6 +7,7 @@ module Juvix.Compiler.Pipeline
   )
 where
 
+import Data.List.Singletons
 import Juvix.Compiler.Asm.Error qualified as Asm
 import Juvix.Compiler.Asm.Options qualified as Asm
 import Juvix.Compiler.Asm.Pipeline qualified as Asm
@@ -40,9 +41,12 @@ import Juvix.Data.Effect.Process
 import Juvix.Data.Effect.TaggedLock
 import Juvix.Prelude
 
-type PipelineEff = '[PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, TaggedLock, Reader EntryPoint, Files, NameIdGen, Builtins, Error JuvixError, HighlightBuilder, Internet, Embed IO, Resource, Final IO]
+type PipelineAppEffects = '[TaggedLock, Embed IO, Resource, Final IO]
 
-type TopPipelineEff = '[PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, TaggedLock, Reader EntryPoint, Files, NameIdGen, Builtins, State Artifacts, Error JuvixError, HighlightBuilder, Embed IO, Resource, Final IO]
+type PipelineLocalEff = '[PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, NameIdGen, Builtins, Error JuvixError, HighlightBuilder, Internet]
+
+-- type PipelineEff r = PipelineLocalEff ++ r
+type PipelineEff r = PathResolver ': EvalFileEff ': Error PackageLoaderError ': Error DependencyError ': GitClone ': Error GitProcessError ': Process ': Log ': Reader EntryPoint ': Files ': NameIdGen ': Builtins ': Error JuvixError ': HighlightBuilder ': Internet ': r
 
 --------------------------------------------------------------------------------
 -- Workflows

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -45,8 +45,7 @@ type PipelineAppEffects = '[TaggedLock, Embed IO, Resource, Final IO]
 
 type PipelineLocalEff = '[PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, NameIdGen, Builtins, Error JuvixError, HighlightBuilder, Internet]
 
--- type PipelineEff r = PipelineLocalEff ++ r
-type PipelineEff r = PathResolver ': EvalFileEff ': Error PackageLoaderError ': Error DependencyError ': GitClone ': Error GitProcessError ': Process ': Log ': Reader EntryPoint ': Files ': NameIdGen ': Builtins ': Error JuvixError ': HighlightBuilder ': Internet ': r
+type PipelineEff r = PipelineLocalEff ++ r
 
 --------------------------------------------------------------------------------
 -- Workflows

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -44,14 +44,14 @@ data EntryPoint = EntryPoint
 
 makeLenses ''EntryPoint
 
-defaultEntryPoint :: Root -> Path Abs File -> EntryPoint
-defaultEntryPoint root mainFile =
-  (defaultEntryPointNoFile root)
+defaultEntryPoint :: Package -> Root -> Path Abs File -> EntryPoint
+defaultEntryPoint pkg root mainFile =
+  (defaultEntryPointNoFile pkg root)
     { _entryPointModulePaths = pure mainFile
     }
 
-defaultEntryPointNoFile :: Root -> EntryPoint
-defaultEntryPointNoFile root =
+defaultEntryPointNoFile :: Package -> Root -> EntryPoint
+defaultEntryPointNoFile pkg root =
   EntryPoint
     { _entryPointRoot = root ^. rootRootDir,
       _entryPointResolverRoot = root ^. rootRootDir,
@@ -61,7 +61,7 @@ defaultEntryPointNoFile root =
       _entryPointNoCoverage = False,
       _entryPointNoStdlib = False,
       _entryPointStdin = Nothing,
-      _entryPointPackage = root ^. rootPackage,
+      _entryPointPackage = pkg,
       _entryPointPackageType = root ^. rootPackageType,
       _entryPointGenericOptions = defaultGenericOptions,
       _entryPointTarget = TargetCore,

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
@@ -143,14 +143,13 @@ loadPackage' packagePath = do
     rootPath = parent packagePath
 
     packageEntryPoint :: EntryPoint
-    packageEntryPoint = defaultEntryPoint root packagePath
+    packageEntryPoint = defaultEntryPoint rootPkg root packagePath
       where
         root :: Root
         root =
           Root
             { _rootRootDir = rootPath,
               _rootPackageType = GlobalPackageDescription,
-              _rootPackage = rootPkg,
               _rootInvokeDir = rootPath,
               _rootBuildDir = DefaultBuildDir
             }

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/Versions.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/Versions.hs
@@ -12,6 +12,9 @@ import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Extra.Paths
 import Juvix.Prelude
 
+currentPackageVersion :: PackageVersion
+currentPackageVersion = PackageVersion2
+
 data PackageVersion
   = PackageVersion1
   | PackageVersion2

--- a/src/Juvix/Compiler/Pipeline/Root.hs
+++ b/src/Juvix/Compiler/Pipeline/Root.hs
@@ -8,18 +8,20 @@ import Control.Exception (SomeException)
 import Control.Exception qualified as IO
 import Juvix.Compiler.Pipeline.Package
 import Juvix.Compiler.Pipeline.Root.Base
+import Juvix.Data.Effect.TaggedLock
 import Juvix.Extra.Paths qualified as Paths
 import Juvix.Prelude
 
 findRootAndChangeDir ::
   forall r.
-  (Members '[Embed IO, Final IO] r) =>
+  (Members '[TaggedLock, Embed IO, Final IO] r) =>
   Maybe (Path Abs Dir) ->
   Maybe (Path Abs Dir) ->
   Path Abs Dir ->
   Sem r Root
 findRootAndChangeDir minputFileDir mbuildDir _rootInvokeDir = do
   r <- runError (fromExceptionSem @SomeException go)
+  runFilesIO ensureGlobalPackage
   case r of
     Left (err :: IO.SomeException) -> liftIO $ do
       putStrLn "Something went wrong when looking for the root of the project"

--- a/src/Juvix/Compiler/Pipeline/Root.hs
+++ b/src/Juvix/Compiler/Pipeline/Root.hs
@@ -4,6 +4,7 @@ module Juvix.Compiler.Pipeline.Root
   )
 where
 
+import Control.Exception (SomeException)
 import Control.Exception qualified as IO
 import Juvix.Compiler.Pipeline.Package
 import Juvix.Compiler.Pipeline.Root.Base
@@ -12,15 +13,16 @@ import Juvix.Extra.Paths qualified as Paths
 import Juvix.Prelude
 
 findRootAndChangeDir ::
-  LockMode ->
+  forall r.
+  (Members '[Embed IO, TaggedLock, Final IO] r) =>
   Maybe (Path Abs Dir) ->
   Maybe (Path Abs Dir) ->
   Path Abs Dir ->
-  IO Root
-findRootAndChangeDir lockMode minputFileDir mbuildDir _rootInvokeDir = do
-  r <- IO.try go
+  Sem r Root
+findRootAndChangeDir minputFileDir mbuildDir _rootInvokeDir = do
+  r <- runError (fromExceptionSem @SomeException go)
   case r of
-    Left (err :: IO.SomeException) -> do
+    Left (err :: IO.SomeException) -> liftIO $ do
       putStrLn "Something went wrong when looking for the root of the project"
       putStrLn (pack (IO.displayException err))
       exitFailure
@@ -29,7 +31,7 @@ findRootAndChangeDir lockMode minputFileDir mbuildDir _rootInvokeDir = do
     possiblePaths :: Path Abs Dir -> [Path Abs Dir]
     possiblePaths p = p : toList (parents p)
 
-    findPackageFile :: IO (Maybe (Path Abs File))
+    findPackageFile :: (Members '[Embed IO] r') => Sem r' (Maybe (Path Abs File))
     findPackageFile = do
       let cwd = fromMaybe _rootInvokeDir minputFileDir
           findPackageFile' = findFile (possiblePaths cwd)
@@ -37,31 +39,31 @@ findRootAndChangeDir lockMode minputFileDir mbuildDir _rootInvokeDir = do
       pFile <- findPackageFile' Paths.packageFilePath
       return (pFile <|> yamlFile)
 
-    go :: IO Root
+    go :: Sem (Error SomeException ': r) Root
     go = do
       l <- findPackageFile
       case l of
         Nothing -> do
           let cwd = fromMaybe _rootInvokeDir minputFileDir
-          packageBaseRootDir <- runM (runFilesIO globalPackageBaseRoot)
+          packageBaseRootDir <- runFilesIO globalPackageBaseRoot
           (_rootPackage, _rootRootDir, _rootPackageType) <-
             if
                 | isPathPrefix packageBaseRootDir cwd ->
                     return (packageBasePackage, packageBaseRootDir, GlobalPackageBase)
                 | otherwise -> do
-                    globalPkg <- readGlobalPackageIO lockMode
-                    r <- runM (runFilesIO globalRoot)
+                    globalPkg <- readGlobalPackageIO
+                    r <- runFilesIO globalRoot
                     return (globalPkg, r, GlobalStdlib)
           let _rootBuildDir = getBuildDir mbuildDir
           return Root {..}
         Just pkgPath -> do
-          packageDescriptionRootDir <- runM (runFilesIO globalPackageDescriptionRoot)
+          packageDescriptionRootDir <- runFilesIO globalPackageDescriptionRoot
           let _rootRootDir = parent pkgPath
               _rootPackageType
                 | isPathPrefix packageDescriptionRootDir _rootRootDir = GlobalPackageDescription
                 | otherwise = LocalPackage
               _rootBuildDir = getBuildDir mbuildDir
-          _rootPackage <- readPackageIO lockMode _rootRootDir _rootBuildDir
+          _rootPackage <- readPackageIO _rootRootDir _rootBuildDir
           return Root {..}
 
 getBuildDir :: Maybe (Path Abs Dir) -> BuildDir

--- a/src/Juvix/Compiler/Pipeline/Root/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Root/Base.hs
@@ -12,11 +12,9 @@ data PackageType
 
 data Root = Root
   { _rootRootDir :: Path Abs Dir,
-    _rootPackage :: Package,
     _rootPackageType :: PackageType,
     _rootBuildDir :: BuildDir,
     _rootInvokeDir :: Path Abs Dir
   }
-  deriving stock (Show)
 
 makeLenses ''Root

--- a/src/Juvix/Data/Effect/Cache.hs
+++ b/src/Juvix/Data/Effect/Cache.hs
@@ -5,7 +5,10 @@ module Juvix.Data.Effect.Cache
     runCacheEmpty,
     cacheGet,
     cacheLookup,
+    evalSingletonCache,
+    cacheSingletonGet,
     Cache,
+    SCache,
   )
 where
 
@@ -14,6 +17,9 @@ import Juvix.Prelude.Base
 data Cache k v m a where
   CacheGet :: k -> Cache k v m v
   CacheLookup :: k -> Cache k v m (Maybe v)
+
+-- | Singleton cache
+type SCache = Cache ()
 
 makeSem ''Cache
 
@@ -51,6 +57,16 @@ runCacheEmpty ::
   Sem r (HashMap k v, a)
 runCacheEmpty f = runCache f mempty
 {-# INLINE runCacheEmpty #-}
+
+cacheSingletonGet :: (Members '[SCache v] r) => Sem r v
+cacheSingletonGet = cacheGet ()
+
+evalSingletonCache ::
+  Sem (SCache v ': r) v ->
+  Sem (SCache v ': r) a ->
+  Sem r a
+evalSingletonCache f c = evalCacheEmpty @() (const f) c
+{-# INLINE evalSingletonCache #-}
 
 re ::
   forall k v r a.

--- a/src/Juvix/Data/Effect/TaggedLock.hs
+++ b/src/Juvix/Data/Effect/TaggedLock.hs
@@ -31,7 +31,9 @@ withTaggedLockDir d = do
       p = maybe lockFile (<//> lockFile) (dropDrive d)
   withTaggedLock p
 
-data LockMode = LockModePermissive | LockModeExclusive
+data LockMode
+  = LockModePermissive
+  | LockModeExclusive
 
 runTaggedLock :: (Members '[Resource, Embed IO] r) => LockMode -> Sem (TaggedLock ': r) a -> Sem r a
 runTaggedLock = \case

--- a/test/BackendGeb/Compilation/Base.hs
+++ b/test/BackendGeb/Compilation/Base.hs
@@ -4,7 +4,6 @@ import BackendGeb.FromCore.Base
 import Base
 import Juvix.Compiler.Backend (Target (TargetGeb))
 import Juvix.Compiler.Core qualified as Core
-import Juvix.Data.Effect.TaggedLock
 
 gebCompilationAssertion ::
   Path Abs Dir ->
@@ -14,6 +13,6 @@ gebCompilationAssertion ::
   Assertion
 gebCompilationAssertion root mainFile expectedFile step = do
   step "Translate to JuvixCore"
-  entryPoint <- set entryPointTarget TargetGeb <$> defaultEntryPointIO' LockModeExclusive root mainFile
-  tab <- (^. Core.coreResultTable) . snd <$> runIOExclusive entryPoint upToCore
+  entryPoint <- set entryPointTarget TargetGeb <$> testDefaultEntryPointIO root mainFile
+  tab <- (^. Core.coreResultTable) . snd <$> testRunIO entryPoint upToCore
   coreToGebTranslationAssertion' tab entryPoint expectedFile step

--- a/test/BackendGeb/FromCore/Base.hs
+++ b/test/BackendGeb/FromCore/Base.hs
@@ -7,7 +7,6 @@ import Juvix.Compiler.Backend (Target (TargetGeb))
 import Juvix.Compiler.Backend.Geb qualified as Geb
 import Juvix.Compiler.Core qualified as Core
 import Juvix.Compiler.Core.Pretty qualified as Core
-import Juvix.Data.Effect.TaggedLock
 import Juvix.Prelude.Pretty
 
 coreToGebTranslationAssertion ::
@@ -19,7 +18,7 @@ coreToGebTranslationAssertion ::
 coreToGebTranslationAssertion root mainFile expectedFile step = do
   step "Parse Juvix Core file"
   input <- readFile . toFilePath $ mainFile
-  entryPoint <- set entryPointTarget TargetGeb <$> defaultEntryPointIO' LockModeExclusive root mainFile
+  entryPoint <- set entryPointTarget TargetGeb <$> testDefaultEntryPointIO root mainFile
   case Core.runParserMain mainFile Core.emptyInfoTable input of
     Left err -> assertFailure . show . pretty $ err
     Right coreInfoTable -> coreToGebTranslationAssertion' coreInfoTable entryPoint expectedFile step

--- a/test/BackendMarkdown/Negative.hs
+++ b/test/BackendMarkdown/Negative.hs
@@ -2,7 +2,6 @@ module BackendMarkdown.Negative where
 
 import Base
 import Juvix.Compiler.Backend.Markdown.Error
-import Juvix.Data.Effect.TaggedLock
 import Juvix.Parser.Error
 
 type FailMsg = String
@@ -22,8 +21,8 @@ testDescr NegTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            entryPoint <- defaultEntryPointIO' LockModeExclusive tRoot file'
-            result <- runIOEither' LockModeExclusive entryPoint upToParsing
+            entryPoint <- testDefaultEntryPointIO tRoot file'
+            result <- testTaggedLockedToIO (snd <$> runIOEither entryPoint upToParsing)
             case mapLeft fromJuvixError result of
               Left (Just err) -> whenJust (_checkErr err) assertFailure
               Right _ -> assertFailure "Unexpected success."

--- a/test/BackendMarkdown/Positive.hs
+++ b/test/BackendMarkdown/Positive.hs
@@ -6,7 +6,6 @@ import Juvix.Compiler.Concrete qualified as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
 import Juvix.Compiler.Pipeline.Setup
-import Juvix.Data.Effect.TaggedLock
 
 data PosTest = PosTest
   { _name :: String,
@@ -36,13 +35,13 @@ testDescr PosTest {..} =
     { _testName = _name,
       _testRoot = _dir,
       _testAssertion = Steps $ \step -> do
-        entryPoint <- defaultEntryPointIO' LockModeExclusive _dir _file
+        entryPoint <- testDefaultEntryPointIO _dir _file
         step "Parsing"
-        p :: Parser.ParserResult <- snd <$> runIOExclusive entryPoint upToParsing
+        p :: Parser.ParserResult <- snd <$> testRunIO entryPoint upToParsing
         step "Scoping"
         s :: Scoper.ScoperResult <-
           snd
-            <$> runIOExclusive
+            <$> testRunIO
               entryPoint
               ( do
                   void (entrySetup defaultDependenciesConfig)

--- a/test/Format.hs
+++ b/test/Format.hs
@@ -5,7 +5,6 @@ import Juvix.Compiler.Concrete qualified as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
 import Juvix.Compiler.Pipeline.Setup
-import Juvix.Data.Effect.TaggedLock
 import Juvix.Formatter
 
 data PosTest = PosTest
@@ -34,19 +33,19 @@ testDescr PosTest {..} =
     { _testName = _name,
       _testRoot = _dir,
       _testAssertion = Steps $ \step -> do
-        entryPoint <- defaultEntryPointIO' LockModeExclusive _dir _file
+        entryPoint <- testDefaultEntryPointIO _dir _file
         let maybeFile = entryPoint ^? entryPointModulePaths . _head
         f <- fromMaybeM (assertFailure "Not a module") (return maybeFile)
 
         original :: Text <- readFile (toFilePath f)
 
         step "Parsing"
-        p :: Parser.ParserResult <- snd <$> runIOExclusive entryPoint upToParsing
+        p :: Parser.ParserResult <- snd <$> testRunIO entryPoint upToParsing
 
         step "Scoping"
         s :: Scoper.ScoperResult <-
           snd
-            <$> runIOExclusive
+            <$> testRunIO
               entryPoint
               ( do
                   void (entrySetup defaultDependenciesConfig)

--- a/test/Formatter/Positive.hs
+++ b/test/Formatter/Positive.hs
@@ -1,7 +1,6 @@
 module Formatter.Positive where
 
 import Base
-import Juvix.Data.Effect.TaggedLock
 import Juvix.Formatter
 import Scope.Positive qualified
 import Scope.Positive qualified as Scope
@@ -9,11 +8,11 @@ import Scope.Positive qualified as Scope
 runScopeEffIO :: (Member (Embed IO) r) => Path Abs Dir -> Sem (ScopeEff ': r) a -> Sem r a
 runScopeEffIO root = interpret $ \case
   ScopeFile p -> do
-    entry <- embed (defaultEntryPointIO' LockModeExclusive root p)
-    embed (snd <$> runIOExclusive entry upToScoping)
+    entry <- embed (testDefaultEntryPointIO root p)
+    embed (snd <$> testRunIO entry upToScoping)
   ScopeStdin -> do
-    entry <- embed (defaultEntryPointNoFileIO' LockModeExclusive root)
-    embed (snd <$> runIOExclusive entry upToScoping)
+    entry <- embed (testDefaultEntryPointNoFileIO root)
+    embed (snd <$> testRunIO entry upToScoping)
 
 makeFormatTest' :: Scope.PosTest -> TestDescr
 makeFormatTest' Scope.PosTest {..} =

--- a/test/Internal/Eval/Base.hs
+++ b/test/Internal/Eval/Base.hs
@@ -11,13 +11,12 @@ import Juvix.Compiler.Core.Info.NoDisplayInfo
 import Juvix.Compiler.Core.Pretty
 import Juvix.Compiler.Core.Transformation (etaExpansionApps)
 import Juvix.Compiler.Core.Translation.FromInternal.Data as Core
-import Juvix.Data.Effect.TaggedLock
 
 internalCoreAssertion :: Path Abs Dir -> Path Abs File -> Path Abs File -> (String -> IO ()) -> Assertion
 internalCoreAssertion root' mainFile expectedFile step = do
   step "Translate to Core"
-  entryPoint <- defaultEntryPointIO' LockModeExclusive root' mainFile
-  tab0 <- (^. Core.coreResultTable) . snd <$> runIOExclusive entryPoint upToCore
+  entryPoint <- testDefaultEntryPointIO root' mainFile
+  tab0 <- (^. Core.coreResultTable) . snd <$> testRunIO entryPoint upToCore
   let tab = etaExpansionApps tab0
   case (tab ^. infoMain) >>= ((tab ^. identContext) HashMap.!?) of
     Just node -> do

--- a/test/Parsing/Negative.hs
+++ b/test/Parsing/Negative.hs
@@ -2,7 +2,6 @@ module Parsing.Negative where
 
 import Base
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.PathResolver.Error
-import Juvix.Data.Effect.TaggedLock
 import Juvix.Parser.Error
 
 root :: Path Abs Dir
@@ -24,8 +23,8 @@ testDescr NegTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            entryPoint <- defaultEntryPointIO' LockModeExclusive tRoot _file
-            res <- runIOEither' LockModeExclusive entryPoint upToParsing
+            entryPoint <- testDefaultEntryPointIO tRoot _file
+            res <- snd <$> testRunIOEither entryPoint upToParsing
             case mapLeft fromJuvixError res of
               Left (Just parErr) -> whenJust (_checkErr parErr) assertFailure
               Left Nothing -> assertFailure "An error ocurred but it was not in the parser."

--- a/test/Reachability/Positive.hs
+++ b/test/Reachability/Positive.hs
@@ -4,7 +4,6 @@ import Base
 import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Internal.Language qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context qualified as Internal
-import Juvix.Data.Effect.TaggedLock
 
 data PosTest = PosTest
   { _name :: String,
@@ -30,10 +29,10 @@ testDescr PosTest {..} =
             let noStdlib = _stdlibMode == StdlibExclude
             entryPoint <-
               set entryPointNoStdlib noStdlib
-                <$> defaultEntryPointIO' LockModeExclusive tRoot file'
+                <$> testDefaultEntryPointIO tRoot file'
 
             step "Pipeline up to reachability"
-            p :: Internal.InternalTypedResult <- snd <$> runIOExclusive entryPoint upToInternalReachability
+            p :: Internal.InternalTypedResult <- snd <$> testRunIO entryPoint upToInternalReachability
 
             step "Check reachability results"
             let names = concatMap getNames (p ^. Internal.resultModules)

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -2,7 +2,6 @@ module Scope.Negative (allTests) where
 
 import Base
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error
-import Juvix.Data.Effect.TaggedLock
 
 type FailMsg = String
 
@@ -24,8 +23,8 @@ testDescr NegTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            entryPoint <- defaultEntryPointIO' LockModeExclusive tRoot file'
-            res <- runIOEitherTermination' LockModeExclusive entryPoint upToInternal
+            entryPoint <- testDefaultEntryPointIO tRoot file'
+            res <- testRunIOEitherTermination entryPoint upToInternal
             case mapLeft fromJuvixError res of
               Left (Just err) -> whenJust (_checkErr err) assertFailure
               Left Nothing -> assertFailure "An error ocurred but it was not in the scoper."

--- a/test/Termination/Negative.hs
+++ b/test/Termination/Negative.hs
@@ -2,7 +2,6 @@ module Termination.Negative (module Termination.Negative) where
 
 import Base
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination
-import Juvix.Data.Effect.TaggedLock
 
 type FailMsg = String
 
@@ -21,8 +20,8 @@ testDescr NegTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            entryPoint <- set entryPointNoStdlib True <$> defaultEntryPointIO' LockModeExclusive tRoot file'
-            result <- runIOEither' LockModeExclusive entryPoint upToInternalTyped
+            entryPoint <- set entryPointNoStdlib True <$> testDefaultEntryPointIO tRoot file'
+            result <- snd <$> testRunIOEither entryPoint upToInternalTyped
             case mapLeft fromJuvixError result of
               Left (Just lexError) -> whenJust (_checkErr lexError) assertFailure
               Left Nothing -> assertFailure "The termination checker did not find an error."

--- a/test/Termination/Positive.hs
+++ b/test/Termination/Positive.hs
@@ -1,7 +1,6 @@
 module Termination.Positive where
 
 import Base
-import Juvix.Data.Effect.TaggedLock (LockMode (LockModeExclusive))
 import Termination.Negative qualified as N
 
 data PosTest = PosTest
@@ -21,8 +20,8 @@ testDescr PosTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            entryPoint <- set entryPointNoStdlib True <$> defaultEntryPointIO' LockModeExclusive tRoot file'
-            (void . runIOExclusive entryPoint) upToInternalTyped
+            entryPoint <- set entryPointNoStdlib True <$> testDefaultEntryPointIO tRoot file'
+            (void . testRunIO entryPoint) upToInternalTyped
         }
 
 --------------------------------------------------------------------------------
@@ -43,8 +42,8 @@ testDescrFlag N.NegTest {..} =
             entryPoint <-
               set entryPointNoTermination True
                 . set entryPointNoStdlib True
-                <$> defaultEntryPointIO' LockModeExclusive tRoot file'
-            (void . runIOExclusive entryPoint) upToInternalTyped
+                <$> testDefaultEntryPointIO tRoot file'
+            (void . testRunIO entryPoint) upToInternalTyped
         }
 
 tests :: [PosTest]

--- a/test/Typecheck/Negative.hs
+++ b/test/Typecheck/Negative.hs
@@ -3,7 +3,6 @@ module Typecheck.Negative where
 import Base
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Positivity.Error
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Error
-import Juvix.Data.Effect.TaggedLock
 
 type FailMsg = String
 
@@ -24,8 +23,8 @@ testDescr NegTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            entryPoint <- defaultEntryPointIO' LockModeExclusive tRoot file'
-            result <- runIOEither' LockModeExclusive entryPoint upToInternalTyped
+            entryPoint <- testDefaultEntryPointIO tRoot file'
+            result <- snd <$> testRunIOEither entryPoint upToInternalTyped
             case mapLeft fromJuvixError result of
               Left (Just tyError) -> whenJust (_checkErr tyError) assertFailure
               Left Nothing -> assertFailure "An error ocurred but it was not in the type checker."

--- a/test/Typecheck/NegativeNew.hs
+++ b/test/Typecheck/NegativeNew.hs
@@ -4,7 +4,6 @@ import Base
 import Data.HashSet qualified as HashSet
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Positivity.Error
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Error
-import Juvix.Data.Effect.TaggedLock
 import Typecheck.Negative qualified as Old
 
 type FailMsg = String
@@ -30,8 +29,8 @@ testDescr Old.NegTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            entryPoint <- defaultEntryPointIO' LockModeExclusive tRoot file'
-            result <- runIOEither' LockModeExclusive entryPoint upToCore
+            entryPoint <- testDefaultEntryPointIO tRoot file'
+            result <- snd <$> testRunIOEither entryPoint upToCore
             case mapLeft fromJuvixError result of
               Left (Just tyError) -> whenJust (_checkErr tyError) assertFailure
               Left Nothing -> assertFailure "An error ocurred but it was not in the type checker."

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -2,7 +2,6 @@ module Typecheck.Positive where
 
 import Base
 import Compilation.Positive qualified as Compilation
-import Juvix.Data.Effect.TaggedLock
 import Typecheck.Negative qualified as N
 
 data PosTest = PosTest
@@ -33,8 +32,8 @@ testDescr PosTest {..} =
     { _testName = _name,
       _testRoot = _dir,
       _testAssertion = Single $ do
-        entryPoint <- defaultEntryPointIO' LockModeExclusive _dir _file
-        (void . runIOExclusive entryPoint) upToInternalTyped
+        entryPoint <- testDefaultEntryPointIO _dir _file
+        (void . testRunIO entryPoint) upToInternalTyped
     }
 
 rootNegTests :: Path Abs Dir
@@ -51,8 +50,8 @@ testNoPositivityFlag N.NegTest {..} =
           _testAssertion = Single $ do
             entryPoint <-
               set entryPointNoPositivity True
-                <$> defaultEntryPointIO' LockModeExclusive tRoot file'
-            (void . runIOExclusive entryPoint) upToInternalTyped
+                <$> testDefaultEntryPointIO tRoot file'
+            (void . testRunIO entryPoint) upToInternalTyped
         }
 
 negPositivityTests :: [N.NegTest]

--- a/test/VampIR/Compilation/Base.hs
+++ b/test/VampIR/Compilation/Base.hs
@@ -4,14 +4,13 @@ import Base
 import Core.VampIR.Base (coreVampIRAssertion')
 import Juvix.Compiler.Core
 import Juvix.Compiler.Core.Data.TransformationId
-import Juvix.Data.Effect.TaggedLock
 import VampIR.Core.Base (VampirBackend (..), vampirAssertion')
 
 vampirCompileAssertion :: Path Abs Dir -> Path Abs File -> Path Abs File -> (String -> IO ()) -> Assertion
 vampirCompileAssertion root' mainFile dataFile step = do
   step "Translate to JuvixCore"
-  entryPoint <- defaultEntryPointIO' LockModeExclusive root' mainFile
-  tab <- (^. coreResultTable) . snd <$> runIOExclusive entryPoint upToCore
+  entryPoint <- testDefaultEntryPointIO root' mainFile
+  tab <- (^. coreResultTable) . snd <$> testRunIO entryPoint upToCore
   coreVampIRAssertion' tab toVampIRTransformations mainFile dataFile step
   vampirAssertion' VampirHalo2 tab dataFile step
 
@@ -22,8 +21,8 @@ vampirCompileErrorAssertion ::
   Assertion
 vampirCompileErrorAssertion root' mainFile step = do
   step "Translate to JuvixCore"
-  entryPoint <- defaultEntryPointIO' LockModeExclusive root' mainFile
-  r <- runIOEither entryPoint upToCore
+  entryPoint <- testDefaultEntryPointIO root' mainFile
+  r <- snd <$> testRunIOEither entryPoint upToCore
   case r of
     Left _ -> return ()
     Right res ->

--- a/tests/Geb/positive/Package.juvix
+++ b/tests/Geb/positive/Package.juvix
@@ -1,0 +1,5 @@
+module Package;
+
+import PackageDescription.V2 open;
+
+package : Package := defaultPackage {name := "positive"};

--- a/tests/smoke/Commands/typecheck.smoke.yaml
+++ b/tests/smoke/Commands/typecheck.smoke.yaml
@@ -55,6 +55,26 @@ tests:
       equals: "Well done! It type checks\n"
     exit-status: 0
 
+  - name: typecheck-global-package
+    command:
+      shell:
+        - bash
+      script: |
+        base=$PWD
+        temp=$(mktemp -d)
+        trap 'rm -rf -- "$temp"' EXIT
+        configDir=$temp/config
+        projDir=$temp/projDir
+        mkdir $configDir
+        export XDG_CONFIG_HOME="$configDir"
+        mkdir $projDir
+        cd $projDir
+        echo 'module foo;' > foo.juvix
+        juvix typecheck foo.juvix
+    stdout:
+      equals: "Well done! It type checks\n"
+    exit-status: 0
+
   - name: typecheck-package-description
     command:
       shell:
@@ -69,7 +89,9 @@ tests:
         export XDG_CONFIG_HOME="$configDir"
         mkdir $projDir
         cd $projDir
+        echo 'module foo;' > foo.juvix
         # side-effect: initializes the global project / the package package
+        juvix typecheck foo.juvix > /dev/null
         globalPackageDir=$(juvix dev root)
         packagePackageDir="$(dirname $globalPackageDir)"/package
         juvix typecheck "$packagePackageDir/PackageDescription/V2.juvix"


### PR DESCRIPTION
This patch dramatically increases the efficiency of `juvix dev root`, which was unnecessarily parsing all dependencies included in the `Package.juvix` file. Other commands that do not require the `Package` will also be faster.

It also refactors some functions so that the `TaggedLock` effect is run globally.

I've added `singletons-base` as a dependency so we can have `++` on the type level. We've tried to define a type family ourselves but inference was not working properly.