### PR TITLE
Update REPL artifacts with builtins from stored modules

### DIFF
--- a/app/Evaluator.hs
+++ b/app/Evaluator.hs
@@ -19,14 +19,6 @@ data EvalOptions = EvalOptions
 
 makeLenses ''EvalOptions
 
-doEvalIO ::
-  Bool ->
-  Interval ->
-  Core.InfoTable ->
-  Core.Node ->
-  IO (Either Core.CoreError Core.Node)
-doEvalIO noIO i tab node = runM (Core.doEval noIO i tab node)
-
 evalAndPrint ::
   forall r a.
   (Members '[EmbedIO, App] r, CanonicalProjection a EvalOptions, CanonicalProjection a Core.Options) =>

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -404,6 +404,14 @@ doEval noIO loc tab node
   | noIO = catchEvalError loc (eval stderr (tab ^. identContext) [] node)
   | otherwise = liftIO (catchEvalErrorIO loc (evalIO (tab ^. identContext) [] node))
 
+doEvalIO ::
+  Bool ->
+  Interval ->
+  InfoTable ->
+  Node ->
+  IO (Either CoreError Node)
+doEvalIO noIO i tab node = runM (doEval noIO i tab node)
+
 -- | Catch EvalError and convert it to CoreError. Needs a default location in case
 -- no location is available in EvalError.
 catchEvalError :: (MonadIO m) => Location -> a -> m (Either CoreError a)

--- a/src/Juvix/Compiler/Core/Extra/Value.hs
+++ b/src/Juvix/Compiler/Core/Extra/Value.hs
@@ -33,7 +33,7 @@ toValue tab = \case
       ValueConstrApp
         ConstrApp
           { _constrAppName = ci ^. constructorName,
-            _constrAppFixity = ci ^. constructorFixity,
+            _constrAppFixity = Irrelevant (ci ^. constructorFixity),
             _constrAppArgs = map (toValue tab) (drop paramsNum _constrArgs)
           }
       where

--- a/src/Juvix/Compiler/Core/Language/Value.hs
+++ b/src/Juvix/Compiler/Core/Language/Value.hs
@@ -5,9 +5,10 @@ import Juvix.Compiler.Core.Language.Nodes
 
 data ConstrApp = ConstrApp
   { _constrAppName :: Text,
-    _constrAppFixity :: Maybe Fixity,
+    _constrAppFixity :: Irrelevant (Maybe Fixity),
     _constrAppArgs :: [Value]
   }
+  deriving stock (Eq)
 
 -- | Specifies Core values for user-friendly pretty printing.
 data Value
@@ -16,13 +17,14 @@ data Value
   | ValueWildcard
   | ValueFun
   | ValueType
+  deriving stock (Eq)
 
 makeLenses ''ConstrApp
 
 instance HasAtomicity ConstrApp where
   atomicity ConstrApp {..}
     | null _constrAppArgs = Atom
-    | otherwise = Aggregate (fromMaybe appFixity _constrAppFixity)
+    | otherwise = Aggregate (fromMaybe appFixity (_constrAppFixity ^. unIrrelevant))
 
 instance HasAtomicity Value where
   atomicity = \case

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -608,7 +608,7 @@ goUnary fixity name = \case
 instance PrettyCode ConstrApp where
   ppCode ConstrApp {..} = do
     n <- ppName KNameConstructor _constrAppName
-    case _constrAppFixity of
+    case _constrAppFixity ^. unIrrelevant of
       Nothing -> do
         args <- mapM (ppRightExpression appFixity) _constrAppArgs
         return $ hsep (n : args)

--- a/src/Juvix/Compiler/Core/Transformation/MatchToCase.hs
+++ b/src/Juvix/Compiler/Core/Transformation/MatchToCase.hs
@@ -215,7 +215,7 @@ goMatchToCase recur node = case node of
                   ValueConstrApp
                     ConstrApp
                       { _constrAppName = ci ^. constructorName,
-                        _constrAppFixity = ci ^. constructorFixity,
+                        _constrAppFixity = Irrelevant (ci ^. constructorFixity),
                         _constrAppArgs = replicate argsNum ValueWildcard
                       }
             Nothing ->
@@ -239,7 +239,7 @@ goMatchToCase recur node = case node of
                 ValueConstrApp
                   ConstrApp
                     { _constrAppName = ci ^. constructorName,
-                      _constrAppFixity = ci ^. constructorFixity,
+                      _constrAppFixity = Irrelevant (ci ^. constructorFixity),
                       _constrAppArgs = drop paramsNum (take argsNum args)
                     }
       binders' <- getBranchBinders col matrix tag

--- a/src/Juvix/Compiler/Pipeline/Artifacts.hs
+++ b/src/Juvix/Compiler/Pipeline/Artifacts.hs
@@ -10,6 +10,7 @@ module Juvix.Compiler.Pipeline.Artifacts
 where
 
 import Juvix.Compiler.Builtins
+import Juvix.Compiler.Builtins.Effect qualified as Builtins
 import Juvix.Compiler.Concrete.Data.InfoTableBuilder qualified as Scoped
 import Juvix.Compiler.Concrete.Data.Scope qualified as S
 import Juvix.Compiler.Core.Data.InfoTableBuilder qualified as Core
@@ -26,6 +27,7 @@ import Juvix.Prelude
 appendArtifactsModuleTable :: ModuleTable -> Artifacts -> Artifacts
 appendArtifactsModuleTable mtab =
   over artifactInternalTypedTable (computeCombinedInfoTable importTab <>)
+    . over (artifactBuiltins . Builtins.builtinsTable) (computeCombinedBuiltins mtab <>)
     . over (artifactCoreModule . Core.moduleImportsTable) (computeCombinedCoreInfoTable mtab <>)
     . over artifactModuleTable (mtab <>)
   where

--- a/src/Juvix/Compiler/Store/Extra.hs
+++ b/src/Juvix/Compiler/Store/Extra.hs
@@ -1,9 +1,11 @@
 module Juvix.Compiler.Store.Extra where
 
 import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Concrete.Data.Builtins
 import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
 import Juvix.Compiler.Concrete.Language (TopModulePath)
 import Juvix.Compiler.Core.Data.InfoTable qualified as Core
+import Juvix.Compiler.Internal.Data.Name
 import Juvix.Compiler.Store.Core.Extra
 import Juvix.Compiler.Store.Internal.Language
 import Juvix.Compiler.Store.Language
@@ -42,3 +44,9 @@ computeCombinedScopedInfoTable mtab =
 computeCombinedCoreInfoTable :: ModuleTable -> Core.InfoTable
 computeCombinedCoreInfoTable mtab =
   mconcatMap (toCore . (^. moduleInfoCoreTable)) (HashMap.elems (mtab ^. moduleTable))
+
+computeCombinedBuiltins :: ModuleTable -> HashMap BuiltinPrim Name
+computeCombinedBuiltins mtab =
+  mconcatMap
+    (^. moduleInfoInternalModule . internalModuleInfoTable . infoBuiltins)
+    (HashMap.elems (mtab ^. moduleTable))

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -74,6 +74,9 @@ render ansi endChar err = do
 renderText :: (ToGenericError e, Member (Reader GenericOptions) r) => e -> Sem r Text
 renderText = render False False
 
+renderTextDefault :: (ToGenericError e) => e -> Text
+renderTextDefault = run . runReader defaultGenericOptions . renderText
+
 -- | Render the error with Ansi formatting (if any).
 renderAnsiText :: (ToGenericError e, Member (Reader GenericOptions) r) => e -> Sem r Text
 renderAnsiText = render True False

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -16,6 +16,7 @@ import Nockma qualified
 import Package qualified
 import Parsing qualified
 import Reg qualified
+import Repl qualified
 import Resolver qualified
 import Runtime qualified
 import Scope qualified
@@ -39,7 +40,8 @@ slowTests =
       Examples.allTests,
       Casm.allTests,
       VampIR.allTests,
-      Anoma.allTests
+      Anoma.allTests,
+      Repl.allTests
     ]
 
 fastTests :: TestTree

