### PR TITLE
Use the target of aliases when resolving name signatures and iterators

### DIFF
--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -106,8 +106,8 @@ anameFromScopedIden s =
     { _anameLoc = getLoc s,
       _anameKind = getNameKind s,
       _anameDocId = s ^. scopedIdenFinal . nameId,
-      _anameDefinedLoc = s ^. scopedIdenName . nameDefined,
-      _anameVerbatim = s ^. scopedIdenName . nameVerbatim
+      _anameDefinedLoc = s ^. scopedIdenSrcName . nameDefined,
+      _anameVerbatim = s ^. scopedIdenSrcName . nameVerbatim
     }
 
 lookupInfo :: (Members '[InfoTableBuilder, Reader InfoTable] r) => (InfoTable -> Maybe a) -> Sem r a

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -101,13 +101,13 @@ recordNameSignatureByIndex = IntMap.fromList . (^.. recordNames . each . to mkAs
 
 getExpressionAtomIden :: ExpressionAtom 'Scoped -> Maybe S.Name
 getExpressionAtomIden = \case
-  AtomIdentifier nm -> Just (nm ^. scopedIdenName)
+  AtomIdentifier nm -> Just (nm ^. scopedIdenSrcName)
   _ -> Nothing
 
 getPatternAtomIden :: PatternAtom 'Scoped -> Maybe S.Name
 getPatternAtomIden = \case
   PatternAtomIden i -> case i of
-    PatternScopedConstructor c -> Just (c ^. scopedIdenName)
+    PatternScopedConstructor c -> Just (c ^. scopedIdenSrcName)
     _ -> Nothing
   _ -> Nothing
 

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -2285,10 +2285,10 @@ instance (SingI s) => HasAtomicity (FunctionParameters s) where
         SScoped -> atomicity (p ^. paramType)
 
 instance Pretty ScopedIden where
-  pretty = pretty . (^. scopedIdenName)
+  pretty = pretty . (^. scopedIdenSrcName)
 
 instance HasLoc ScopedIden where
-  getLoc = getLoc . (^. scopedIdenName)
+  getLoc = getLoc . (^. scopedIdenSrcName)
 
 instance (SingI s) => HasLoc (InductiveParameters s) where
   getLoc i = getLocSymbolType (i ^. inductiveParametersNames . _head1) <>? (getLocExpressionType <$> (i ^? inductiveParametersRhs . _Just . inductiveParametersType))
@@ -2668,7 +2668,7 @@ instance IsApe PatternInfixApp ApeLeaf where
         { _infixFixity = getFixity i,
           _infixLeft = toApe l,
           _infixRight = toApe r,
-          _infixIsDelimiter = isDelimiterStr (prettyText (op ^. scopedIdenName . S.nameConcrete)),
+          _infixIsDelimiter = isDelimiterStr (prettyText (op ^. scopedIdenSrcName . S.nameConcrete)),
           _infixOp = ApeLeafPattern (PatternConstructor op)
         }
 
@@ -2732,7 +2732,7 @@ instance IsApe InfixApplication ApeLeaf where
         { _infixFixity = getFixity i,
           _infixLeft = toApe l,
           _infixRight = toApe r,
-          _infixIsDelimiter = isDelimiterStr (prettyText (op ^. scopedIdenName . S.nameConcrete)),
+          _infixIsDelimiter = isDelimiterStr (prettyText (op ^. scopedIdenSrcName . S.nameConcrete)),
           _infixOp = ApeLeafExpression (ExpressionIdentifier op)
         }
 
@@ -2856,8 +2856,8 @@ _RecordStatementField f x = case x of
   RecordStatementField p -> RecordStatementField <$> f p
   _ -> pure x
 
-scopedIdenName :: Lens' ScopedIden S.Name
-scopedIdenName f n = case n ^. scopedIdenAlias of
+scopedIdenSrcName :: Lens' ScopedIden S.Name
+scopedIdenSrcName f n = case n ^. scopedIdenAlias of
   Nothing -> scopedIdenFinal f n
   Just a -> do
     a' <- f a
@@ -2871,16 +2871,16 @@ fromParsedIteratorInfo ParsedIteratorInfo {..} =
     }
 
 instance HasFixity PostfixApplication where
-  getFixity (PostfixApplication _ op) = fromMaybe impossible (op ^. scopedIdenName . S.nameFixity)
+  getFixity (PostfixApplication _ op) = fromMaybe impossible (op ^. scopedIdenSrcName . S.nameFixity)
 
 instance HasFixity InfixApplication where
-  getFixity (InfixApplication _ op _) = fromMaybe impossible (op ^. scopedIdenName . S.nameFixity)
+  getFixity (InfixApplication _ op _) = fromMaybe impossible (op ^. scopedIdenSrcName . S.nameFixity)
 
 instance HasFixity PatternInfixApp where
-  getFixity (PatternInfixApp _ op _) = fromMaybe impossible (op ^. scopedIdenName . S.nameFixity)
+  getFixity (PatternInfixApp _ op _) = fromMaybe impossible (op ^. scopedIdenSrcName . S.nameFixity)
 
 instance HasFixity PatternPostfixApp where
-  getFixity (PatternPostfixApp _ op) = fromMaybe impossible (op ^. scopedIdenName . S.nameFixity)
+  getFixity (PatternPostfixApp _ op) = fromMaybe impossible (op ^. scopedIdenSrcName . S.nameFixity)
 
 instance HasAtomicity (ListPattern s) where
   atomicity = const Atom

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -461,7 +461,7 @@ instance PrettyPrint ScopedModule where
   ppCode m = ppCode (m ^. scopedModuleName)
 
 instance PrettyPrint ScopedIden where
-  ppCode = ppCode . (^. scopedIdenName)
+  ppCode = ppCode . (^. scopedIdenSrcName)
 
 instance (SingI s) => PrettyPrint (AliasDef s) where
   ppCode AliasDef {..} =

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -757,7 +757,7 @@ goExpression = \case
     goNamedApplicationNew napp extraArgs = case nonEmpty (napp ^. namedApplicationNewArguments) of
       Nothing -> return (goIden (napp ^. namedApplicationNewName))
       Just appargs -> do
-        let name = napp ^. namedApplicationNewName . scopedIdenName
+        let name = napp ^. namedApplicationNewName . scopedIdenFinal
         sig <- fromJust <$> asks (^. S.infoNameSigs . at (name ^. S.nameId))
         cls <- goArgs appargs
         let args :: [Internal.Name] = appargs ^.. each . namedArgumentNewFunDef . signName . to goSymbol

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete/NamedArguments.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete/NamedArguments.hs
@@ -70,7 +70,7 @@ runNamedArguments napp extraArgs = do
   where
     mkIniBuilderState :: Sem r BuilderState
     mkIniBuilderState = do
-      let name = napp ^. namedAppName . scopedIdenName
+      let name = napp ^. namedAppName . scopedIdenFinal
       msig <- asks @NameSignatures (^. at (name ^. S.nameId))
       let sig = fromMaybe err msig
             where

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -319,6 +319,10 @@ tests =
       "Typecheck constructor wildcard"
       $(mkRelDir ".")
       $(mkRelFile "ConstructorWildcard.juvix"),
+    posTest
+      "Typecheck record constructor alias"
+      $(mkRelDir ".")
+      $(mkRelFile "AliasRecordConstructor.juvix"),
     posTestAbsDir
       "Typecheck orphan file"
       (relToProject $(mkRelDir "tests/WithoutPackageFile"))

--- a/tests/positive/AliasRecordConstructor.juvix
+++ b/tests/positive/AliasRecordConstructor.juvix
@@ -1,0 +1,12 @@
+module AliasRecordConstructor;
+
+type A := a;
+
+type T := mkT {field : A};
+
+syntax alias mkT' := mkT;
+
+t : T :=
+  mkT'@{
+    field := a
+  };

--- a/tests/positive/AliasRecordConstructor.juvix
+++ b/tests/positive/AliasRecordConstructor.juvix
@@ -10,3 +10,14 @@ t : T :=
   mkT'@{
     field := a
   };
+
+t1 : T -> A
+ | mkT'@{ field := x } := x;
+
+syntax iterator it {init := 0; range := 1};
+it : (A → A) → T → A
+  | _ (mkT a) := a;
+
+syntax alias it' := it;
+
+t2 (t : T) : A := it' (a in t) a;


### PR DESCRIPTION
* Closes https://github.com/anoma/juvix/issues/2664

As well as this fix we rename lens scopedIdenName to scopedIdenSrcName. `scopedIdenSrcName` refers to the name of an identifier from the source code. The name `scopedIdenName` is confusing because users of `ScopedIden` may think that this lens refers to the only name associated with `ScopedIden`, they may want `scopedIdenNameFinal` instead.