### PR TITLE
Require semicolon to separate case/if branches in JuvixAsm syntax

### DIFF
--- a/runtime/src/asm/apply.jva
+++ b/runtime/src/asm/apply.jva
@@ -9,13 +9,13 @@ function juvix_apply_1(*, *) : * {
             push arg[1];
             push arg[0];
             tcall $ 1;
-        }
+        };
         false: { -- argsnum > 1
             push arg[1];
             push arg[0];
             cextend 1;
             ret;
-        }
+        };
     };
 }
 
@@ -32,7 +32,7 @@ function juvix_apply_2(*, *, *) : * {
                 push arg[1];
                 push arg[0];
                 tcall $ 2;
-            }
+            };
             false: {
                 push n;
                 push 1;
@@ -44,16 +44,16 @@ function juvix_apply_2(*, *, *) : * {
                         push arg[0];
                         call $ 1;
                         tcall juvix_apply_1;
-                    }
+                    };
                     false: { -- argsnum > 2
                         push arg[2];
                         push arg[1];
                         push arg[0];
                         cextend 2;
                         ret;
-                    }
+                    };
                 };
-            }
+            };
         };
     };
 }
@@ -72,7 +72,7 @@ function juvix_apply_3(*, *, *, *) : * {
                 push arg[1];
                 push arg[0];
                 tcall $ 3;
-            }
+            };
             false: {
                 push n;
                 push 3;
@@ -85,7 +85,7 @@ function juvix_apply_3(*, *, *, *) : * {
                         push arg[0];
                         cextend 3;
                         ret;
-                    }
+                    };
                     false: { -- argsnum <= 2
                         push n;
                         push 2;
@@ -98,7 +98,7 @@ function juvix_apply_3(*, *, *, *) : * {
                                 push arg[0];
                                 call $ 2;
                                 tcall juvix_apply_1;
-                            }
+                            };
                             false: { -- argsnum = 1
                                 push arg[3];
                                 push arg[2];
@@ -106,11 +106,11 @@ function juvix_apply_3(*, *, *, *) : * {
                                 push arg[0];
                                 call $ 1;
                                 tcall juvix_apply_2;
-                            }
+                            };
                         };
-                    }
+                    };
                 };
-            }
+            };
         };
     };
 }
@@ -130,7 +130,7 @@ function juvix_apply_4(*, *, *, *, *) : * {
                 push arg[1];
                 push arg[0];
                 tcall $ 4;
-            }
+            };
             false: {
                 push n;
                 push 4;
@@ -144,7 +144,7 @@ function juvix_apply_4(*, *, *, *, *) : * {
                         push arg[0];
                         cextend 4;
                         ret;
-                    }
+                    };
                     false: { -- argsnum <= 3
                         push n;
                         push 3;
@@ -158,7 +158,7 @@ function juvix_apply_4(*, *, *, *, *) : * {
                                 push arg[0];
                                 call $ 3;
                                 tcall juvix_apply_1;
-                            }
+                            };
                             false: {
                                 push n;
                                 push 2;
@@ -172,7 +172,7 @@ function juvix_apply_4(*, *, *, *, *) : * {
                                         push arg[0];
                                         call $ 2;
                                         tcall juvix_apply_2;
-                                    }
+                                    };
                                     false: { -- argsnum = 1
                                         push arg[4];
                                         push arg[3];
@@ -181,13 +181,13 @@ function juvix_apply_4(*, *, *, *, *) : * {
                                         push arg[0];
                                         call $ 1;
                                         tcall juvix_apply_3;
-                                    }
+                                    };
                                 };
-                            }
+                            };
                         };
-                    }
+                    };
                 };
-            }
+            };
         };
     };
 }

--- a/src/Juvix/Compiler/Asm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource.hs
@@ -547,14 +547,18 @@ trueBranch ::
   ParsecS r Code
 trueBranch = do
   symbol "true:"
