### PR TITLE
Improved errors for nockma eval

### DIFF
--- a/app/Commands/Dev/Nockma/Repl.hs
+++ b/app/Commands/Dev/Nockma/Repl.hs
@@ -10,13 +10,13 @@ import Data.String.Interpolate (__i)
 import Juvix.Compiler.Nockma.Evaluator (NockEvalError, evalRepl, fromReplTerm, programAssignments)
 import Juvix.Compiler.Nockma.Evaluator.Options
 import Juvix.Compiler.Nockma.Language
+import Juvix.Compiler.Nockma.Pretty
 import Juvix.Compiler.Nockma.Pretty qualified as Nockma
 import Juvix.Compiler.Nockma.Translation.FromSource (parseProgramFile, parseReplStatement, parseReplText, parseText)
 import Juvix.Parser.Error
 import System.Console.Haskeline
 import System.Console.Repline qualified as Repline
 import Prelude (read)
-import Juvix.Compiler.Nockma.Pretty
 
 type ReplS = State.StateT ReplState IO
 
@@ -117,7 +117,7 @@ readReplTerm s = do
   mprog <- getProgram
   let t =
         run
-          . runError @NockEvalError
+          . runError @(NockEvalError Natural)
           . fromReplTerm (programAssignments mprog)
           . fromMegaParsecError
           . parseReplText
@@ -143,7 +143,7 @@ evalStatement = \case
         . runM
         . runReader defaultEvalOptions
         . runError @(ErrNockNatural Natural)
-        . runError @NockEvalError
+        . runError @(NockEvalError Natural)
         $ evalRepl (putStrLn . Nockma.ppTrace) prog s t
     case et of
       Left e -> error (show e)

--- a/app/Commands/Dev/Nockma/Repl.hs
+++ b/app/Commands/Dev/Nockma/Repl.hs
@@ -10,13 +10,13 @@ import Data.String.Interpolate (__i)
 import Juvix.Compiler.Nockma.Evaluator (NockEvalError, evalRepl, fromReplTerm, programAssignments)
 import Juvix.Compiler.Nockma.Evaluator.Options
 import Juvix.Compiler.Nockma.Language
-import Juvix.Compiler.Nockma.Pretty (ppPrint)
 import Juvix.Compiler.Nockma.Pretty qualified as Nockma
 import Juvix.Compiler.Nockma.Translation.FromSource (parseProgramFile, parseReplStatement, parseReplText, parseText)
 import Juvix.Parser.Error
 import System.Console.Haskeline
 import System.Console.Repline qualified as Repline
 import Prelude (read)
+import Juvix.Compiler.Nockma.Pretty
 
 type ReplS = State.StateT ReplState IO
 
@@ -110,14 +110,20 @@ direction' s = Repline.dontCrash $ do
   liftIO (putStrLn (ppPrint p))
 
 readTerm :: String -> Repl (Term Natural)
-readTerm s = return (fromMegaParsecError (parseText (strip (pack s))))
+readTerm = return . fromMegaParsecError . parseText . strip . pack
 
 readReplTerm :: String -> Repl (Term Natural)
 readReplTerm s = do
   mprog <- getProgram
-  let t = run $ runError @NockEvalError (fromReplTerm (programAssignments mprog) (fromMegaParsecError (parseReplText (strip (pack s)))))
+  let t =
+        run
+          . runError @NockEvalError
+          . fromReplTerm (programAssignments mprog)
+          . fromMegaParsecError
+          . parseReplText
+          $ strip (pack s)
   case t of
-    Left e -> error (show e)
+    Left e -> error (ppTrace e)
     Right tv -> return tv
 
 readStatement :: String -> Repl (ReplStatement Natural)
@@ -142,7 +148,7 @@ evalStatement = \case
     case et of
       Left e -> error (show e)
       Right ev -> case ev of
-        Left e -> error (show e)
+        Left e -> error (ppTrace e)
         Right res -> liftIO (putStrLn (ppPrint res))
 
 replCommand :: String -> Repl ()

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -63,7 +63,7 @@ parseCell ::
   Cell a ->
   Sem r (ParsedCell a)
 parseCell c = case c ^. cellLeft of
