### PR TITLE
Transform JuvixReg into SSA form

### DIFF
--- a/src/Juvix/Compiler/Asm/Transformation/StackUsage.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/StackUsage.hs
@@ -22,12 +22,12 @@ computeFunctionStackUsage tab fi = do
       RecursorSig
         { _recursorInfoTable = tab,
           _recurseInstr = \si _ -> return (si ^. stackInfoValueStackHeight, si ^. stackInfoTempStackHeight),
-          _recurseBranch = \si _ l r ->
+          _recurseBranch = \_ si _ l r ->
             return
               ( max (si ^. stackInfoValueStackHeight) (max (maximum (map fst l)) (maximum (map fst r))),
                 max (si ^. stackInfoTempStackHeight) (max (maximum (map snd l)) (maximum (map snd r)))
               ),
-          _recurseCase = \si _ cs md ->
+          _recurseCase = \_ si _ cs md ->
             return
               ( max (si ^. stackInfoValueStackHeight) (max (maximum (map (maximum . map fst) cs)) (maybe 0 (maximum . map fst) md)),
                 max (si ^. stackInfoTempStackHeight) (max (maximum (map (maximum . map snd) cs)) (maybe 0 (maximum . map snd) md))

--- a/src/Juvix/Compiler/Asm/Transformation/Validate.hs
+++ b/src/Juvix/Compiler/Asm/Transformation/Validate.hs
@@ -12,8 +12,8 @@ validateCode tab fi code = do
       RecursorSig
         { _recursorInfoTable = tab,
           _recurseInstr = \_ _ -> return (),
-          _recurseBranch = \_ _ _ _ -> return (),
-          _recurseCase = \_ _ _ _ -> return (),
+          _recurseBranch = \_ _ _ _ _ -> return (),
+          _recurseCase = \_ _ _ _ _ -> return (),
           _recurseSave = \_ _ _ -> return ()
         }
 

--- a/src/Juvix/Compiler/Reg/Data/IndexMap.hs
+++ b/src/Juvix/Compiler/Reg/Data/IndexMap.hs
@@ -33,8 +33,11 @@ assign IndexMap {..} k =
       }
   )
 
+lookup' :: (Hashable k) => IndexMap k -> k -> Maybe Index
+lookup' IndexMap {..} k = HashMap.lookup k _indexMapTable
+
 lookup :: (Hashable k) => IndexMap k -> k -> Index
-lookup IndexMap {..} k = fromJust $ HashMap.lookup k _indexMapTable
+lookup mp = fromJust . lookup' mp
 
 combine :: forall k. (Hashable k) => IndexMap k -> IndexMap k -> IndexMap k
 combine mp1 mp2 =

--- a/src/Juvix/Compiler/Reg/Data/IndexMap.hs
+++ b/src/Juvix/Compiler/Reg/Data/IndexMap.hs
@@ -1,0 +1,39 @@
+module Juvix.Compiler.Reg.Data.IndexMap where
+
+import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Reg.Language.Base
+
+data IndexMap k = IndexMap
+  { _indexMapSize :: Int,
+    _indexMapTable :: HashMap k Index
+  }
+
+makeLenses ''IndexMap
+
+instance (Hashable k) => Semigroup (IndexMap k) where
+  m1 <> m2 =
+    IndexMap
+      { _indexMapTable = m,
+        _indexMapSize = HashMap.size m
+      }
+    where
+      m = m1 ^. indexMapTable <> m2 ^. indexMapTable
+
+instance (Hashable k) => Monoid (IndexMap k) where
+  mempty =
+    IndexMap
+      { _indexMapSize = 0,
+        _indexMapTable = mempty
+      }
+
+assign :: (Hashable k) => IndexMap k -> k -> (Index, IndexMap k)
+assign IndexMap {..} k =
+  ( _indexMapSize,
+    IndexMap
+      { _indexMapSize = _indexMapSize + 1,
+        _indexMapTable = HashMap.insert k _indexMapSize _indexMapTable
+      }
+  )
+
+lookup :: (Hashable k) => IndexMap k -> k -> Index
+lookup IndexMap {..} k = fromJust $ HashMap.lookup k _indexMapTable

--- a/src/Juvix/Compiler/Reg/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Reg/Data/TransformationId.hs
@@ -6,6 +6,7 @@ import Juvix.Prelude
 
 data TransformationId
   = Identity
+  | SSA
   deriving stock (Data, Bounded, Enum, Show)
 
 data PipelineId
@@ -19,12 +20,13 @@ toCTransformations :: [TransformationId]
 toCTransformations = []
 
 toCairoTransformations :: [TransformationId]
-toCairoTransformations = []
+toCairoTransformations = [SSA]
 
 instance TransformationId' TransformationId where
   transformationText :: TransformationId -> Text
   transformationText = \case
     Identity -> strIdentity
+    SSA -> strSSA
 
 instance PipelineId' TransformationId PipelineId where
   pipelineText :: PipelineId -> Text

--- a/src/Juvix/Compiler/Reg/Data/TransformationId/Strings.hs
+++ b/src/Juvix/Compiler/Reg/Data/TransformationId/Strings.hs
@@ -10,3 +10,6 @@ strCairoPipeline = "pipeline-cairo"
 
 strIdentity :: Text
 strIdentity = "identity"