-  branchCode
+  c <- branchCode
+  kw delimSemicolon
+  return c
 
 falseBranch ::
   (Members '[InfoTableBuilder, State LocalNameMap, State Index] r) =>
   ParsecS r Code
 falseBranch = do
   symbol "false:"
-  branchCode
+  c <- branchCode
+  kw delimSemicolon
+  return c
 
 caseBranch ::
   (Members '[InfoTableBuilder, State LocalNameMap, State Index] r) =>
@@ -562,9 +566,15 @@ caseBranch ::
 caseBranch = do
   tag <- P.try constrTag
   kw kwColon
-  CaseBranch tag <$> branchCode
+  c <- CaseBranch tag <$> branchCode
+  kw delimSemicolon
+  return c
 
 defaultBranch ::
   (Members '[InfoTableBuilder, State LocalNameMap, State Index] r) =>
   ParsecS r Code
-defaultBranch = symbol "default:" >> branchCode
+defaultBranch = do
+  symbol "default:"
+  c <- branchCode
+  kw delimSemicolon
+  return c

--- a/tests/Asm/negative/test003.jva
+++ b/tests/Asm/negative/test003.jva
@@ -8,7 +8,7 @@ type list {
 function f(list) {
   push arg[0];
   case list {
-    cons: ret
+    cons: ret;
   };
 }
 

--- a/tests/Asm/negative/vtest006.jva
+++ b/tests/Asm/negative/vtest006.jva
@@ -3,8 +3,8 @@
 function main() {
   push true;
   br {
-    true: { push 1; push 2; }
-    false: { push 1; }
+    true: { push 1; push 2; };
+    false: { push 1; };
   };
   ret;
 }

--- a/tests/Asm/negative/vtest007.jva
+++ b/tests/Asm/negative/vtest007.jva
@@ -3,8 +3,8 @@
 function main() {
   push true;
   br {
-    true: { push "a"; }
-    false: { push 1; }
+    true: { push "a"; };
+    false: { push 1; };
   };
   ret;
 }

--- a/tests/Asm/negative/vtest008.jva
+++ b/tests/Asm/negative/vtest008.jva
@@ -8,8 +8,8 @@ type list {
 function main() {
   alloc nil;
   case list {
-    nil: { push 1; push 2; }
-    cons: { push 1; }
+    nil: { push 1; push 2; };
+    cons: { push 1; };
   };
   pop;
   ret;

--- a/tests/Asm/negative/vtest009.jva
+++ b/tests/Asm/negative/vtest009.jva
@@ -8,8 +8,8 @@ type list {
 function main() {
   alloc nil;
   case list {
-    nil: { pop; push "a"; }
-    cons: { pop; push 1; }
+    nil: { pop; push "a"; };
+    cons: { pop; push 1; };
   };
   ret;
 }

--- a/tests/Asm/positive/test008.jva
+++ b/tests/Asm/positive/test008.jva
@@ -9,23 +9,23 @@ function main() {
   push 0;
   lt;
   br {
-    true: push 1
-    false: call loop
+    true: push 1;
+    false: call loop;
   };
   push 1;
   push 2;
   le;
   br {
-    true: call loop
+    true: call loop;
     false: {
       push 7;
       push 8;
       le;
       br {
-        true: call loop
-        false: push 1
+        true: call loop;
+        false: push 1;
       };
-    }
+    };
   };
   add;
   ret;

--- a/tests/Asm/positive/test009.jva
+++ b/tests/Asm/positive/test009.jva
@@ -18,15 +18,15 @@ function tl(list) : list {
 function null(list) : bool {
   push arg[0];
   case list {
-    nil: { pop; push true; ret; }
-    default: { pop; push false; ret; }
+    nil: { pop; push true; ret; };
+    default: { pop; push false; ret; };
   };
 }
 
 function map(* -> *, list) : list {
   push arg[1];
   case list {
-    nil: ret
+    nil: ret;
     cons: {
       tsave {
         push tmp[0].cons[1];
@@ -38,7 +38,7 @@ function map(* -> *, list) : list {
         alloc cons;
         ret;
       };
-    }
+    };
   };
 }
 
@@ -49,7 +49,7 @@ function map'(* -> *, list) : list {
     true: {
       alloc nil;
       ret;
-    }
+    };
     false: {
       push arg[1];
       call tl;
@@ -61,7 +61,7 @@ function map'(* -> *, list) : list {
       call $ 1;
       alloc cons;
       ret;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test010.jva
+++ b/tests/Asm/positive/test010.jva
@@ -5,7 +5,7 @@ function sum(integer) : integer {
   push 0;
   eq;
   br {
-    true: push 0
+    true: push 0;
     false: {
       push 1;
       push arg[0];
@@ -13,7 +13,7 @@ function sum(integer) : integer {
       call sum;
       push arg[0];
       add;
-    }
+    };
   };
   ret;
 }

--- a/tests/Asm/positive/test011.jva
+++ b/tests/Asm/positive/test011.jva
@@ -5,7 +5,7 @@ function sum'(integer, integer) : integer {
   push 0;
   eq;
   br {
-    true: { push arg[1]; ret; }
+    true: { push arg[1]; ret; };
     false: {
       push arg[1];
       push arg[0];
@@ -14,7 +14,7 @@ function sum'(integer, integer) : integer {
       push arg[0];
       sub;
       tcall sum';
-    }
+    };
   };
 }
 
@@ -29,7 +29,7 @@ function fact'(integer, integer) : integer {
   push 0;
   eq;
   br {
-    true: { push arg[1]; ret; }
+    true: { push arg[1]; ret; };
     false: {
       push arg[0];
       push arg[1];
@@ -38,7 +38,7 @@ function fact'(integer, integer) : integer {
       push arg[0];
       sub;
       tcall fact';
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test013.jva
+++ b/tests/Asm/positive/test013.jva
@@ -5,7 +5,7 @@ function fib'(integer, integer, integer) : integer {
   push 0;
   eq;
   br {
-    true: { push arg[1]; ret; }
+    true: { push arg[1]; ret; };
     false: {
       push 16777216;
       push arg[2];
@@ -17,7 +17,7 @@ function fib'(integer, integer, integer) : integer {
       push arg[0];
       sub;
       tcall fib';
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test014.jva
+++ b/tests/Asm/positive/test014.jva
@@ -12,7 +12,7 @@ function gen(integer) : tree {
   push 0;
   eq;
   br {
-    true: { alloc leaf; ret; }
+    true: { alloc leaf; ret; };
     false: {
       push 3;
       push arg[0];
@@ -29,7 +29,7 @@ function gen(integer) : tree {
             call gen;
             alloc node1;
             ret;
-          }
+          };
           false: {
             push tmp[0];
             push 1;
@@ -47,7 +47,7 @@ function gen(integer) : tree {
                   alloc node2;
                   ret;
                 };
-              }
+              };
               false: {
                 push 1;
                 push arg[0];
@@ -62,12 +62,12 @@ function gen(integer) : tree {
                   alloc node3;
                   ret;
                 };
-              }
+              };
             };
-          }
+          };
         };
       };
-    }
+    };
   };
 }
 
@@ -81,7 +81,7 @@ function preorder(tree) {
       pop;
       push arg[0].node1[0];
       tcall preorder;
-    }
+    };
     node2: {
       pop;
       push 2;
@@ -92,7 +92,7 @@ function preorder(tree) {
       pop;
       push arg[0].node2[1];
       tcall preorder;
-    }
+    };
     node3: {
       pop;
       push 3;
@@ -106,7 +106,7 @@ function preorder(tree) {
       pop;
       push arg[0].node3[2];
       tcall preorder;
-    }
+    };
     leaf: {
       pop;
       push 0;
@@ -114,7 +114,7 @@ function preorder(tree) {
       pop;
       push void;
       ret;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test015.jva
+++ b/tests/Asm/positive/test015.jva
@@ -24,7 +24,7 @@ function f(integer) : integer -> integer {
       push 0;
       calloc const 1;
       ret;
-    }
+    };
     false: {
       push arg[0];
       push 5;
@@ -34,7 +34,7 @@ function f(integer) : integer -> integer {
           push 1;
           calloc const 1;
           ret;
-        }
+        };
         false: {
           push arg[0];
           push 10;
@@ -43,15 +43,15 @@ function f(integer) : integer -> integer {
             true: {
               calloc g 0;
               ret;
-            }
+            };
             false: {
               calloc id 0;
               ret;
-            }
+            };
           };
