### PR TITLE
Use `writeFileEnsureLn` in place of `writeFile`

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -14,11 +14,13 @@ import Juvix.Prelude.Pretty hiding
   ( Doc,
   )
 import System.Console.ANSI qualified as Ansi
+import Juvix.Prelude.Base qualified as Prelude
 
 data App m a where
   ExitMsg :: ExitCode -> Text -> App m a
   ExitFailMsg :: Text -> App m a
   ExitJuvixError :: JuvixError -> App m a
+  WriteFileEnsureLn :: FilePath -> Text -> App m ()
   PrintJuvixError :: JuvixError -> App m ()
   AskRoot :: App m Root
   AskArgs :: App m RunAppIOArgs
@@ -65,6 +67,7 @@ reAppIO args@RunAppIOArgs {..} =
     FromAppPathFile p -> embed (prepathToAbsFile invDir (p ^. pathPath))
     GetMainFile m -> getMainFile' m
     FromAppPathDir p -> liftIO (prepathToAbsDir invDir (p ^. pathPath))
+    WriteFileEnsureLn p txt -> embed @IO (Prelude.writeFileEnsureLn p txt)
     RenderStdOut t
       | _runAppIOArgsGlobalOptions ^. globalOnlyErrors -> return ()
       | otherwise -> embed $ do

--- a/app/App.hs
+++ b/app/App.hs
@@ -10,17 +10,17 @@ import Juvix.Compiler.Pipeline.Root
 import Juvix.Compiler.Pipeline.Run
 import Juvix.Data.Error qualified as Error
 import Juvix.Extra.Paths.Base hiding (rootBuildDir)
+import Juvix.Prelude.Base qualified as Prelude
 import Juvix.Prelude.Pretty hiding
   ( Doc,
   )
 import System.Console.ANSI qualified as Ansi
-import Juvix.Prelude.Base qualified as Prelude
 
 data App m a where
   ExitMsg :: ExitCode -> Text -> App m a
   ExitFailMsg :: Text -> App m a
   ExitJuvixError :: JuvixError -> App m a
-  WriteFileEnsureLn :: FilePath -> Text -> App m ()
+  WriteFileEnsureLn :: Path Abs File -> Text -> App m ()
   PrintJuvixError :: JuvixError -> App m ()
   AskRoot :: App m Root
   AskArgs :: App m RunAppIOArgs

--- a/app/App.hs
+++ b/app/App.hs
@@ -10,7 +10,6 @@ import Juvix.Compiler.Pipeline.Root
 import Juvix.Compiler.Pipeline.Run
 import Juvix.Data.Error qualified as Error
 import Juvix.Extra.Paths.Base hiding (rootBuildDir)
-import Juvix.Prelude.Base qualified as Prelude
 import Juvix.Prelude.Pretty hiding
   ( Doc,
   )
@@ -20,7 +19,6 @@ data App m a where
   ExitMsg :: ExitCode -> Text -> App m a
   ExitFailMsg :: Text -> App m a
   ExitJuvixError :: JuvixError -> App m a
-  WriteFileEnsureLn :: Path Abs File -> Text -> App m ()
   PrintJuvixError :: JuvixError -> App m ()
   AskRoot :: App m Root
   AskArgs :: App m RunAppIOArgs
@@ -67,7 +65,6 @@ reAppIO args@RunAppIOArgs {..} =
     FromAppPathFile p -> embed (prepathToAbsFile invDir (p ^. pathPath))
     GetMainFile m -> getMainFile' m
     FromAppPathDir p -> liftIO (prepathToAbsDir invDir (p ^. pathPath))
-    WriteFileEnsureLn p txt -> embed @IO (Prelude.writeFileEnsureLn p txt)
     RenderStdOut t
       | _runAppIOArgsGlobalOptions ^. globalOnlyErrors -> return ()
       | otherwise -> embed $ do

--- a/app/Commands/Base.hs
+++ b/app/Commands/Base.hs
@@ -8,7 +8,7 @@ module Commands.Base
 where
 
 import App
