### PR TITLE
Support  `MemRepTuple` in the Nockma backend

### DIFF
--- a/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
@@ -46,6 +46,7 @@ data ConstructorInfo = ConstructorInfo
     _constructorTag :: Tag,
     _constructorType :: Type,
     _constructorArgNames :: [Maybe Text],
+    _constructorArgsNum :: Int,
     _constructorFixity :: Maybe Fixity
   }
 

--- a/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/Stripped/InfoTable.hs
@@ -46,6 +46,7 @@ data ConstructorInfo = ConstructorInfo
     _constructorTag :: Tag,
     _constructorType :: Type,
     _constructorArgNames :: [Maybe Text],
+    -- | _constructorArgsNum == length _constructorArgNames == length (typeArgs _constructorType)
     _constructorArgsNum :: Int,
     _constructorFixity :: Maybe Fixity
   }

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -144,6 +144,7 @@ translateConstructorInfo ConstructorInfo {..} =
       _constructorTag = _constructorTag,
       _constructorType = translateType _constructorType,
       _constructorArgNames,
+      _constructorArgsNum,
       _constructorFixity
     }
 

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -38,7 +38,7 @@ fromAsm tab =
           _constructorTag = ci ^. Asm.constructorTag,
           _constructorArgsNum = ci ^. Asm.constructorArgsNum,
           _constructorInductive = ci ^. Asm.constructorInductive,
-          _constructorRepresentation = MemRepConstr,
+          _constructorRepresentation = ci ^. Asm.constructorRepresentation,
           _constructorFixity = ci ^. Asm.constructorFixity
         }
 

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -38,7 +38,7 @@ fromAsm tab =
           _constructorTag = ci ^. Asm.constructorTag,
           _constructorArgsNum = ci ^. Asm.constructorArgsNum,
           _constructorInductive = ci ^. Asm.constructorInductive,
-          _constructorRepresentation = ci ^. Asm.constructorRepresentation,
+          _constructorRepresentation = MemRepConstr,
           _constructorFixity = ci ^. Asm.constructorFixity
         }
 

--- a/src/Juvix/Compiler/Tree/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromCore.hs
@@ -15,11 +15,9 @@ fromCore tab =
   InfoTable
     { _infoMainFunction = tab ^. Core.infoMain,
       _infoFunctions = genCode tab <$> tab ^. Core.infoFunctions,
-      _infoInductives = inductiveInfos,
+      _infoInductives = translateInductiveInfo <$> tab ^. Core.infoInductives,
       _infoConstrs = translateConstructorInfo <$> tab ^. Core.infoConstructors
     }
-  where
-    inductiveInfos = translateInductiveInfo <$> tab ^. Core.infoInductives
 
 -- Generate code for a single function.
 genCode :: Core.InfoTable -> Core.FunctionInfo -> FunctionInfo
@@ -332,13 +330,11 @@ translateConstructorInfo ci =
       _constructorLocation = ci ^. Core.constructorLocation,
       _constructorTag = ci ^. Core.constructorTag,
       _constructorArgNames = ci ^. Core.constructorArgNames,
-      _constructorArgsNum = numArgs,
+      _constructorArgsNum = ci ^. Core.constructorArgsNum,
       _constructorType = ty,
       _constructorInductive = ci ^. Core.constructorInductive,
       _constructorRepresentation = MemRepConstr,
       _constructorFixity = ci ^. Core.constructorFixity
     }
   where
-    numArgs = ci ^. Core.constructorArgsNum
-
     ty = convertType 0 (ci ^. Core.constructorType)


### PR DESCRIPTION
 We can represent Anoma types like [resource](https://github.com/anoma/anoma/blob/e18e50e3c380b2867da6cb81f427334eb5c0b2d9/hoon/resource-machine.hoon#L7) as Juvix records.

The Nockma encoding of types uses Nockma 'tuples' where each component of the tuple holds a value of a field. So for Juvix->Anoma integration it is convenient to compile values of record types as Nockma tuples.

We already have the concept of representing constructors of inductive types that have only one non-zero-field constructor in the compiler, see [`MemRepTuple`](https://github.com/anoma/juvix/blob/1147e1fce131f5b423fd558e5636e6aaf23120ac/src/Juvix/Compiler/Tree/Language/Rep.hs#L13).

In this PR, as part of the Nockma step, we mark constructors that satisfy the requirements of the `MemRepTuple` translation as such. Then we use a tuple encoding for those constructors.


 