-        }
+        };
       };
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test017.jva
+++ b/tests/Asm/positive/test017.jva
@@ -26,7 +26,7 @@ function f(integer) : integer -> integer {
       true: {
         push 10;
         tcall f;
-      }
+      };
       false: {
         push 10;
         push arg[0];
@@ -40,13 +40,13 @@ function f(integer) : integer -> integer {
             push tmp[0];
             calloc h 2;
             ret;
-          }
+          };
           false: {
             push tmp[0];
             ret;
-          }
+          };
         };
-      }
+      };
     };
   };
 }
@@ -68,14 +68,14 @@ function h'(integer) : integer {
     true: {
       push 0;
       ret;
-    }
+    };
     false: {
       calloc h' 0;
       push 1;
       push arg[0];
       sub;
       tcall g';
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test019.jva
+++ b/tests/Asm/positive/test019.jva
@@ -8,14 +8,14 @@ function g(integer -> integer, integer) : integer {
     true: {
       push 0;
       ret;
-    }
+    };
     false: {
       push 1;
       push arg[1];
       sub;
       push arg[0];
       tcall $ 1;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test020.jva
+++ b/tests/Asm/positive/test020.jva
@@ -8,7 +8,7 @@ function sumb((integer, integer) -> integer, integer, integer) : integer {
     true: {
       push arg[2];
       ret;
-    }
+    };
     false: {
       push arg[2];
       push 1;
@@ -16,7 +16,7 @@ function sumb((integer, integer) -> integer, integer, integer) : integer {
       sub;
       push arg[0];
       tcall $ 2;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test023.jva
+++ b/tests/Asm/positive/test023.jva
@@ -10,14 +10,14 @@ function f91(integer) : integer {
       push arg[0];
       sub;
       ret;
-    }
+    };
     false: {
       push 11;
       push arg[0];
       add;
       call f91;
       tcall f91;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test024.jva
+++ b/tests/Asm/positive/test024.jva
@@ -20,7 +20,7 @@ function f((*, integer -> integer, integer) -> *, integer -> integer, integer) {
       pop;
       push void;
       ret;
-    }
+    };
     false: {
       push 9;
       trace;
@@ -32,7 +32,7 @@ function f((*, integer -> integer, integer) -> *, integer -> integer, integer) {
       push arg[0];
       push $;
       tcall $ 3;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test027.jva
+++ b/tests/Asm/positive/test027.jva
@@ -8,7 +8,7 @@ function power'(integer, integer, integer) : integer {
     true: {
       push arg[2];
       ret;
-    }
+    };
     false: {
       push 2;
       push arg[1];
@@ -25,7 +25,7 @@ function power'(integer, integer, integer) : integer {
           push $;
           mul;
           tcall power';
-        }
+        };
         false: {
           push arg[2];
           push arg[0];
@@ -37,9 +37,9 @@ function power'(integer, integer, integer) : integer {
           push $;
           mul;
           tcall power';
-        }
+        };
       };
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test028.jva
+++ b/tests/Asm/positive/test028.jva
@@ -12,7 +12,7 @@ function head(list) {
       pop;
       push arg[0].cons[0];
       ret;
-    }
+    };
   };
 }
 