--- a/test/Repl.hs
+++ b/test/Repl.hs
@@ -1,0 +1,7 @@
+module Repl where
+
+import Base
+import Repl.Positive qualified as P
+
+allTests :: TestTree
+allTests = testGroup "Juvix REPL tests" [P.allTests]

--- a/test/Repl/Assertions.hs
+++ b/test/Repl/Assertions.hs
@@ -1,0 +1,49 @@
+module Repl.Assertions where
+
+import Base
+import Juvix.Compiler.Core qualified as Core
+import Juvix.Compiler.Core.Extra.Value qualified as Core
+import Juvix.Compiler.Core.Language.Value qualified as Core
+import Juvix.Compiler.Core.Pretty qualified as Core
+
+assertNoJuvixError :: Either JuvixError a -> IO a
+assertNoJuvixError = either (assertFailure . ("JuvixError: " <>) . unpack . renderTextDefault) return
+
+assertPrettyCodeEqual :: (Core.PrettyCode a) => (a -> a -> Bool) -> a -> a -> Assertion
+assertPrettyCodeEqual eq expected actual = unless (eq expected actual) (assertFailure (unpack msg))
+  where
+    msg :: Text
+    msg = "expected: " <> Core.ppTrace expected <> "\n but got: " <> Core.ppTrace actual
+
+assertNodeEqual :: Core.Node -> Core.Node -> Assertion
+assertNodeEqual = assertPrettyCodeEqual (==)
+
+assertValueEqual :: Core.Value -> Core.Value -> Assertion
+assertValueEqual = assertPrettyCodeEqual valueEq
+
+valueEqList :: [Core.Value] -> [Core.Value] -> Bool
+valueEqList vs1 vs2 = case (vs1, vs2) of
+  ([], []) -> True
+  ([], _) -> False
+  (_, []) -> False
+  (x : xs, y : ys) -> valueEq x y && valueEqList xs ys
+
+valueEq :: Core.Value -> Core.Value -> Bool
+valueEq n = \case
+  Core.ValueConstrApp app1 -> case n of
+    Core.ValueConstrApp app2 ->
+      app1 ^. Core.constrAppName == app2 ^. Core.constrAppName
+        && valueEqList (app1 ^. Core.constrAppArgs) (app2 ^. Core.constrAppArgs)
+    _ -> False
+  Core.ValueConstant v1 -> case n of
+    Core.ValueConstant v2 -> v1 == v2
+    _ -> False
+  Core.ValueWildcard -> case n of
+    Core.ValueWildcard -> True
+    _ -> False
+  Core.ValueFun -> case n of
+    Core.ValueFun -> True
+    _ -> False
+  Core.ValueType -> case n of
+    Core.ValueType -> True
+    _ -> False