+
+strSSA :: Text
+strSSA = "ssa"

--- a/src/Juvix/Compiler/Reg/Extra.hs
+++ b/src/Juvix/Compiler/Reg/Extra.hs
@@ -1,0 +1,10 @@
+module Juvix.Compiler.Reg.Extra
+  ( module Juvix.Compiler.Reg.Extra.Base,
+    module Juvix.Compiler.Reg.Extra.Recursors,
+    module Juvix.Compiler.Reg.Extra.Info,
+  )
+where
+
+import Juvix.Compiler.Reg.Extra.Base
+import Juvix.Compiler.Reg.Extra.Info
+import Juvix.Compiler.Reg.Extra.Recursors

--- a/src/Juvix/Compiler/Reg/Extra/Base.hs
+++ b/src/Juvix/Compiler/Reg/Extra/Base.hs
@@ -1,0 +1,156 @@
+module Juvix.Compiler.Reg.Extra.Base where
+
+import Juvix.Compiler.Reg.Language
+
+getResultVar :: Instruction -> Maybe VarRef
+getResultVar = \case
+  Binop x -> Just $ x ^. binaryOpResult
+  Show x -> Just $ x ^. instrShowResult
+  StrToInt x -> Just $ x ^. instrStrToIntResult
+  Assign x -> Just $ x ^. instrAssignResult
+  ArgsNum x -> Just $ x ^. instrArgsNumResult
+  Alloc x -> Just $ x ^. instrAllocResult
+  AllocClosure x -> Just $ x ^. instrAllocClosureResult
+  ExtendClosure x -> Just $ x ^. instrExtendClosureResult
+  Call x -> Just $ x ^. instrCallResult
+  CallClosures x -> Just $ x ^. instrCallClosuresResult
+  _ -> Nothing
+
+setResultVar :: Instruction -> VarRef -> Instruction
+setResultVar instr vref = case instr of
+  Binop x -> Binop $ set binaryOpResult vref x
+  Show x -> Show $ set instrShowResult vref x
+  StrToInt x -> StrToInt $ set instrStrToIntResult vref x
+  Assign x -> Assign $ set instrAssignResult vref x
+  ArgsNum x -> ArgsNum $ set instrArgsNumResult vref x
+  Alloc x -> Alloc $ set instrAllocResult vref x
+  AllocClosure x -> AllocClosure $ set instrAllocClosureResult vref x
+  ExtendClosure x -> ExtendClosure $ set instrExtendClosureResult vref x
+  Call x -> Call $ set instrCallResult vref x
+  CallClosures x -> CallClosures $ set instrCallClosuresResult vref x
+  _ -> impossible
+
+overValueRefs :: (VarRef -> VarRef) -> Instruction -> Instruction
+overValueRefs f = \case
+  Binop x -> Binop $ goBinop x
+  Show x -> Show $ goShow x
+  StrToInt x -> StrToInt $ goStrToInt x
+  Assign x -> Assign $ goAssign x
+  ArgsNum x -> ArgsNum $ goArgsNum x
+  Alloc x -> Alloc $ goAlloc x
+  AllocClosure x -> AllocClosure $ goAllocClosure x
+  ExtendClosure x -> ExtendClosure $ goExtendClosure x
+  Call x -> Call $ goCall x
+  CallClosures x -> CallClosures $ goCallClosures x
+  TailCall x -> TailCall $ goTailCall x
+  TailCallClosures x -> TailCallClosures $ goTailCallClosures x
+  Return x -> Return $ goReturn x
+  Branch x -> Branch $ goBranch x
+  Case x -> Case $ goCase x
+  Trace x -> Trace $ goTrace x
+  Dump -> Dump
+  Failure x -> Failure $ goFailure x
+  Prealloc x -> Prealloc $ goPrealloc x
+  Nop -> Nop
+  Block x -> Block $ goBlock x
+  where
+    goConstrField :: ConstrField -> ConstrField
+    goConstrField = over constrFieldRef f
+
+    goValue :: Value -> Value
+    goValue = \case
+      Const c -> Const c
+      CRef x -> CRef $ goConstrField x
+      VRef x -> VRef $ f x
+
+    goBinop :: BinaryOp -> BinaryOp
+    goBinop BinaryOp {..} =
+      BinaryOp
+        { _binaryOpArg1 = goValue _binaryOpArg1,
+          _binaryOpArg2 = goValue _binaryOpArg2,
+          ..
+        }
+
+    goShow :: InstrShow -> InstrShow
+    goShow = over instrShowValue goValue
+
+    goStrToInt :: InstrStrToInt -> InstrStrToInt
+    goStrToInt = over instrStrToIntValue goValue
+
+    goAssign :: InstrAssign -> InstrAssign
+    goAssign = over instrAssignValue goValue
+
+    goArgsNum :: InstrArgsNum -> InstrArgsNum
+    goArgsNum = over instrArgsNumValue goValue
+
+    goAlloc :: InstrAlloc -> InstrAlloc
+    goAlloc = over instrAllocArgs (map goValue)
+
+    goAllocClosure :: InstrAllocClosure -> InstrAllocClosure
+    goAllocClosure = over instrAllocClosureArgs (map goValue)
+
+    goExtendClosure :: InstrExtendClosure -> InstrExtendClosure
+    goExtendClosure InstrExtendClosure {..} =
+      InstrExtendClosure
+        { _instrExtendClosureValue = f _instrExtendClosureValue,
+          _instrExtendClosureArgs = map goValue _instrExtendClosureArgs,
+          ..
+        }
+
+    goCallType :: CallType -> CallType
+    goCallType = \case
+      CallFun sym -> CallFun sym
+      CallClosure cl -> CallClosure (f cl)
+
+    goCall :: InstrCall -> InstrCall
+    goCall InstrCall {..} =
+      InstrCall
+        { _instrCallType = goCallType _instrCallType,
+          _instrCallArgs = map goValue _instrCallArgs,
+          ..
+        }
+
+    goCallClosures :: InstrCallClosures -> InstrCallClosures
+    goCallClosures InstrCallClosures {..} =
+      InstrCallClosures
+        { _instrCallClosuresArgs = map goValue _instrCallClosuresArgs,
+          _instrCallClosuresValue = f _instrCallClosuresValue,
+          ..
+        }
+
+    goTailCall :: InstrTailCall -> InstrTailCall
+    goTailCall InstrTailCall {..} =
+      InstrTailCall
+        { _instrTailCallType = goCallType _instrTailCallType,
+          _instrTailCallArgs = map goValue _instrTailCallArgs,
+          ..
+        }
+
+    goTailCallClosures :: InstrTailCallClosures -> InstrTailCallClosures
+    goTailCallClosures InstrTailCallClosures {..} =
+      InstrTailCallClosures
+        { _instrTailCallClosuresValue = f _instrTailCallClosuresValue,
+          _instrTailCallClosuresArgs = map goValue _instrTailCallClosuresArgs,
+          ..
+        }
+
+    goReturn :: InstrReturn -> InstrReturn
+    goReturn = over instrReturnValue goValue
+
+    goBranch :: InstrBranch -> InstrBranch
+    goBranch = over instrBranchValue goValue
+
+    goCase :: InstrCase -> InstrCase
+    goCase = over instrCaseValue goValue
+
+    goTrace :: InstrTrace -> InstrTrace
+    goTrace = over instrTraceValue goValue
+
+    goFailure :: InstrFailure -> InstrFailure
+    goFailure = over instrFailureValue goValue
+
+    goPrealloc :: InstrPrealloc -> InstrPrealloc
+    goPrealloc x = x
+
+    goBlock :: InstrBlock -> InstrBlock
+    goBlock x = x