@@ -23,7 +23,7 @@ function tail(list) : list {
       pop;
       push arg[0].cons[1];
       ret;
-    }
+    };
   };
 }
 
@@ -34,12 +34,12 @@ function null(list) {
       pop;
       push true;
       ret;
-    }
+    };
     cons: {
       pop;
       push false;
       ret;
-    }
+    };
   };
 }
 
@@ -48,7 +48,7 @@ function map(* -> *, list) : list {
   case list {
     nil: {
       ret;
-    }
+    };
     cons: {
       pop;
       push arg[1].cons[1];
@@ -59,7 +59,7 @@ function map(* -> *, list) : list {
       call $ 1;
       alloc cons;
       ret;
-    }
+    };
   };
 }
 
@@ -70,7 +70,7 @@ function foldl((*, *) -> *, *, list) : * {
       pop;
       push arg[1];
       ret;
-    }
+    };
     cons: {
       pop;
       push arg[2].cons[1];
@@ -80,7 +80,7 @@ function foldl((*, *) -> *, *, list) : * {
       call $ 2;
       push arg[0];
       tcall foldl;
-    }
+    };
   };
 }
 
@@ -91,7 +91,7 @@ function foldr((*, *) -> *, *, list) {
       pop;
       push arg[1];
       ret;
-    }
+    };
     cons: {
       pop;
       push arg[2].cons[1];
@@ -101,14 +101,14 @@ function foldr((*, *) -> *, *, list) {
       push arg[2].cons[0];
       push arg[0];
       tcall $ 2;
-    }
+    };
   };
 }
 
 function filter(* -> bool, list) : list {
   push arg[1];
   case list {
-    nil: ret
+    nil: ret;
     cons: {
       pop;
       push arg[1].cons[0];
@@ -122,14 +122,14 @@ function filter(* -> bool, list) : list {
           push arg[1].cons[0];
           alloc cons;
           ret;
-        }
+        };
         false: {
           push arg[1].cons[1];
           push arg[0];
           tcall filter;
-        }
+        };
       };
