### PR TITLE
Add error message for ill-scoped variables

### DIFF
--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error.hs
@@ -39,6 +39,7 @@ data TypeCheckerError
   | ErrBuiltinNotDefined NotDefined
   | ErrArityCheckerError ArityCheckerError
   | ErrDefaultArgLoop DefaultArgLoop
+  | ErrBadScope BadScope
 
 instance ToGenericError TypeCheckerError where
   genericError :: (Member (Reader GenericOptions) r) => TypeCheckerError -> Sem r GenericError
@@ -67,6 +68,7 @@ instance ToGenericError TypeCheckerError where
     ErrBuiltinNotDefined e -> genericError e
     ErrArityCheckerError e -> genericError e
     ErrDefaultArgLoop e -> genericError e
+    ErrBadScope e -> genericError e
 
 instance Show TypeCheckerError where
   show = \case
@@ -94,3 +96,4 @@ instance Show TypeCheckerError where
     ErrArityCheckerError {} -> "ErrArityCheckerError"
     ErrDefaultArgLoop {} -> "ErrDefaultArgLoop"
     ErrBuiltinNotDefined {} -> "ErrBuiltinNotDefined"
+    ErrBadScope {} -> "ErrBadScope"

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -634,3 +634,34 @@ instance ToGenericError DefaultArgLoop where
             "Inserting default arguments caused a loop. The involved arguments are:"
               <> line
               <> itemize (ppCode opts' <$> e ^. defaultArgLoop)
+
+newtype BadScope = BadScope
+  { _badScopeVar :: VarName
+  }
+
+makeLenses ''BadScope
+
+instance ToGenericError BadScope where
+  genericError e = ask >>= generr
+    where
+      generr opts =
+        return
+          GenericError
+            { _genericErrorLoc = i,
+              _genericErrorMessage = ppOutput msg,
+              _genericErrorIntervals = [i]
+            }
+        where
+          opts' = fromGenericOptions opts
+          i = getLoc (e ^. badScopeVar)
+          var = e ^. badScopeVar
+          msg :: Doc Ann =
+            annotate AnnImportant "Oops! This is a bug of the juvix compiler."
+              <> line
+              <> "Most likely, the inference algorithm inserted the variable"
+              <+> ppCode opts' var
+              <+> "in a place where it is not in scope."
+                <> line
+                <> "As a workaround, explicitly provide a type in the place where you think the variable got inserted."
+                <> line
+                <> "More information at https://github.com/anoma/juvix/issues/2247"

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -656,7 +656,7 @@ instance ToGenericError BadScope where
           i = getLoc (e ^. badScopeVar)
           var = e ^. badScopeVar
           msg :: Doc Ann =
-            annotate AnnImportant "Oops! This is a bug of the juvix compiler."
+            annotate AnnImportant "Oops! This is a known bug in the juvix compiler."
               <> line
               <> "Most likely, the inference algorithm inserted the variable"
               <+> ppCode opts' var

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -206,7 +206,7 @@ instance ToGenericError WrongType where
               <+> thing
               <+> "has type:"
                 <> line
-                <> indent' (ppCode opts' (err ^. wrongTypeActual ^. normalizedExpression))
+                <> indent' (ppCode opts' (err ^. wrongTypeActual . normalizedExpression))
                 <> line
                 <> "but is expected to have type:"
                 <> line
@@ -656,7 +656,7 @@ instance ToGenericError BadScope where
           i = getLoc (e ^. badScopeVar)
           var = e ^. badScopeVar
           msg :: Doc Ann =
-            annotate AnnImportant "Oops! This is a known bug in the juvix compiler."
+            annotate AnnImportant "Oops! This is a known bug in the Juvix compiler."
               <> line
               <> "Most likely, the inference algorithm inserted the variable"
               <+> ppCode opts' var

--- a/test/Compilation/Negative.hs
+++ b/test/Compilation/Negative.hs
@@ -49,5 +49,9 @@ tests =
     NegTest
       "Test005: Axiom"
       $(mkRelDir ".")
-      $(mkRelFile "test005.juvix")
+      $(mkRelFile "test005.juvix"),
+    NegTest
+      "Test006: Ill scoped term (Thi is a bug. It should be positive)"
+      $(mkRelDir ".")
+      $(mkRelFile "test006.juvix")
   ]

--- a/test/Compilation/Negative.hs
+++ b/test/Compilation/Negative.hs
@@ -51,7 +51,7 @@ tests =
       $(mkRelDir ".")
       $(mkRelFile "test005.juvix"),
     NegTest
-      "Test006: Ill scoped term (Thi is a bug. It should be positive)"
+      "Test006: Ill scoped term (This is a bug. It should be positive)"
       $(mkRelDir ".")
       $(mkRelFile "test006.juvix")
   ]

--- a/tests/Compilation/negative/test006.juvix
+++ b/tests/Compilation/negative/test006.juvix
@@ -1,0 +1,11 @@
+-- Once https://github.com/anoma/juvix/issues/2247 is fixed, this should be moved to positive tests
+module test006;
+
+type Box (A : Type) :=
+  | box : A → Box A;
+
+x : Box ((B : Type) → B → B) :=
+  box {_} λ {C x := x};
+
+-- (B : Type) → B → B
+-- (x1 : _@1) -> (x2 : _@2) -> _@3

--- a/tests/Compilation/negative/test006.juvix
+++ b/tests/Compilation/negative/test006.juvix
@@ -6,6 +6,3 @@ type Box (A : Type) :=
 
 x : Box ((B : Type) → B → B) :=
   box {_} λ {C x := x};
-
--- (B : Type) → B → B
--- (x1 : _@1) -> (x2 : _@2) -> _@3


### PR DESCRIPTION
- This PR adds a temporary compiler error for when the bug #2247 happens. We do not have plans to fix this bug until we move the typechecker to Core, so it makes sense to add a better error message.