--- a/src/Juvix/Compiler/Reg/Language.hs
+++ b/src/Juvix/Compiler/Reg/Language.hs
@@ -12,8 +12,6 @@ data Value
   | VRef VarRef
   deriving stock (Eq)
 
-type Index = Int
-
 -- | Reference to a constructor field (argument).
 data ConstrField = ConstrField
   { -- | Tag of the constructor being referenced.
@@ -29,7 +27,9 @@ data ConstrField = ConstrField
 data VarGroup
   = VarGroupArgs
   | VarGroupLocal
-  deriving stock (Eq)
+  deriving stock (Eq, Generic)
+
+instance Hashable VarGroup
 
 data VarRef = VarRef
   { _varRefGroup :: VarGroup,
@@ -38,27 +38,33 @@ data VarRef = VarRef
   }
   deriving stock (Eq)
 
+instance Hashable VarRef where
+  hashWithSalt salt VarRef {..} = hashWithSalt salt (_varRefGroup, _varRefIndex)
+
 data Instruction
-  = Nop -- no operation
-  | Binop BinaryOp
+  = Binop BinaryOp
   | Show InstrShow
   | StrToInt InstrStrToInt
   | Assign InstrAssign
-  | Trace InstrTrace
-  | Dump
-  | Failure InstrFailure
   | ArgsNum InstrArgsNum
-  | Prealloc InstrPrealloc
   | Alloc InstrAlloc
   | AllocClosure InstrAllocClosure
   | ExtendClosure InstrExtendClosure
   | Call InstrCall
-  | TailCall InstrTailCall
   | CallClosures InstrCallClosures
+  | ----
+    TailCall InstrTailCall
   | TailCallClosures InstrTailCallClosures
   | Return InstrReturn
-  | Branch InstrBranch
+  | ----
+    Branch InstrBranch
   | Case InstrCase
+  | ----
+    Trace InstrTrace
+  | Dump
+  | Failure InstrFailure
+  | Prealloc InstrPrealloc
+  | Nop -- no operation
   | Block InstrBlock
   deriving stock (Eq)
 
@@ -236,6 +242,10 @@ makeLenses ''InstrBranch
 makeLenses ''InstrCase
 makeLenses ''CaseBranch
 makeLenses ''InstrReturn
+makeLenses ''InstrShow
+makeLenses ''InstrStrToInt
+makeLenses ''InstrArgsNum
+makeLenses ''InstrTailCall
 
 mkVarRef :: VarGroup -> Index -> VarRef
 mkVarRef g i =

--- a/src/Juvix/Compiler/Reg/Language.hs
+++ b/src/Juvix/Compiler/Reg/Language.hs
@@ -156,7 +156,7 @@ data InstrCall = InstrCall
   { _instrCallResult :: VarRef,
     _instrCallType :: CallType,
     _instrCallArgs :: [Value],
-    -- | Variables live at the point of the call. Live variables need to be
+    -- | Variables live after the call. Live variables need to be
     -- saved before the call and restored after it.
     _instrCallLiveVars :: [VarRef]
   }
@@ -190,7 +190,10 @@ newtype InstrReturn = InstrReturn
 data InstrBranch = InstrBranch
   { _instrBranchValue :: Value,
     _instrBranchTrue :: Code,
-    _instrBranchFalse :: Code
+    _instrBranchFalse :: Code,
+    -- | Live variable storing the result (corresponds to the top of the value
+    -- stack in JuvixAsm after executing the branches)
+    _instrBranchVar :: Maybe VarRef
   }
   deriving stock (Eq)
 
@@ -199,7 +202,8 @@ data InstrCase = InstrCase
     _instrCaseInductive :: Symbol,
     _instrCaseIndRep :: IndRep,
     _instrCaseBranches :: [CaseBranch],
-    _instrCaseDefault :: Maybe Code
+    _instrCaseDefault :: Maybe Code,
+    _instrCaseVar :: Maybe VarRef
   }
   deriving stock (Eq)
 