--- a/test/Repl/Assertions.hs
+++ b/test/Repl/Assertions.hs
@@ -8,41 +8,14 @@ import Juvix.Compiler.Core.Pretty qualified as Core
 assertNoJuvixError :: Either JuvixError a -> IO a
 assertNoJuvixError = either (assertFailure . ("JuvixError: " <>) . unpack . renderTextDefault) return
 
-assertPrettyCodeEqual :: (Core.PrettyCode a) => (a -> a -> Bool) -> a -> a -> Assertion
-assertPrettyCodeEqual eq expected actual = unless (eq expected actual) (assertFailure (unpack msg))
+assertPrettyCodeEqual :: (Core.PrettyCode a, Eq a) => a -> a -> Assertion
+assertPrettyCodeEqual expected actual = unless (expected == actual) (assertFailure (unpack msg))
   where
     msg :: Text
     msg = "expected: " <> Core.ppTrace expected <> "\n but got: " <> Core.ppTrace actual
 
 assertNodeEqual :: Core.Node -> Core.Node -> Assertion
-assertNodeEqual = assertPrettyCodeEqual (==)
+assertNodeEqual = assertPrettyCodeEqual
 
 assertValueEqual :: Core.Value -> Core.Value -> Assertion
-assertValueEqual = assertPrettyCodeEqual valueEq
-
-valueEqList :: [Core.Value] -> [Core.Value] -> Bool
-valueEqList vs1 vs2 = case (vs1, vs2) of
-  ([], []) -> True
-  ([], _) -> False
-  (_, []) -> False
-  (x : xs, y : ys) -> valueEq x y && valueEqList xs ys
-
-valueEq :: Core.Value -> Core.Value -> Bool
-valueEq n = \case
-  Core.ValueConstrApp app1 -> case n of
-    Core.ValueConstrApp app2 ->
-      app1 ^. Core.constrAppName == app2 ^. Core.constrAppName
-        && valueEqList (app1 ^. Core.constrAppArgs) (app2 ^. Core.constrAppArgs)
-    _ -> False
-  Core.ValueConstant v1 -> case n of
-    Core.ValueConstant v2 -> v1 == v2
-    _ -> False
-  Core.ValueWildcard -> case n of
-    Core.ValueWildcard -> True
-    _ -> False
-  Core.ValueFun -> case n of
-    Core.ValueFun -> True
-    _ -> False
-  Core.ValueType -> case n of
-    Core.ValueType -> True
-    _ -> False
+assertValueEqual = assertPrettyCodeEqual