-  TermAtom a -> operatorOrStdlibCall a (c ^. cellRight) (c ^. cellInfo . unIrrelevant)
+  TermAtom a -> operatorOrStdlibCall a (c ^. cellRight) (c ^. cellCall)
   TermCell l -> return (ParsedAutoConsCell (AutoConsCell l (c ^. cellRight)))
   where
     operatorOrStdlibCall :: Atom a -> Term a -> Maybe (StdlibCall a) -> Sem r (ParsedCell a)

--- a/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
@@ -1,0 +1,48 @@
+module Juvix.Compiler.Nockma.Evaluator.Crumbs where
+
+import Juvix.Compiler.Nockma.Language
+import Juvix.Compiler.Nockma.Pretty.Base
+import Juvix.Prelude hiding (Atom)
+
+data EvalCrumb
+  = EvalCrumbStdlibCallArgs CrumbStdlibCallArgs
+  | EvalCrumbOperator CrumbOperator
+  | EvalCrumbAutoCons CrumbAutoCons
+
+newtype EvalCtx = EvalCtx
+  { _evalStack :: [EvalCrumb]
+  }
+
+topEvalCtx :: Sem (Reader EvalCtx ': r) a -> Sem r a
+topEvalCtx = runReader (EvalCtx [])
+
+newtype CrumbStdlibCallArgs = CrumbStdlibCallArgs
+  { _crumbStdlibCallArgsFunction :: StdlibFunction
+  }
+
+data ArgName
+  = Itself
+  | FirstArg
+  | SecondArg
+  | ThirdArg
+  | TrueBranch
+  | FalseBranch
+
+data CrumbAutoCons = CrumbAutoCons
+  { _crumbAutoConsArgName :: ArgName,
+    _crumbAutoConsLoc :: Maybe Interval
+  }
+
+data CrumbOperator = CrumbOperator
+  { _crumbOperatorOp :: NockOp,
+    _crumbOperatorArgName :: ArgName,
+    _crumbOperatorLoc :: Maybe Interval
+  }
+
+makeLenses ''EvalCtx
+
+withCrumb :: (Members '[Reader EvalCtx] r) => EvalCrumb -> Sem r a -> Sem r a
+withCrumb c = local (over evalStack (c :))
+
+instance PrettyCode EvalCtx where
+  ppCode (EvalCtx l) = undefined

--- a/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
@@ -108,4 +108,4 @@ instance PrettyCode EvalCrumb where
 
 instance PrettyCode EvalCtx where
   ppCode (EvalCtx l) =
-    vsep <$> mapM (fmap nest' . ppCode) (reverse l)
+    itemize <$> mapM (fmap nest' . ppCode) (reverse l)

--- a/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
@@ -20,22 +20,40 @@ newtype CrumbStdlibCallArgs = CrumbStdlibCallArgs
   { _crumbStdlibCallArgsFunction :: StdlibFunction
   }
 
-data ArgName
-  = Itself
-  | FirstArg
-  | SecondArg
-  | ThirdArg
-  | TrueBranch
-  | FalseBranch
+newtype CrumbTag = CrumbTag {_crumbTag :: Text}
+
+crumbEval :: CrumbTag
+crumbEval = CrumbTag "Evaluating itself"
+
+crumbDecodeThird :: CrumbTag
+crumbDecodeThird = CrumbTag "Decoding third argument"
+
+crumbDecodeSecond :: CrumbTag
+crumbDecodeSecond = CrumbTag "Decoding second argument"
+
+crumbDecodeFirst :: CrumbTag
+crumbDecodeFirst = CrumbTag "Decoding first argument"
+
+crumbEvalFirst :: CrumbTag
+crumbEvalFirst = CrumbTag "Evaluating first argument"
+
+crumbTrueBranch :: CrumbTag
+crumbTrueBranch = CrumbTag "Evaluating true branch"
+
+crumbFalseBranch :: CrumbTag
+crumbFalseBranch = CrumbTag "Evaluating false branch"
+
+crumbEvalSecond :: CrumbTag
+crumbEvalSecond = CrumbTag "Evaluating second argument"
 
 data CrumbAutoCons = CrumbAutoCons
-  { _crumbAutoConsArgName :: ArgName,
+  { _crumbAutoConsTag :: CrumbTag,
     _crumbAutoConsLoc :: Maybe Interval
   }
 
 data CrumbOperator = CrumbOperator
   { _crumbOperatorOp :: NockOp,
-    _crumbOperatorArgName :: ArgName,
+    _crumbOperatorTag :: CrumbTag,
     _crumbOperatorLoc :: Maybe Interval
   }
 
@@ -44,5 +62,50 @@ makeLenses ''EvalCtx
 withCrumb :: (Members '[Reader EvalCtx] r) => EvalCrumb -> Sem r a -> Sem r a
 withCrumb c = local (over evalStack (c :))
 
+instance PrettyCode CrumbTag where
+  ppCode (CrumbTag a) =
+    return
+      . annotate AnnImportant
+      $ pretty a
+
+instance PrettyCode CrumbStdlibCallArgs where
+  ppCode CrumbStdlibCallArgs {..} = do
+    op <- annotate AnnImportant <$> ppCode _crumbStdlibCallArgsFunction
+    return ("Evaluating address to arguments to stdlib call for" <+> op)
+
+ppCtx :: (Member (Reader Options) r) => EvalCtx -> Sem r (Doc Ann)
+ppCtx c = do
+  ctx <- ppCode c
+  let title = annotate AnnImportant "Evaluation trace:"
+  return (title <> line <> ctx <> line)
+
+ppLoc :: (Member (Reader Options) r) => Maybe Interval -> Sem r (Doc Ann)
+ppLoc = \case
+  Nothing -> return mempty
+  Just x -> do
+    x' <- ppCode x
+    return (x' <> ":")
+
+instance PrettyCode CrumbOperator where
+  ppCode CrumbOperator {..} = do
+    tag <- ppCode _crumbOperatorTag
+    loc <- ppLoc _crumbOperatorLoc
+    op <- ppCode _crumbOperatorOp
+    return (loc <+> tag <+> "for" <+> op)
+
+instance PrettyCode CrumbAutoCons where
+  ppCode CrumbAutoCons {..} = do
+    let au = annotate AnnImportant "AutoCons"
+    loc <- ppLoc _crumbAutoConsLoc
+    tag <- ppCode _crumbAutoConsTag
+    return (loc <+> tag <+> "for" <+> au)
+
+instance PrettyCode EvalCrumb where
+  ppCode = \case
+    EvalCrumbAutoCons a -> ppCode a
+    EvalCrumbStdlibCallArgs a -> ppCode a
+    EvalCrumbOperator a -> ppCode a
+
 instance PrettyCode EvalCtx where
-  ppCode (EvalCtx l) = undefined
+  ppCode (EvalCtx l) =
+    vsep <$> mapM (fmap nest' . ppCode) (reverse l)

--- a/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
@@ -5,16 +5,18 @@ module Juvix.Compiler.Nockma.Evaluator.Error
 where
 
 import Juvix.Compiler.Nockma.Evaluator.Crumbs
+import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Pretty.Base
-import Juvix.Prelude hiding (Atom)
-import Juvix.Prelude.Pretty
+import Juvix.Prelude hiding (Atom, Path)
 
-data NockEvalError
-  = InvalidPath EvalCtx
-  | ExpectedAtom
-  | ExpectedCell Text
-  | NoStack
-  | AssignmentNotFound Text
+data NockEvalError a
+  = ErrInvalidPath (InvalidPath a)
+  | ErrExpectedAtom (ExpectedAtom a)
+  | ErrExpectedCell (ExpectedCell a)
+  | -- TODO perhaps this should be a repl error type
+    ErrNoStack NoStack
+  | -- TODO perhaps this should be a repl error type
+    ErrAssignmentNotFound Text
 
 newtype GenericNockEvalError = GenericNockEvalError
   { _genericNockEvalErrorMessage :: AnsiText
@@ -23,6 +25,83 @@ newtype GenericNockEvalError = GenericNockEvalError
 class ToGenericNockEvalError a where
   toGenericNockEvalError :: a -> GenericNockEvalError
 
-instance PrettyCode NockEvalError where
+data ExpectedCell a = ExpectedCell
+  { _expectedCellCtx :: EvalCtx,
+    _expectedCellAtom :: Atom a
+  }
+
+data ExpectedAtom a = ExpectedAtom
+  { _expectedAtomCtx :: EvalCtx,
+    _expectedAtomCell :: Cell a
+  }
+
+data InvalidPath a = InvalidPath
+  { _invalidPathCtx :: EvalCtx,
+    _invalidPathTerm :: Term a,
+    _invalidPathPath :: Path
+  }
+
+data NoStack = NoStack
+
+throwInvalidPath :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Term a -> Path -> Sem r x
+throwInvalidPath tm p = do
+  ctx <- ask
+  throw $
+    ErrInvalidPath
+      InvalidPath
+        { _invalidPathCtx = ctx,
+          _invalidPathTerm = tm,
+          _invalidPathPath = p
+        }
+
+throwExpectedCell :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Atom a -> Sem r x
+throwExpectedCell a = do
+  ctx <- ask
+  throw $
+    ErrExpectedCell
+      ExpectedCell
+        { _expectedCellCtx = ctx,
+          _expectedCellAtom = a
+        }
+
+throwExpectedAtom :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Cell a -> Sem r x
+throwExpectedAtom a = do
+  ctx <- ask
+  throw $
+    ErrExpectedAtom
+      ExpectedAtom
+        { _expectedAtomCtx = ctx,
+          _expectedAtomCell = a
+        }
+
+instance PrettyCode NoStack where
+  ppCode _ = return "Missing stack"
+
+instance (PrettyCode a, NockNatural a) => PrettyCode (InvalidPath a) where
+  ppCode InvalidPath {..} = do
+    ctx <- ppCtx _invalidPathCtx
+    path <- ppCode _invalidPathPath
+    tm <- ppCode _invalidPathTerm
+    return (ctx <> "The path" <+> path <+> "is invalid for the following term:" <> line <> tm)
+
+instance (PrettyCode a, NockNatural a) => PrettyCode (ExpectedAtom a) where
+  ppCode ExpectedAtom {..} = do
+    cell <- ppCode _expectedAtomCell
+    ctx <- ppCtx _expectedAtomCtx
+    let atm = annotate AnnImportant "atom"
+    return (ctx <> "Expected an" <+> atm <+> "but got:" <> line <> cell)
+
+instance (PrettyCode a, NockNatural a) => PrettyCode (ExpectedCell a) where
+  ppCode ExpectedCell {..} = do
+    atm <- ppCode _expectedCellAtom
+    ctx <- ppCtx _expectedCellCtx
+    let cell = annotate AnnImportant "cell"
+    return (ctx <> "Expected an" <+> atm <+> "but got:" <> line <> cell)
+
+instance (PrettyCode a, NockNatural a) => PrettyCode (NockEvalError a) where
   ppCode = \case
-    InvalidPath ctx -> ppCode ctx
+    ErrInvalidPath e -> ppCode e
+    ErrExpectedAtom e -> ppCode e
+    ErrExpectedCell e -> ppCode e
+    ErrNoStack e -> ppCode e
+    ErrAssignmentNotFound e -> return (pretty e)

--- a/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
@@ -1,15 +1,20 @@
-module Juvix.Compiler.Nockma.Evaluator.Error where
+module Juvix.Compiler.Nockma.Evaluator.Error
+  ( module Juvix.Compiler.Nockma.Evaluator.Error,
+    module Juvix.Compiler.Nockma.Evaluator.Crumbs,
+  )
+where
 
+import Juvix.Compiler.Nockma.Evaluator.Crumbs
+import Juvix.Compiler.Nockma.Pretty.Base
 import Juvix.Prelude hiding (Atom)
 import Juvix.Prelude.Pretty
 
 data NockEvalError
-  = InvalidPath Text
+  = InvalidPath EvalCtx
   | ExpectedAtom
   | ExpectedCell Text
   | NoStack
   | AssignmentNotFound Text
-  deriving stock (Show)
 
 newtype GenericNockEvalError = GenericNockEvalError
   { _genericNockEvalErrorMessage :: AnsiText
@@ -17,3 +22,7 @@ newtype GenericNockEvalError = GenericNockEvalError
 
 class ToGenericNockEvalError a where
   toGenericNockEvalError :: a -> GenericNockEvalError
+
+instance PrettyCode NockEvalError where
+  ppCode = \case
+    InvalidPath ctx -> ppCode ctx

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -211,7 +211,9 @@ atomHint :: Lens' (Atom a) (Maybe AtomHint)
 atomHint = atomInfo . unIrrelevant . atomInfoHint
 
 termLoc :: Lens' (Term a) (Maybe Interval)
-termLoc = undefined
+termLoc f = \case
+  TermAtom a -> TermAtom <$> atomLoc f a
+  TermCell a -> TermCell <$> cellLoc f a
 
 cellLoc :: Lens' (Cell a) (Maybe Interval)
 cellLoc = cellInfo . unIrrelevant . cellInfoLoc

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -24,7 +24,7 @@ runPrettyCode :: (PrettyCode c) => Options -> c -> Doc Ann
 runPrettyCode opts = run . runReader opts . ppCode
 
 instance (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
-  ppCode atm@(Atom k h) = runFailDefaultM (annotate (AnnKind KNameFunction) <$> ppCode k)
+  ppCode atm = runFailDefaultM (annotate (AnnKind KNameFunction) <$> ppCode (atm ^. atom))
     . failFromError @(ErrNockNatural a)
     $ do
       whenM (asks (^. optIgnoreHints)) fail
@@ -70,7 +70,7 @@ instance (PrettyCode a, NockNatural a) => PrettyCode (Cell a) where
     m <- asks (^. optPrettyMode)
     stdlibCall <- runFail $ do
       failWhenM (asks (^. optIgnoreHints))
-      failMaybe (c ^. cellInfo . unIrrelevant) >>= ppCode
+      failMaybe (c ^. cellCall) >>= ppCode
     components <- case m of
       AllDelimiters -> do
         l' <- ppCode (c ^. cellLeft)

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -38,6 +38,9 @@ instance (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
           | otherwise -> fail
         AtomHintNil -> return (annotate (AnnKind KNameConstructor) "nil")
 
+instance PrettyCode Interval where
+  ppCode = return . pretty
+
 instance PrettyCode Natural where
   ppCode = return . pretty
 

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -28,7 +28,7 @@ instance (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
     . failFromError @(ErrNockNatural a)
     $ do
       whenM (asks (^. optIgnoreHints)) fail
-      h' <- failMaybe (h ^. unIrrelevant)
+      h' <- failMaybe (atm ^. atomHint)
       case h' of
         AtomHintOp -> nockOp atm >>= ppCode
         AtomHintPath -> nockPath atm >>= ppCode

--- a/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
@@ -1019,9 +1019,15 @@ evalCompiledNock' stack mainTerm = do
   case evalT of
     Left e -> error (show e)
     Right ev -> case ev of
-      Left e -> error (show e)
+      Left e -> error (ppTrace e)
       Right res -> return res
 
 -- | Used in testing and app
 getStack :: StackId -> Term Natural -> Term Natural
-getStack st m = fromRight' (run (runError @NockEvalError (subTerm m (stackPath st))))
+getStack st m =
+  fromRight'
+    . run
+    . runError @NockEvalError
+    . topEvalCtx
+    . subTerm m
+    $ stackPath st

--- a/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
@@ -771,7 +771,7 @@ callStdlibOn' s f = do
             _stdlibCallFunction = f
           }
 
-      callCell = (OpPush #. (decodeFn # callFn)) {_cellInfo = Irrelevant (Just meta)}
+      callCell = set cellCall (Just meta) (OpPush #. (decodeFn # callFn))
 
   output (toNock callCell)
   output (replaceTopStackN fNumArgs s)

--- a/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
@@ -764,7 +764,6 @@ callStdlibOn' s f = do
       preargs = stdlibStackTake s fNumArgs
       arguments = OpSequence # (OpAddress # [R]) # preargs
       extractResult = (OpAddress # [L]) # (OpAddress # [R, R])
-      -- callFn = OpPush # (OpCall # [L] # (OpReplace # ([R, L] # arguments) # (OpAddress # [L]))) # extractResult
       callFn = OpPush # (OpCall # [L] # (OpReplace # ([R, L] # arguments) # (OpAddress # [L]))) # extractResult
       meta =
         StdlibCall

--- a/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromAsm.hs
@@ -764,6 +764,7 @@ callStdlibOn' s f = do
       preargs = stdlibStackTake s fNumArgs
       arguments = OpSequence # (OpAddress # [R]) # preargs
       extractResult = (OpAddress # [L]) # (OpAddress # [R, R])
+      -- callFn = OpPush # (OpCall # [L] # (OpReplace # ([R, L] # arguments) # (OpAddress # [L]))) # extractResult
       callFn = OpPush # (OpCall # [L] # (OpReplace # ([R, L] # arguments) # (OpAddress # [L]))) # extractResult
       meta =
         StdlibCall
@@ -1014,7 +1015,7 @@ evalCompiledNock' :: (Members '[Reader EvalOptions, Output (Term Natural)] r) =>
 evalCompiledNock' stack mainTerm = do
   evalT <-
     runError @(ErrNockNatural Natural)
-      . runError @NockEvalError
+      . runError @(NockEvalError Natural)
       $ eval stack mainTerm
   case evalT of
     Left e -> error (show e)
@@ -1027,7 +1028,7 @@ getStack :: StackId -> Term Natural -> Term Natural
 getStack st m =
   fromRight'
     . run
-    . runError @NockEvalError
+    . runError @(NockEvalError Natural)
     . topEvalCtx
     . subTerm m
     $ stackPath st

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -6,7 +6,7 @@ import Data.Text qualified as Text
 import Juvix.Compiler.Nockma.Language
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Parser.Error
-import Juvix.Parser.Lexer (withLoc)
+import Juvix.Parser.Lexer (onlyInterval, withLoc)
 import Juvix.Prelude hiding (Atom, many, some)
 import Juvix.Prelude.Parsing hiding (runParser)
 import Text.Megaparsec qualified as P
@@ -15,10 +15,10 @@ import Text.Megaparsec.Char.Lexer qualified as L
 type Parser = Parsec Void Text
 
 parseText :: Text -> Either MegaparsecError (Term Natural)
-parseText = runParser ""
+parseText = runParser noFile
 
 parseReplText :: Text -> Either MegaparsecError (ReplTerm Natural)
-parseReplText = runParserFor replTerm ""
+parseReplText = runParserFor replTerm noFile
 
 parseTermFile :: (MonadIO m) => FilePath -> m (Either MegaparsecError (Term Natural))
 parseTermFile fp = do
@@ -31,7 +31,10 @@ parseProgramFile fp = do
   return (runParserProgram fp txt)
 
 parseReplStatement :: Text -> Either MegaparsecError (ReplStatement Natural)
-parseReplStatement = runParserFor replStatement ""
+parseReplStatement = runParserFor replStatement noFile
+
+noFile :: FilePath
+noFile = "/<text>"
 
 runParserProgram :: FilePath -> Text -> Either MegaparsecError (Program Natural)
 runParserProgram = runParserFor program
@@ -97,7 +100,14 @@ atomDirection = do
   return (Atom (serializePath dirs) (Irrelevant info))
 
 atomNat :: Parser (Atom Natural)
-atomNat = (\n -> Atom n (Irrelevant emptyAtomInfo)) <$> dottedNatural
+atomNat = do
+  WithLoc loc n <- withLoc dottedNatural
+  let info =
+        AtomInfo
+          { _atomInfoHint = Nothing,
+            _atomInfoLoc = Just loc
+          }
+  return (Atom n (Irrelevant info))
 
 atomBool :: Parser (Atom Natural)
 atomBool =
@@ -105,6 +115,11 @@ atomBool =
     [ symbol "true" $> nockTrue,
       symbol "false" $> nockFalse
     ]
+
+atomWithLoc :: Parser a -> Atom Natural -> Parser (Atom Natural)
+atomWithLoc p n = do
+  loc <- onlyInterval p
+  return (set atomLoc (Just loc) n)
 
 atomNil :: Parser (Atom Natural)
 atomNil = symbol "nil" $> nockNil
@@ -122,13 +137,18 @@ iden = lexeme (takeWhile1P (Just "<iden>") isAlphaNum)
 
 cell :: Parser (Cell Natural)
 cell = do
-  lsbracket
+  lloc <- onlyInterval lsbracket
   c <- optional stdlibCall
   firstTerm <- term
   restTerms <- some term
-  rsbracket
+  rloc <- onlyInterval rsbracket
   let r = buildCell firstTerm restTerms
-  return (set cellInfo (Irrelevant c) r)
+      info =
+        CellInfo
+          { _cellInfoCall = c,
+            _cellInfoLoc = Just (lloc <> rloc)
+          }
+  return (set cellInfo (Irrelevant info) r)
   where
     stdlibCall :: Parser (StdlibCall Natural)
     stdlibCall = do

--- a/src/Juvix/Data/Loc.hs
+++ b/src/Juvix/Data/Loc.hs
@@ -7,7 +7,7 @@ import Prettyprinter
 import Text.Megaparsec qualified as M
 
 newtype Pos = Pos {_unPos :: Word64}
-  deriving stock (Show, Eq, Ord, Data, Generic)
+  deriving stock (Show, Eq, Ord, Data, Generic, Lift)
   deriving newtype (Hashable, Num, Enum, Real, Integral)
 
 instance Serialize Pos
@@ -26,7 +26,7 @@ data FileLoc = FileLoc
     -- | Offset wrt the start of the input. Used for syntax highlighting.
     _locOffset :: !Pos
   }
-  deriving stock (Show, Eq, Generic, Data)
+  deriving stock (Show, Eq, Generic, Data, Lift)
 
 instance Hashable FileLoc
 
@@ -72,7 +72,7 @@ data Interval = Interval
     _intervalStart :: FileLoc,
     _intervalEnd :: FileLoc
   }
-  deriving stock (Show, Ord, Eq, Generic, Data)
+  deriving stock (Show, Ord, Eq, Generic, Data, Lift)
 
 instance Hashable Interval
 

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -215,7 +215,7 @@ interval ma = do
   end <- curLoc
   return (res, mkInterval start end)
 
-withLoc :: ParsecS r a -> ParsecS r (WithLoc a)
+withLoc :: (MonadParsec e Text m) => m a -> m (WithLoc a)
 withLoc ma = do
   (a, i) <- interval ma
   return (WithLoc i a)

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -205,7 +205,7 @@ curLoc = do
   offset <- getOffset
   return (mkLoc offset sp)
 
-onlyInterval :: ParsecS r a -> ParsecS r Interval
+onlyInterval :: (MonadParsec e Text m) => m a -> m Interval
 onlyInterval = fmap snd . interval
 
 interval :: (MonadParsec e Text m) => m a -> m (a, Interval)

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -162,7 +162,12 @@ eqTraces expected = do
 subStackPred :: StackId -> Path -> (Term Natural -> Check ()) -> Check ()
 subStackPred st subp p = do
   s <- getStack st <$> ask
-  case run (runError @NockEvalError (subTerm s subp)) of
+  let res =
+        run
+          . runError @NockEvalError
+          . topEvalCtx
+          $ subTerm s subp
+  case res of
     Left {} -> assertFailure "Subterm path is not valid"
     Right n -> p n
 

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -164,7 +164,7 @@ subStackPred st subp p = do
   s <- getStack st <$> ask
   let res =
         run
-          . runError @NockEvalError
+          . runError @(NockEvalError Natural)
           . topEvalCtx
           $ subTerm s subp
   case res of

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -29,7 +29,7 @@ allTests = testGroup "Nockma eval unit positive" (map mk tests)
               . runReader defaultEvalOptions
               . ignoreOutput @(Term Natural)
               . runError @(ErrNockNatural Natural)
-              . runError @NockEvalError
+              . runError @(NockEvalError Natural)
               $ eval _testProgramSubject _testProgramFormula
       case evalResult of
         Left natErr -> assertFailure ("Evaluation error: " <> show natErr)

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -34,7 +34,7 @@ allTests = testGroup "Nockma eval unit positive" (map mk tests)
       case evalResult of
         Left natErr -> assertFailure ("Evaluation error: " <> show natErr)
         Right r -> case r of
-          Left evalErr -> assertFailure ("Evaluation error: " <> show evalErr)
+          Left evalErr -> assertFailure ("Evaluation error: " <> unpack (ppTrace evalErr))
           Right res -> runM (runReader res _testCheck)
 
 eqNock :: Term Natural -> Check ()


### PR DESCRIPTION
This is needed if we want to debug nockma in a more sane manner.

Evaluation errors now include an evaluation trace (with source locations when present). It looks like this:
![image](https://github.com/anoma/juvix/assets/5511599/4a553035-f56e-4f7c-bb69-9a2aeb41afcb)