--- a/src/Juvix/Compiler/Reg/Language.hs
+++ b/src/Juvix/Compiler/Reg/Language.hs
@@ -206,9 +206,9 @@ data InstrBranch = InstrBranch
   { _instrBranchValue :: Value,
     _instrBranchTrue :: Code,
     _instrBranchFalse :: Code,
-    -- | Live variable storing the result (corresponds to the top of the value
+    -- | Output variable storing the result (corresponds to the top of the value
     -- stack in JuvixAsm after executing the branches)
-    _instrBranchVar :: Maybe VarRef
+    _instrBranchOutVar :: Maybe VarRef
   }
   deriving stock (Eq)
 
@@ -218,7 +218,7 @@ data InstrCase = InstrCase
     _instrCaseIndRep :: IndRep,
     _instrCaseBranches :: [CaseBranch],
     _instrCaseDefault :: Maybe Code,
-    _instrCaseVar :: Maybe VarRef
+    _instrCaseOutVar :: Maybe VarRef
   }
   deriving stock (Eq)
 

--- a/src/Juvix/Compiler/Reg/Language.hs
+++ b/src/Juvix/Compiler/Reg/Language.hs
@@ -10,7 +10,6 @@ data Value
   = Const Constant
   | CRef ConstrField
   | VRef VarRef
-  deriving stock (Eq)
 
 -- | Reference to a constructor field (argument).
 data ConstrField = ConstrField
@@ -22,7 +21,6 @@ data ConstrField = ConstrField
     _constrFieldRef :: VarRef,
     _constrFieldIndex :: Index
   }
-  deriving stock (Eq)
 
 data VarGroup
   = VarGroupArgs
@@ -36,10 +34,21 @@ data VarRef = VarRef
     _varRefIndex :: Index,
     _varRefName :: Maybe Text
   }
-  deriving stock (Eq)
+
+makeLenses ''VarRef
+makeLenses ''ConstrField
 
 instance Hashable VarRef where
   hashWithSalt salt VarRef {..} = hashWithSalt salt (_varRefGroup, _varRefIndex)
+
+instance Eq VarRef where
+  vr1 == vr2 =
+    vr1 ^. varRefGroup == vr2 ^. varRefGroup
+      && vr1 ^. varRefIndex == vr2 ^. varRefIndex
+
+deriving stock instance (Eq ConstrField)
+
+deriving stock instance (Eq Value)
 
 data Instruction
   = Binop BinaryOp
@@ -227,7 +236,6 @@ newtype InstrBlock = InstrBlock
   }
   deriving stock (Eq)
 
-makeLenses ''ConstrField
 makeLenses ''BinaryOp
 makeLenses ''InstrAssign
 makeLenses ''InstrTrace

--- a/src/Juvix/Compiler/Reg/Language/Base.hs
+++ b/src/Juvix/Compiler/Reg/Language/Base.hs
@@ -5,6 +5,6 @@ module Juvix.Compiler.Reg.Language.Base
   )
 where
 
-import Juvix.Compiler.Core.Language.Base hiding (Index)
+import Juvix.Compiler.Core.Language.Base
 import Juvix.Compiler.Tree.Language.Base (Constant (..))
 import Juvix.Compiler.Tree.Language.Rep

--- a/src/Juvix/Compiler/Reg/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Reg/Pretty/Base.hs
@@ -108,12 +108,12 @@ ppLiveVars vars
       vars' <- mapM ppCode vars
       return $ comma <+> primitive "live:" <+> arglist vars'
 
-ppBranchVar :: (Member (Reader Options) r) => Maybe VarRef -> Sem r (Doc Ann)
-ppBranchVar = \case
+ppOutVar :: (Member (Reader Options) r) => Maybe VarRef -> Sem r (Doc Ann)
+ppOutVar = \case
   Nothing -> return mempty
   Just var -> do
     var' <- ppCode var
-    return $ comma <+> primitive "var:" <+> var'
+    return $ comma <+> primitive "out:" <+> var'
 
 instance PrettyCode InstrPrealloc where
   ppCode InstrPrealloc {..} = do