-import CommonOptions
+import CommonOptions hiding (writeFileEnsureLn)
 import GlobalOptions
 import Juvix.Compiler.Pipeline
-import Juvix.Prelude
+import Juvix.Prelude hiding (writeFileEnsureLn)

--- a/app/Commands/Base.hs
+++ b/app/Commands/Base.hs
@@ -8,7 +8,7 @@ module Commands.Base
 where
 
 import App
-import CommonOptions hiding (writeFileEnsureLn)
+import CommonOptions hiding (ensureLn, writeFileEnsureLn)
 import GlobalOptions
 import Juvix.Compiler.Pipeline
-import Juvix.Prelude hiding (writeFileEnsureLn)
+import Juvix.Prelude

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -37,4 +37,4 @@ writeCoreFile pa@Compile.PipelineArg {..} = do
     Left e -> exitJuvixError e
     Right md -> do
       let txt = show (Core.ppOutDefault (Core.disambiguateNames md ^. Core.moduleInfoTable))
-      writeFileEnsureLn coreFile txt
+      embed @IO $ writeFileEnsureLn coreFile txt

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -37,4 +37,4 @@ writeCoreFile pa@Compile.PipelineArg {..} = do
     Left e -> exitJuvixError e
     Right md -> do
       let txt = show (Core.ppOutDefault (Core.disambiguateNames md ^. Core.moduleInfoTable))
-      writeFileEnsureLn (toFilePath coreFile) txt
+      writeFileEnsureLn coreFile txt

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -35,5 +35,6 @@ writeCoreFile pa@Compile.PipelineArg {..} = do
   r <- runReader entryPoint . runError @JuvixError $ Core.toStored _pipelineArgModule
   case r of
     Left e -> exitJuvixError e
-    Right md ->
-      embed @IO (writeFile (toFilePath coreFile) (show $ Core.ppOutDefault (Core.disambiguateNames md ^. Core.moduleInfoTable)))
+    Right md -> do
+      let txt = show (Core.ppOutDefault (Core.disambiguateNames md ^. Core.moduleInfoTable))
+      writeFileEnsureLn (toFilePath coreFile) txt

--- a/app/Commands/Dev/Asm/Compile.hs
+++ b/app/Commands/Dev/Asm/Compile.hs
@@ -31,7 +31,7 @@ runCommand opts = do
           let outputCell = Nockma.TermCell c
               outputText = Nockma.ppPrintOpts nockmaOpts outputCell
           outfile <- Compile.outputFile opts file
-          embed @IO (writeFileEnsureLn (toFilePath outfile) outputText)
+          writeFileEnsureLn (toFilePath outfile) outputText
         _ -> do
           case run $ runReader entryPoint $ runError $ asmToMiniC tab of
             Left err -> exitJuvixError err
@@ -39,7 +39,7 @@ runCommand opts = do
               buildDir <- askBuildDir
               ensureDir buildDir
               cFile <- inputCFile file
-              embed @IO $ writeFileEnsureLn (toFilePath cFile) _resultCCode
+              writeFileEnsureLn (toFilePath cFile) _resultCCode
               outfile <- Compile.outputFile opts file
               Compile.runCommand
                 opts

--- a/app/Commands/Dev/Asm/Compile.hs
+++ b/app/Commands/Dev/Asm/Compile.hs
@@ -31,7 +31,7 @@ runCommand opts = do
           let outputCell = Nockma.TermCell c
               outputText = Nockma.ppPrintOpts nockmaOpts outputCell
           outfile <- Compile.outputFile opts file
-          writeFileEnsureLn (toFilePath outfile) outputText
+          writeFileEnsureLn outfile outputText
         _ -> do
           case run $ runReader entryPoint $ runError $ asmToMiniC tab of
             Left err -> exitJuvixError err
@@ -39,7 +39,7 @@ runCommand opts = do
               buildDir <- askBuildDir
               ensureDir buildDir
               cFile <- inputCFile file
