### PR TITLE
JuvixReg cleanup transformation

### DIFF
--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -34,7 +34,7 @@ import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Compiler.Pipeline.Result
 import Juvix.Compiler.Pipeline.Root.Base
-import Juvix.Compiler.Reg.Data.InfoTable qualified as Reg
+import Juvix.Compiler.Reg.Pipeline qualified as Reg
 import Juvix.Compiler.Reg.Translation.FromAsm qualified as Reg
 import Juvix.Compiler.Store.Language qualified as Store
 import Juvix.Compiler.Tree qualified as Tree
@@ -202,8 +202,9 @@ asmToMiniC = asmToReg >=> regToMiniC
 
 regToMiniC :: (Member (Reader EntryPoint) r) => Reg.InfoTable -> Sem r C.MiniCResult
 regToMiniC tab = do
+  tab' <- Reg.toC tab
   e <- ask
-  return $ C.fromReg (Backend.getLimits (e ^. entryPointTarget) (e ^. entryPointDebug)) tab
+  return $ C.fromReg (Backend.getLimits (e ^. entryPointTarget) (e ^. entryPointDebug)) tab'
 
 treeToNockma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Cell Natural)
 treeToNockma' = Tree.toNockma >=> NockmaTree.fromTreeTable

--- a/src/Juvix/Compiler/Reg/Data/TransformationId.hs
+++ b/src/Juvix/Compiler/Reg/Data/TransformationId.hs
@@ -7,26 +7,28 @@ import Juvix.Prelude
 data TransformationId
   = Identity
   | SSA
+  | Cleanup
   deriving stock (Data, Bounded, Enum, Show)
 
 data PipelineId
-  = PipelineC
-  | PipelineCairo
+  = PipelineCairo
+  | PipelineC
   deriving stock (Data, Bounded, Enum)
 
 type TransformationLikeId = TransformationLikeId' TransformationId PipelineId
 
 toCTransformations :: [TransformationId]
-toCTransformations = []
+toCTransformations = [Cleanup]
 
 toCairoTransformations :: [TransformationId]
-toCairoTransformations = [SSA]
+toCairoTransformations = [Cleanup, SSA]
 
 instance TransformationId' TransformationId where
   transformationText :: TransformationId -> Text
   transformationText = \case
     Identity -> strIdentity
     SSA -> strSSA
+    Cleanup -> strCleanup
 
 instance PipelineId' TransformationId PipelineId where
   pipelineText :: PipelineId -> Text

--- a/src/Juvix/Compiler/Reg/Data/TransformationId/Strings.hs
+++ b/src/Juvix/Compiler/Reg/Data/TransformationId/Strings.hs
@@ -13,3 +13,6 @@ strIdentity = "identity"
 
 strSSA :: Text
 strSSA = "ssa"
+
+strCleanup :: Text
+strCleanup = "cleanup"

--- a/src/Juvix/Compiler/Reg/Pipeline.hs
+++ b/src/Juvix/Compiler/Reg/Pipeline.hs
@@ -1,0 +1,16 @@
+module Juvix.Compiler.Reg.Pipeline
+  ( module Juvix.Compiler.Reg.Pipeline,
+    module Juvix.Compiler.Reg.Data.InfoTable,
+  )
+where
+
+import Juvix.Compiler.Reg.Data.InfoTable
+import Juvix.Compiler.Reg.Transformation
+
+-- | Perform transformations on JuvixReg necessary before the translation to C
+toC :: InfoTable -> Sem r InfoTable
+toC = applyTransformations toCTransformations
+
+-- | Perform transformations on JuvixReg necessary before the translation to Cairo
+toCairo :: InfoTable -> Sem r InfoTable
+toCairo = applyTransformations toCairoTransformations

--- a/src/Juvix/Compiler/Reg/Transformation.hs
+++ b/src/Juvix/Compiler/Reg/Transformation.hs
@@ -7,6 +7,7 @@ where
 
 import Juvix.Compiler.Reg.Data.TransformationId
 import Juvix.Compiler.Reg.Transformation.Base
+import Juvix.Compiler.Reg.Transformation.Cleanup
 import Juvix.Compiler.Reg.Transformation.Identity
 import Juvix.Compiler.Reg.Transformation.SSA
 
@@ -17,3 +18,4 @@ applyTransformations ts tbl = foldM (flip appTrans) tbl ts
     appTrans = \case
       Identity -> return . identity
       SSA -> return . computeSSA
+      Cleanup -> return . cleanup

--- a/src/Juvix/Compiler/Reg/Transformation/Cleanup.hs
+++ b/src/Juvix/Compiler/Reg/Transformation/Cleanup.hs
@@ -1,0 +1,13 @@
+module Juvix.Compiler.Reg.Transformation.Cleanup where
+
+import Juvix.Compiler.Reg.Extra.Recursors
+import Juvix.Compiler.Reg.Transformation.Base
+
+cleanup :: InfoTable -> InfoTable
+cleanup = mapT (const (cmap go))
+  where
+    go :: Code -> Code
+    go = \case
+      Nop : is -> is
+      Block InstrBlock {..} : is -> _instrBlockCode ++ is
+      is -> is


### PR DESCRIPTION
* Adds a cleanup transformation which removes `Nop` and `Block` instructions.
* Depends on #2646 