@@ -217,7 +217,7 @@ instance PrettyCode InstrBranch where
     val <- ppCode _instrBranchValue
     br1 <- ppCodeCode _instrBranchTrue
     br2 <- ppCodeCode _instrBranchFalse
-    var <- ppBranchVar _instrBranchVar
+    var <- ppOutVar _instrBranchOutVar
     return $
       primitive Str.br
         <+> val
@@ -249,7 +249,7 @@ instance PrettyCode InstrCase where
     val <- ppCode _instrCaseValue
     brs <- mapM ppCode _instrCaseBranches
     def <- maybe (return Nothing) (fmap Just . ppDefaultBranch) _instrCaseDefault
-    var <- ppBranchVar _instrCaseVar
+    var <- ppOutVar _instrCaseOutVar
     let brs' = brs ++ catMaybes [def]
     return $ primitive Str.case_ <> brackets ind <+> val <> var <+> braces' (vsep brs')
 

--- a/src/Juvix/Compiler/Reg/Transformation.hs
+++ b/src/Juvix/Compiler/Reg/Transformation.hs
@@ -8,6 +8,7 @@ where
 import Juvix.Compiler.Reg.Data.TransformationId
 import Juvix.Compiler.Reg.Transformation.Base
 import Juvix.Compiler.Reg.Transformation.Identity
+import Juvix.Compiler.Reg.Transformation.SSA
 
 applyTransformations :: forall r. [TransformationId] -> InfoTable -> Sem r InfoTable
 applyTransformations ts tbl = foldM (flip appTrans) tbl ts
@@ -15,3 +16,4 @@ applyTransformations ts tbl = foldM (flip appTrans) tbl ts
     appTrans :: TransformationId -> InfoTable -> Sem r InfoTable
     appTrans = \case
       Identity -> return . identity
+      SSA -> return . computeSSA