-              writeFileEnsureLn (toFilePath cFile) _resultCCode
+              writeFileEnsureLn cFile _resultCCode
               outfile <- Compile.outputFile opts file
               Compile.runCommand
                 opts

--- a/app/Commands/Dev/Asm/Compile.hs
+++ b/app/Commands/Dev/Asm/Compile.hs
@@ -31,7 +31,7 @@ runCommand opts = do
           let outputCell = Nockma.TermCell c
               outputText = Nockma.ppPrintOpts nockmaOpts outputCell
           outfile <- Compile.outputFile opts file
-          writeFileEnsureLn outfile outputText
+          embed @IO $ writeFileEnsureLn outfile outputText
         _ -> do
           case run $ runReader entryPoint $ runError $ asmToMiniC tab of
             Left err -> exitJuvixError err
@@ -39,7 +39,7 @@ runCommand opts = do
               buildDir <- askBuildDir
               ensureDir buildDir
               cFile <- inputCFile file
-              writeFileEnsureLn cFile _resultCCode
+              embed @IO $ writeFileEnsureLn cFile _resultCCode
               outfile <- Compile.outputFile opts file
               Compile.runCommand
                 opts

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -56,7 +56,7 @@ runCPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa
   C.MiniCResult {..} <- getRight (run (runReader entryPoint (runError (coreToMiniC _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] C.MiniCResult))))
   cFile <- inputCFile _pipelineArgFile
-  writeFileEnsureLn (toFilePath cFile) _resultCCode
+  writeFileEnsureLn cFile _resultCCode
   outfile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   Compile.runCommand
     _pipelineArgOptions
@@ -87,7 +87,7 @@ runGebPipeline pa@PipelineArg {..} = do
                   _lispPackageEntry = "*entry*"
                 }
   Geb.Result {..} <- getRight (run (runReader entryPoint (runError (coreToGeb spec _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] Geb.Result))))
-  writeFileEnsureLn (toFilePath gebFile) _resultCode
+  writeFileEnsureLn gebFile _resultCode
 
 runVampIRPipeline ::
   forall r.
@@ -98,7 +98,7 @@ runVampIRPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa
   vampirFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   VampIR.Result {..} <- getRight (run (runReader entryPoint (runError (coreToVampIR _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] VampIR.Result))))
-  writeFileEnsureLn (toFilePath vampirFile) _resultCode
+  writeFileEnsureLn vampirFile _resultCode
 
 runAsmPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runAsmPipeline pa@PipelineArg {..} = do
@@ -111,7 +111,7 @@ runAsmPipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Asm.ppPrint tab' tab'
-  writeFileEnsureLn (toFilePath asmFile) code
+  writeFileEnsureLn asmFile code
 
 runTreePipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runTreePipeline pa@PipelineArg {..} = do
@@ -124,7 +124,7 @@ runTreePipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Tree.ppPrint tab' tab'
-  writeFileEnsureLn (toFilePath treeFile) code
+  writeFileEnsureLn treeFile code
 
 runNockmaPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runNockmaPipeline pa@PipelineArg {..} = do
@@ -137,4 +137,4 @@ runNockmaPipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Nockma.ppSerialize tab'
-  writeFileEnsureLn (toFilePath nockmaFile) code
+  writeFileEnsureLn nockmaFile code

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -56,7 +56,7 @@ runCPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa
   C.MiniCResult {..} <- getRight (run (runReader entryPoint (runError (coreToMiniC _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] C.MiniCResult))))
   cFile <- inputCFile _pipelineArgFile
-  writeFileEnsureLn cFile _resultCCode
+  embed @IO $ writeFileEnsureLn cFile _resultCCode
   outfile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   Compile.runCommand
     _pipelineArgOptions
@@ -87,7 +87,7 @@ runGebPipeline pa@PipelineArg {..} = do
                   _lispPackageEntry = "*entry*"
                 }
   Geb.Result {..} <- getRight (run (runReader entryPoint (runError (coreToGeb spec _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] Geb.Result))))
