### PR TITLE
Fast nockma eval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,13 @@ jobs:
         with:
           version: 0.5.3.0
           extra-args: >-
-            --ghc-opt -XDerivingStrategies --ghc-opt -XImportQualifiedPost
-            --ghc-opt -XMultiParamTypeClasses --ghc-opt -XStandaloneDeriving
-            --ghc-opt -XTemplateHaskell --ghc-opt -XUnicodeSyntax
+            --ghc-opt -XDerivingStrategies
+            --ghc-opt -XImportQualifiedPost
+            --ghc-opt -XMultiParamTypeClasses
+            --ghc-opt -XPatternSynonyms
+            --ghc-opt -XStandaloneDeriving
+            --ghc-opt -XTemplateHaskell
+            --ghc-opt -XUnicodeSyntax
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ ormolu:
 		--ghc-opt -XStandaloneDeriving \
 		--ghc-opt -XUnicodeSyntax \
 		--ghc-opt -XDerivingStrategies \
+		--ghc-opt -XPatternSynonyms \
 		--ghc-opt -XMultiParamTypeClasses  \
 		--ghc-opt -XTemplateHaskell \
 		--ghc-opt -XImportQualifiedPost \

--- a/app/Commands/Dev/Nockma/Eval.hs
+++ b/app/Commands/Dev/Nockma/Eval.hs
@@ -2,6 +2,7 @@ module Commands.Dev.Nockma.Eval where
 
 import Commands.Base hiding (Atom)
 import Commands.Dev.Nockma.Eval.Options
+import Juvix.Compiler.Nockma.Evaluator.Options
 import Juvix.Compiler.Nockma.Pretty
 import Juvix.Compiler.Nockma.Translation.FromAsm
 import Juvix.Compiler.Nockma.Translation.FromSource qualified as Nockma
@@ -13,7 +14,10 @@ runCommand opts = do
   case parsedTerm of
     Left err -> exitJuvixError (JuvixError err)
     Right (TermCell c) -> do