-    }
+    };
   };
 }
 
@@ -155,7 +155,7 @@ function gen(integer) : list {
     true: {
       alloc nil;
       ret;
-    }
+    };
     false: {
       push 1;
       push arg[0];
@@ -164,7 +164,7 @@ function gen(integer) : list {
       push arg[0];
       alloc cons;
       ret;
-    }
+    };
   };
 }
 
@@ -198,7 +198,7 @@ function foldl'((*, *) -> *, *, list) {
     true: {
       push arg[1];
       ret;
-    }
+    };
     false: {
       push arg[2];
       call tail;
@@ -209,7 +209,7 @@ function foldl'((*, *) -> *, *, list) {
       call $ 2;
       push arg[0];
       tcall foldl';
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test030.jva
+++ b/tests/Asm/positive/test030.jva
@@ -10,7 +10,7 @@ function f(integer) : integer {
     true: {
       push 1;
       ret;
-    }
+    };
     false: {
       push 268435456;
       push 1;
@@ -23,7 +23,7 @@ function f(integer) : integer {
       add;
       mod;
       ret;
-    }
+    };
   };
 }
 
@@ -37,7 +37,7 @@ function g(integer) : integer {
     true: {
       push 1;
       ret;
-    }
+    };
     false: {
       push 268435456;
       push 1;
@@ -48,7 +48,7 @@ function g(integer) : integer {
       add;
       mod;
       ret;
-    }
+    };
   };
 }
 
@@ -60,7 +60,7 @@ function h(integer) : integer {
     true: {
       push 1;
       ret;
-    }
+    };
     false: {
       push 268435456;
       push 1;
@@ -71,7 +71,7 @@ function h(integer) : integer {
       mul;
       mod;
       ret;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test031.jva
+++ b/tests/Asm/positive/test031.jva
@@ -13,7 +13,7 @@ function gen(integer) : tree {
     true: {
       alloc leaf;
       ret;
-    }
+    };
     false: {
       push 1;
       push arg[0];
@@ -25,7 +25,7 @@ function gen(integer) : tree {
       call gen;
       alloc node;
       ret;
-    }
+    };
   };
 }
 
@@ -38,7 +38,7 @@ function f(tree) : integer {
       pop;
       push 1;
       ret;
-    }
+    };
     node: {
       tsave {
         push tmp[0].node[0];
@@ -54,7 +54,7 @@ function f(tree) : integer {
                 push 3;
                 push 0;
                 sub;
-              }
+              };
               node: {
                 save {
                   push 32768;
@@ -65,7 +65,7 @@ function f(tree) : integer {
                   add;
                   mod;
                 };
-              }
+              };
             };
             tsave {
               push tmp[2];
@@ -80,11 +80,11 @@ function f(tree) : integer {
                     add;
                     mod;
                   };
-                }
+                };
                 default: {
                   pop;
                   push 2;
-                }
+                };
               };
               tsave {
                 push 32768;
@@ -98,23 +98,23 @@ function f(tree) : integer {
           };
         };
       };
-    }
+    };
   };
 }
 
 function isNode(tree) : bool {
   push arg[0];
   case tree {
-    node: { pop; push true; ret; }
-    default: { pop; push false; ret; }
+    node: { pop; push true; ret; };
+    default: { pop; push false; ret; };
   };
 }
 
 function isLeaf(tree) : bool {
   push arg[0];
   case tree {
-    leaf: { pop; push true; ret; }
-    default: { pop; push false; ret; }
+    leaf: { pop; push true; ret; };
+    default: { pop; push false; ret; };
   };
 }
 
@@ -125,7 +125,7 @@ function g(tree) : tree {
     true: {
       push arg[0];
       ret;
-    }
+    };
     false: {
       push arg[0];
       case tree {
@@ -137,18 +137,18 @@ function g(tree) : tree {
               true: {
                 push tmp[0].node[1];
                 ret;
-              }
+              };
               false: {
                 push tmp[0].node[1];
                 push tmp[0].node[0];
                 alloc node;
                 ret;
-              }
+              };
             };
           };