-  writeFileEnsureLn gebFile _resultCode
+  embed @IO $ writeFileEnsureLn gebFile _resultCode
 
 runVampIRPipeline ::
   forall r.
@@ -98,7 +98,7 @@ runVampIRPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa
   vampirFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   VampIR.Result {..} <- getRight (run (runReader entryPoint (runError (coreToVampIR _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] VampIR.Result))))
-  writeFileEnsureLn vampirFile _resultCode
+  embed @IO $ writeFileEnsureLn vampirFile _resultCode
 
 runAsmPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runAsmPipeline pa@PipelineArg {..} = do
@@ -111,7 +111,7 @@ runAsmPipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Asm.ppPrint tab' tab'
-  writeFileEnsureLn asmFile code
+  embed @IO $ writeFileEnsureLn asmFile code
 
 runTreePipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runTreePipeline pa@PipelineArg {..} = do
@@ -124,7 +124,7 @@ runTreePipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Tree.ppPrint tab' tab'
-  writeFileEnsureLn treeFile code
+  embed @IO $ writeFileEnsureLn treeFile code
 
 runNockmaPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runNockmaPipeline pa@PipelineArg {..} = do
@@ -137,4 +137,4 @@ runNockmaPipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Nockma.ppSerialize tab'
-  writeFileEnsureLn nockmaFile code
+  embed @IO $ writeFileEnsureLn nockmaFile code

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -56,7 +56,7 @@ runCPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa
   C.MiniCResult {..} <- getRight (run (runReader entryPoint (runError (coreToMiniC _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] C.MiniCResult))))
   cFile <- inputCFile _pipelineArgFile
-  embed @IO (writeFile (toFilePath cFile) _resultCCode)
+  writeFileEnsureLn (toFilePath cFile) _resultCCode
   outfile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   Compile.runCommand
     _pipelineArgOptions
@@ -87,7 +87,7 @@ runGebPipeline pa@PipelineArg {..} = do
                   _lispPackageEntry = "*entry*"
                 }
   Geb.Result {..} <- getRight (run (runReader entryPoint (runError (coreToGeb spec _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] Geb.Result))))
-  embed @IO (writeFile (toFilePath gebFile) _resultCode)
+  writeFileEnsureLn (toFilePath gebFile) _resultCode
 
 runVampIRPipeline ::
   forall r.
