### PR TITLE
Replace `egrep` with `grep -E`

### DIFF
--- a/runtime/Makefile.generic
+++ b/runtime/Makefile.generic
@@ -154,22 +154,22 @@ ALLOBJECTS  := $(strip $(COBJECTS) $(ALLCPPOBJECTS))
 
 # object files which contain the "main" function
 ifneq ($(strip $(CSOURCES)),)
-   CMAINOBJECTS := $(patsubst %.c,$(BUILDDIR)%.o,$(shell egrep -l '\bint[[:space:]]+main\b' $(CSOURCES)))
+   CMAINOBJECTS := $(patsubst %.c,$(BUILDDIR)%.o,$(shell grep -E -l '\bint[[:space:]]+main\b' $(CSOURCES)))
 else
    CMAINOBJECTS :=
 endif
 ifneq ($(strip $(CPPSOURCES)),)
-   CPPMAINOBJECTS := $(patsubst %.cpp,$(BUILDDIR)%.o,$(shell egrep -l '\bint[[:space:]]+main\b' $(CPPSOURCES)))
+   CPPMAINOBJECTS := $(patsubst %.cpp,$(BUILDDIR)%.o,$(shell grep -E -l '\bint[[:space:]]+main\b' $(CPPSOURCES)))
 else
    CPPMAINOBJECTS :=
 endif
 ifneq ($(strip $(CXXSOURCES)),)
-   CXXMAINOBJECTS := $(patsubst %.cxx,$(BUILDDIR)%.o,$(shell egrep -l 'int[[:space:]]+main\b' $(CXXSOURCES)))
+   CXXMAINOBJECTS := $(patsubst %.cxx,$(BUILDDIR)%.o,$(shell grep -E -l 'int[[:space:]]+main\b' $(CXXSOURCES)))
 else
    CXXMAINOBJECTS :=
 endif
 ifneq ($(strip $(CCSOURCES)),)
-   CCMAINOBJECTS := $(patsubst %.cxx,$(BUILDDIR)%.o,$(shell egrep -l 'int[[:space:]]+main\b' $(CCSOURCES)))
+   CCMAINOBJECTS := $(patsubst %.cxx,$(BUILDDIR)%.o,$(shell grep -E -l 'int[[:space:]]+main\b' $(CCSOURCES)))
 else
    CCMAINOBJECTS :=
 endif


### PR DESCRIPTION
Quoting the [release notes of gnu `grep-3.8`](https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html)

>   The egrep and fgrep commands, which have been deprecated since
  release 2.5.3 (2007), now warn that they are obsolescent and should
  be replaced by grep -E and grep -F.

In order to fix the warning, I've replaced all instances of `egrep` with `grep -E`