-        }
+        };
       };
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test032.jva
+++ b/tests/Asm/positive/test032.jva
@@ -36,7 +36,7 @@ function num(integer, * -> *, *) {
       push arg[2];
       push arg[1];
       tcall zero;
-    }
+    };
     false: {
       push arg[2];
       push arg[1];
@@ -46,7 +46,7 @@ function num(integer, * -> *, *) {
       calloc num 2;
       push arg[1];
       tcall compose;
-    }
+    };
   };
 }
 
@@ -110,7 +110,7 @@ function pred_step(Pair) : (* -> *, *) -> * {
       push arg[0].pair[0];
       alloc pair;
       ret;
-    }
+    };
     false: {
       push arg[0].pair[1];
       calloc succ 1;
@@ -120,7 +120,7 @@ function pred_step(Pair) : (* -> *, *) -> * {
       calloc uncurry 1;
       alloc pair;
       ret;
-    }
+    };
   };
 }
 
@@ -158,7 +158,7 @@ function fib((* -> *, *) -> *) : (* -> *, *) -> * {
     true: {
       calloc zero 0;
       ret;
-    }
+    };
     false: {
       push arg[0];
       call pred;
@@ -171,7 +171,7 @@ function fib((* -> *, *) -> *) : (* -> *, *) -> * {
             calloc succ 1;
             calloc uncurry 1;
             ret;
-          }
+          };
           false: {
             push tmp[0];
             call pred;
@@ -181,10 +181,10 @@ function fib((* -> *, *) -> *) : (* -> *, *) -> * {
             calloc add 2;
             calloc uncurry 1;
             ret;
-          }
+          };
         };
       };
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test033.jva
+++ b/tests/Asm/positive/test033.jva
@@ -10,7 +10,7 @@ function ack(integer, integer) : integer {
       push arg[1];
       add;
       ret;
-    }
+    };
     false: {
       push 0;
       push arg[1];
@@ -22,7 +22,7 @@ function ack(integer, integer) : integer {
           push arg[0];
           sub;
           tcall ack;
-        }
+        };
         false: {
           push 1;
           push arg[1];
@@ -33,9 +33,9 @@ function ack(integer, integer) : integer {
           push arg[0];
           sub;
           tcall ack;
-        }
+        };
       };
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test034.jva
+++ b/tests/Asm/positive/test034.jva
@@ -21,7 +21,7 @@ function iterate(* -> *, integer) : * -> * {
     true: {
       calloc id 0;
       ret;
-    }
+    };
     false: {
       push 1;
       push arg[1];
@@ -31,7 +31,7 @@ function iterate(* -> *, integer) : * -> * {
       push arg[0];
       calloc compose 2;
       ret;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test035.jva
+++ b/tests/Asm/positive/test035.jva
@@ -13,7 +13,7 @@ function mklst(integer) : list {
     true: {
       alloc nil;
       ret;
-    }
+    };
     false: {
       push 1;
       push arg[0];
@@ -22,7 +22,7 @@ function mklst(integer) : list {
       push arg[0];
       alloc cons;
       ret;
-    }
+    };
   };
 }
 
@@ -34,7 +34,7 @@ function mklst2(integer) : list {
     true: {
       alloc nil;
       ret;
-    }
+    };
     false: {
       push 1;
       push arg[0];
@@ -44,14 +44,14 @@ function mklst2(integer) : list {
       call mklst;
       alloc cons;
       ret;
-    }
+    };
   };
 }
 
 function append(list, list) : list {
   push arg[0];
   case list {
-    nil: { pop; push arg[1]; ret; }
+    nil: { pop; push arg[1]; ret; };
     cons: {
       pop;
       push arg[1];
@@ -60,21 +60,21 @@ function append(list, list) : list {
       push arg[0].cons[0];
       alloc cons;
       ret;
-    }
+    };
   };
 }
 
 function flatten(list) : list {
   push arg[0];
   case list {
-    nil: ret
+    nil: ret;
     cons: {
       pop;
       push arg[0].cons[1];
       call flatten;
       push arg[0].cons[0];
       tcall append;
-    }
+    };
   };
 }
 

--- a/tests/Asm/positive/test036.jva
+++ b/tests/Asm/positive/test036.jva
@@ -25,13 +25,13 @@ function filter(f : integer -> bool, s : unit -> stream, unit) : stream {
         push s1.cons[0];
         alloc cons;
         ret;
-      }
+      };
       false: {
         push unit;
         push s1.cons[1];
         push f;
         tcall filter;
-      }
+      };
     };
   };
 }
