### PR TITLE
Add nockma as a valid target for the tree compile command

### DIFF
--- a/app/Commands/Dev/Tree/Compile/Options.hs
+++ b/app/Commands/Dev/Tree/Compile/Options.hs
@@ -12,7 +12,8 @@ treeSupportedTargets =
   nonEmpty'
     [ TargetWasm32Wasi,
       TargetNative64,
-      TargetAsm
+      TargetAsm,
+      TargetNockma
     ]
 
 parseTreeCompileOptions :: Parser CompileOptions


### PR DESCRIPTION
This allows us to do `juvix dev tree compile --target nockma test.jvt`. The pipeline was already implemented, this pr only adds the `TargetNockma` to the list of supported backends so that the cli recognizes it.