@@ -98,7 +98,7 @@ runVampIRPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa
   vampirFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   VampIR.Result {..} <- getRight (run (runReader entryPoint (runError (coreToVampIR _pipelineArgModule :: Sem '[Error JuvixError, Reader EntryPoint] VampIR.Result))))
-  embed @IO (writeFile (toFilePath vampirFile) _resultCode)
+  writeFileEnsureLn (toFilePath vampirFile) _resultCode
 
 runAsmPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runAsmPipeline pa@PipelineArg {..} = do
@@ -111,7 +111,7 @@ runAsmPipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Asm.ppPrint tab' tab'
-  embed @IO (writeFile (toFilePath asmFile) code)
+  writeFileEnsureLn (toFilePath asmFile) code
 
 runTreePipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runTreePipeline pa@PipelineArg {..} = do
@@ -124,7 +124,7 @@ runTreePipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Tree.ppPrint tab' tab'
-  embed @IO (writeFile (toFilePath treeFile) code)
+  writeFileEnsureLn (toFilePath treeFile) code
 
 runNockmaPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runNockmaPipeline pa@PipelineArg {..} = do
@@ -137,4 +137,4 @@ runNockmaPipeline pa@PipelineArg {..} = do
       $ _pipelineArgModule
   tab' <- getRight r
   let code = Nockma.ppSerialize tab'
-  embed @IO (writeFile (toFilePath nockmaFile) code)
+  writeFileEnsureLn (toFilePath nockmaFile) code

--- a/app/Commands/Dev/Tree/Compile/Base.hs
+++ b/app/Commands/Dev/Tree/Compile/Base.hs
@@ -57,7 +57,7 @@ runCPipeline pa@PipelineArg {..} = do
       . runError @JuvixError
       $ treeToMiniC _pipelineArgTable
   cFile <- inputCFile _pipelineArgFile
-  writeFileEnsureLn (toFilePath cFile) _resultCCode
+  writeFileEnsureLn cFile _resultCCode
   outfile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   Compile.runCommand
     _pipelineArgOptions
@@ -82,7 +82,7 @@ runAsmPipeline pa@PipelineArg {..} = do
       $ _pipelineArgTable
   tab' <- getRight r
   let code = Asm.ppPrint tab' tab'
-  writeFileEnsureLn (toFilePath asmFile) code
+  writeFileEnsureLn asmFile code
 
 runNockmaPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runNockmaPipeline pa@PipelineArg {..} = do
@@ -95,4 +95,4 @@ runNockmaPipeline pa@PipelineArg {..} = do
       $ _pipelineArgTable
   tab' <- getRight r
   let code = Nockma.ppSerialize tab'
-  writeFileEnsureLn (toFilePath nockmaFile) code
+  writeFileEnsureLn nockmaFile code

--- a/app/Commands/Dev/Tree/Compile/Base.hs
+++ b/app/Commands/Dev/Tree/Compile/Base.hs
@@ -57,7 +57,7 @@ runCPipeline pa@PipelineArg {..} = do
       . runError @JuvixError
       $ treeToMiniC _pipelineArgTable
   cFile <- inputCFile _pipelineArgFile
-  writeFileEnsureLn cFile _resultCCode
+  embed @IO $ writeFileEnsureLn cFile _resultCCode
   outfile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   Compile.runCommand
     _pipelineArgOptions
@@ -82,7 +82,7 @@ runAsmPipeline pa@PipelineArg {..} = do
       $ _pipelineArgTable
   tab' <- getRight r
   let code = Asm.ppPrint tab' tab'
-  writeFileEnsureLn asmFile code
+  embed @IO $ writeFileEnsureLn asmFile code
 
 runNockmaPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runNockmaPipeline pa@PipelineArg {..} = do
@@ -95,4 +95,4 @@ runNockmaPipeline pa@PipelineArg {..} = do
       $ _pipelineArgTable
   tab' <- getRight r
   let code = Nockma.ppSerialize tab'
-  writeFileEnsureLn nockmaFile code
+  embed @IO $ writeFileEnsureLn nockmaFile code

--- a/app/Commands/Dev/Tree/Compile/Base.hs
+++ b/app/Commands/Dev/Tree/Compile/Base.hs
@@ -57,7 +57,7 @@ runCPipeline pa@PipelineArg {..} = do
       . runError @JuvixError
       $ treeToMiniC _pipelineArgTable
   cFile <- inputCFile _pipelineArgFile
-  embed @IO (writeFile (toFilePath cFile) _resultCCode)
+  writeFileEnsureLn (toFilePath cFile) _resultCCode
   outfile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
   Compile.runCommand
     _pipelineArgOptions
@@ -82,7 +82,7 @@ runAsmPipeline pa@PipelineArg {..} = do
       $ _pipelineArgTable
   tab' <- getRight r
   let code = Asm.ppPrint tab' tab'
-  embed @IO (writeFile (toFilePath asmFile) code)
+  writeFileEnsureLn (toFilePath asmFile) code
 
 runNockmaPipeline :: (Members '[Embed IO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runNockmaPipeline pa@PipelineArg {..} = do
@@ -95,4 +95,4 @@ runNockmaPipeline pa@PipelineArg {..} = do
       $ _pipelineArgTable
   tab' <- getRight r
   let code = Nockma.ppSerialize tab'
-  embed @IO (writeFile (toFilePath nockmaFile) code)
+  writeFileEnsureLn (toFilePath nockmaFile) code

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -92,7 +92,7 @@ renderFormattedOutput target opts fInfo = do
       EditInPlace i@FormattedFileInfo {..} ->
         runTempFileIO
           . restoreFileOnError _formattedFileInfoPath
-          $ writeFile' _formattedFileInfoPath (i ^. formattedFileInfoContents)
+          $ writeFileEnsureLn' _formattedFileInfoPath (i ^. formattedFileInfoContents)
       NoEdit m -> case m of
         ReformattedFile ts -> renderStdOut ts
         InputPath p -> say (pack (toFilePath p))

--- a/src/Juvix/Compiler/Pipeline/Package.hs
+++ b/src/Juvix/Compiler/Pipeline/Package.hs
@@ -138,7 +138,7 @@ writeGlobalPackage :: (Members '[Files] r) => Sem r ()
 writeGlobalPackage = do
   packagePath <- globalPackageJuvix
   ensureDir' (parent packagePath)
-  writeFile' packagePath (renderPackageVersion currentPackageVersion (globalPackage packagePath))
+  writeFileEnsureLn' packagePath (renderPackageVersion currentPackageVersion (globalPackage packagePath))
 
 packageBasePackage :: Package
 packageBasePackage =

--- a/src/Juvix/Data/Effect/Files/Base.hs
+++ b/src/Juvix/Data/Effect/Files/Base.hs
@@ -36,7 +36,7 @@ data Files m a where
   ReadFile' :: Path Abs File -> Files m Text
   ReadFileBS' :: Path Abs File -> Files m ByteString
   RemoveDirectoryRecursive' :: Path Abs Dir -> Files m ()
-  WriteFile' :: Path Abs File -> Text -> Files m ()
+  WriteFileEnsureLn' :: Path Abs File -> Text -> Files m ()
   WriteFileBS :: Path Abs File -> ByteString -> Files m ()
   RemoveFile' :: Path Abs File -> Files m ()
   RenameFile' :: Path Abs File -> Path Abs File -> Files m ()

--- a/src/Juvix/Data/Effect/Files/IO.hs
+++ b/src/Juvix/Data/Effect/Files/IO.hs
@@ -32,7 +32,7 @@ runFilesIO = interpret helper
     helper' = \case
       ReadFile' f -> readFile (toFilePath f)
       WriteFileBS p bs -> ByteString.writeFile (toFilePath p) bs
-      WriteFile' f txt -> writeFile (toFilePath f) txt
+      WriteFileEnsureLn' f txt -> writeFileEnsureLn (toFilePath f) txt
       EnsureDir' p -> Path.ensureDir p
       DirectoryExists' p -> Path.doesDirExist p
       ReadFileBS' f -> ByteString.readFile (toFilePath f)

--- a/src/Juvix/Data/Effect/Files/IO.hs
+++ b/src/Juvix/Data/Effect/Files/IO.hs
@@ -32,7 +32,7 @@ runFilesIO = interpret helper
     helper' = \case
       ReadFile' f -> readFile (toFilePath f)
       WriteFileBS p bs -> ByteString.writeFile (toFilePath p) bs
-      WriteFileEnsureLn' f txt -> writeFileEnsureLn (toFilePath f) txt
+      WriteFileEnsureLn' f txt -> writeFileEnsureLn f txt
       EnsureDir' p -> Path.ensureDir p
       DirectoryExists' p -> Path.doesDirExist p
       ReadFileBS' f -> ByteString.readFile (toFilePath f)

--- a/src/Juvix/Data/Effect/Files/Pure.hs
+++ b/src/Juvix/Data/Effect/Files/Pure.hs
@@ -74,7 +74,7 @@ re cwd = reinterpret $ \case
   ReadFileBS' f -> encodeUtf8 <$> lookupFile' f
   EnsureDir' p -> ensureDirHelper p
   DirectoryExists' p -> isJust <$> lookupDir p
-  WriteFile' p t -> writeFileHelper p t
+  WriteFileEnsureLn' p t -> writeFileHelper p t
   WriteFileBS p t -> writeFileHelper p (decodeUtf8 t)
   RemoveDirectoryRecursive' p -> removeDirRecurHelper p
   ListDirRel p -> do
@@ -163,7 +163,7 @@ writeFileHelper p contents = do
     (r, dirs, f) = destructAbsFile p
     go :: [Path Rel Dir] -> FSNode -> FSNode
     go = \case
-      [] -> set (dirFiles . at f) (Just contents)
+      [] -> set (dirFiles . at f) (Just (ensureLn contents))
       (d : ds) -> over dirDirs (HashMap.alter (Just . helper) d)
         where
           helper :: Maybe FSNode -> FSNode

--- a/src/Juvix/Extra/Files.hs
+++ b/src/Juvix/Extra/Files.hs
@@ -42,7 +42,7 @@ writeVersion :: forall r. (Members '[Reader OutputRoot, Files] r) => Sem r ()
 writeVersion = do
   vf <- versionFile
   ensureDir' (parent vf)
-  writeFile' vf versionTag
+  writeFileEnsureLn' vf versionTag
 
 readVersion :: (Members '[Reader OutputRoot, Files] r) => Sem r (Maybe Text)
 readVersion = do

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -150,7 +150,8 @@ import Data.Text qualified as Text
 import Data.Text.Encoding
 import Data.Text.IO hiding (appendFile, putStr, putStrLn, readFile, writeFile)
 import Data.Text.IO qualified as Text
-import Data.Text.IO.Utf8
+import Data.Text.IO.Utf8 hiding (writeFile)
+import Data.Text.IO.Utf8 qualified as Utf8
 import Data.Traversable
 import Data.Tuple.Extra hiding (both)
 import Data.Type.Equality (type (~))
@@ -589,11 +590,13 @@ runInputInfinite s =
             return i
       )
 
+ensureLn :: Text -> Text
+ensureLn t =
+  case Text.unsnoc t of
+    Nothing -> t
+    Just (_, y) -> case y of
+      '\n' -> t
+      _ -> Text.snoc t '\n'
+
 writeFileEnsureLn :: (MonadMask m, MonadIO m) => FilePath -> Text -> m ()
-writeFileEnsureLn p t =
-  let t' = case Text.unsnoc t of
-        Nothing -> t
-        Just (_, y) -> case y of
-          '\n' -> t
-          _ -> Text.snoc t '\n'
-   in writeFile p t'
+writeFileEnsureLn p = Utf8.writeFile p . ensureLn

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -599,4 +599,5 @@ ensureLn t =
       _ -> Text.snoc t '\n'
 
 writeFileEnsureLn :: (MonadMask m, MonadIO m) => Path Abs File -> Text -> m ()
-writeFileEnsureLn p = Utf8.writeFile (toFilePath p) . ensureLn
+writeFileEnsureLn p = Utf8.writeFile (toFilePath p)
+{-# INLINE writeFileEnsureLn #-}

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -598,5 +598,5 @@ ensureLn t =
       '\n' -> t
       _ -> Text.snoc t '\n'
 
-writeFileEnsureLn :: (MonadMask m, MonadIO m) => FilePath -> Text -> m ()
-writeFileEnsureLn p = Utf8.writeFile p . ensureLn
+writeFileEnsureLn :: (MonadMask m, MonadIO m) => Path Abs File -> Text -> m ()
+writeFileEnsureLn p = Utf8.writeFile (toFilePath p) . ensureLn

--- a/src/Juvix/Prelude/Trace.hs
+++ b/src/Juvix/Prelude/Trace.hs
@@ -9,6 +9,7 @@ import Debug.Trace hiding (trace, traceM, traceShow)
 import Debug.Trace qualified as T
 import GHC.IO (unsafePerformIO)
 import Juvix.Prelude.Base
+import Juvix.Prelude.Path
 
 setDebugMsg :: Text -> Text
 setDebugMsg msg = "[debug] " <> fmsg <> "\n"
@@ -33,19 +34,15 @@ traceShow :: (Show b) => b -> b
 traceShow b = traceLabel "" (pack . show $ b) b
 {-# WARNING traceShow "Using traceShow" #-}
 
-traceToFile :: FilePath -> Text -> a -> a
+traceToFile :: Path Abs File -> Text -> a -> a
 traceToFile fpath t a =
-  traceLabel (pack ("[" <> fpath <> "]")) t $
+  traceLabel (pack ("[" <> toFilePath fpath <> "]")) t $
     unsafePerformIO $
       do
         writeFileEnsureLn fpath t
         return a
 {-# WARNING traceToFile "Using traceToFile" #-}
 
-traceToFile' :: Text -> a -> a
-traceToFile' = traceToFile "./juvix.log"
-{-# WARNING traceToFile' "Using traceToFile'" #-}
-
-traceToFileM :: (Applicative m) => FilePath -> Text -> a -> m ()
+traceToFileM :: (Applicative m) => Path Abs File -> Text -> a -> m ()
 traceToFileM fpath t a = pure (traceToFile fpath t a) $> ()
 {-# WARNING traceToFileM "Using traceFileM" #-}

--- a/src/Juvix/Prelude/Trace.hs
+++ b/src/Juvix/Prelude/Trace.hs
@@ -38,7 +38,7 @@ traceToFile fpath t a =
   traceLabel (pack ("[" <> fpath <> "]")) t $
     unsafePerformIO $
       do
-        writeFile fpath t
+        writeFileEnsureLn fpath t
         return a
 {-# WARNING traceToFile "Using traceToFile" #-}
 

--- a/test/Asm/Compile/Base.hs
+++ b/test/Asm/Compile/Base.hs
@@ -21,7 +21,7 @@ asmCompileAssertion' optLevel tab mainFile expectedFile stdinText step = do
       withTempDir'
         ( \dirPath -> do
             let cFile = dirPath <//> replaceExtension' ".c" (filename mainFile)
-            writeFile (toFilePath cFile) _resultCCode
+            writeFileEnsureLn cFile _resultCCode
             Runtime.clangAssertion optLevel cFile expectedFile stdinText step
         )
   where

--- a/test/Core/Compile/Base.hs
+++ b/test/Core/Compile/Base.hs
@@ -48,12 +48,12 @@ coreCompileAssertion' ::
   Assertion
 coreCompileAssertion' optLevel tab mainFile expectedFile stdinText step = do
   step "Translate to JuvixAsm"
-  case run $ runReader opts $ runError $ toStored' (moduleFromInfoTable tab) >>= toStripped' of
+  case run . runReader opts . runError $ toStored' (moduleFromInfoTable tab) >>= toStripped' of
     Left err -> assertFailure (show (pretty (fromJuvixError @GenericError err)))
     Right m -> do
       let tab0 = computeCombinedInfoTable m
       assertBool "Check info table" (checkInfoTable tab0)
-      let tab' = Asm.fromTree $ Tree.fromCore $ Stripped.fromCore tab0
+      let tab' = Asm.fromTree . Tree.fromCore $ Stripped.fromCore tab0
       length (fromText (Asm.ppPrint tab' tab') :: String) `seq`
         Asm.asmCompileAssertion' optLevel tab' mainFile expectedFile stdinText step
   where

--- a/test/VampIR/Core/Base.hs
+++ b/test/VampIR/Core/Base.hs
@@ -25,7 +25,7 @@ vampirAssertion' backend tab dataFile step = do
         case run (runReader defaultCoreOptions (runError @JuvixError (coreToVampIR' (moduleFromInfoTable tab)))) of
           Left err -> assertFailure (show (pretty (fromJuvixError @GenericError err)))
           Right VampIR.Result {..} -> do
-            writeFile (toFilePath vampirFile) _resultCode
+            writeFileEnsureLn vampirFile _resultCode
 
             step "Check vamp-ir on path"
             assertCmdExists $(mkRelFile "vamp-ir")


### PR DESCRIPTION
Now we guarantee that whenever we write a file there is a newline character at the end, which is a [Unix convention](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap03.html#tag_03_205).

The juvix prelude now exports `writeFileEnsureLn` and it no longer exports `writeFile`. If at some point we need the behaviour of `writeFile` I'd suggest that we export it renamed as `writeFileVerbatim` or something similar.