@@ -44,14 +44,14 @@ function nth(n : integer, s : unit -> stream) : integer {
     push 0;
     eq;
     br {
-      true: { push s1.cons[0]; ret; }
+      true: { push s1.cons[0]; ret; };
       false: {
         push s1.cons[1];
         push 1;
         push n;
         sub;
         tcall nth;
-      }
+      };
     };
   };
 }
@@ -73,8 +73,8 @@ function indivisible(n : integer, m : integer) : bool {
   push 0;
   eq;
   br {
-    true: { push false; ret; }
-    false: { push true; ret; }
+    true: { push false; ret; };
+    false: { push true; ret; };
   };
 }
 

--- a/tests/Asm/positive/test038.jva
+++ b/tests/Asm/positive/test038.jva
@@ -10,13 +10,13 @@ function apply_1(*, *) : * {
             push arg[1];
             push arg[0];
             tcall $ 1;
-        }
+        };
         false: { -- argsnum > 1
             push arg[1];
             push arg[0];
             cextend 1;
             ret;
-        }
+        };
     };
 }
 
@@ -33,7 +33,7 @@ function apply_2(*, *, *) : * {
                 push arg[1];
                 push arg[0];
                 tcall $ 2;
-            }
+            };
             false: {
                 push n;
                 push 1;
@@ -45,16 +45,16 @@ function apply_2(*, *, *) : * {
                         push arg[0];
                         call $ 1;
                         tcall apply_1;
-                    }
+                    };
                     false: { -- argsnum > 2
                         push arg[2];
                         push arg[1];
                         push arg[0];
                         cextend 2;
                         ret;
-                    }
+                    };
                 };
-            }
+            };
         };
     };
 }
@@ -73,7 +73,7 @@ function apply_3(*, *, *, *) : * {
                 push arg[1];
                 push arg[0];
                 tcall $ 3;
-            }
+            };
             false: {
                 push n;
                 push 3;
@@ -86,7 +86,7 @@ function apply_3(*, *, *, *) : * {
                         push arg[0];
                         cextend 3;
                         ret;
-                    }
+                    };
                     false: { -- argsnum <= 2
                         push n;
                         push 2;
@@ -99,7 +99,7 @@ function apply_3(*, *, *, *) : * {
                                 push arg[0];
                                 call $ 2;
                                 tcall apply_1;
-                            }
+                            };
                             false: { -- argsnum = 1
                                 push arg[3];
                                 push arg[2];
@@ -107,11 +107,11 @@ function apply_3(*, *, *, *) : * {
                                 push arg[0];
                                 call $ 1;
                                 tcall apply_2;
-                            }
+                            };
                         };
-                    }
+                    };
                 };
-            }
+            };
         };
     };
 }
@@ -131,7 +131,7 @@ function apply_4(*, *, *, *, *) : * {
                 push arg[1];
                 push arg[0];
                 tcall $ 4;
-            }
+            };
             false: {
                 push n;
                 push 4;
@@ -145,7 +145,7 @@ function apply_4(*, *, *, *, *) : * {
                         push arg[0];
                         cextend 4;
                         ret;
-                    }
+                    };
                     false: { -- argsnum <= 3
                         push n;
                         push 3;
@@ -159,7 +159,7 @@ function apply_4(*, *, *, *, *) : * {
                                 push arg[0];
                                 call $ 3;
                                 tcall apply_1;
-                            }
+                            };
                             false: {
                                 push n;
                                 push 2;
@@ -173,7 +173,7 @@ function apply_4(*, *, *, *, *) : * {
                                         push arg[0];
                                         call $ 2;
                                         tcall apply_2;
-                                    }
+                                    };
                                     false: { -- argsnum = 1
                                         push arg[4];
                                         push arg[3];
@@ -182,13 +182,13 @@ function apply_4(*, *, *, *, *) : * {
                                         push arg[0];
                                         call $ 1;
                                         tcall apply_3;
-                                    }
+                                    };
                                 };
-                            }
+                            };
                         };
-                    }
+                    };
                 };
-            }
+            };
         };
     };
 }


### PR DESCRIPTION
This makes the syntax more uniform. It was especially confusing with nested branching, where some closing braces had to and others couldn't be followed by a semicolon. Now all have to be followed by a semicolon (except function ending braces).
