### PR TITLE
Add jvt files to `extra-source-files`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -38,6 +38,7 @@ extra-source-files:
   - include/package-base/**/*.juvix
   - runtime/include/**/*.h
   - runtime/**/*.a
+  - runtime/src/tree/*.jvt
   - runtime/src/vampir/*.pir
 
 dependencies:


### PR DESCRIPTION
If this line is omitted then the project cannot be built with cabal