### PR TITLE
Remove BangPattern pragmas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
             --ghc-opt -XStandaloneDeriving
             --ghc-opt -XTemplateHaskell
             --ghc-opt -XUnicodeSyntax
+            --ghc-opt -XBangPatterns
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ ormolu:
 		--ghc-opt -XMultiParamTypeClasses  \
 		--ghc-opt -XTemplateHaskell \
 		--ghc-opt -XImportQualifiedPost \
+		--ghc-opt -XBangPatterns \
 			--mode ${ORMOLUMODE} \
 		$(ORMOLUFILES)
 

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{-# HLINT ignore "Avoid restricted extensions" #-}
-{-# HLINT ignore "Avoid restricted flags" #-}
-
 module Juvix.Compiler.Core.Evaluator where
 
 import Control.Exception qualified as Exception

--- a/src/Juvix/Compiler/Tree/Evaluator.hs
+++ b/src/Juvix/Compiler/Tree/Evaluator.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{-# HLINT ignore "Avoid restricted extensions" #-}
-{-# HLINT ignore "Avoid restricted flags" #-}
 module Juvix.Compiler.Tree.Evaluator where
 
 import Control.Exception qualified as Exception

--- a/src/Juvix/Prelude/Base.hs
+++ b/src/Juvix/Prelude/Base.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{-# HLINT ignore "Avoid restricted extensions" #-}
-{-# HLINT ignore "Avoid restricted flags" #-}
-
 module Juvix.Prelude.Base
   ( module Juvix.Prelude.Base,
     module Control.Applicative,


### PR DESCRIPTION
`BangPatterns` is already enabled by [`GHC2021`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021), so it makes sense to remove the pragmas and add the corresponding flag to ormolu