### PR TITLE
Implement wildcard constructor

### DIFF
--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -316,6 +316,10 @@ tests =
       $(mkRelDir "MarkdownImport")
       $(mkRelFile "C.juvix.md"),
     posTestAbsDir
+      "Typecheck constructor wildcard"
+      (relToProject $(mkRelDir "."))
+      $(mkRelFile "ConstructorWildcard.juvix"),
+    posTestAbsDir
       "Typecheck orphan file"
       (relToProject $(mkRelDir "tests/WithoutPackageFile"))
       $(mkRelFile "Good.juvix")

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -315,9 +315,9 @@ tests =
       "Import a .juvix.md module in a .juvix.md file"
       $(mkRelDir "MarkdownImport")
       $(mkRelFile "C.juvix.md"),
-    posTestAbsDir
+    posTest
       "Typecheck constructor wildcard"
-      (relToProject $(mkRelDir "."))
+      $(mkRelDir ".")
       $(mkRelFile "ConstructorWildcard.juvix"),
     posTestAbsDir
       "Typecheck orphan file"

--- a/tests/positive/ConstructorWildcard.juvix
+++ b/tests/positive/ConstructorWildcard.juvix
@@ -10,3 +10,7 @@ type either (A B : Type) :=
 isLeft {A B} : either A B → Bool
  | left@{} := true
  | right@{} := false;
+
+not : Bool → Bool
+ | false@{} := true
+ | true := false;

--- a/tests/positive/ConstructorWildcard.juvix
+++ b/tests/positive/ConstructorWildcard.juvix
@@ -1,0 +1,12 @@
+module ConstructorWildcard;
+
+type Bool :=
+ false | true;
+
+type either (A B : Type) :=
+  left A
+  | right B;
+
+isLeft {A B} : either A B → Bool
+ | left@{} := true
+ | right@{} := false;


### PR DESCRIPTION
- Closes #2549 

The implementation of wildcard constructors was previously done in the arity checker. I did not realise I was missing it because there was not tests for it that included typechecking (we were only checking formatting).