### PR TITLE
Remove redundant `QuasiQuotes` pragmas

### DIFF
--- a/app/Commands/Dev/Geb/Repl.hs
+++ b/app/Commands/Dev/Geb/Repl.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Commands.Dev.Geb.Repl where
 
 import Commands.Base hiding

--- a/app/Commands/Dev/Nockma/Repl.hs
+++ b/app/Commands/Dev/Nockma/Repl.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Commands.Dev.Nockma.Repl where
 
 import Commands.Base hiding (Atom)

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Commands.Repl where
 
 import Commands.Base hiding

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Main (main) where
 
 import App

--- a/src/Juvix/Compiler/Nockma/Stdlib.hs
+++ b/src/Juvix/Compiler/Nockma/Stdlib.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Juvix.Compiler.Nockma.Stdlib where
 
 import Juvix.Compiler.Nockma.Translation.FromSource.QQ

--- a/src/Juvix/Compiler/Pipeline/Lockfile.hs
+++ b/src/Juvix/Compiler/Pipeline/Lockfile.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Juvix.Compiler.Pipeline.Lockfile where
 
 import Data.Aeson.BetterErrors

--- a/test/Nockma/Compile/Positive.hs
+++ b/test/Nockma/Compile/Positive.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Nockma.Compile.Positive where
 
 import Base hiding (Path)

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Nockma.Eval.Positive where
 
 import Base hiding (Path)


### PR DESCRIPTION
We already have `QuasiQuotes` in the default extensions list.