--- a/src/Juvix/Compiler/Reg/Transformation/SSA.hs
+++ b/src/Juvix/Compiler/Reg/Transformation/SSA.hs
@@ -1,0 +1,43 @@
+module Juvix.Compiler.Reg.Transformation.SSA where
+
+import Data.Functor.Identity
+import Juvix.Compiler.Reg.Data.IndexMap (IndexMap)
+import Juvix.Compiler.Reg.Data.IndexMap qualified as IndexMap
+import Juvix.Compiler.Reg.Extra
+import Juvix.Compiler.Reg.Transformation.Base
+
+computeFunctionSSA :: Code -> Code
+computeFunctionSSA =
+  snd
+    . runIdentity
+    . recurseF
+      ForwardRecursorSig
+        { _forwardFun = \i acc -> return (go i acc),
+          _forwardCombine = combine
+        }
+      mempty
+  where
+    go :: Instruction -> IndexMap VarRef -> (IndexMap VarRef, Instruction)
+    go instr mp = case getResultVar instr' of
+      Just vref -> (mp', setResultVar instr' (mkVarRef VarGroupLocal idx))
+        where
+          (idx, mp') = IndexMap.assign mp vref
+      Nothing -> (mp, instr')
+      where
+        instr' = overValueRefs (adjustVarRef mp) instr
+
+    combine :: Instruction -> NonEmpty (IndexMap VarRef) -> (IndexMap VarRef, Instruction)
+    combine instr mps = case instr of
+      Branch InstrBranch {..} -> case mps of
+        mp1 :| mp2 : [] -> undefined
+        _ -> impossible
+      Case InstrCase {..} -> undefined
+      _ -> impossible
+
+    adjustVarRef :: IndexMap VarRef -> VarRef -> VarRef
+    adjustVarRef mpv vref@VarRef {..} = case _varRefGroup of
+      VarGroupArgs -> vref
+      VarGroupLocal -> mkVarRef VarGroupLocal (IndexMap.lookup mpv vref)
+
+computeSSA :: InfoTable -> InfoTable
+computeSSA = mapT (const computeFunctionSSA)

--- a/src/Juvix/Compiler/Reg/Transformation/SSA.hs
+++ b/src/Juvix/Compiler/Reg/Transformation/SSA.hs
@@ -31,7 +31,8 @@ computeFunctionSSA =
     combine instr mps = case instr of
       Branch InstrBranch {..} -> case mps of
         mp1 :| mp2 : []
-          | idx1 == idx2 -> (mp, instr)
+          | isNothing _instrBranchVar || idx1 == idx2 ->
+              (mp, instr)
           | otherwise ->
               ( mp',
                 Branch
@@ -50,7 +51,8 @@ computeFunctionSSA =
         _ -> impossible
       Case InstrCase {..} -> case mps of
         mp0 :| mps'
-          | all (== head idxs) (NonEmpty.tail idxs) -> (mp, instr)
+          | isNothing _instrCaseVar || all (== head idxs) (NonEmpty.tail idxs) ->
+              (mp, instr)
           | otherwise ->
               ( mp',
                 Case

--- a/src/Juvix/Compiler/Reg/Transformation/SSA.hs
+++ b/src/Juvix/Compiler/Reg/Transformation/SSA.hs
@@ -1,6 +1,7 @@
 module Juvix.Compiler.Reg.Transformation.SSA where
 
 import Data.Functor.Identity
+import Data.List.NonEmpty qualified as NonEmpty
 import Juvix.Compiler.Reg.Data.IndexMap (IndexMap)
 import Juvix.Compiler.Reg.Data.IndexMap qualified as IndexMap
 import Juvix.Compiler.Reg.Extra
@@ -29,15 +30,64 @@ computeFunctionSSA =
     combine :: Instruction -> NonEmpty (IndexMap VarRef) -> (IndexMap VarRef, Instruction)
     combine instr mps = case instr of
       Branch InstrBranch {..} -> case mps of
-        mp1 :| mp2 : [] -> undefined
+        mp1 :| mp2 : []
+          | idx1 == idx2 -> (mp, instr)
+          | otherwise ->
+              ( mp',
+                Branch
+                  InstrBranch
+                    { _instrBranchTrue = assignInBranch _instrBranchTrue idx' idx1,
+                      _instrBranchFalse = assignInBranch _instrBranchFalse idx' idx2,
+                      ..
+                    }
+              )
+          where
+            var = fromJust _instrBranchVar
+            idx1 = IndexMap.lookup mp1 var
+            idx2 = IndexMap.lookup mp2 var
+            mp = IndexMap.combine mp1 mp2
+            (idx', mp') = IndexMap.assign mp var
         _ -> impossible
-      Case InstrCase {..} -> undefined
+      Case InstrCase {..} -> case mps of
+        mp0 :| mps'
+          | all (== head idxs) (NonEmpty.tail idxs) -> (mp, instr)
+          | otherwise ->
+              ( mp',
+                Case
+                  InstrCase
+                    { _instrCaseBranches = brs',
+                      _instrCaseDefault = def',
+                      ..
+                    }
+              )
+          where
+            var = fromJust _instrCaseVar
+            idxs = fmap (flip IndexMap.lookup var) mps
+            mp = foldr IndexMap.combine mp0 mps'
+            (idx', mp') = IndexMap.assign mp var
+            n = length _instrCaseBranches
+            brs' = zipWithExact updateBranch _instrCaseBranches (take n (toList idxs))
+            def' = fmap (\is -> assignInBranch is idx' (last idxs)) _instrCaseDefault
+
+            updateBranch :: CaseBranch -> Index -> CaseBranch
+            updateBranch br idx =
+              over caseBranchCode (\is -> assignInBranch is idx' idx) br
       _ -> impossible
 
     adjustVarRef :: IndexMap VarRef -> VarRef -> VarRef
     adjustVarRef mpv vref@VarRef {..} = case _varRefGroup of
       VarGroupArgs -> vref
       VarGroupLocal -> mkVarRef VarGroupLocal (IndexMap.lookup mpv vref)
+
+    assignInBranch :: Code -> Index -> Index -> Code
+    assignInBranch is idx idx' =
+      is
+        ++ [ Assign
+               InstrAssign
+                 { _instrAssignResult = mkVarRef VarGroupLocal idx,
+                   _instrAssignValue = VRef $ mkVarRef VarGroupLocal idx'
+                 }
+           ]
 
 computeSSA :: InfoTable -> InfoTable
 computeSSA = mapT (const computeFunctionSSA)

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -255,19 +255,20 @@ fromAsmInstr funInfo tab si Asm.CmdInstr {..} =
 
 fromAsmBranch ::
   Asm.FunctionInfo ->
+  Bool ->
   Asm.StackInfo ->
   Asm.CmdBranch ->
   Code ->
   Code ->
   Sem r Instruction
-fromAsmBranch fi si Asm.CmdBranch {} codeTrue codeFalse =
+fromAsmBranch fi isTail si Asm.CmdBranch {} codeTrue codeFalse =
   return $
     Branch $
       InstrBranch
         { _instrBranchValue = VRef $ mkVarRef VarGroupLocal topIdx,
           _instrBranchTrue = codeTrue,
           _instrBranchFalse = codeFalse,
-          _instrBranchVar = Just $ mkVarRef VarGroupLocal topIdx
+          _instrBranchVar = if isTail then Nothing else Just $ mkVarRef VarGroupLocal topIdx
         }
   where
     topIdx :: Int
@@ -276,12 +277,13 @@ fromAsmBranch fi si Asm.CmdBranch {} codeTrue codeFalse =
 fromAsmCase ::
   Asm.FunctionInfo ->
   Asm.InfoTable ->
+  Bool ->
   Asm.StackInfo ->
   Asm.CmdCase ->
   [Code] ->
   Maybe Code ->
   Sem r Instruction
-fromAsmCase fi tab si Asm.CmdCase {..} brs def =
+fromAsmCase fi tab isTail si Asm.CmdCase {..} brs def =
   return $
     Case $
       InstrCase
@@ -305,7 +307,7 @@ fromAsmCase fi tab si Asm.CmdCase {..} brs def =
               _cmdCaseBranches
               brs,
           _instrCaseDefault = def,
-          _instrCaseVar = Just $ mkVarRef VarGroupLocal topIdx
+          _instrCaseVar = if isTail then Nothing else Just $ mkVarRef VarGroupLocal topIdx
         }
   where
     topIdx = fromJust (fi ^. Asm.functionExtra) ^. Asm.functionMaxTempStackHeight + si ^. Asm.stackInfoValueStackHeight - 1

--- a/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromAsm.hs
@@ -268,7 +268,7 @@ fromAsmBranch fi isTail si Asm.CmdBranch {} codeTrue codeFalse =
         { _instrBranchValue = VRef $ mkVarRef VarGroupLocal topIdx,
           _instrBranchTrue = codeTrue,
           _instrBranchFalse = codeFalse,
-          _instrBranchVar = if isTail then Nothing else Just $ mkVarRef VarGroupLocal topIdx
+          _instrBranchOutVar = if isTail then Nothing else Just $ mkVarRef VarGroupLocal topIdx
         }
   where
     topIdx :: Int
@@ -307,7 +307,7 @@ fromAsmCase fi tab isTail si Asm.CmdCase {..} brs def =
               _cmdCaseBranches
               brs,
           _instrCaseDefault = def,
-          _instrCaseVar = if isTail then Nothing else Just $ mkVarRef VarGroupLocal topIdx
+          _instrCaseOutVar = if isTail then Nothing else Just $ mkVarRef VarGroupLocal topIdx
         }
   where
     topIdx = fromJust (fi ^. Asm.functionExtra) ^. Asm.functionMaxTempStackHeight + si ^. Asm.stackInfoValueStackHeight - 1

--- a/src/Juvix/Compiler/Reg/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromSource.hs
@@ -262,11 +262,11 @@ liveVars = do
   P.try (comma >> symbol "live:")
   parens (P.sepBy varRef comma)
 
-branchVar ::
+outVar ::
   (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r VarRef
-branchVar = do
-  P.try (comma >> symbol "var:")
+outVar = do
+  P.try (comma >> symbol "out:")
   varRef
 
 parseArgs ::
@@ -359,7 +359,7 @@ instrBranch ::
 instrBranch = do
   kw kwBr
   val <- value
-  var <- optional branchVar
+  var <- optional outVar
   (br1, br2) <- braces $ do
     symbol "true:"
     br1 <- braces parseCode
@@ -373,7 +373,7 @@ instrBranch = do
       { _instrBranchValue = val,
         _instrBranchTrue = br1,
         _instrBranchFalse = br2,
-        _instrBranchVar = var
+        _instrBranchOutVar = var
       }
 
 instrCase ::
@@ -383,7 +383,7 @@ instrCase = do
   kw kwCase
   sym <- brackets (indSymbol @Code @() @VarRef)
   val <- value
-  var <- optional branchVar
+  var <- optional outVar
   lbrace
   brs <- many caseBranch
   def <- optional defaultBranch
@@ -395,7 +395,7 @@ instrCase = do
         _instrCaseIndRep = IndRepStandard,
         _instrCaseBranches = brs,
         _instrCaseDefault = def,
-        _instrCaseVar = var
+        _instrCaseOutVar = var
       }
 
 caseBranch ::

--- a/src/Juvix/Compiler/Reg/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromSource.hs
@@ -262,6 +262,13 @@ liveVars = do
   P.try (comma >> symbol "live:")
   parens (P.sepBy varRef comma)
 
+branchVar ::
+  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  ParsecS r VarRef
+branchVar = do
+  P.try (comma >> symbol "var:")
+  varRef
+
 parseArgs ::
   (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r [Value]
@@ -352,6 +359,7 @@ instrBranch ::
 instrBranch = do
   kw kwBr
   val <- value
+  var <- optional branchVar
   (br1, br2) <- braces $ do
     symbol "true:"
     br1 <- braces parseCode
@@ -364,7 +372,8 @@ instrBranch = do
     InstrBranch
       { _instrBranchValue = val,
         _instrBranchTrue = br1,
-        _instrBranchFalse = br2
+        _instrBranchFalse = br2,
+        _instrBranchVar = var
       }
 
 instrCase ::
@@ -374,6 +383,7 @@ instrCase = do
   kw kwCase
   sym <- brackets (indSymbol @Code @() @VarRef)
   val <- value
+  var <- optional branchVar
   lbrace
   brs <- many caseBranch
   def <- optional defaultBranch
@@ -384,7 +394,8 @@ instrCase = do
         _instrCaseInductive = sym,
         _instrCaseIndRep = IndRepStandard,
         _instrCaseBranches = brs,
-        _instrCaseDefault = def
+        _instrCaseDefault = def,
+        _instrCaseVar = var
       }
 
 caseBranch ::

--- a/test/Reg/Transformation.hs
+++ b/test/Reg/Transformation.hs
@@ -2,10 +2,12 @@ module Reg.Transformation where
 
 import Base
 import Reg.Transformation.Identity qualified as Identity
+import Reg.Transformation.SSA qualified as SSA
 
 allTests :: TestTree
 allTests =
   testGroup
     "JuvixReg transformations"
-    [ Identity.allTests
+    [ Identity.allTests,
+      SSA.allTests
     ]

--- a/test/Reg/Transformation/SSA.hs
+++ b/test/Reg/Transformation/SSA.hs
@@ -1,0 +1,22 @@
+module Reg.Transformation.SSA where
+
+import Base
+import Juvix.Compiler.Reg.Transformation
+import Juvix.Compiler.Reg.Transformation.SSA
+import Reg.Parse.Positive qualified as Parse
+import Reg.Transformation.Base
+
+allTests :: TestTree
+allTests = testGroup "SSA" (map liftTest Parse.tests)
+
+pipe :: [TransformationId]
+pipe = [SSA]
+
+liftTest :: Parse.PosTest -> TestTree
+liftTest _testRun =
+  fromTest
+    Test
+      { _testTransformations = pipe,
+        _testAssertion = \tab -> unless (checkSSA tab) $ error "check SSA",
+        _testRun
+      }

--- a/tests/Reg/positive/test008.jvr
+++ b/tests/Reg/positive/test008.jvr
@@ -10,7 +10,7 @@ function main() : * {
   tmp[0] = 3;
   tmp[1] = 0;
   tmp[0] = lt tmp[1] tmp[0];
-  br tmp[0], var: tmp[0] {
+  br tmp[0], out: tmp[0] {
     true: {
       tmp[0] = 1;
     };
@@ -21,7 +21,7 @@ function main() : * {
   tmp[1] = 1;
   tmp[2] = 2;
   tmp[1] = le tmp[2] tmp[1];
-  br tmp[1], var: tmp[1] {
+  br tmp[1], out: tmp[1] {
     true: {
       tmp[1] = call loop (), live: (tmp[0]);
     };
@@ -29,7 +29,7 @@ function main() : * {
       tmp[1] = 7;
       tmp[2] = 8;
       tmp[1] = le tmp[2] tmp[1];
-      br tmp[1], var: tmp[1] {
+      br tmp[1], out: tmp[1] {
         true: {
           tmp[1] = call loop (), live: (tmp[0]);
         };

--- a/tests/Reg/positive/test008.jvr
+++ b/tests/Reg/positive/test008.jvr
@@ -10,7 +10,7 @@ function main() : * {
   tmp[0] = 3;
   tmp[1] = 0;
   tmp[0] = lt tmp[1] tmp[0];
-  br tmp[0] {
+  br tmp[0], var: tmp[0] {
     true: {
       tmp[0] = 1;
     };
@@ -21,7 +21,7 @@ function main() : * {
   tmp[1] = 1;
   tmp[2] = 2;
   tmp[1] = le tmp[2] tmp[1];
-  br tmp[1] {
+  br tmp[1], var: tmp[1] {
     true: {
       tmp[1] = call loop (), live: (tmp[0]);
     };
@@ -29,7 +29,7 @@ function main() : * {
       tmp[1] = 7;
       tmp[2] = 8;
       tmp[1] = le tmp[2] tmp[1];
-      br tmp[1] {
+      br tmp[1], var: tmp[1] {
         true: {
           tmp[1] = call loop (), live: (tmp[0]);
         };

--- a/tests/Reg/positive/test010.jvr
+++ b/tests/Reg/positive/test010.jvr
@@ -6,7 +6,7 @@ function sum(integer) : integer {
   tmp[0] = arg[0];
   tmp[1] = 0;
   tmp[0] = eq tmp[1] tmp[0];
-  br tmp[0] {
+  br tmp[0], var: tmp[0] {
     true: {
       tmp[0] = 0;
     };

--- a/tests/Reg/positive/test010.jvr
+++ b/tests/Reg/positive/test010.jvr
@@ -6,7 +6,7 @@ function sum(integer) : integer {
   tmp[0] = arg[0];
   tmp[1] = 0;
   tmp[0] = eq tmp[1] tmp[0];
-  br tmp[0], var: tmp[0] {
+  br tmp[0], out: tmp[0] {
     true: {
       tmp[0] = 0;
     };

--- a/tests/Reg/positive/test031.jvr
+++ b/tests/Reg/positive/test031.jvr
@@ -56,7 +56,7 @@ function f(tree) : integer {
           {
             tmp[2] = tmp[5];
             tmp[5] = tmp[1];
-            case[tree] tmp[5], var: tmp[5] {
+            case[tree] tmp[5], out: tmp[5] {
               leaf: {
                 nop;
                 tmp[5] = 3;
@@ -79,7 +79,7 @@ function f(tree) : integer {
             {
               tmp[3] = tmp[5];
               tmp[5] = tmp[2];
-              case[tree] tmp[5], var: tmp[5] {
+              case[tree] tmp[5], out: tmp[5] {
                 node: {
                   {
                     tmp[4] = tmp[5];

--- a/tests/Reg/positive/test031.jvr
+++ b/tests/Reg/positive/test031.jvr
@@ -56,7 +56,7 @@ function f(tree) : integer {
           {
             tmp[2] = tmp[5];
             tmp[5] = tmp[1];
-            case[tree] tmp[5] {
+            case[tree] tmp[5], var: tmp[5] {
               leaf: {
                 nop;
                 tmp[5] = 3;
@@ -79,7 +79,7 @@ function f(tree) : integer {
             {
               tmp[3] = tmp[5];
               tmp[5] = tmp[2];
-              case[tree] tmp[5] {
+              case[tree] tmp[5], var: tmp[5] {
                 node: {
                   {
                     tmp[4] = tmp[5];


### PR DESCRIPTION
* Closes #2560 
* Adds a transformation of JuvixReg into SSA form.
* Adds an "output variable" field to branching instructions (`Case`, `Branch`) which indicates the output variable to which the result is assigned in both branches. The output variable corresponds to top of stack in JuvixAsm after executing the branches. In the SSA transformation, differently renamed output variables are unified by inserting assignment instructions at the end of branches.
* Adds tests for the SSA transformation.
* Depends on #2641.