--- a/test/Repl/Assertions.hs
+++ b/test/Repl/Assertions.hs
@@ -2,7 +2,6 @@ module Repl.Assertions where
 
 import Base
 import Juvix.Compiler.Core qualified as Core
-import Juvix.Compiler.Core.Extra.Value qualified as Core
 import Juvix.Compiler.Core.Language.Value qualified as Core
 import Juvix.Compiler.Core.Pretty qualified as Core
 

--- a/test/Repl/Positive.hs
+++ b/test/Repl/Positive.hs
@@ -1,0 +1,85 @@
+module Repl.Positive where
+
+import Base
+import Juvix.Data.Effect.TaggedLock
+import Juvix.Extra.Stdlib
+import Juvix.Compiler.Pipeline.Root
+import Juvix.Compiler.Core qualified as Core
+import Juvix.Compiler.Pipeline.Repl
+import Juvix.Extra.Paths qualified as P
+
+runTaggedLockIO' :: Sem '[TaggedLock, Files, Embed IO, Resource, Final IO] a -> IO a
+runTaggedLockIO' = runFinal
+       . resourceToIOFinal
+       . embedToFinal @IO
+       . runFilesIO
+       . runTaggedLock LockModePermissive
+
+loadPrelude :: Path Abs Dir -> IO (Artifacts, EntryPoint)
+loadPrelude rootDir = runTaggedLockIO' $ do
+  runReader rootDir writeStdlib
+  pkg <- readPackageRootIO root
+  let ep = defaultEntryPoint pkg root (rootDir <//> preludePath)
+  artif <- embed (runReplPipelineIO ep)
+  return (artif, ep)
+
+  where
+    root :: Root
+    root = Root {_rootRootDir=rootDir,
+                 _rootPackageType=LocalPackage,
+                 _rootInvokeDir=rootDir,
+                 _rootBuildDir=DefaultBuildDir}
+
+data TestCtx = TestCtx {
+  _testCtxRootDir :: Path Abs Dir,
+  _testCtxEntryPoint :: EntryPoint,
+  _testCtxArtifacts :: Artifacts
+                       }
+
+makeLenses ''TestCtx
+
+assertNodeEqual :: Core.Node -> Core.Node -> Assertion
+assertNodeEqual n1 n2 = undefined
+
+replSetup :: IO TestCtx
+replSetup = do
+  _testCtxRootDir <- do
+    sysTemp <- getTempDir
+    createTempDir sysTemp "repl"
+  (_testCtxArtifacts, _testCtxEntryPoint) <- loadPrelude _testCtxRootDir
+  return TestCtx {..}
+
+replTeardown :: TestCtx -> IO ()
+replTeardown = removeDirRecur . (^. testCtxRootDir)
+
+replTest :: IO TestCtx -> IO ()
+replTest getTestCtx = do
+  ctx <- getTestCtx
+  (_, res) <- compileReplInputIO' ctx "1 + 1"
+  case res of
+    Left err -> assertFailure "err"
+    Right Nothing -> assertFailure "nothing"
+    Right n -> assertBool "expected equal" (n  == (Just (Core.mkConstant' (Core.ConstInteger 2))))
+
+
+allTests :: TestTree
+allTests = withResource
+  replSetup
+  replTeardown
+  (\getTestCtx -> testGroup "REPL positive tests"
+     (map (\f -> f getTestCtx ) [testCase "repl test" . replTest]))
+
+compileReplInputIO' :: TestCtx -> Text -> IO (Artifacts, (Either JuvixError (Maybe Core.Node)))
+compileReplInputIO' ctx txt =
+  runM
+    . runState (ctx ^. testCtxArtifacts)
+    . runReader (ctx ^. testCtxEntryPoint)
+    $ do
+      r <- compileReplInputIO P.replPath txt
+      return (extractNode <$> r)
+  where
+    extractNode :: ReplPipelineResult -> Maybe Core.Node
+    extractNode = \case
+      ReplPipelineResultNode n -> Just n
+      ReplPipelineResultImport {} -> Nothing
+      ReplPipelineResultOpen {} -> Nothing

--- a/test/Repl/Positive.hs
+++ b/test/Repl/Positive.hs
@@ -10,8 +10,8 @@ import Juvix.Compiler.Pipeline.Root
 import Juvix.Data.Effect.TaggedLock
 import Juvix.Extra.Paths qualified as P
 import Juvix.Extra.Stdlib
-import Juvix.Extra.Strings qualified as Str
 import Repl.Assertions
+import Repl.Value
 
 runTaggedLockIO' :: Sem '[Files, TaggedLock, Embed IO] a -> IO a
 runTaggedLockIO' =
@@ -76,24 +76,6 @@ replTest input' expectedNode getTestCtx = do
       let ep = ctx ^. testCtxEntryPoint
       n' <- evalRepl artif ep n
       assertValueEqual expectedNode n'
-
-mkInteger :: Integer -> Core.Value
-mkInteger = Core.ValueConstant . Core.ConstInteger
-
-mkBool :: Bool -> Core.Value
-mkBool b =
-  Core.ValueConstrApp
-    ( Core.ConstrApp
-        { _constrAppName = name,
-          _constrAppFixity = Nothing,
-          _constrAppArgs = []
-        }
-    )
-  where
-    name :: Text
-    name = case b of
-      True -> Str.true
-      False -> Str.false
 
 allTests :: TestTree
 allTests =

--- a/test/Repl/Value.hs
+++ b/test/Repl/Value.hs
@@ -1,0 +1,24 @@
+module Repl.Value where
+
+import Base
+import Juvix.Compiler.Core qualified as Core
+import Juvix.Compiler.Core.Language.Value qualified as Core
+import Juvix.Extra.Strings qualified as Str
+
+mkInteger :: Integer -> Core.Value
+mkInteger = Core.ValueConstant . Core.ConstInteger
+
+mkBool :: Bool -> Core.Value
+mkBool b =
+  Core.ValueConstrApp
+    ( Core.ConstrApp
+        { _constrAppName = name,
+          _constrAppFixity = Irrelevant Nothing,
+          _constrAppArgs = []
+        }
+    )
+  where
+    name :: Text
+    name = case b of
+      True -> Str.true
+      False -> Str.false

--- a/tests/smoke/Commands/repl.smoke.yaml
+++ b/tests/smoke/Commands/repl.smoke.yaml
@@ -227,16 +227,6 @@ tests:
           Nat
     exit-status: 0
 
-  - name: eval-let-expression
-    command:
-      - juvix
-      - repl
-    stdin: "let x : Nat := 2 + 1 in x"
-    stdout:
-      contains:
-        "3"
-    exit-status: 0
-
   - name: load-builtin-bool
     command:
       shell:
@@ -297,16 +287,6 @@ tests:
         Juvix REPL .*
         OK loaded: .*
         Stdlib.Prelude> .*/global-project/
-    exit-status: 0
-
-  - name: eval-adding-two-literal-nats
-    command:
-      - juvix
-      - repl
-    stdin: "1 + 2"
-    stdout:
-      contains: |
-        3
     exit-status: 0
 
   - name: repl-trace
@@ -449,16 +429,6 @@ tests:
       - juvix
       - repl
     stdin: "import Stdlib.Data.Int.Ord as Int open\n1 Int.== 1"
-    stdout:
-      contains: "true"
-    exit-status: 0
-
-  - name: literal-comparison
-    command:
-      - juvix
-      - repl
-    stdin: |
-      1 == 1
     stdout:
       contains: "true"
     exit-status: 0


### PR DESCRIPTION
Builtin information needs to be propagated from stored modules to REPL artifacts to avoid "The builtin _ has not been defined" errors.

This PR adds a test suite for the REPL in the Haskell test code. This means some of the slow smoke tests can be moved to fast haskell unit tests. In future we should refactor the REPL code by putting in the main src target and unit testing more features (e.g :doc, :def).

* Closes https://github.com/anoma/juvix/issues/2638