-      res <- runOutputSem @(Term Natural) (say . ppTrace) (evalCompiledNock' (c ^. cellLeft) (c ^. cellRight))
+      res <-
+        runReader defaultEvalOptions
+          . runOutputSem @(Term Natural) (say . ppTrace)
+          $ evalCompiledNock' (c ^. cellLeft) (c ^. cellRight)
       ret <- getReturn res
       putStrLn (ppPrint ret)
     Right TermAtom {} -> exitFailMsg "Expected nockma input to be a cell"

--- a/app/Commands/Dev/Nockma/Repl.hs
+++ b/app/Commands/Dev/Nockma/Repl.hs
@@ -8,6 +8,7 @@ import Control.Exception (throwIO)
 import Control.Monad.State.Strict qualified as State
 import Data.String.Interpolate (__i)
 import Juvix.Compiler.Nockma.Evaluator (NockEvalError, evalRepl, fromReplTerm, programAssignments)
+import Juvix.Compiler.Nockma.Evaluator.Options
 import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Pretty (ppPrint)
 import Juvix.Compiler.Nockma.Pretty qualified as Nockma
@@ -16,7 +17,6 @@ import Juvix.Parser.Error
 import System.Console.Haskeline
 import System.Console.Repline qualified as Repline
 import Prelude (read)
-import Juvix.Compiler.Nockma.Evaluator.Options
 
 type ReplS = State.StateT ReplState IO
 

--- a/app/Commands/Dev/Nockma/Repl.hs
+++ b/app/Commands/Dev/Nockma/Repl.hs
@@ -16,6 +16,7 @@ import Juvix.Parser.Error
 import System.Console.Haskeline
 import System.Console.Repline qualified as Repline
 import Prelude (read)
+import Juvix.Compiler.Nockma.Evaluator.Options
 
 type ReplS = State.StateT ReplState IO
 
@@ -133,9 +134,10 @@ evalStatement = \case
     prog <- getProgram
     et <-
       liftIO
-        $ runM
-          . runError @(ErrNockNatural Natural)
-          . runError @NockEvalError
+        . runM
+        . runReader defaultEvalOptions
+        . runError @(ErrNockNatural Natural)
+        . runError @NockEvalError
         $ evalRepl (putStrLn . Nockma.ppTrace) prog s t
     case et of
       Left e -> error (show e)

--- a/package.yaml
+++ b/package.yaml
@@ -143,6 +143,7 @@ default-extensions:
   - NoFieldSelectors
   - NoImplicitPrelude
   - OverloadedStrings
+  - PatternSynonyms
   - QuasiQuotes
   - RecordWildCards
   - TemplateHaskell

--- a/src/Juvix/Compiler/Nockma/Evaluator/Options.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Options.hs
@@ -1,0 +1,12 @@
+module Juvix.Compiler.Nockma.Evaluator.Options where
+
+import Juvix.Prelude.Base
+
+newtype EvalOptions = EvalOptions
+  { _evalIgnoreStdlibCalls :: Bool
+  }
+
+defaultEvalOptions :: EvalOptions
+defaultEvalOptions = EvalOptions False
+
+makeLenses ''EvalOptions

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -344,8 +344,9 @@ stdlibNumArgs = \case
   StdlibLe -> 2
   StdlibLt -> 2
 
--- Does not play well with ormolu :(
 {-# COMPLETE Cell #-}
+
 pattern Cell :: Term a -> Term a -> Cell a
-pattern Cell {_cellLeft', _cellRight'} <- Cell' _cellLeft' _cellRight' _ where
-  Cell a b = Cell' a b (Irrelevant Nothing)
+pattern Cell {_cellLeft', _cellRight'} <- Cell' _cellLeft' _cellRight' _
+  where
+    Cell a b = Cell' a b (Irrelevant Nothing)

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -45,17 +45,18 @@ data Term a
   | TermCell (Cell a)
   deriving stock (Show, Eq, Lift)
 
+data StdlibCall a = StdlibCall
+  { _stdlibCallArgs :: Term a,
+    _stdlibCallFunction :: StdlibFunction
+  }
+  deriving stock (Show, Lift)
+
 data Cell a = Cell'
   { _cellLeft :: Term a,
     _cellRight :: Term a,
-    _cellInfo :: Irrelevant ()
+    _cellInfo :: Irrelevant (Maybe (StdlibCall a))
   }
   deriving stock (Show, Eq, Lift)
-
-{-# COMPLETE Cell #-}
-pattern Cell :: Term a -> Term a -> Cell a
-pattern Cell {_cellLeft', _cellRight'} <- Cell' _cellLeft' _cellRight' _ where
-  Cell a b = Cell' a b (Irrelevant ())
 
 data Atom a = Atom
   { _atom :: a,
@@ -104,8 +105,25 @@ instance Pretty NockOp where
     OpHint -> "hint"
     OpTrace -> "trace"
 
+data StdlibFunction
+  = StdlibDec
+  | StdlibAdd
+  | StdlibSub
+  | StdlibMul
+  | StdlibDiv
+  | StdlibMod
+  | StdlibLt
+  | StdlibLe
+  deriving stock (Show, Lift)
+
 atomOps :: HashMap Text NockOp
 atomOps = HashMap.fromList [(prettyText op, op) | op <- allElements]
+
+-- TODO better field names
+data StdlibCallCell a = StdlibCallCell
+  { _stdlibCallCell :: StdlibCall a,
+    _stdlibCallRaw :: OperatorCell a
+  }
 
 data OperatorCell a = OperatorCell
   { _operatorCellOp :: NockOp,
@@ -120,6 +138,7 @@ data AutoConsCell a = AutoConsCell
 data ParsedCell a
   = ParsedOperatorCell (OperatorCell a)
   | ParsedAutoConsCell (AutoConsCell a)
+  | ParsedStdlibCallCell (StdlibCallCell a)
 
 newtype EncodedPath = EncodedPath
   { _encodedPath :: Natural
@@ -144,6 +163,8 @@ emptyPath :: Path
 emptyPath = []
 
 makeLenses ''Cell
+makeLenses ''StdlibCallCell
+makeLenses ''StdlibCall
 makeLenses ''Atom
 makeLenses ''OperatorCell
 makeLenses ''AutoConsCell
@@ -270,7 +291,7 @@ instance IsNock (Cell Natural) where
   toNock = TermCell
 
 instance IsNock Natural where
-  toNock n = toNock (Atom n (Irrelevant Nothing))
+  toNock n = TermAtom (Atom n (Irrelevant Nothing))
 
 instance IsNock NockOp where
   toNock op = toNock (Atom (serializeOp op) (Irrelevant (Just AtomHintOp)))
@@ -303,22 +324,14 @@ infixr 5 #
 a # b = TermCell (a #. b)
 
 infixl 1 >>#.
+
 (>>#.) :: (IsNock x, IsNock y) => x -> y -> Cell Natural
 a >>#. b = OpSequence #. a # b
 
 infixl 1 >>#
+
 (>>#) :: (IsNock x, IsNock y) => x -> y -> Term Natural
 a >># b = TermCell (a >>#. b)
-
-data StdlibFunction
-  = StdlibDec
-  | StdlibAdd
-  | StdlibSub
-  | StdlibMul
-  | StdlibDiv
-  | StdlibMod
-  | StdlibLt
-  | StdlibLe
 
 stdlibNumArgs :: StdlibFunction -> Natural
 stdlibNumArgs = \case
@@ -330,3 +343,9 @@ stdlibNumArgs = \case
   StdlibDiv -> 2
   StdlibLe -> 2
   StdlibLt -> 2
+
+-- Does not play well with ormolu :(
+{-# COMPLETE Cell #-}
+pattern Cell :: Term a -> Term a -> Cell a
+pattern Cell {_cellLeft', _cellRight'} <- Cell' _cellLeft' _cellRight' _ where
+  Cell a b = Cell' a b (Irrelevant Nothing)

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -140,7 +140,6 @@ parseStdlibFunction t = textToStdlibFunctionMap ^. at t
 atomOps :: HashMap Text NockOp
 atomOps = HashMap.fromList [(prettyText op, op) | op <- allElements]
 
--- TODO better field names
 data StdlibCallCell a = StdlibCallCell
   { _stdlibCallCell :: StdlibCall a,
     _stdlibCallRaw :: OperatorCell a

--- a/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
@@ -113,7 +113,7 @@ functionPath = \case
   FunctionArgs -> [R]
 
 -- | The stdlib paths are obtained using scripts/nockma-stdlib-parser.sh
-stdlibPath :: StdlibFunction -> Path
+stdlibPath :: StdlibFunction nat ty -> Path
 stdlibPath =
   decodePath' . EncodedPath . \case
     StdlibDec -> 342
@@ -140,7 +140,7 @@ data Compiler m a where
   IncrementOn :: StackId -> Compiler m ()
   Branch :: m () -> m () -> Compiler m ()
   Save :: Bool -> m () -> Compiler m ()
-  CallStdlibOn :: StackId -> StdlibFunction -> Compiler m ()
+  CallStdlibOn :: StackId -> StdlibFunction Natural ty -> Compiler m ()
   AsmReturn :: Compiler m ()
   GetConstructorArity :: Asm.Tag -> Compiler m Natural
   GetFunctionArity :: FunctionId -> Compiler m Natural
@@ -753,10 +753,10 @@ traceTerm' t =
 incrementOn' :: (Members '[Output (Term Natural)] r) => StackId -> Sem r ()
 incrementOn' s = output (replaceOnStack s (OpInc # stackSliceAsCell s 0 0))
 
-callStdlib :: (Members '[Compiler] r) => StdlibFunction -> Sem r ()
+callStdlib :: (Members '[Compiler] r) => StdlibFunction Natural ty -> Sem r ()
 callStdlib = callStdlibOn ValueStack
 
-callStdlibOn' :: (Members '[Output (Term Natural)] r) => StackId -> StdlibFunction -> Sem r ()
+callStdlibOn' :: (Members '[Output (Term Natural)] r) => StackId -> StdlibFunction Natural ty -> Sem r ()
 callStdlibOn' s f = do
   let fNumArgs = stdlibNumArgs f
       fPath = stdlibPath f

--- a/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
@@ -113,7 +113,7 @@ functionPath = \case
   FunctionArgs -> [R]
 
 -- | The stdlib paths are obtained using scripts/nockma-stdlib-parser.sh
-stdlibPath :: StdlibFunction nat ty -> Path
+stdlibPath :: StdlibFunction -> Path
 stdlibPath =
   decodePath' . EncodedPath . \case
     StdlibDec -> 342
@@ -140,7 +140,7 @@ data Compiler m a where
   IncrementOn :: StackId -> Compiler m ()
   Branch :: m () -> m () -> Compiler m ()
   Save :: Bool -> m () -> Compiler m ()
-  CallStdlibOn :: StackId -> StdlibFunction Natural ty -> Compiler m ()
+  CallStdlibOn :: StackId -> StdlibFunction -> Compiler m ()
   AsmReturn :: Compiler m ()
   GetConstructorArity :: Asm.Tag -> Compiler m Natural
   GetFunctionArity :: FunctionId -> Compiler m Natural
@@ -753,10 +753,10 @@ traceTerm' t =
 incrementOn' :: (Members '[Output (Term Natural)] r) => StackId -> Sem r ()
 incrementOn' s = output (replaceOnStack s (OpInc # stackSliceAsCell s 0 0))
 
-callStdlib :: (Members '[Compiler] r) => StdlibFunction Natural ty -> Sem r ()
+callStdlib :: (Members '[Compiler] r) => StdlibFunction -> Sem r ()
 callStdlib = callStdlibOn ValueStack
 
-callStdlibOn' :: (Members '[Output (Term Natural)] r) => StackId -> StdlibFunction Natural ty -> Sem r ()
+callStdlibOn' :: (Members '[Output (Term Natural)] r) => StackId -> StdlibFunction -> Sem r ()
 callStdlibOn' s f = do
   let fNumArgs = stdlibNumArgs f
       fPath = stdlibPath f
@@ -1005,18 +1005,12 @@ pushNat = pushNatOnto ValueStack
 pushNatOnto :: (Member Compiler r) => StackId -> Natural -> Sem r ()
 pushNatOnto s n = pushOnto s (OpQuote # toNock n)
 
-compileAndRunNock :: CompilerOptions -> ConstructorArities -> [CompilerFunction] -> CompilerFunction -> Term Natural
-compileAndRunNock opts constrs funs = run . ignoreOutput @(Term Natural) . compileAndRunNock' opts constrs funs
-
-compileAndRunNock' :: (Member (Output (Term Natural)) r) => CompilerOptions -> ConstructorArities -> [CompilerFunction] -> CompilerFunction -> Sem r (Term Natural)
+compileAndRunNock' :: (Members '[Reader EvalOptions, Output (Term Natural)] r) => CompilerOptions -> ConstructorArities -> [CompilerFunction] -> CompilerFunction -> Sem r (Term Natural)
 compileAndRunNock' opts constrs funs mainfun =
   let Cell nockSubject t = runCompilerWith opts constrs funs mainfun
    in evalCompiledNock' nockSubject t
 
-evalCompiledNock :: Term Natural -> Term Natural -> Term Natural
-evalCompiledNock stack = run . ignoreOutput @(Term Natural) . evalCompiledNock' stack
-
-evalCompiledNock' :: (Member (Output (Term Natural)) r) => Term Natural -> Term Natural -> Sem r (Term Natural)
+evalCompiledNock' :: (Members '[Reader EvalOptions, Output (Term Natural)] r) => Term Natural -> Term Natural -> Sem r (Term Natural)
 evalCompiledNock' stack mainTerm = do
   evalT <-
     runError @(ErrNockNatural Natural)

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -43,7 +43,9 @@ runParser :: FilePath -> Text -> Either MegaparsecError (N.Term Natural)
 runParser = runParserFor term
 
 spaceConsumer :: Parser ()
-spaceConsumer = L.space space1 empty empty
+spaceConsumer = L.space space1 lineComment empty
+  where
+    lineComment :: Parser () = L.skipLineComment "--"
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme spaceConsumer
@@ -102,14 +104,37 @@ patom =
     <|> atomBool
     <|> atomNil
 
+iden :: Parser Text
+iden = lexeme (takeWhile1P (Just "<iden>") isAlphaNum)
+
 cell :: Parser (N.Cell Natural)
 cell = do
   lsbracket
+  c <- optional stdlibCall
   firstTerm <- term
   restTerms <- some term
   rsbracket
-  return (buildCell firstTerm restTerms)
+  let r = buildCell firstTerm restTerms
+  return (set N.cellInfo (Irrelevant c) r)
   where
+    stdlibCall :: Parser (N.StdlibCall Natural)
+    stdlibCall = do
+      chunk "stdlib@"
+      f <- stdlibFun
+      chunk "args@"
+      args <- term
+      return
+        N.StdlibCall
+          { _stdlibCallArgs = args,
+            _stdlibCallFunction = f
+          }
+
+    stdlibFun :: Parser N.StdlibFunction
+    stdlibFun = do
+      i <- iden
+      let err = error ("invalid stdlib function identifier: " <> i)
+      maybe err return (N.parseStdlibFunction i)
+
     buildCell :: N.Term Natural -> NonEmpty (N.Term Natural) -> N.Cell Natural
     buildCell h = \case
       x :| [] -> N.Cell h x

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -4,6 +4,7 @@ import Data.HashMap.Internal.Strict qualified as HashMap
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text qualified as Text
 import Juvix.Compiler.Nockma.Language qualified as N
+import Juvix.Extra.Strings qualified as Str
 import Juvix.Parser.Error
 import Juvix.Prelude hiding (Atom, many, some)
 import Juvix.Prelude.Parsing hiding (runParser)
@@ -119,9 +120,9 @@ cell = do
   where
     stdlibCall :: Parser (N.StdlibCall Natural)
     stdlibCall = do
-      chunk "stdlib@"
+      chunk Str.stdlibTag
       f <- stdlibFun
-      chunk "args@"
+      chunk Str.argsTag
       args <- term
       return
         N.StdlibCall

--- a/src/Juvix/Data/Effect/Fail.hs
+++ b/src/Juvix/Data/Effect/Fail.hs
@@ -45,6 +45,10 @@ failWhen :: (Member Fail r) => Bool -> Sem r ()
 failWhen c = when c fail
 {-# INLINE failWhen #-}
 
+failWhenM :: (Member Fail r) => Sem r Bool -> Sem r ()
+failWhenM c = whenM c fail
+{-# INLINE failWhenM #-}
+
 failUnlessM :: (Member Fail r) => Sem r Bool -> Sem r ()
 failUnlessM c = unlessM c fail
 {-# INLINE failUnlessM #-}

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -581,6 +581,12 @@ tmp = "tmp"
 instrAdd :: (IsString s) => s
 instrAdd = "add"
 
+argsTag :: (IsString s) => s
+argsTag = "args@"
+
+stdlibTag :: (IsString s) => s
+stdlibTag = "stdlib@"
+
 instrSub :: (IsString s) => s
 instrSub = "sub"
 

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -232,6 +232,18 @@ tests =
       pushNat 33333
       pushNat 22222
       add,
+    Test "mul big" (eqStack ValueStack [nock| [1111088889 nil] |]) $ do
+      pushNat 33333
+      pushNat 33333
+      mul,
+    Test "sub big" (eqStack ValueStack [nock| [66666 nil] |]) $ do
+      pushNat 33333
+      pushNat 99999
+      callStdlib StdlibSub,
+    Test "le big" (eqStack ValueStack [nock| [true nil] |]) $ do
+      pushNat 99999
+      pushNat 999
+      callStdlib StdlibLe,
     Test "pow2" (eqStack ValueStack [nock| [1 2 8 32 nil] |]) $ do
       pushNat 5
       pow2

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -198,6 +198,16 @@ defTest _testName _testCheck _testProgram =
       ..
     }
 
+defTestNoJets :: Text -> Check () -> Sem '[Compiler] () -> Test
+defTestNoJets _testName _testCheck _testProgram =
+  Test
+    { _testEvalOptions =
+        EvalOptions
+          { _evalIgnoreStdlibCalls = True
+          },
+      ..
+    }
+
 tests :: [Test]
 tests =
   [ defTest "push" (eqStack ValueStack [nock| [1 5 nil] |]) $ do
@@ -233,6 +243,18 @@ tests =
       pushNat 15
       callStdlib StdlibDiv,
     defTest "mod" (eqStack ValueStack [nock| [5 nil] |]) $ do
+      pushNat 10
+      pushNat 15
+      callStdlib StdlibMod,
+    defTestNoJets "mul no jets" (eqStack ValueStack [nock| [24 nil] |]) $ do
+      pushNat 8
+      pushNat 3
+      callStdlib StdlibMul,
+    defTestNoJets "div no jets" (eqStack ValueStack [nock| [3 nil] |]) $ do
+      pushNat 5
+      pushNat 15
+      callStdlib StdlibDiv,
+    defTestNoJets "mod no jets" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 10
       pushNat 15
       callStdlib StdlibMod,

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -16,6 +16,7 @@ type Check = Sem '[Reader [Term Natural], Reader (Term Natural), Embed IO]
 data Test = Test
   { _testName :: Text,
     _testCheck :: Check (),
+    _testEvalOptions :: EvalOptions,
     _testProgram :: Sem '[Compiler] ()
   }
 
@@ -33,8 +34,12 @@ data FunctionName
 sym :: (Enum a) => a -> FunctionId
 sym = UserFunction . Asm.defaultSymbol . fromIntegral . fromEnum
 
-debugProg :: Sem '[Compiler] () -> ([Term Natural], Term Natural)
-debugProg mkMain = run . runOutputList $ compileAndRunNock' opts exampleConstructors exampleFunctions mainFun
+debugProg :: EvalOptions -> Sem '[Compiler] () -> ([Term Natural], Term Natural)
+debugProg evalOpts mkMain =
+  run
+    . runReader evalOpts
+    . runOutputList
+    $ compileAndRunNock' opts exampleConstructors exampleFunctions mainFun
   where
     mainFun =
       CompilerFunction
@@ -122,7 +127,7 @@ allTests = testGroup "Nockma compile unit positive" (map mk tests)
   where
     mk :: Test -> TestTree
     mk Test {..} = testCase (unpack _testName) $ do
-      let (traces, n) = debugProg _testProgram
+      let (traces, n) = debugProg _testEvalOptions _testProgram
       runM (runReader n (runReader traces _testCheck))
 
 eqSubStack :: StackId -> Path -> Term Natural -> Check ()
@@ -186,65 +191,72 @@ checkStackSize st stSize = subStackPred st ([] :: Path) $ \s -> do
               <> show n
       assertFailure (unpack msg)
 
+defTest :: Text -> Check () -> Sem '[Compiler] () -> Test
+defTest _testName _testCheck _testProgram =
+  Test
+    { _testEvalOptions = defaultEvalOptions,
+      ..
+    }
+
 tests :: [Test]
 tests =
-  [ Test "push" (eqStack ValueStack [nock| [1 5 nil] |]) $ do
+  [ defTest "push" (eqStack ValueStack [nock| [1 5 nil] |]) $ do
       pushNat 5
       pushNat 1,
-    Test "pop" (eqStack ValueStack [nock| [1 nil] |]) $ do
+    defTest "pop" (eqStack ValueStack [nock| [1 nil] |]) $ do
       pushNat 1
       pushNat 33
       pop,
-    Test "increment" (eqStack ValueStack [nock| [3 nil] |]) $ do
+    defTest "increment" (eqStack ValueStack [nock| [3 nil] |]) $ do
       pushNat 1
       increment
       increment,
-    Test "dec" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "dec" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 6
       dec,
-    Test "branch true" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "branch true" (eqStack ValueStack [nock| [5 nil] |]) $ do
       push (nockBoolLiteral True)
       branch (pushNat 5) (pushNat 666),
-    Test "branch false" (eqStack ValueStack [nock| [666 nil] |]) $ do
+    defTest "branch false" (eqStack ValueStack [nock| [666 nil] |]) $ do
       push (nockBoolLiteral False)
       branch (pushNat 5) (pushNat 666),
-    Test "sub" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "sub" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 3
       pushNat 8
       callStdlib StdlibSub,
-    Test "mul" (eqStack ValueStack [nock| [24 nil] |]) $ do
+    defTest "mul" (eqStack ValueStack [nock| [24 nil] |]) $ do
       pushNat 8
       pushNat 3
       callStdlib StdlibMul,
-    Test "div" (eqStack ValueStack [nock| [3 nil] |]) $ do
+    defTest "div" (eqStack ValueStack [nock| [3 nil] |]) $ do
       pushNat 5
       pushNat 15
       callStdlib StdlibDiv,
-    Test "mod" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "mod" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 10
       pushNat 15
       callStdlib StdlibMod,
-    Test "add" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "add" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 2
       pushNat 3
       add,
-    Test "add big" (eqStack ValueStack [nock| [55555 nil] |]) $ do
+    defTest "add big" (eqStack ValueStack [nock| [55555 nil] |]) $ do
       pushNat 33333
       pushNat 22222
       add,
-    Test "mul big" (eqStack ValueStack [nock| [1111088889 nil] |]) $ do
+    defTest "mul big" (eqStack ValueStack [nock| [1111088889 nil] |]) $ do
       pushNat 33333
       pushNat 33333
       mul,
-    Test "sub big" (eqStack ValueStack [nock| [66666 nil] |]) $ do
+    defTest "sub big" (eqStack ValueStack [nock| [66666 nil] |]) $ do
       pushNat 33333
       pushNat 99999
       callStdlib StdlibSub,
-    Test "le big" (eqStack ValueStack [nock| [true nil] |]) $ do
+    defTest "le big" (eqStack ValueStack [nock| [true nil] |]) $ do
       pushNat 99999
       pushNat 999
       callStdlib StdlibLe,
-    Test "pow2" (eqStack ValueStack [nock| [1 2 8 32 nil] |]) $ do
+    defTest "pow2" (eqStack ValueStack [nock| [1 2 8 32 nil] |]) $ do
       pushNat 5
       pow2
       pushNat 3
@@ -253,38 +265,38 @@ tests =
       pow2
       pushNat 0
       pow2,
-    Test "append rights" (eqStack ValueStack [nock| [95 3 nil] |]) $ do
+    defTest "append rights" (eqStack ValueStack [nock| [95 3 nil] |]) $ do
       push (OpQuote # toNock ([] :: Path))
       pushNat 1
       appendRights
       push (OpQuote # toNock [L])
       pushNat 5
       appendRights,
-    Test "le less" (eqStack ValueStack [nock| [1 nil] |]) $ do
+    defTest "le less" (eqStack ValueStack [nock| [1 nil] |]) $ do
       pushNat 2
       pushNat 3
       callStdlib StdlibLe,
-    Test "lt true" (eqStack ValueStack [nock| [0 nil] |]) $ do
+    defTest "lt true" (eqStack ValueStack [nock| [0 nil] |]) $ do
       pushNat 4
       pushNat 3
       callStdlib StdlibLt,
-    Test "lt eq" (eqStack ValueStack [nock| [1 nil] |]) $ do
+    defTest "lt eq" (eqStack ValueStack [nock| [1 nil] |]) $ do
       pushNat 3
       pushNat 3
       callStdlib StdlibLt,
-    Test "le eq" (eqStack ValueStack [nock| [0 nil] |]) $ do
+    defTest "le eq" (eqStack ValueStack [nock| [0 nil] |]) $ do
       pushNat 3
       pushNat 3
       callStdlib StdlibLe,
-    Test "primitive eq true" (eqStack ValueStack [nock| [0 nil] |]) $ do
+    defTest "primitive eq true" (eqStack ValueStack [nock| [0 nil] |]) $ do
       pushNat 4
       pushNat 4
       testEq,
-    Test "primitive eq false" (eqStack ValueStack [nock| [1 nil] |]) $ do
+    defTest "primitive eq false" (eqStack ValueStack [nock| [1 nil] |]) $ do
       pushNat 4
       pushNat 1
       testEq,
-    Test
+    defTest
       "save"
       ( do
           eqStack ValueStack [nock| [67 2 nil] |]
@@ -295,21 +307,21 @@ tests =
         pushNat 3
         save False (pushNat 77)
         save True (pushNat 67),
-    Test "primitive increment" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "primitive increment" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 3
       increment
       increment,
-    Test "call increment" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "call increment" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 2
       callEnum FunIncrement 1
       callEnum FunIncrement 1
       callEnum FunIncrement 1,
-    Test "call increment indirectly" (eqStack ValueStack [nock| [5 nil] |]) $ do
+    defTest "call increment indirectly" (eqStack ValueStack [nock| [5 nil] |]) $ do
       pushNat 2
       callEnum FunIncrement 1
       callEnum FunCallInc 1
       callEnum FunIncrement 1,
-    Test
+    defTest
       "push temp"
       ( do
           eqStack ValueStack [nock| [5 6 nil] |]
@@ -320,20 +332,20 @@ tests =
         pushNatOnto TempStack 6
         pushTempRef 2 1
         pushTempRef 2 0,
-    Test "push cell" (eqStack ValueStack [nock| [[1 2] nil] |]) $ do
+    defTest "push cell" (eqStack ValueStack [nock| [[1 2] nil] |]) $ do
       push (OpQuote # (1 :: Natural) # (2 :: Natural)),
-    Test "push unit" (eqStack ValueStack [nock| [[0 nil nil] nil] |]) $ do
+    defTest "push unit" (eqStack ValueStack [nock| [[0 nil nil] nil] |]) $ do
       push constUnit,
-    Test "alloc nullary constructor" (eqStack ValueStack [nock| [[0 nil nil] nil] |]) $ do
+    defTest "alloc nullary constructor" (eqStack ValueStack [nock| [[0 nil nil] nil] |]) $ do
       allocConstr (constructorTag ConstructorFalse),
-    Test "alloc unary constructor" (eqStack ValueStack [nock| [[2 [[55 66] nil] nil] nil]|]) $ do
+    defTest "alloc unary constructor" (eqStack ValueStack [nock| [[2 [[55 66] nil] nil] nil]|]) $ do
       push (OpQuote # (55 :: Natural) # (66 :: Natural))
       allocConstr (constructorTag ConstructorWrapper),
-    Test "alloc binary constructor" (eqStack ValueStack [nock| [[3 [9 7 nil] nil] nil] |]) $ do
+    defTest "alloc binary constructor" (eqStack ValueStack [nock| [[3 [9 7 nil] nil] nil] |]) $ do
       pushNat 7
       pushNat 9
       allocConstr (constructorTag ConstructorPair),
-    Test
+    defTest
       "alloc closure"
       ( do
           eqSubStack ValueStack (indexStack 0 ++ closurePath ClosureTotalArgsNum) [nock| 5 |]
@@ -347,7 +359,7 @@ tests =
         pushNat 9
         pushNat 10
         allocClosure (sym FunConst5) 3,
-    Test
+    defTest
       "alloc closure no args from value stack"
       ( do
           eqSubStack ValueStack (indexStack 0 ++ closurePath ClosureTotalArgsNum) [nock| 3 |]
@@ -356,7 +368,7 @@ tests =
           checkStackSize ValueStack 1
       )
       $ allocClosure (sym FunAdd3) 0,
-    Test
+    defTest
       "extend closure"
       ( do
           eqSubStack ValueStack (indexStack 0 ++ closurePath ClosureTotalArgsNum) [nock| 5 |]
@@ -371,7 +383,7 @@ tests =
         pushNat 10
         allocClosure (sym FunConst5) 1
         extendClosure 2,
-    Test "alloc, extend and call closure" (eqStack ValueStack [nock| [6 nil] |]) $
+    defTest "alloc, extend and call closure" (eqStack ValueStack [nock| [6 nil] |]) $
       do
         pushNat 1
         pushNat 2
@@ -379,13 +391,13 @@ tests =
         allocClosure (sym FunAdd3) 1
         extendClosure 1
         callHelper False Nothing 1,
-    Test "call closure" (eqStack ValueStack [nock| [110 nil] |]) $
+    defTest "call closure" (eqStack ValueStack [nock| [110 nil] |]) $
       do
         pushNat 100
         pushNat 110
         allocClosure (sym FunConst) 1
         callHelper False Nothing 1,
-    Test
+    defTest
       "compute argsNum of a closure"
       (eqStack ValueStack [nock| [2 7 nil] |])
       $ do
@@ -395,7 +407,7 @@ tests =
         pushNat 10
         allocClosure (sym FunConst5) 3
         closureArgsNum,
-    Test
+    defTest
       "save not tail"
       ( do
           eqStack ValueStack [nock| [17 nil] |]
@@ -408,7 +420,7 @@ tests =
           addOn TempStack
           moveTopFromTo TempStack ValueStack
           pushNatOnto TempStack 9,
-    Test
+    defTest
       "save tail"
       ( do
           eqStack ValueStack [nock| [17 nil] |]
@@ -421,7 +433,7 @@ tests =
           addOn TempStack
           moveTopFromTo TempStack ValueStack
           pushNatOnto TempStack 9,
-    Test
+    defTest
       "cmdCase: single branch"
       (eqStack ValueStack [nock| [777 [2 [123 nil] nil] nil] |])
       $ do
@@ -431,7 +443,7 @@ tests =
           Nothing
           [ (constructorTag ConstructorWrapper, pushNat 777)
           ],
-    Test
+    defTest
       "cmdCase: default branch"
       (eqStack ValueStack [nock| [5 nil] |])
       $ do
@@ -441,7 +453,7 @@ tests =
           (Just (pop >> pushNat 5))
           [ (constructorTag ConstructorFalse, pushNat 777)
           ],
-    Test
+    defTest
       "cmdCase: second branch"
       (eqStack ValueStack [nock| [5 nil] |])
       $ do
@@ -452,7 +464,7 @@ tests =
           [ (constructorTag ConstructorFalse, pushNat 0),
             (constructorTag ConstructorWrapper, pop >> pushNat 5)
           ],
-    Test
+    defTest
       "cmdCase: case on builtin true"
       (eqStack ValueStack [nock| [5 nil] |])
       $ do
@@ -462,7 +474,7 @@ tests =
           [ (Asm.BuiltinTag Asm.TagTrue, pop >> pushNat 5),
             (Asm.BuiltinTag Asm.TagFalse, pushNat 0)
           ],
-    Test
+    defTest
       "cmdCase: case on builtin false"
       (eqStack ValueStack [nock| [5 nil] |])
       $ do
@@ -472,7 +484,7 @@ tests =
           [ (Asm.BuiltinTag Asm.TagTrue, pushNat 0),
             (Asm.BuiltinTag Asm.TagFalse, pop >> pushNat 5)
           ],
-    Test
+    defTest
       "push constructor field"
       (eqStack TempStack [nock| [30 nil] |])
       $ do
@@ -482,7 +494,7 @@ tests =
         pushConstructorFieldOnto TempStack Asm.StackRef 0
         pushConstructorFieldOnto TempStack Asm.StackRef 1
         addOn TempStack,
-    Test
+    defTest
       "trace"
       ( do
           eqStack ValueStack [nock| [10 nil] |]

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -167,7 +167,7 @@ eqStack st = eqSubStack st []
 unfoldTerm :: Term Natural -> NonEmpty (Term Natural)
 unfoldTerm t = case t of
   TermAtom {} -> t :| []
-  TermCell Cell {..} -> _cellLeft NonEmpty.<| unfoldTerm _cellRight
+  TermCell (Cell l r) -> l NonEmpty.<| unfoldTerm r
 
 checkStackSize :: StackId -> Natural -> Check ()
 checkStackSize st stSize = subStackPred st ([] :: Path) $ \s -> do

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -228,6 +228,10 @@ tests =
       pushNat 2
       pushNat 3
       add,
+    Test "add big" (eqStack ValueStack [nock| [55555 nil] |]) $ do
+      pushNat 33333
+      pushNat 22222
+      add,
     Test "pow2" (eqStack ValueStack [nock| [1 2 8 32 nil] |]) $ do
       pushNat 5
       pow2

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -26,6 +26,7 @@ allTests = testGroup "Nockma eval unit positive" (map mk tests)
     mk Test {..} = testCase (unpack _testName) $ do
       let evalResult =
             run
+              . runReader defaultEvalOptions
               . ignoreOutput @(Term Natural)
               . runError @(ErrNockNatural Natural)
               . runError @NockEvalError

--- a/test/Nockma/Parse/Positive.hs
+++ b/test/Nockma/Parse/Positive.hs
@@ -52,5 +52,6 @@ tests :: [PosTest]
 tests =
   [ PosTest "Identity" $(mkRelDir ".") $(mkRelFile "Identity.nock"),
     PosTest "Identity Pretty" $(mkRelDir ".") $(mkRelFile "IdentityPretty.pnock"),
+    PosTest "StdlibCall" $(mkRelDir ".") $(mkRelFile "StdlibCall.pnock"),
     PosTest "Stdlib" $(mkRelDir ".") $(mkRelFile "Stdlib.nock")
   ]

--- a/tests/nockma/positive/StdlibCall.pnock
+++ b/tests/nockma/positive/StdlibCall.pnock
@@ -1,0 +1,2 @@
+-- It only tests parsing and printing. It cannot be evaluated
+[stdlib@add args@[0 1] 123 [0 1]]


### PR DESCRIPTION
Adds annotations to cells to indicate that it is a call to the stdlib and might be evaluated faster in the Haskell evaluator.

The syntax for stdlib calls is as follows:
```
[stdlib@add args@<args-term> <left-term> <right-term>]
```
where `add` is the name of the function being called, `<args-term>` is a nockma term that points to the position of the arguments, and `<left-term>` and `<right-term>` are the actual components of the cell.