### PR TITLE
Anoma transaction fix

### DIFF
--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -27,7 +27,7 @@ runCommand opts@CompileOptions {..} = do
     TargetTree -> Compile.runTreePipeline arg
     TargetAsm -> Compile.runAsmPipeline arg
     TargetReg -> Compile.runRegPipeline arg
-    TargetNockma -> Compile.runNockmaPipeline arg
+    TargetNockma -> impossible
     TargetAnoma -> Compile.runAnomaPipeline arg
     TargetCasm -> Compile.runCasmPipeline arg
 

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -27,7 +27,6 @@ runCommand opts@CompileOptions {..} = do
     TargetTree -> Compile.runTreePipeline arg
     TargetAsm -> Compile.runAsmPipeline arg
     TargetReg -> Compile.runRegPipeline arg
-    TargetNockma -> impossible
     TargetAnoma -> Compile.runAnomaPipeline arg
     TargetCasm -> Compile.runCasmPipeline arg
 

--- a/app/Commands/Dev/Asm/Compile.hs
+++ b/app/Commands/Dev/Asm/Compile.hs
@@ -70,7 +70,6 @@ runCommand opts = do
       TargetNative64 -> return Backend.TargetCNative64
       TargetReg -> return Backend.TargetReg
       TargetCasm -> return Backend.TargetCairo
-      TargetNockma -> err "Nockma"
       TargetAnoma -> err "Anoma"
       TargetTree -> err "JuvixTree"
       TargetGeb -> err "GEB"

--- a/app/Commands/Dev/Core/Compile.hs
+++ b/app/Commands/Dev/Core/Compile.hs
@@ -21,7 +21,6 @@ runCommand opts = do
     TargetAsm -> runAsmPipeline arg
     TargetReg -> runRegPipeline arg
     TargetTree -> runTreePipeline arg
-    TargetNockma -> impossible
     TargetAnoma -> runAnomaPipeline arg
     TargetCasm -> runCasmPipeline arg
   where

--- a/app/Commands/Dev/Core/Compile.hs
+++ b/app/Commands/Dev/Core/Compile.hs
@@ -21,7 +21,7 @@ runCommand opts = do
     TargetAsm -> runAsmPipeline arg
     TargetReg -> runRegPipeline arg
     TargetTree -> runTreePipeline arg
-    TargetNockma -> runNockmaPipeline arg
+    TargetNockma -> impossible
     TargetAnoma -> runAnomaPipeline arg
     TargetCasm -> runCasmPipeline arg
   where

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -46,7 +46,6 @@ getEntry PipelineArg {..} = do
       TargetAsm -> Backend.TargetAsm
       TargetReg -> Backend.TargetReg
       TargetTree -> Backend.TargetTree
-      TargetNockma -> Backend.TargetNockma
       TargetAnoma -> Backend.TargetAnoma
       TargetCasm -> Backend.TargetCairo
 

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -2,6 +2,7 @@ module Commands.Dev.Core.Compile.Base where
 
 import Commands.Base
 import Commands.Dev.Core.Compile.Options
+import Commands.Dev.Tree.Compile.Base (outputAnomaResult)
 import Commands.Extra.Compile qualified as Compile
 import Juvix.Compiler.Asm.Pretty qualified as Asm
 import Juvix.Compiler.Backend qualified as Backend
@@ -12,7 +13,6 @@ import Juvix.Compiler.Casm.Data.Result qualified as Casm
 import Juvix.Compiler.Casm.Pretty qualified as Casm
 import Juvix.Compiler.Core.Data.Module qualified as Core
 import Juvix.Compiler.Core.Data.TransformationId qualified as Core
-import Juvix.Compiler.Nockma.Pretty qualified as Nockma
 import Juvix.Compiler.Reg.Pretty qualified as Reg
 import Juvix.Compiler.Tree.Pretty qualified as Tree
 import Juvix.Prelude.Pretty
@@ -156,9 +156,8 @@ runAnomaPipeline pa@PipelineArg {..} = do
       . runError @JuvixError
       . coreToAnoma
       $ _pipelineArgModule
-  tab' <- getRight r
-  let code = Nockma.ppSerialize tab'
-  writeFileEnsureLn nockmaFile code
+  res <- getRight r
+  outputAnomaResult nockmaFile res
 
 runCasmPipeline :: (Members '[EmbedIO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runCasmPipeline pa@PipelineArg {..} = do

--- a/app/Commands/Dev/Core/Compile/Base.hs
+++ b/app/Commands/Dev/Core/Compile/Base.hs
@@ -147,19 +147,6 @@ runTreePipeline pa@PipelineArg {..} = do
   let code = Tree.ppPrint tab' tab'
   writeFileEnsureLn treeFile code
 
-runNockmaPipeline :: (Members '[EmbedIO, App, TaggedLock] r) => PipelineArg -> Sem r ()
-runNockmaPipeline pa@PipelineArg {..} = do
-  entryPoint <- getEntry pa
-  nockmaFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
-  r <-
-    runReader entryPoint
-      . runError @JuvixError
-      . coreToNockma
-      $ _pipelineArgModule
-  tab' <- getRight r
-  let code = Nockma.ppSerialize tab'
-  writeFileEnsureLn nockmaFile code
-
 runAnomaPipeline :: (Members '[EmbedIO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runAnomaPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa

--- a/app/Commands/Dev/Nockma.hs
+++ b/app/Commands/Dev/Nockma.hs
@@ -5,9 +5,11 @@ import Commands.Dev.Nockma.Eval as Eval
 import Commands.Dev.Nockma.Format as Format
 import Commands.Dev.Nockma.Options
 import Commands.Dev.Nockma.Repl as Repl
+import Commands.Dev.Nockma.Run as Run
 
 runCommand :: forall r. (Members '[EmbedIO, App] r) => NockmaCommand -> Sem r ()
 runCommand = \case
   NockmaRepl opts -> Repl.runCommand opts
   NockmaEval opts -> Eval.runCommand opts
   NockmaFormat opts -> Format.runCommand opts
+  NockmaRun opts -> Run.runCommand opts

--- a/app/Commands/Dev/Nockma/Eval.hs
+++ b/app/Commands/Dev/Nockma/Eval.hs
@@ -3,7 +3,7 @@ module Commands.Dev.Nockma.Eval where
 import Commands.Base hiding (Atom)
 import Commands.Dev.Nockma.Eval.Options
 import Juvix.Compiler.Nockma.EvalCompiled
-import Juvix.Compiler.Nockma.Evaluator.Options
+import Juvix.Compiler.Nockma.Evaluator
 import Juvix.Compiler.Nockma.Pretty
 import Juvix.Compiler.Nockma.Translation.FromSource qualified as Nockma
 
@@ -14,12 +14,18 @@ runCommand opts = do
   case parsedTerm of
     Left err -> exitJuvixError (JuvixError err)
     Right (TermCell c) -> do
-      res <-
-        runReader defaultEvalOptions
+      (counts, res) <-
+        runOpCounts
+          . runReader defaultEvalOptions
           . runOutputSem @(Term Natural) (say . ppTrace)
           $ evalCompiledNock' (c ^. cellLeft) (c ^. cellRight)
       putStrLn (ppPrint res)
+      let statsFile = replaceExtension' ".profile" afile
+      writeFileEnsureLn statsFile (prettyText counts)
     Right TermAtom {} -> exitFailMsg "Expected nockma input to be a cell"
   where
     file :: AppPath File
     file = opts ^. nockmaEvalFile
+
+--- run-anoma --env ENV_FILE --profile INPUT_FILE
+---

--- a/app/Commands/Dev/Nockma/Eval/Options.hs
+++ b/app/Commands/Dev/Nockma/Eval/Options.hs
@@ -2,8 +2,9 @@ module Commands.Dev.Nockma.Eval.Options where
 
 import CommonOptions
 
-newtype NockmaEvalOptions = NockmaEvalOptions
-  { _nockmaEvalFile :: AppPath File
+data NockmaEvalOptions = NockmaEvalOptions
+  { _nockmaEvalFile :: AppPath File,
+    _nockmaEvalProfile :: Bool
   }
   deriving stock (Data)
 
@@ -12,4 +13,9 @@ makeLenses ''NockmaEvalOptions
 parseNockmaEvalOptions :: Parser NockmaEvalOptions
 parseNockmaEvalOptions = do
   _nockmaEvalFile <- parseInputFile FileExtNockma
+  _nockmaEvalProfile <-
+    switch
+      ( long "profile"
+          <> help "Report evaluator profiling statistics"
+      )
   pure NockmaEvalOptions {..}

--- a/app/Commands/Dev/Nockma/Options.hs
+++ b/app/Commands/Dev/Nockma/Options.hs
@@ -3,12 +3,14 @@ module Commands.Dev.Nockma.Options where
 import Commands.Dev.Nockma.Eval.Options
 import Commands.Dev.Nockma.Format.Options
 import Commands.Dev.Nockma.Repl.Options
+import Commands.Dev.Nockma.Run.Options
 import CommonOptions
 
 data NockmaCommand
   = NockmaRepl NockmaReplOptions
   | NockmaEval NockmaEvalOptions
   | NockmaFormat NockmaFormatOptions
+  | NockmaRun NockmaRunOptions
   deriving stock (Data)
 
 parseNockmaCommand :: Parser NockmaCommand
@@ -17,9 +19,19 @@ parseNockmaCommand =
     mconcat
       [ commandRepl,
         commandFromAsm,
-        commandFormat
+        commandFormat,
+        commandRun
       ]
   where
+    commandRun :: Mod CommandFields NockmaCommand
+    commandRun = command "run" runInfo
+      where
+        runInfo :: ParserInfo NockmaCommand
+        runInfo =
+          info
+            (NockmaRun <$> parseNockmaRunOptions)
+            (progDesc "Run an Anoma program. It should be used with artefacts obtained from compilation with the anoma target.")
+
     commandFromAsm :: Mod CommandFields NockmaCommand
     commandFromAsm = command "eval" fromAsmInfo
       where

--- a/app/Commands/Dev/Nockma/Run.hs
+++ b/app/Commands/Dev/Nockma/Run.hs
@@ -1,0 +1,37 @@
+module Commands.Dev.Nockma.Run where
+
+import Commands.Base hiding (Atom)
+import Commands.Dev.Nockma.Run.Options
+import Juvix.Compiler.Nockma.Anoma
+import Juvix.Compiler.Nockma.EvalCompiled
+import Juvix.Compiler.Nockma.Evaluator
+import Juvix.Compiler.Nockma.Pretty
+import Juvix.Compiler.Nockma.Translation.FromSource qualified as Nockma
+import Juvix.Parser.Error
+
+runCommand :: forall r. (Members '[EmbedIO, App] r) => NockmaRunOptions -> Sem r ()
+runCommand opts = do
+  afile <- fromAppPathFile inputFile
+  envFile <- fromAppPathFile (opts ^. nockmaEnvFile)
+  parsedEnvFile <- Nockma.parseTermFile envFile >>= checkParsed
+  parsedTerm <- Nockma.parseTermFile afile >>= checkParsed
+  case parsedTerm of
+    t@(TermCell {}) -> do
+      let formula = anomaCall parsedEnvFile []
+      (counts, res) <-
+        runOpCounts
+          . runReader defaultEvalOptions
+          . runOutputSem @(Term Natural) (say . ppTrace)
+          $ evalCompiledNock' t formula
+      putStrLn (ppPrint res)
+      let statsFile = replaceExtension' ".profile" afile
+      writeFileEnsureLn statsFile (prettyText counts)
+    TermAtom {} -> exitFailMsg "Expected nockma input to be a cell"
+  where
+    inputFile :: AppPath File
+    inputFile = opts ^. nockmaRunFile
+
+    checkParsed :: Either MegaparsecError (Term Natural) -> Sem r (Term Natural)
+    checkParsed = \case
+      Left err -> exitJuvixError (JuvixError err)
+      Right tm -> return tm

--- a/app/Commands/Dev/Nockma/Run/Options.hs
+++ b/app/Commands/Dev/Nockma/Run/Options.hs
@@ -1,0 +1,32 @@
+module Commands.Dev.Nockma.Run.Options where
+
+import CommonOptions
+
+data NockmaRunOptions = NockmaRunOptions
+  { _nockmaRunFile :: AppPath File,
+    _nockmaEnvFile :: AppPath File,
+    _nockmaRunProfile :: Bool
+  }
+  deriving stock (Data)
+
+makeLenses ''NockmaRunOptions
+
+parseNockmaRunOptions :: Parser NockmaRunOptions
+parseNockmaRunOptions = do
+  _nockmaRunFile <- parseInputFile FileExtNockma
+  _nockmaEnvFile <- do
+    _pathPath <-
+      option
+        somePreFileOpt
+        ( long "env"
+            <> metavar "INPUT_ENV_FILE"
+            <> help "Path to environment file"
+            <> action "file"
+        )
+    pure AppPath {_pathIsInput = True, ..}
+  _nockmaRunProfile <-
+    switch
+      ( long "profile"
+          <> help "Report evaluator profiling statistics"
+      )
+  pure NockmaRunOptions {..}

--- a/app/Commands/Dev/Reg/Compile.hs
+++ b/app/Commands/Dev/Reg/Compile.hs
@@ -59,7 +59,6 @@ runCommand opts = do
       TargetNative64 -> return Backend.TargetCNative64
       TargetCasm -> return Backend.TargetCairo
       TargetReg -> err "JuvixReg"
-      TargetNockma -> err "Nockma"
       TargetAnoma -> err "Anoma"
       TargetTree -> err "JuvixTree"
       TargetGeb -> err "GEB"

--- a/app/Commands/Dev/Tree/Compile.hs
+++ b/app/Commands/Dev/Tree/Compile.hs
@@ -20,7 +20,7 @@ runCommand opts = do
     TargetAsm -> runAsmPipeline arg
     TargetReg -> runRegPipeline arg
     TargetTree -> return ()
-    TargetNockma -> runNockmaPipeline arg
+    TargetNockma -> impossible
     TargetAnoma -> runAnomaPipeline arg
     TargetCasm -> runCasmPipeline arg
   where

--- a/app/Commands/Dev/Tree/Compile.hs
+++ b/app/Commands/Dev/Tree/Compile.hs
@@ -20,7 +20,6 @@ runCommand opts = do
     TargetAsm -> runAsmPipeline arg
     TargetReg -> runRegPipeline arg
     TargetTree -> return ()
-    TargetNockma -> impossible
     TargetAnoma -> runAnomaPipeline arg
     TargetCasm -> runCasmPipeline arg
   where

--- a/app/Commands/Dev/Tree/Compile/Base.hs
+++ b/app/Commands/Dev/Tree/Compile/Base.hs
@@ -119,9 +119,9 @@ runAnomaPipeline pa@PipelineArg {..} = do
 
 outputAnomaResult :: (Members '[EmbedIO, App] r) => Path Abs File -> Nockma.AnomaResult -> Sem r ()
 outputAnomaResult nockmaFile Nockma.AnomaResult {..} = do
-  let envFile = replaceExtension' ".env.nockma" nockmaFile
+  let envFile = replaceExtensions' [".env", ".nockma"] nockmaFile
       code = Nockma.ppSerialize _anomaClosure
-      prettyNockmaFile = replaceExtension' ".pretty.nockma" nockmaFile
+      prettyNockmaFile = replaceExtensions' [".pretty",".nockma"] nockmaFile
   writeFileEnsureLn nockmaFile code
   writeFileEnsureLn envFile (Nockma.ppSerialize _anomaEnv)
   writeFileEnsureLn prettyNockmaFile (Nockma.ppPrint _anomaClosure)

--- a/app/Commands/Dev/Tree/Compile/Base.hs
+++ b/app/Commands/Dev/Tree/Compile/Base.hs
@@ -104,19 +104,6 @@ runRegPipeline pa@PipelineArg {..} = do
   let code = Reg.ppPrint tab' tab'
   writeFileEnsureLn regFile code
 
-runNockmaPipeline :: (Members '[EmbedIO, App, TaggedLock] r) => PipelineArg -> Sem r ()
-runNockmaPipeline pa@PipelineArg {..} = do
-  entryPoint <- getEntry pa
-  nockmaFile <- Compile.outputFile _pipelineArgOptions _pipelineArgFile
-  r <-
-    runReader entryPoint
-      . runError @JuvixError
-      . treeToNockma
-      $ _pipelineArgTable
-  tab' <- getRight r
-  let code = Nockma.ppSerialize tab'
-  writeFileEnsureLn nockmaFile code
-
 runAnomaPipeline :: (Members '[EmbedIO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runAnomaPipeline pa@PipelineArg {..} = do
   entryPoint <- getEntry pa

--- a/app/Commands/Dev/Tree/Compile/Base.hs
+++ b/app/Commands/Dev/Tree/Compile/Base.hs
@@ -42,7 +42,6 @@ getEntry PipelineArg {..} = do
       TargetAsm -> Backend.TargetAsm
       TargetReg -> Backend.TargetReg
       TargetTree -> Backend.TargetTree
-      TargetNockma -> Backend.TargetNockma
       TargetAnoma -> Backend.TargetAnoma
       TargetCasm -> Backend.TargetCairo
 
@@ -121,7 +120,7 @@ outputAnomaResult :: (Members '[EmbedIO, App] r) => Path Abs File -> Nockma.Anom
 outputAnomaResult nockmaFile Nockma.AnomaResult {..} = do
   let envFile = replaceExtensions' [".env", ".nockma"] nockmaFile
       code = Nockma.ppSerialize _anomaClosure
-      prettyNockmaFile = replaceExtensions' [".pretty",".nockma"] nockmaFile
+      prettyNockmaFile = replaceExtensions' [".pretty", ".nockma"] nockmaFile
   writeFileEnsureLn nockmaFile code
   writeFileEnsureLn envFile (Nockma.ppSerialize _anomaEnv)
   writeFileEnsureLn prettyNockmaFile (Nockma.ppPrint _anomaClosure)

--- a/app/Commands/Dev/Tree/Compile/Base.hs
+++ b/app/Commands/Dev/Tree/Compile/Base.hs
@@ -121,9 +121,11 @@ outputAnomaResult nockmaFile Nockma.AnomaResult {..} = do
   let envFile = replaceExtensions' [".env", ".nockma"] nockmaFile
       code = Nockma.ppSerialize _anomaClosure
       prettyNockmaFile = replaceExtensions' [".pretty", ".nockma"] nockmaFile
+      prettyEnvFile = replaceExtensions' [".env", ".pretty", ".nockma"] nockmaFile
   writeFileEnsureLn nockmaFile code
   writeFileEnsureLn envFile (Nockma.ppSerialize _anomaEnv)
   writeFileEnsureLn prettyNockmaFile (Nockma.ppPrint _anomaClosure)
+  writeFileEnsureLn prettyEnvFile (Nockma.ppPrint _anomaEnv)
 
 runCasmPipeline :: (Members '[EmbedIO, App, TaggedLock] r) => PipelineArg -> Sem r ()
 runCasmPipeline pa@PipelineArg {..} = do

--- a/app/Commands/Dev/Tree/Compile/Options.hs
+++ b/app/Commands/Dev/Tree/Compile/Options.hs
@@ -14,8 +14,8 @@ treeSupportedTargets =
       TargetNative64,
       TargetAsm,
       TargetReg,
-      TargetNockma,
-      TargetCasm
+      TargetCasm,
+      TargetAnoma
     ]
 
 parseTreeCompileOptions :: Parser CompileOptions

--- a/app/Commands/Extra/Compile.hs
+++ b/app/Commands/Extra/Compile.hs
@@ -35,7 +35,6 @@ runCompile inputFile o = do
     TargetAsm -> return (Right ())
     TargetReg -> return (Right ())
     TargetTree -> return (Right ())
-    TargetNockma -> return (Right ())
     TargetAnoma -> return (Right ())
     TargetCasm -> return (Right ())
 
@@ -55,7 +54,6 @@ prepareRuntime buildDir o = do
     TargetAsm -> return ()
     TargetReg -> return ()
     TargetTree -> return ()
-    TargetNockma -> return ()
     TargetAnoma -> return ()
     TargetCasm -> return ()
   where
@@ -119,8 +117,6 @@ outputFile opts inputFile =
           replaceExtension' juvixRegFileExt baseOutputFile
         TargetTree ->
           replaceExtension' juvixTreeFileExt baseOutputFile
-        TargetNockma ->
-          replaceExtension' nockmaFileExt baseOutputFile
         TargetAnoma ->
           replaceExtension' nockmaFileExt baseOutputFile
         TargetCasm ->

--- a/app/Commands/Extra/Compile/Options.hs
+++ b/app/Commands/Extra/Compile/Options.hs
@@ -13,7 +13,6 @@ data CompileTarget
   | TargetAsm
   | TargetReg
   | TargetTree
-  | TargetNockma
   | TargetAnoma
   | TargetCasm
   deriving stock (Eq, Data, Bounded, Enum)
@@ -28,7 +27,6 @@ instance Show CompileTarget where
     TargetAsm -> "asm"
     TargetReg -> "reg"
     TargetTree -> "tree"
-    TargetNockma -> "nockma"
     TargetAnoma -> "anoma"
     TargetCasm -> "casm"
 

--- a/src/Juvix/Compiler/Backend.hs
+++ b/src/Juvix/Compiler/Backend.hs
@@ -12,7 +12,6 @@ data Target
   | TargetAsm
   | TargetReg
   | TargetTree
-  | TargetNockma
   | TargetAnoma
   | TargetCairo
   deriving stock (Data, Eq, Show)
@@ -93,8 +92,6 @@ getLimits tgt debug = case tgt of
         _limitsSpecialisedApply = 3
       }
   TargetTree ->
-    defaultLimits
-  TargetNockma ->
     defaultLimits
   TargetAnoma ->
     defaultLimits

--- a/src/Juvix/Compiler/Nockma/Anoma.hs
+++ b/src/Juvix/Compiler/Nockma/Anoma.hs
@@ -1,8 +1,8 @@
-module Nockma.Base where
+module Juvix.Compiler.Nockma.Anoma where
 
-import Base
 import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Translation.FromTree
+import Juvix.Prelude
 
 -- | Call a function at the head of the subject using the Anoma calling convention
 anomaCall :: Term Natural -> [Term Natural] -> Term Natural

--- a/src/Juvix/Compiler/Nockma/EvalCompiled.hs
+++ b/src/Juvix/Compiler/Nockma/EvalCompiled.hs
@@ -5,13 +5,13 @@ import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Pretty (ppTrace)
 import Juvix.Prelude
 
-evalCompiledNock' :: (Members '[Reader EvalOptions, Output (Term Natural)] r) => Term Natural -> Term Natural -> Sem r (Term Natural)
+evalCompiledNock' :: (Members '[State OpCounts, Reader EvalOptions, Output (Term Natural)] r) => Term Natural -> Term Natural -> Sem r (Term Natural)
 evalCompiledNock' stack mainTerm = do
   evalT <-
     runError @(ErrNockNatural Natural)
       . runError @(NockEvalError Natural)
       . runReader @(Storage Natural) emptyStorage
-      $ eval stack mainTerm
+      $ evalProfile stack mainTerm
   case evalT of
     Left e -> error (show e)
     Right ev -> case ev of

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -89,6 +89,7 @@ parseCell c = case c ^. cellLeft of
       return
         OperatorCell
           { _operatorCellOp = op,
+            _operatorCellTag = c ^. cellTag,
             _operatorCellTerm = t
           }
 
@@ -222,6 +223,7 @@ eval inistack initerm =
               EvalCrumbOperator $
                 CrumbOperator
                   { _crumbOperatorOp = c ^. operatorCellOp,
+                    _crumbOperatorCellTag = c ^. operatorCellTag,
                     _crumbOperatorTag = crumbTag,
                     _crumbOperatorLoc = loc
                   }

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -170,7 +170,7 @@ eval initstack initterm = ignoreOpCounts (evalProfile initstack initterm)
 
 evalProfile ::
   forall s a.
-  (Integral a, Members '[State OpCounts, Reader EvalOptions, Output (Term a), Error (NockEvalError a), Error (ErrNockNatural a)] s, NockNatural a) =>
+  (Hashable a, Integral a, Members '[Reader (Storage a), State OpCounts, Reader EvalOptions, Output (Term a), Error (NockEvalError a), Error (ErrNockNatural a)] s, NockNatural a) =>
   Term a ->
   Term a ->
   Sem s (Term a)

--- a/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Crumbs.hs
@@ -54,6 +54,7 @@ data CrumbAutoCons = CrumbAutoCons
 data CrumbOperator = CrumbOperator
   { _crumbOperatorOp :: NockOp,
     _crumbOperatorTag :: CrumbTag,
+    _crumbOperatorCellTag :: Maybe Tag,
     _crumbOperatorLoc :: Maybe Interval
   }
 
@@ -91,7 +92,8 @@ instance PrettyCode CrumbOperator where
     tag <- ppCode _crumbOperatorTag
     loc <- ppLoc _crumbOperatorLoc
     op <- ppCode _crumbOperatorOp
-    return (loc <+> tag <+> "for" <+> op)
+    celltag <- mapM ppCode _crumbOperatorCellTag
+    return (loc <+> tag <+> "for" <+> op <+?> celltag)
 
 instance PrettyCode CrumbAutoCons where
   ppCode CrumbAutoCons {..} = do

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -391,6 +391,9 @@ a >># b = TermCell (a >>#. b)
 opCall :: Text -> Path -> Term Natural -> Term Natural
 opCall txt p t = txt @ (OpCall #. (p # t))
 
+opReplace :: Text -> Path -> Term Natural -> Term Natural -> Term Natural
+opReplace txt p t1 t2 = txt @ OpReplace #. ((p #. t1) #. t2)
+
 opAddress :: Text -> Path -> Term Natural
 opAddress txt p = txt @ OpAddress #. p
 

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -62,7 +62,9 @@ instance (Hashable a) => Hashable (StdlibCall a)
 newtype Tag = Tag
   { _unTag :: Text
   }
-  deriving stock (Show, Eq, Lift)
+  deriving stock (Show, Eq, Lift, Generic)
+
+instance Hashable Tag
 
 data CellInfo a = CellInfo
   { _cellInfoLoc :: Irrelevant (Maybe Interval),

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -98,6 +98,7 @@ data AtomHint
   | AtomHintBool
   | AtomHintNil
   | AtomHintVoid
+  | AtomHintFunctionsPlaceholder
   deriving stock (Show, Eq, Lift, Generic)
 
 instance Hashable AtomHint

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -84,6 +84,7 @@ instance (Hashable a) => Hashable (Cell a)
 
 data AtomInfo = AtomInfo
   { _atomInfoHint :: Maybe AtomHint,
+    _atomInfoTag :: Maybe Tag,
     _atomInfoLoc :: Irrelevant (Maybe Interval)
   }
   deriving stock (Show, Eq, Lift, Generic)
@@ -215,6 +216,9 @@ cellTag = cellInfo . cellInfoTag
 
 cellCall :: Lens' (Cell a) (Maybe (StdlibCall a))
 cellCall = cellInfo . cellInfoCall
+
+atomTag :: Lens' (Atom a) (Maybe Tag)
+atomTag = atomInfo . atomInfoTag
 
 atomLoc :: Lens' (Atom a) (Maybe Interval)
 atomLoc = atomInfo . atomInfoLoc . unIrrelevant
@@ -417,6 +421,7 @@ emptyAtomInfo :: AtomInfo
 emptyAtomInfo =
   AtomInfo
     { _atomInfoHint = Nothing,
+      _atomInfoTag = Nothing,
       _atomInfoLoc = Irrelevant Nothing
     }
 

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -262,6 +262,10 @@ class (NockmaEq a) => NockNatural a where
 
   nockOp :: (Member (Error (ErrNockNatural a)) r) => Atom a -> Sem r NockOp
   nockOp atm = do
+    case atm ^. atomHint of
+      Just h
+       | h /= AtomHintOp -> throw (errInvalidOp atm)
+      _ -> return ()
     n <- nockNatural atm
     failWithError (errInvalidOp atm) (parseOp n)
 

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -243,6 +243,7 @@ class (NockmaEq a) => NockNatural a where
   errInvalidOp :: Atom a -> ErrNockNatural a
 
   errInvalidPath :: Atom a -> ErrNockNatural a
+  errGetAtom :: ErrNockNatural a -> Atom a
 
   nockOp :: (Member (Error (ErrNockNatural a)) r) => Atom a -> Sem r NockOp
   nockOp atm = do
@@ -290,6 +291,9 @@ instance NockNatural Natural where
   nockTrue = Atom 0 (atomHintInfo AtomHintBool)
   nockFalse = Atom 1 (atomHintInfo AtomHintBool)
   nockNil = Atom 0 (atomHintInfo AtomHintNil)
+  errGetAtom = \case
+    NaturalInvalidPath a -> a
+    NaturalInvalidOp a -> a
   nockSucc = over atom succ
   nockVoid = Atom 0 (atomHintInfo AtomHintVoid)
   errInvalidOp atm = NaturalInvalidOp atm

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -264,7 +264,7 @@ class (NockmaEq a) => NockNatural a where
   nockOp atm = do
     case atm ^. atomHint of
       Just h
-       | h /= AtomHintOp -> throw (errInvalidOp atm)
+        | h /= AtomHintOp -> throw (errInvalidOp atm)
       _ -> return ()
     n <- nockNatural atm
     failWithError (errInvalidOp atm) (parseOp n)
@@ -285,8 +285,11 @@ nockBool = \case
   True -> nockTrue
   False -> nockFalse
 
-nockNil' :: Term Natural
-nockNil' = TermAtom nockNil
+nockNilTagged :: Text -> Term Natural
+nockNilTagged txt = TermAtom (set atomTag (Just (Tag txt)) nockNil)
+
+nockNilUntagged :: Term Natural
+nockNilUntagged = TermAtom nockNil
 
 data NockNaturalNaturalError
   = NaturalInvalidPath (Atom Natural)
@@ -386,12 +389,12 @@ infixl 1 >>#
 a >># b = TermCell (a >>#. b)
 
 opCall :: Text -> Path -> Term Natural -> Term Natural
-opCall txt p t = txt @ OpCall #. p # t
+opCall txt p t = txt @ (OpCall #. (p # t))
 
 opAddress :: Text -> Path -> Term Natural
 opAddress txt p = txt @ OpAddress #. p
 
-opQuote :: IsNock x => Text -> x -> Term Natural
+opQuote :: (IsNock x) => Text -> x -> Term Natural
 opQuote txt p = txt @ OpQuote #. p
 
 {-# COMPLETE Cell #-}

--- a/src/Juvix/Compiler/Nockma/Pretty.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty.hs
@@ -28,7 +28,7 @@ ppSerialize :: (PrettyCode c) => c -> Text
 ppSerialize = ppPrintOpts serializeOptions
 
 ppPrint :: (PrettyCode c) => c -> Text
-ppPrint = ppPrintOpts defaultOptions
+ppPrint = toPlainText . ppOut defaultOptions
 
 ppPrintOpts :: (PrettyCode c) => Options -> c -> Text
 ppPrintOpts opts = renderStrict . toTextStream . ppOut opts

--- a/src/Juvix/Compiler/Nockma/Pretty.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty.hs
@@ -30,5 +30,8 @@ ppSerialize = ppPrintOpts serializeOptions
 ppPrint :: (PrettyCode c) => c -> Text
 ppPrint = toPlainText . ppOut defaultOptions
 
+ppTest :: (PrettyCode c) => c -> Text
+ppTest = toPlainText . ppOut testOptions
+
 ppPrintOpts :: (PrettyCode c) => Options -> c -> Text
 ppPrintOpts opts = renderStrict . toTextStream . ppOut opts

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -38,6 +38,7 @@ instance (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
           | otherwise -> fail
         AtomHintNil -> return (annotate (AnnKind KNameConstructor) "nil")
         AtomHintVoid -> return (annotate (AnnKind KNameAxiom) "void")
+        AtomHintFunctionsPlaceholder -> return (annotate (AnnKind KNameAxiom) "functions_placeholder")
 
 instance PrettyCode Interval where
   ppCode = return . pretty

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -25,10 +25,10 @@ runPrettyCode opts = run . runReader opts . ppCode
 
 instance (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
   ppCode atm = do
-    let def = annotate (AnnKind KNameFunction) <$> ppCode (atm ^. atom)
     t <- mapM ppCode (atm ^. atomTag)
-    fmap (t <?+>) . runFailDefaultM def . failFromError @(ErrNockNatural a)
-      $ do
+    let def = fmap (t <?+>) (annotate (AnnKind KNameFunction) <$> ppCode (atm ^. atom))
+    fmap (t <?+>) . runFailDefaultM def . failFromError @(ErrNockNatural a) $
+      do
         whenM (asks (^. optIgnoreHints)) fail
         h' <- failMaybe (atm ^. atomHint)
         case h' of

--- a/src/Juvix/Compiler/Nockma/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Options.hs
@@ -11,26 +11,38 @@ defaultOptions :: Options
 defaultOptions =
   Options
     { _optPrettyMode = MinimizeDelimiters,
-      _optIgnoreHints = False
+      _optIgnoreHints = False,
+      _optIgnoreTags = False
     }
 
 data Options = Options
   { _optPrettyMode :: PrettyMode,
-    _optIgnoreHints :: Bool
+    _optIgnoreHints :: Bool,
+    _optIgnoreTags :: Bool
   }
 
 serializeOptions :: Options
 serializeOptions =
   Options
     { _optPrettyMode = MinimizeDelimiters,
-      _optIgnoreHints = True
+      _optIgnoreHints = True,
+      _optIgnoreTags = True
+    }
+
+testOptions :: Options
+testOptions =
+  Options
+    { _optPrettyMode = MinimizeDelimiters,
+      _optIgnoreHints = False,
+      _optIgnoreTags = True
     }
 
 traceOptions :: Options
 traceOptions =
   Options
     { _optPrettyMode = MinimizeDelimiters,
-      _optIgnoreHints = False
+      _optIgnoreHints = False,
+      _optIgnoreTags = False
     }
 
 makeLenses ''Options

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -7,7 +7,7 @@ import Juvix.Compiler.Nockma.Language
 import Juvix.Extra.Paths
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Parser.Error
-import Juvix.Parser.Lexer (onlyInterval, withLoc)
+import Juvix.Parser.Lexer (isWhiteSpace, onlyInterval, withLoc)
 import Juvix.Prelude hiding (Atom, Path, many, some)
 import Juvix.Prelude qualified as Prelude
 import Juvix.Prelude.Parsing hiding (runParser)
@@ -154,6 +154,9 @@ pTag = do
   void (chunk Str.tagTag)
   Tag <$> iden
 
+stdlibIden :: Parser Text
+stdlibIden = lexeme (takeWhile1P (Just "<stdlibIden>") (isAscii .&&. not . isWhiteSpace))
+
 cell :: Parser (Cell Natural)
 cell = do
   lloc <- onlyInterval lsbracket
@@ -185,7 +188,7 @@ cell = do
 
     stdlibFun :: Parser StdlibFunction
     stdlibFun = do
-      i <- iden
+      i <- stdlibIden
       let err = error ("invalid stdlib function identifier: " <> i)
       maybe err return (parseStdlibFunction i)
 

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -147,15 +147,12 @@ patom = do
     <|> atomVoid
 
 iden :: Parser Text
-iden = lexeme (takeWhile1P (Just "<iden>") isAlphaNum)
+iden = lexeme (takeWhile1P (Just "<iden>") (isAscii .&&. not . isWhiteSpace))
 
 pTag :: Parser Tag
 pTag = do
   void (chunk Str.tagTag)
   Tag <$> iden
-
-stdlibIden :: Parser Text
-stdlibIden = lexeme (takeWhile1P (Just "<stdlibIden>") (isAscii .&&. not . isWhiteSpace))
 
 cell :: Parser (Cell Natural)
 cell = do
@@ -188,7 +185,7 @@ cell = do
 
     stdlibFun :: Parser StdlibFunction
     stdlibFun = do
-      i <- stdlibIden
+      i <- iden
       let err = error ("invalid stdlib function identifier: " <> i)
       maybe err return (parseStdlibFunction i)
 

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -148,6 +148,7 @@ iden = lexeme (takeWhile1P (Just "<iden>") isAlphaNum)
 cell :: Parser (Cell Natural)
 cell = do
   lloc <- onlyInterval lsbracket
+  lbl <- optional pTag
   c <- optional stdlibCall
   firstTerm <- term
   restTerms <- some term
@@ -156,10 +157,16 @@ cell = do
       info =
         CellInfo
           { _cellInfoCall = c,
+            _cellInfoTag = lbl,
             _cellInfoLoc = Irrelevant (Just (lloc <> rloc))
           }
   return (set cellInfo info r)
   where
+    pTag :: Parser Tag
+    pTag = do
+      void (chunk Str.tagTag)
+      Tag <$> iden
+
     stdlibCall :: Parser (StdlibCall Natural)
     stdlibCall = do
       chunk Str.stdlibTag

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -305,8 +305,8 @@ anomaCallableClosureWrapper =
             (getClosureFieldInSubject ArgsTuple)
             (sub closureTotalArgsNum closureArgsNum)
       closureArgsIsEmpty = isZero closureArgsNum
-      adjustArgs = OpIf # closureArgsIsEmpty # (OpAddress # emptyPath) # appendAndReplaceArgsTuple
-   in OpCall # closurePath RawCode # adjustArgs
+      adjustArgs = OpIf # closureArgsIsEmpty # (opAddress "wrapperSubject" emptyPath) # appendAndReplaceArgsTuple
+   in opCall "closureWrapper" (closurePath RawCode) adjustArgs
 
 compile :: forall r. (Members '[Reader FunctionCtx, Reader CompilerCtx] r) => Tree.Node -> Sem r (Term Natural)
 compile = \case
@@ -352,12 +352,12 @@ compile = \case
                 NockmaMemRepList constr -> case constr of
                   NockmaMemRepListConstrNil -> impossible
                   NockmaMemRepListConstrCons -> fr ++ indexTuple 2 argIx
-        (OpAddress #) <$> path
+        (opAddress "constrRef") <$> path
       where
         goDirectRef :: Tree.DirectRef -> Sem r (Term Natural)
         goDirectRef dr = do
           p <- directRefPath dr
-          return (OpAddress # p)
+          return (opAddress "directRef" p)
 
     goConstant :: Tree.Constant -> Term Natural
     goConstant = \case
@@ -463,7 +463,7 @@ compile = \case
       return . makeClosure $ \case
         WrapperCode -> OpQuote # anomaCallableClosureWrapper
         ArgsTuple -> OpQuote # argsTuplePlaceholder
-        RawCode -> OpAddress # fpath
+        RawCode -> opAddress "allocClosureFunPath" fpath
         TempStack -> remakeList []
         StandardLibrary -> OpQuote # stdlib
         FunctionsLibrary ->
@@ -495,23 +495,24 @@ compile = \case
               oldArgs = getClosureField ClosureArgs closure
               allArgs = appendToTuple oldArgs argsNum (foldTermsOrNil newargs) (nockIntegralLiteral (length newargs))
               newSubject = replaceSubject $ \case
-                WrapperCode -> Just (OpQuote # anomaCallableClosureWrapper)
-                RawCode -> Just (OpQuote # closure)
+                -- WrapperCode -> Just (OpQuote # anomaCallableClosureWrapper)
+                WrapperCode -> Just (getClosureField RawCode closure) -- We Want RawCode because we already have all args.
+                RawCode -> Just (OpQuote # nockNil')
                 ArgsTuple -> Just allArgs
+                TempStack -> Just (OpQuote # nockNil')
                 FunctionsLibrary -> Nothing
                 StandardLibrary -> Nothing
-                TempStack -> Nothing
                 -- TODO revise below
                 ClosureArgs -> Nothing
                 ClosureTotalArgsNum -> Nothing
                 ClosureArgsNum -> Nothing
-          return (OpCall # closurePath WrapperCode # newSubject)
+          return (opCall "callClosure" (closurePath WrapperCode) newSubject)
 
 isZero :: Term Natural -> Term Natural
 isZero a = OpEq # a # nockNatLiteral 0
 
 opAddress' :: Term Natural -> Term Natural
-opAddress' x = evaluated $ (OpQuote # OpAddress) # x
+opAddress' x = evaluated $ (opQuote "opAddress'" OpAddress) # x
 
 -- [a [b [c 0]]] -> [a [b c]]
 -- len = quote 3
@@ -519,7 +520,7 @@ opAddress' x = evaluated $ (OpQuote # OpAddress) # x
 listToTuple :: Term Natural -> Term Natural -> Term Natural
 listToTuple lst len =
   let posOfLast = appendRights emptyPath (dec len)
-      t1 = lst >># (opAddress' posOfLast) >># (OpAddress # [L])
+      t1 = lst >># (opAddress' posOfLast) >># (opAddress "listToTupleLast" [L])
    in OpIf # isZero len # lst # (replaceSubterm' lst posOfLast t1)
 
 argsTuplePlaceholder :: Term Natural
@@ -531,7 +532,7 @@ appendRights path n = dec (mul (pow2 n) (OpInc # OpQuote # path))
 pushTemp :: Term Natural -> Term Natural
 pushTemp toBePushed =
   remakeList
-    [ let p = OpAddress # stackPath s
+    [ let p = opAddress "pushTemp" (stackPath s)
        in if
               | TempStack == s -> toBePushed # p
               | otherwise -> p
@@ -604,11 +605,11 @@ extendClosure Tree.NodeExtendClosure {..} = do
 callStdlib :: StdlibFunction -> [Term Natural] -> Term Natural
 callStdlib fun args =
   let fPath = stdlibPath fun
-      getFunCode = OpAddress # stackPath StandardLibrary >># fPath
+      getFunCode = opAddress "callStdlibFunCode" (stackPath StandardLibrary) >># fPath
       adjustArgs = case nonEmpty args of
         Just args' -> OpReplace # ([R, L] # ((OpAddress # [R]) >># foldTerms args')) # (OpAddress # [L])
-        Nothing -> OpAddress # [L]
-      callFn = OpCall # [L] # adjustArgs
+        Nothing -> opAddress "adjustArgsNothing" [L]
+      callFn = opCall "callStdlib" [L] adjustArgs
       callCell = set cellCall (Just meta) (OpPush #. (getFunCode # callFn))
       meta =
         StdlibCall
@@ -764,6 +765,7 @@ closurePath :: AnomaCallablePathId -> Path
 closurePath = stackPath
 
 -- | Call a function. Arguments to the function are assumed to be in the ArgsTuple stack
+-- TODO what about temporary stack?
 callFun ::
   (Members '[Reader CompilerCtx] r) =>
   FunctionId ->
@@ -771,7 +773,7 @@ callFun ::
 callFun fun = do
   fpath <- getFunctionPath fun
   let p' = fpath ++ closurePath WrapperCode
-  return (OpCall # p' # (OpAddress # emptyPath))
+  return (opCall "callFun" p' (opAddress "callFunSubject" emptyPath))
 
 -- [f1_code f1_args env] / [call L [@ S]]
 -- [f1_code f1_args env] / f1_code
@@ -799,7 +801,7 @@ replaceSubject :: (AnomaCallablePathId -> Maybe (Term Natural)) -> Term Natural
 replaceSubject f =
   remakeList
     [ case f s of
-        Nothing -> OpAddress # closurePath s
+        Nothing -> opAddress "replaceSubject" (closurePath s)
         Just t' -> t'
       | s <- allElements
     ]
@@ -817,7 +819,7 @@ getFunctionPath :: (Members '[Reader CompilerCtx] r) => FunctionId -> Sem r Path
 getFunctionPath funName = asks (^?! compilerFunctionInfos . at funName . _Just . functionInfoPath)
 
 evaluated :: Term Natural -> Term Natural
-evaluated t = OpApply # (OpAddress # emptyPath) # t
+evaluated t = OpApply # (opAddress "evaluated" emptyPath) # t
 
 -- | obj[eval(relPath)] := newVal
 -- relPath is relative to obj
@@ -938,13 +940,13 @@ getField :: (Enum field) => field -> Term Natural -> Term Natural
 getField field t = t >># getFieldInSubject field
 
 getFieldInSubject :: (Enum field) => field -> Term Natural
-getFieldInSubject field = OpAddress # pathFromEnum field
+getFieldInSubject field = opAddress "getFieldInSubject" (pathFromEnum field)
 
 getConstructorMemRep :: (Members '[Reader CompilerCtx] r) => Tree.Tag -> Sem r NockmaMemRep
 getConstructorMemRep tag = (^. constructorInfoMemRep) <$> getConstructorInfo tag
 
 crash :: Term Natural
-crash = (OpAddress # OpAddress # OpAddress)
+crash = ("crash" @ OpAddress #. OpAddress # OpAddress)
 
 mul :: Term Natural -> Term Natural -> Term Natural
 mul a b = callStdlib StdlibMul [a, b]

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -22,7 +22,10 @@ module Juvix.Compiler.Nockma.Translation.FromTree
     pathToArg,
     makeList,
     listToTuple,
+    appendToTuple,
+    append,
     opAddress',
+    replaceSubterm',
   )
 where
 
@@ -530,6 +533,9 @@ nockNatLiteral = nockIntegralLiteral
 nockIntegralLiteral :: (Integral a) => a -> Term Natural
 nockIntegralLiteral = (OpQuote #) . toNock @Natural . fromIntegral
 
+-- | xs must be a list.
+-- ys is a (possibly empty) tuple.
+-- the result is a tuple.
 appendToTuple :: Term Natural -> Term Natural -> Term Natural -> Term Natural -> Term Natural
 appendToTuple xs lenXs ys lenYs =
   OpIf # isZero lenYs # listToTuple xs lenXs # append xs lenXs ys
@@ -549,7 +555,7 @@ extendClosure Tree.NodeExtendClosure {..} = do
   let argsNum = getClosureField ClosureArgsNum closure
       oldArgs = getClosureField ClosureArgs closure
       fcode = getClosureField RawCode closure
-      allArgs = append oldArgs argsNum (remakeList (toList args))
+      allArgs = append oldArgs argsNum (remakeList args)
       newArgsNum = add argsNum (nockIntegralLiteral (length _nodeExtendClosureArgs))
   return . makeClosure $ \case
     WrapperCode -> anomaCallableClosureWrapper
@@ -652,8 +658,8 @@ fieldErr = unsupported "the field type"
 sub :: Term Natural -> Term Natural -> Term Natural
 sub a b = callStdlib StdlibSub [a, b]
 
-makeList :: [Term Natural] -> Term Natural
-makeList ts = foldTerms (ts `prependList` pure (TermAtom nockNil))
+makeList :: (Foldable f) => f (Term Natural) -> Term Natural
+makeList ts = foldTerms (toList ts `prependList` pure (TermAtom nockNil))
 
 remakeList :: (Foldable l) => l (Term Natural) -> Term Natural
 remakeList ts = foldTerms (toList ts `prependList` pure (OpQuote # nockNil'))
@@ -684,7 +690,7 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO
             )
 
     exportEnv :: Term Natural
-    exportEnv = makeList (toList compiledFuns)
+    exportEnv = makeList compiledFuns
 
     makeLibraryFunction :: Term Natural -> Term Natural
     makeLibraryFunction c = makeClosure $ \case

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -30,6 +30,7 @@ import Juvix.Compiler.Tree.Data.InfoTable qualified as Tree
 import Juvix.Compiler.Tree.Language qualified as Tree
 import Juvix.Compiler.Tree.Language.Rep
 import Juvix.Prelude hiding (Atom, Path)
+import System.IO.Unsafe (unsafePerformIO)
 
 data ProgramCallingConvention
   = ProgramCallingConventionJuvix
@@ -108,21 +109,13 @@ data CompilerFunction = CompilerFunction
 -- The Code and Args constructors must be first and second respectively. This is
 -- because the stack must have the structure of a Nock function,
 -- i.e [code args env]
-data StackId
-  = Code
+data AnomaCallablePathId
+  = WrapperCode
   | Args
+  | FunctionsLibrary
+  | RawCode
   | TempStack
   | StandardLibrary
-  | FunctionsLibrary
-  deriving stock (Enum, Bounded, Eq, Show)
-
-data AnomaCallablePathId
-  = WrapperCode'
-  | Args'
-  | FunctionsLibrary'
-  | RawCode'
-  | TempStack'
-  | StandardLibrary'
   | ClosureTotalArgsNum
   | ClosureArgsNum
   | ClosureArgs
@@ -154,7 +147,7 @@ functionPath :: FunctionPathId -> Path
 functionPath = \case
   FunctionCode -> []
 
-stackPath :: StackId -> Path
+stackPath :: AnomaCallablePathId -> Path
 stackPath s = indexStack (fromIntegral (fromEnum s))
 
 indexTuple :: Natural -> Natural -> Path
@@ -169,7 +162,7 @@ indexTuple len idx
 indexStack :: Natural -> Path
 indexStack idx = replicate idx R ++ [L]
 
-indexInStack :: StackId -> Natural -> Path
+indexInStack :: AnomaCallablePathId -> Natural -> Path
 indexInStack s idx = stackPath s ++ indexStack idx
 
 pathToArg :: Natural -> Path
@@ -278,8 +271,8 @@ fromOffsetRef = fromIntegral . (^. Tree.offsetRefOffset)
 anomaCallableClosureWrapper :: Term Natural
 anomaCallableClosureWrapper =
   -- TODO: Consider avoiding the append in if there are no ClosureArgs.
-  let newArgs = append (getClosureFieldInSubject ClosureArgs) (getClosureFieldInSubject ClosureArgsNum) (getClosureFieldInSubject Args')
-   in OpCall # getClosureFieldInSubject RawCode' # replaceArgsWithTerm newArgs
+  let newArgs = append (getClosureFieldInSubject ClosureArgs) (getClosureFieldInSubject ClosureArgsNum) (getClosureFieldInSubject Args)
+   in OpCall # getClosureFieldInSubject RawCode # replaceArgsWithTerm newArgs
 
 compile :: forall r. (Members '[Reader CompilerCtx] r) => Tree.Node -> Sem r (Term Natural)
 compile = \case
@@ -429,21 +422,22 @@ compile = \case
       farity <- getFunctionArity fun
       args <- mapM compile _nodeAllocClosureArgs
       return . makeClosure $ \case
-        WrapperCode' -> OpQuote # anomaCallableClosureWrapper
-        Args' -> remakeList []
-        RawCode' -> OpAddress # fpath
-        TempStack' -> remakeList []
-        StandardLibrary' -> OpQuote # stdlib
-        FunctionsLibrary' -> OpQuote #
-          TermAtom
-            Atom
-              { _atomInfo =
-                  AtomInfo
-                    { _atomInfoLoc = Irrelevant Nothing,
-                      _atomInfoHint = Just AtomHintFunctionsPlaceholder
-                    },
-                _atom = 0 :: Natural
-              }
+        WrapperCode -> OpQuote # anomaCallableClosureWrapper
+        Args -> remakeList []
+        RawCode -> OpAddress # fpath
+        TempStack -> remakeList []
+        StandardLibrary -> OpQuote # stdlib
+        FunctionsLibrary ->
+          OpQuote
+            # TermAtom
+              Atom
+                { _atomInfo =
+                    AtomInfo
+                      { _atomInfoLoc = Irrelevant Nothing,
+                        _atomInfoHint = Just AtomHintFunctionsPlaceholder
+                      },
+                  _atom = 0 :: Natural
+                }
         ClosureTotalArgsNum -> nockNatLiteral farity
         ClosureArgsNum -> nockIntegralLiteral (length args)
         ClosureArgs -> remakeList args
@@ -460,7 +454,7 @@ compile = \case
           f' <- compile f
           let argsNum = getClosureField ClosureArgsNum f'
               oldArgs = getClosureField ClosureArgs f'
-              fcode = getClosureField RawCode' f'
+              fcode = getClosureField RawCode f'
               posOfArgsNil = appendRights emptyPath argsNum
               allArgs = replaceSubterm' oldArgs posOfArgsNil (remakeList newargs)
           return (OpApply # replaceArgsWithTerm allArgs # fcode)
@@ -508,19 +502,19 @@ extendClosure Tree.NodeExtendClosure {..} = do
   closure <- compile _nodeExtendClosureFun
   let argsNum = getClosureField ClosureArgsNum closure
       oldArgs = getClosureField ClosureArgs closure
-      fcode = getClosureField RawCode' closure
+      fcode = getClosureField RawCode closure
       allArgs = append oldArgs argsNum (remakeList (toList args))
       newArgsNum = add argsNum (nockIntegralLiteral (length _nodeExtendClosureArgs))
   return . makeClosure $ \case
-    WrapperCode' -> anomaCallableClosureWrapper
-    RawCode' -> OpQuote # fcode
+    WrapperCode -> anomaCallableClosureWrapper
+    RawCode -> OpQuote # fcode
     ClosureTotalArgsNum -> getClosureField ClosureTotalArgsNum closure
     ClosureArgsNum -> newArgsNum
     ClosureArgs -> allArgs
-    Args' -> getClosureField Args' closure
-    FunctionsLibrary' -> getClosureField FunctionsLibrary' closure
-    TempStack' -> getClosureField TempStack' closure
-    StandardLibrary' -> getClosureField StandardLibrary' closure
+    Args -> getClosureField Args closure
+    FunctionsLibrary -> getClosureField FunctionsLibrary closure
+    TempStack -> getClosureField TempStack closure
+    StandardLibrary -> getClosureField StandardLibrary closure
 
 -- Calling convention for Anoma stdlib
 --
@@ -616,40 +610,25 @@ makeList ts = foldTerms (ts `prependList` pure (TermAtom nockNil))
 remakeList :: (Foldable l) => l (Term Natural) -> Term Natural
 remakeList ts = foldTerms (toList ts `prependList` pure (OpQuote # nockNil'))
 
--- | Initialize the stack. The resulting term is intended to be evaulated
--- against a subject that contains function arguments.
--- initStackWithArgs :: Term Natural -> [Term Natural] -> [Term Natural] -> Term Natural
--- initStackWithArgs funCode defs getArgs = remakeList (initSubStack <$> allElements)
---   where
---     initSubStack :: StackId -> Term Natural
---     initSubStack = \case
---       Code -> OpQuote # funCode
---       Args -> remakeList getArgs
---       TempStack -> OpQuote # nockNil'
---       StandardLibrary -> OpQuote # stdlib
---       FunctionsLibrary -> OpQuote # makeList defs
 makeNockFunction :: Term Natural -> [Term Natural] -> Term Natural
 makeNockFunction funCode defs = remakeList (initSubStack <$> allElements)
   where
-    initSubStack :: StackId -> Term Natural
+    initSubStack :: AnomaCallablePathId -> Term Natural
     initSubStack = \case
-      Code -> funCode
+      WrapperCode -> funCode
       Args -> nockNil'
+      FunctionsLibrary -> makeList defs
+      RawCode -> funCode
       TempStack -> nockNil'
       StandardLibrary -> stdlib
-      FunctionsLibrary -> makeList defs
+      ClosureTotalArgsNum -> nockNil'
+      ClosureArgsNum -> nockNil'
+      ClosureArgs -> nockNil'
 
--- | Initialize the stack. Populate the FunctionsLibrary and function code with the passed terms.
-initStack :: Term Natural -> [Term Natural] -> Term Natural
-initStack funCode defs = makeList (initSubStack <$> allElements)
-  where
-    initSubStack :: StackId -> Term Natural
-    initSubStack = \case
-      Code -> funCode
-      Args -> nockNil'
-      TempStack -> nockNil'
-      StandardLibrary -> stdlib
-      FunctionsLibrary -> makeList defs
+asCell :: Term Natural -> Cell Natural
+asCell = \case
+  TermCell c -> c
+  TermAtom {} -> impossible
 
 runCompilerWithAnoma :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Cell Natural
 runCompilerWithAnoma = runCompilerWith ProgramCallingConventionAnoma
@@ -658,7 +637,9 @@ runCompilerWithJuvix :: CompilerOptions -> ConstructorInfos -> [CompilerFunction
 runCompilerWithJuvix = runCompilerWith ProgramCallingConventionJuvix
 
 runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Cell Natural
-runCompilerWith callingConvention opts constrs libFuns mainFun = run . runReader compilerCtx $ mkEntryPoint
+runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO $ do
+  writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
+  return (run . runReader compilerCtx $ mkEntryPoint)
   where
     allFuns :: NonEmpty CompilerFunction
     allFuns = mainFun :| libFuns ++ (builtinFunction <$> allElements)
@@ -677,6 +658,9 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = run . runReader
         <$> ( run . runReader compilerCtx . (^. compilerFunction)
                 <$> allFuns
             )
+
+    exportEnv :: Term Natural
+    exportEnv = makeList (toList compiledFuns)
 
     makeFunction' :: Term Natural -> Term Natural
     makeFunction' c = makeFunction $ \case
@@ -707,9 +691,10 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = run . runReader
 
     makeJuvixFun :: (Members '[Reader CompilerCtx] r) => Sem r (Cell Natural)
     makeJuvixFun = do
-      entryTerm <- callFunWithArgs (mainFun ^. compilerFunctionName) []
-      return (initStack crash (toList compiledFuns) #. entryTerm)
+      res <- callFunWithEnv (mainFun ^. compilerFunctionName) exportEnv
+      return (asCell res)
 
+    mkEntryPoint :: (Members '[Reader CompilerCtx] r) => Sem r (Cell Natural)
     mkEntryPoint = case callingConvention of
       ProgramCallingConventionAnoma -> makeAnomaFun
       ProgramCallingConventionJuvix -> makeJuvixFun
@@ -722,6 +707,17 @@ builtinFunction = \case
         _compilerFunctionArity = 0,
         _compilerFunction = return crash
       }
+
+-- | Call a function. Arguments to the function are assumed to be in the Args stack
+callFunWithEnv ::
+  (Members '[Reader CompilerCtx] r) =>
+  FunctionId ->
+  Term Natural ->
+  Sem r (Term Natural)
+callFunWithEnv fun env = do
+  fpath <- getFunctionPath fun
+  let p' = fpath ++ functionPath FunctionCode
+  return (OpCall # p' # (OpReplace # (stackPath FunctionsLibrary # (OpQuote # env)) # OpAddress # emptyPath))
 
 -- | Call a function. Arguments to the function are assumed to be in the Args stack
 callFun ::

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -473,6 +473,7 @@ compile = \case
                 { _atomInfo =
                     AtomInfo
                       { _atomInfoLoc = Irrelevant Nothing,
+                        _atomInfoTag = Nothing,
                         _atomInfoHint = Just AtomHintFunctionsPlaceholder
                       },
                   _atom = 0 :: Natural
@@ -496,6 +497,8 @@ compile = \case
               allArgs = appendToTuple oldArgs argsNum (foldTermsOrNil newargs) (nockIntegralLiteral (length newargs))
               newSubject = replaceSubject $ \case
                 -- WrapperCode -> Just (OpQuote # anomaCallableClosureWrapper)
+                -- WrapperCode -> Just (getClosureField RawCode closure) -- We Want RawCode because we already have all args.
+                -- WrapperCode -> Just (getClosureField RawCode closure) -- We Want RawCode because we already have all args.
                 WrapperCode -> Just (getClosureField RawCode closure) -- We Want RawCode because we already have all args.
                 RawCode -> Just (OpQuote # nockNil')
                 ArgsTuple -> Just allArgs
@@ -607,7 +610,7 @@ callStdlib fun args =
   let fPath = stdlibPath fun
       getFunCode = opAddress "callStdlibFunCode" (stackPath StandardLibrary) >># fPath
       adjustArgs = case nonEmpty args of
-        Just args' -> OpReplace # ([R, L] # ((OpAddress # [R]) >># foldTerms args')) # (OpAddress # [L])
+        Just args' -> OpReplace # ([R, L] # ((opAddress "stdlibR" [R]) >># foldTerms args')) # (opAddress "stdlibL" [L])
         Nothing -> opAddress "adjustArgsNothing" [L]
       callFn = opCall "callStdlib" [L] adjustArgs
       callCell = set cellCall (Just meta) (OpPush #. (getFunCode # callFn))

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -503,7 +503,7 @@ listToTuple lst len =
    in OpIf # isZero len # lst # (replaceSubterm' lst posOfLast t1)
 
 argsTuplePlaceholder :: Term Natural
-argsTuplePlaceholder = nockNil'
+argsTuplePlaceholder = OpQuote # nockNil'
 
 appendRights :: Path -> Term Natural -> Term Natural
 appendRights path n = dec (mul (pow2 n) (OpInc # OpQuote # path))
@@ -559,7 +559,7 @@ extendClosure Tree.NodeExtendClosure {..} = do
       allArgs = append oldArgs argsNum (remakeList args)
       newArgsNum = add argsNum (nockIntegralLiteral (length _nodeExtendClosureArgs))
   return . makeClosure $ \case
-    WrapperCode -> anomaCallableClosureWrapper
+    WrapperCode -> OpQuote # anomaCallableClosureWrapper
     RawCode -> OpQuote # fcode
     ClosureTotalArgsNum -> getClosureField ClosureTotalArgsNum closure
     ClosureArgsNum -> newArgsNum
@@ -670,7 +670,7 @@ runCompilerWithAnoma = runCompilerWith ProgramCallingConventionAnoma
 
 runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Term Natural
 runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO $ do
-  -- writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
+  writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
   return (run . runReader compilerCtx $ mkEntryPoint)
   where
     allFuns :: NonEmpty CompilerFunction

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -29,6 +29,7 @@ module Juvix.Compiler.Nockma.Translation.FromTree
     append,
     opAddress',
     replaceSubterm',
+    runCompilerWith,
   )
 where
 

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -502,7 +502,6 @@ compile = \case
                 TempStack -> Just (OpQuote # nockNilTagged "callClosure-TempStack")
                 FunctionsLibrary -> Nothing
                 StandardLibrary -> Nothing
-                -- TODO revise below
                 ClosureArgs -> Nothing
                 ClosureTotalArgsNum -> Nothing
                 ClosureArgsNum -> Nothing

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -1,12 +1,10 @@
 module Juvix.Compiler.Nockma.Translation.FromTree
-  ( runCompilerWithAnoma,
-    fromEntryPoint,
+  ( fromEntryPoint,
     fromTreeTable,
     AnomaResult (..),
     anomaEnv,
     anomaClosure,
     compilerFunctionName,
-    ProgramCallingConvention (..),
     AnomaCallablePathId (..),
     CompilerOptions (..),
     CompilerFunction (..),
@@ -43,9 +41,6 @@ import Juvix.Compiler.Tree.Data.InfoTable qualified as Tree
 import Juvix.Compiler.Tree.Language qualified as Tree
 import Juvix.Compiler.Tree.Language.Rep
 import Juvix.Prelude hiding (Atom, Path)
-
-data ProgramCallingConvention
-  = ProgramCallingConventionAnoma
 
 data AnomaResult = AnomaResult
   { _anomaEnv :: Term Natural,
@@ -235,8 +230,8 @@ supportsListNockmaRep tab ci = case allConstructors tab ci of
   _ -> Nothing
 
 -- | Use `Tree.toNockma` before calling this function
-fromTreeTable :: (Members '[Error JuvixError, Reader CompilerOptions] r) => ProgramCallingConvention -> Tree.InfoTable -> Sem r AnomaResult
-fromTreeTable cc t = case t ^. Tree.infoMainFunction of
+fromTreeTable :: (Members '[Error JuvixError, Reader CompilerOptions] r) => Tree.InfoTable -> Sem r AnomaResult
+fromTreeTable t = case t ^. Tree.infoMainFunction of
   Just mainFun -> do
     opts <- ask
     return (fromTree opts mainFun t)
@@ -262,7 +257,7 @@ fromTreeTable cc t = case t ^. Tree.infoMainFunction of
 
           getInductiveInfo :: Symbol -> Tree.InductiveInfo
           getInductiveInfo s = _infoInductives ^?! at s . _Just
-       in runCompilerWith cc opts constrs funs mainFun
+       in runCompilerWith opts constrs funs mainFun
       where
         mainFun :: CompilerFunction
         mainFun = compileFunction (_infoFunctions ^?! at mainSym . _Just)
@@ -683,11 +678,8 @@ makeList ts = foldTerms (toList ts `prependList` pure (nockNilTagged "makeList")
 remakeList :: (Foldable l) => l (Term Natural) -> Term Natural
 remakeList ts = foldTerms (toList ts `prependList` pure (OpQuote # nockNilTagged "remakeList"))
 
-runCompilerWithAnoma :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> AnomaResult
-runCompilerWithAnoma = runCompilerWith ProgramCallingConventionAnoma
-
-runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> AnomaResult
-runCompilerWith callingConvention opts constrs libFuns mainFun = mkEntryPoint
+runCompilerWith :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> AnomaResult
+runCompilerWith opts constrs libFuns mainFun = makeAnomaFun
   where
     allFuns :: NonEmpty CompilerFunction
     allFuns = mainFun :| libFuns ++ (builtinFunction <$> allElements)
@@ -745,10 +737,6 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = mkEntryPoint
             { _anomaClosure = mainClosure,
               _anomaEnv = exportEnv
             }
-
-    mkEntryPoint :: AnomaResult
-    mkEntryPoint = case callingConvention of
-      ProgramCallingConventionAnoma -> makeAnomaFun
 
 builtinFunction :: BuiltinFunctionId -> CompilerFunction
 builtinFunction = \case

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -2,6 +2,10 @@ module Juvix.Compiler.Nockma.Translation.FromTree
   ( runCompilerWithAnoma,
     fromEntryPoint,
     fromTreeTable,
+    AnomaResult (..),
+    anomaEnv,
+    anomaClosure,
+    compilerFunctionName,
     ProgramCallingConvention (..),
     AnomaCallablePathId (..),
     CompilerOptions (..),
@@ -43,6 +47,11 @@ import System.IO.Unsafe (unsafePerformIO)
 
 data ProgramCallingConvention
   = ProgramCallingConventionAnoma
+
+data AnomaResult = AnomaResult
+  { _anomaEnv :: Term Natural,
+    _anomaClosure :: Term Natural
+  }
 
 nockmaMemRep :: MemRep -> NockmaMemRep
 nockmaMemRep = \case
@@ -171,6 +180,7 @@ indexInStack :: AnomaCallablePathId -> Natural -> Path
 indexInStack s idx = stackPath s ++ indexStack idx
 
 makeLenses ''CompilerOptions
+makeLenses ''AnomaResult
 makeLenses ''CompilerFunction
 makeLenses ''CompilerCtx
 makeLenses ''FunctionCtx
@@ -226,14 +236,14 @@ supportsListNockmaRep tab ci = case allConstructors tab ci of
   _ -> Nothing
 
 -- | Use `Tree.toNockma` before calling this function
-fromTreeTable :: (Members '[Error JuvixError, Reader CompilerOptions] r) => ProgramCallingConvention -> Tree.InfoTable -> Sem r (Term Natural)
+fromTreeTable :: (Members '[Error JuvixError, Reader CompilerOptions] r) => ProgramCallingConvention -> Tree.InfoTable -> Sem r AnomaResult
 fromTreeTable cc t = case t ^. Tree.infoMainFunction of
   Just mainFun -> do
     opts <- ask
     return (fromTree opts mainFun t)
   Nothing -> throw @JuvixError (error "TODO missing main")
   where
-    fromTree :: CompilerOptions -> Tree.Symbol -> Tree.InfoTable -> Term Natural
+    fromTree :: CompilerOptions -> Tree.Symbol -> Tree.InfoTable -> AnomaResult
     fromTree opts mainSym tab@Tree.InfoTable {..} =
       let funs = map compileFunction allFunctions
           mkConstructorInfo :: Tree.ConstructorInfo -> ConstructorInfo
@@ -294,9 +304,9 @@ anomaCallableClosureWrapper =
             closureArgsNum
             (getClosureFieldInSubject ArgsTuple)
             (sub closureTotalArgsNum closureArgsNum)
-      adjustArgs = OpIf # closureArgsIsEmpty # (OpQuote # (OpAddress # emptyPath)) # (OpQuote # appendAndReplaceArgsTuple)
       closureArgsIsEmpty = isZero closureArgsNum
-   in OpCall # getClosureFieldInSubject RawCode # adjustArgs
+      adjustArgs = OpIf # closureArgsIsEmpty # (OpAddress # emptyPath) # appendAndReplaceArgsTuple
+   in OpCall # closurePath RawCode # adjustArgs
 
 compile :: forall r. (Members '[Reader FunctionCtx, Reader CompilerCtx] r) => Tree.Node -> Sem r (Term Natural)
 compile = \case
@@ -452,7 +462,7 @@ compile = \case
       args <- mapM compile _nodeAllocClosureArgs
       return . makeClosure $ \case
         WrapperCode -> OpQuote # anomaCallableClosureWrapper
-        ArgsTuple -> argsTuplePlaceholder
+        ArgsTuple -> OpQuote # argsTuplePlaceholder
         RawCode -> OpAddress # fpath
         TempStack -> remakeList []
         StandardLibrary -> OpQuote # stdlib
@@ -480,12 +490,22 @@ compile = \case
       case _nodeCallType of
         Tree.CallFun fun -> callFunWithArgs (UserFunction fun) newargs
         Tree.CallClosure f -> do
-          f' <- compile f
-          let argsNum = getClosureField ClosureArgsNum f'
-              oldArgs = getClosureField ClosureArgs f'
-              fcode = getClosureField RawCode f'
+          closure <- compile f
+          let argsNum = getClosureField ClosureArgsNum closure
+              oldArgs = getClosureField ClosureArgs closure
               allArgs = appendToTuple oldArgs argsNum (foldTermsOrNil newargs) (nockIntegralLiteral (length newargs))
-          return (OpApply # replaceArgsWithTerm allArgs # fcode)
+              newSubject = replaceSubject $ \case
+                WrapperCode -> Just (OpQuote # anomaCallableClosureWrapper)
+                RawCode -> Just (OpQuote # closure)
+                ArgsTuple -> Just allArgs
+                FunctionsLibrary -> Nothing
+                StandardLibrary -> Nothing
+                TempStack -> Nothing
+                -- TODO revise below
+                ClosureArgs -> Nothing
+                ClosureTotalArgsNum -> Nothing
+                ClosureArgsNum -> Nothing
+          return (OpCall # closurePath WrapperCode # newSubject)
 
 isZero :: Term Natural -> Term Natural
 isZero a = OpEq # a # nockNatLiteral 0
@@ -503,7 +523,7 @@ listToTuple lst len =
    in OpIf # isZero len # lst # (replaceSubterm' lst posOfLast t1)
 
 argsTuplePlaceholder :: Term Natural
-argsTuplePlaceholder = OpQuote # nockNil'
+argsTuplePlaceholder = nockNil'
 
 appendRights :: Path -> Term Natural -> Term Natural
 appendRights path n = dec (mul (pow2 n) (OpInc # OpQuote # path))
@@ -555,12 +575,11 @@ extendClosure Tree.NodeExtendClosure {..} = do
   closure <- compile _nodeExtendClosureFun
   let argsNum = getClosureField ClosureArgsNum closure
       oldArgs = getClosureField ClosureArgs closure
-      fcode = getClosureField RawCode closure
       allArgs = append oldArgs argsNum (remakeList args)
       newArgsNum = add argsNum (nockIntegralLiteral (length _nodeExtendClosureArgs))
   return . makeClosure $ \case
-    WrapperCode -> OpQuote # anomaCallableClosureWrapper
-    RawCode -> OpQuote # fcode
+    WrapperCode -> getClosureField WrapperCode closure
+    RawCode -> getClosureField RawCode closure
     ClosureTotalArgsNum -> getClosureField ClosureTotalArgsNum closure
     ClosureArgsNum -> newArgsNum
     ClosureArgs -> allArgs
@@ -593,7 +612,7 @@ callStdlib fun args =
       callCell = set cellCall (Just meta) (OpPush #. (getFunCode # callFn))
       meta =
         StdlibCall
-          { _stdlibCallArgs = maybe nockNil' foldTerms (nonEmpty args),
+          { _stdlibCallArgs = foldTermsOrNil args,
             _stdlibCallFunction = fun
           }
    in TermCell callCell
@@ -665,13 +684,13 @@ makeList ts = foldTerms (toList ts `prependList` pure (TermAtom nockNil))
 remakeList :: (Foldable l) => l (Term Natural) -> Term Natural
 remakeList ts = foldTerms (toList ts `prependList` pure (OpQuote # nockNil'))
 
-runCompilerWithAnoma :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Term Natural
+runCompilerWithAnoma :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> AnomaResult
 runCompilerWithAnoma = runCompilerWith ProgramCallingConventionAnoma
 
-runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Term Natural
+runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> AnomaResult
 runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO $ do
-  writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
-  return (run . runReader compilerCtx $ mkEntryPoint)
+  -- writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
+  return mkEntryPoint
   where
     allFuns :: NonEmpty CompilerFunction
     allFuns = mainFun :| libFuns ++ (builtinFunction <$> allElements)
@@ -719,13 +738,16 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO
             }
         )
 
-    makeAnomaFun :: Sem r (Term Natural)
-    makeAnomaFun = do
+    makeAnomaFun :: AnomaResult
+    makeAnomaFun =
       let mainClosure :: Term Natural
           mainClosure = head compiledFuns
-      return mainClosure
+       in AnomaResult
+            { _anomaClosure = mainClosure,
+              _anomaEnv = exportEnv
+            }
 
-    mkEntryPoint :: Sem r (Term Natural)
+    mkEntryPoint :: AnomaResult
     mkEntryPoint = case callingConvention of
       ProgramCallingConventionAnoma -> makeAnomaFun
 
@@ -741,10 +763,7 @@ builtinFunction = \case
 closurePath :: AnomaCallablePathId -> Path
 closurePath = stackPath
 
--- makeNockFunction :: Term Natural -> [Term Natural] -> Term Natural
--- makeNockFunction funCode defs = callF
-
--- | Call a function. Arguments to the function are assumed to be in the Args stack
+-- | Call a function. Arguments to the function are assumed to be in the ArgsTuple stack
 callFun ::
   (Members '[Reader CompilerCtx] r) =>
   FunctionId ->
@@ -776,23 +795,23 @@ callFunWithArgs ::
   Sem r (Term Natural)
 callFunWithArgs fun args = (replaceArgs args >>#) <$> callFun fun
 
-replaceArgsWithTerm :: Term Natural -> Term Natural
-replaceArgsWithTerm term =
+replaceSubject :: (AnomaCallablePathId -> Maybe (Term Natural)) -> Term Natural
+replaceSubject f =
   remakeList
-    [ if
-          | ArgsTuple == s -> term
-          | otherwise -> OpAddress # stackPath s
+    [ case f s of
+        Nothing -> OpAddress # closurePath s
+        Just t' -> t'
       | s <- allElements
     ]
 
+replaceArgsWithTerm :: Term Natural -> Term Natural
+replaceArgsWithTerm term =
+  replaceSubject $ \case
+    ArgsTuple -> Just term
+    _ -> Nothing
+
 replaceArgs :: [Term Natural] -> Term Natural
-replaceArgs args =
-  remakeList
-    [ if
-          | ArgsTuple == s -> foldTermsOrNil args
-          | otherwise -> OpAddress # stackPath s
-      | s <- allElements
-    ]
+replaceArgs = replaceArgsWithTerm . foldTermsOrNil
 
 getFunctionPath :: (Members '[Reader CompilerCtx] r) => FunctionId -> Sem r Path
 getFunctionPath funName = asks (^?! compilerFunctionInfos . at funName . _Just . functionInfoPath)

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -6,6 +6,7 @@ module Juvix.Compiler.Nockma.Translation.FromTree
     ProgramCallingConvention (..),
     CompilerOptions (..),
     CompilerFunction (..),
+    FunctionCtx (..),
     FunctionId (..),
     add,
     dec,
@@ -13,11 +14,14 @@ module Juvix.Compiler.Nockma.Translation.FromTree
     sub,
     pow2,
     nockNatLiteral,
+    nockIntegralLiteral,
     callStdlib,
     appendRights,
     foldTerms,
     pathToArg,
     makeList,
+    listToTuple,
+    opAddress',
   )
 where
 
@@ -218,14 +222,14 @@ supportsListNockmaRep tab ci = case allConstructors tab ci of
   _ -> Nothing
 
 -- | Use `Tree.toNockma` before calling this function
-fromTreeTable :: (Members '[Error JuvixError, Reader CompilerOptions] r) => ProgramCallingConvention -> Tree.InfoTable -> Sem r (Cell Natural)
+fromTreeTable :: (Members '[Error JuvixError, Reader CompilerOptions] r) => ProgramCallingConvention -> Tree.InfoTable -> Sem r (Term Natural)
 fromTreeTable cc t = case t ^. Tree.infoMainFunction of
   Just mainFun -> do
     opts <- ask
     return (fromTree opts mainFun t)
   Nothing -> throw @JuvixError (error "TODO missing main")
   where
-    fromTree :: CompilerOptions -> Tree.Symbol -> Tree.InfoTable -> Cell Natural
+    fromTree :: CompilerOptions -> Tree.Symbol -> Tree.InfoTable -> Term Natural
     fromTree opts mainSym tab@Tree.InfoTable {..} =
       let funs = map compileFunction allFunctions
           mkConstructorInfo :: Tree.ConstructorInfo -> ConstructorInfo
@@ -281,13 +285,13 @@ anomaCallableClosureWrapper =
       closureTotalArgsNum :: Term Natural = getClosureFieldInSubject ClosureTotalArgsNum
       appendAndReplaceArgsTuple =
         replaceArgsWithTerm $
-           appendToTuple
-              (getClosureFieldInSubject ClosureArgs)
-              closureArgsNum
-              (getClosureFieldInSubject ArgsTuple)
-              (sub closureTotalArgsNum closureArgsNum)
+          appendToTuple
+            (getClosureFieldInSubject ClosureArgs)
+            closureArgsNum
+            (getClosureFieldInSubject ArgsTuple)
+            (sub closureTotalArgsNum closureArgsNum)
       adjustArgs = OpIf # closureArgsIsEmpty # (OpQuote # (OpAddress # emptyPath)) # (OpQuote # appendAndReplaceArgsTuple)
-      closureArgsIsEmpty = OpEq # closureArgsNum # nockNatLiteral 0
+      closureArgsIsEmpty = isZero closureArgsNum
    in OpCall # getClosureFieldInSubject RawCode # adjustArgs
 
 compile :: forall r. (Members '[Reader FunctionCtx, Reader CompilerCtx] r) => Tree.Node -> Sem r (Term Natural)
@@ -486,12 +490,13 @@ opAddress' :: Term Natural -> Term Natural
 opAddress' x = evaluated $ (OpQuote # OpAddress) # x
 
 -- [a [b [c 0]]] -> [a [b c]]
--- len = 3
+-- len = quote 3
+-- TODO lst is being evaluated three times!
 listToTuple :: Term Natural -> Term Natural -> Term Natural
 listToTuple lst len =
   let posOfLast = appendRights emptyPath (dec len)
-      t1 = (OpQuote # lst) >># (opAddress' posOfLast) >># (OpAddress # [L])
-   in OpIf # isZero (OpQuote # len) # (OpQuote # lst) # (replaceSubterm' posOfLast t1 (OpQuote # lst))
+      t1 = lst >># (opAddress' posOfLast) >># (OpAddress # [L])
+   in OpIf # isZero len # lst # (replaceSubterm' posOfLast t1 lst)
 
 argsTuplePlaceholder :: Term Natural
 argsTuplePlaceholder = nockNil'
@@ -653,20 +658,15 @@ makeList ts = foldTerms (ts `prependList` pure (TermAtom nockNil))
 remakeList :: (Foldable l) => l (Term Natural) -> Term Natural
 remakeList ts = foldTerms (toList ts `prependList` pure (OpQuote # nockNil'))
 
-asCell :: Term Natural -> Cell Natural
-asCell = \case
-  TermCell c -> c
-  TermAtom {} -> impossible
-
-runCompilerWithAnoma :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Cell Natural
+runCompilerWithAnoma :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Term Natural
 runCompilerWithAnoma = runCompilerWith ProgramCallingConventionAnoma
 
-runCompilerWithJuvix :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Cell Natural
+runCompilerWithJuvix :: CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Term Natural
 runCompilerWithJuvix = runCompilerWith ProgramCallingConventionJuvix
 
-runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Cell Natural
+runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> Term Natural
 runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO $ do
-  writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
+  -- writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
   return (run . runReader compilerCtx $ mkEntryPoint)
   where
     allFuns :: NonEmpty CompilerFunction
@@ -715,18 +715,18 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO
             }
         )
 
-    makeAnomaFun :: Sem r (Cell Natural)
+    makeAnomaFun :: Sem r (Term Natural)
     makeAnomaFun = do
       let mainClosure :: Term Natural
           mainClosure = head compiledFuns
-      return (asCell mainClosure)
+      return mainClosure
 
-    makeJuvixFun :: (Members '[Reader CompilerCtx] r) => Sem r (Cell Natural)
+    makeJuvixFun :: (Members '[Reader CompilerCtx] r) => Sem r (Term Natural)
     makeJuvixFun = do
       res <- callFunWithEnv (mainFun ^. compilerFunctionName) exportEnv
-      return (asCell res)
+      return res
 
-    mkEntryPoint :: (Members '[Reader CompilerCtx] r) => Sem r (Cell Natural)
+    mkEntryPoint :: (Members '[Reader CompilerCtx] r) => Sem r (Term Natural)
     mkEntryPoint = case callingConvention of
       ProgramCallingConventionAnoma -> makeAnomaFun
       ProgramCallingConventionJuvix -> makeJuvixFun

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -420,7 +420,7 @@ compile = \case
       Tree.OpFieldToInt -> fieldErr
 
     goAnomaGet :: Term Natural -> Sem r (Term Natural)
-    goAnomaGet arg = return (OpScry # (OpQuote # nockNil') # arg)
+    goAnomaGet arg = return (OpScry # (OpQuote # nockNilTagged "OpScry-typehint") # arg)
 
     goTrace :: Term Natural -> Sem r (Term Natural)
     goTrace arg = do

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -9,6 +9,7 @@ module Juvix.Compiler.Nockma.Translation.FromTree
     FunctionCtx (..),
     FunctionId (..),
     closurePath,
+    foldTermsOrNil,
     add,
     dec,
     mul,
@@ -198,7 +199,7 @@ makeConstructor :: (ConstructorPathId -> Term Natural) -> Term Natural
 makeConstructor = termFromParts
 
 foldTermsOrNil :: [Term Natural] -> Term Natural
-foldTermsOrNil = maybe nockNil' foldTerms . nonEmpty
+foldTermsOrNil = maybe (OpQuote # nockNil') foldTerms . nonEmpty
 
 foldTerms :: NonEmpty (Term Natural) -> Term Natural
 foldTerms = foldr1 (#)

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -43,7 +43,6 @@ import Juvix.Compiler.Tree.Data.InfoTable qualified as Tree
 import Juvix.Compiler.Tree.Language qualified as Tree
 import Juvix.Compiler.Tree.Language.Rep
 import Juvix.Prelude hiding (Atom, Path)
-import System.IO.Unsafe (unsafePerformIO)
 
 data ProgramCallingConvention
   = ProgramCallingConventionAnoma
@@ -688,9 +687,7 @@ runCompilerWithAnoma :: CompilerOptions -> ConstructorInfos -> [CompilerFunction
 runCompilerWithAnoma = runCompilerWith ProgramCallingConventionAnoma
 
 runCompilerWith :: ProgramCallingConvention -> CompilerOptions -> ConstructorInfos -> [CompilerFunction] -> CompilerFunction -> AnomaResult
-runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO $ do
-  -- writeFileEnsureLn $(mkAbsFile "/home/jan/projects/anoma/JuvixEnv.nockma") (ppSerialize exportEnv)
-  return mkEntryPoint
+runCompilerWith callingConvention opts constrs libFuns mainFun = mkEntryPoint
   where
     allFuns :: NonEmpty CompilerFunction
     allFuns = mainFun :| libFuns ++ (builtinFunction <$> allElements)

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -606,9 +606,9 @@ callStdlib fun args =
   let fPath = stdlibPath fun
       getFunCode = opAddress "callStdlibFunCode" (stackPath StandardLibrary) >># fPath
       adjustArgs = case nonEmpty args of
-        Just args' -> OpReplace # ([R, L] # ((opAddress "stdlibR" [R]) >># foldTerms args')) # (opAddress "stdlibL" [L])
+        Just args' -> opReplace "callStdlib-args" (closurePath ArgsTuple) ((opAddress "stdlibR" [R]) >># foldTerms args') (opAddress "stdlibL" [L])
         Nothing -> opAddress "adjustArgsNothing" [L]
-      callFn = opCall "callStdlib" [L] adjustArgs
+      callFn = opCall "callStdlib" (closurePath WrapperCode) adjustArgs
       callCell = set cellCall (Just meta) (OpPush #. (getFunCode # callFn))
       meta =
         StdlibCall

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -87,6 +87,10 @@ data FunctionInfo = FunctionInfo
     _functionInfoArity :: Natural
   }
 
+data FunctionCtx = FunctionCtx
+  { _functionCtxArity :: Natural
+  }
+
 data CompilerCtx = CompilerCtx
   { _compilerFunctionInfos :: HashMap FunctionId FunctionInfo,
     _compilerConstructorInfos :: ConstructorInfos,
@@ -103,7 +107,7 @@ type ConstructorInfos = HashMap Tree.Tag ConstructorInfo
 data CompilerFunction = CompilerFunction
   { _compilerFunctionName :: FunctionId,
     _compilerFunctionArity :: Natural,
-    _compilerFunction :: Sem '[Reader CompilerCtx] (Term Natural)
+    _compilerFunction :: Sem '[Reader CompilerCtx, Reader FunctionCtx] (Term Natural)
   }
 
 -- The Code and Args constructors must be first and second respectively. This is
@@ -111,7 +115,7 @@ data CompilerFunction = CompilerFunction
 -- i.e [code args env]
 data AnomaCallablePathId
   = WrapperCode
-  | Args
+  | ArgsTuple
   | FunctionsLibrary
   | RawCode
   | TempStack
@@ -140,13 +144,6 @@ data ConstructorPathId
 constructorPath :: ConstructorPathId -> Path
 constructorPath = pathFromEnum
 
-data FunctionPathId
-  = FunctionCode
-
-functionPath :: FunctionPathId -> Path
-functionPath = \case
-  FunctionCode -> []
-
 stackPath :: AnomaCallablePathId -> Path
 stackPath s = indexStack (fromIntegral (fromEnum s))
 
@@ -165,14 +162,24 @@ indexStack idx = replicate idx R ++ [L]
 indexInStack :: AnomaCallablePathId -> Natural -> Path
 indexInStack s idx = stackPath s ++ indexStack idx
 
-pathToArg :: Natural -> Path
-pathToArg = indexInStack Args
-
 makeLenses ''CompilerOptions
 makeLenses ''CompilerFunction
 makeLenses ''CompilerCtx
+makeLenses ''FunctionCtx
 makeLenses ''ConstructorInfo
 makeLenses ''FunctionInfo
+
+runCompilerFunction :: CompilerCtx -> CompilerFunction -> Term Natural
+runCompilerFunction ctx fun =
+  run
+    . runReader (FunctionCtx (fun ^. compilerFunctionArity))
+    . runReader ctx
+    $ fun ^. compilerFunction
+
+pathToArg :: (Members '[Reader FunctionCtx] r) => Natural -> Sem r Path
+pathToArg n = do
+  ari <- asks (^. functionCtxArity)
+  return (stackPath ArgsTuple <> indexTuple ari n)
 
 termFromParts :: (Bounded p, Enum p) => (p -> Term Natural) -> Term Natural
 termFromParts f = remakeList [f pi | pi <- allElements]
@@ -183,8 +190,8 @@ makeClosure = termFromParts
 makeConstructor :: (ConstructorPathId -> Term Natural) -> Term Natural
 makeConstructor = termFromParts
 
-makeFunction :: (FunctionPathId -> Term Natural) -> Term Natural
-makeFunction f = f FunctionCode
+foldTermsOrNil :: [Term Natural] -> Term Natural
+foldTermsOrNil = maybe nockNil' foldTerms . nonEmpty
 
 foldTerms :: NonEmpty (Term Natural) -> Term Natural
 foldTerms = foldr1 (#)
@@ -270,11 +277,20 @@ fromOffsetRef = fromIntegral . (^. Tree.offsetRefOffset)
 
 anomaCallableClosureWrapper :: Term Natural
 anomaCallableClosureWrapper =
-  -- TODO: Consider avoiding the append in if there are no ClosureArgs.
-  let newArgs = append (getClosureFieldInSubject ClosureArgs) (getClosureFieldInSubject ClosureArgsNum) (getClosureFieldInSubject Args)
-   in OpCall # getClosureFieldInSubject RawCode # replaceArgsWithTerm newArgs
+  let closureArgsNum :: Term Natural = getClosureFieldInSubject ClosureArgsNum
+      closureTotalArgsNum :: Term Natural = getClosureFieldInSubject ClosureTotalArgsNum
+      appendAndReplaceArgsTuple =
+        replaceArgsWithTerm $
+           appendToTuple
+              (getClosureFieldInSubject ClosureArgs)
+              closureArgsNum
+              (getClosureFieldInSubject ArgsTuple)
+              (sub closureTotalArgsNum closureArgsNum)
+      adjustArgs = OpIf # closureArgsIsEmpty # (OpQuote # (OpAddress # emptyPath)) # (OpQuote # appendAndReplaceArgsTuple)
+      closureArgsIsEmpty = OpEq # closureArgsNum # nockNatLiteral 0
+   in OpCall # getClosureFieldInSubject RawCode # adjustArgs
 
-compile :: forall r. (Members '[Reader CompilerCtx] r) => Tree.Node -> Sem r (Term Natural)
+compile :: forall r. (Members '[Reader FunctionCtx, Reader CompilerCtx] r) => Tree.Node -> Sem r (Term Natural)
 compile = \case
   Tree.Binop b -> goBinop b
   Tree.Unop b -> goUnop b
@@ -298,27 +314,32 @@ compile = \case
 
     goMemRef :: Tree.MemRef -> Sem r (Term Natural)
     goMemRef = \case
-      Tree.DRef d -> return (goDirectRef d)
+      Tree.DRef d -> goDirectRef d
       Tree.ConstrRef Tree.Field {..} -> do
         info <- getConstructorInfo _fieldTag
         let memrep = info ^. constructorInfoMemRep
             argIx = fromIntegral _fieldOffset
             arity = info ^. constructorInfoArity
-            path = case memrep of
-              NockmaMemRepConstr ->
-                directRefPath _fieldRef
-                  ++ constructorPath ConstructorArgs
-                  ++ indexStack argIx
-              NockmaMemRepTuple ->
-                directRefPath _fieldRef
-                  ++ indexTuple arity argIx
-              NockmaMemRepList constr -> case constr of
-                NockmaMemRepListConstrNil -> impossible
-                NockmaMemRepListConstrCons -> directRefPath _fieldRef ++ indexTuple 2 argIx
-        return (OpAddress # path)
+            path :: Sem r Path
+            path = do
+              fr <- directRefPath _fieldRef
+              return $ case memrep of
+                NockmaMemRepConstr ->
+                  fr
+                    ++ constructorPath ConstructorArgs
+                    ++ indexStack argIx
+                NockmaMemRepTuple ->
+                  fr
+                    ++ indexTuple arity argIx
+                NockmaMemRepList constr -> case constr of
+                  NockmaMemRepListConstrNil -> impossible
+                  NockmaMemRepListConstrCons -> fr ++ indexTuple 2 argIx
+        (OpAddress #) <$> path
       where
-        goDirectRef :: Tree.DirectRef -> Term Natural
-        goDirectRef dr = OpAddress # directRefPath dr
+        goDirectRef :: Tree.DirectRef -> Sem r (Term Natural)
+        goDirectRef dr = do
+          p <- directRefPath dr
+          return (OpAddress # p)
 
     goConstant :: Tree.Constant -> Term Natural
     goConstant = \case
@@ -423,7 +444,7 @@ compile = \case
       args <- mapM compile _nodeAllocClosureArgs
       return . makeClosure $ \case
         WrapperCode -> OpQuote # anomaCallableClosureWrapper
-        Args -> remakeList []
+        ArgsTuple -> argsTuplePlaceholder
         RawCode -> OpAddress # fpath
         TempStack -> remakeList []
         StandardLibrary -> OpQuote # stdlib
@@ -455,9 +476,25 @@ compile = \case
           let argsNum = getClosureField ClosureArgsNum f'
               oldArgs = getClosureField ClosureArgs f'
               fcode = getClosureField RawCode f'
-              posOfArgsNil = appendRights emptyPath argsNum
-              allArgs = replaceSubterm' oldArgs posOfArgsNil (remakeList newargs)
+              allArgs = appendToTuple oldArgs argsNum (foldTermsOrNil newargs) (nockIntegralLiteral (length newargs))
           return (OpApply # replaceArgsWithTerm allArgs # fcode)
+
+isZero :: Term Natural -> Term Natural
+isZero a = OpEq # a # nockNatLiteral 0
+
+opAddress' :: Term Natural -> Term Natural
+opAddress' x = evaluated $ (OpQuote # OpAddress) # x
+
+-- [a [b [c 0]]] -> [a [b c]]
+-- len = 3
+listToTuple :: Term Natural -> Term Natural -> Term Natural
+listToTuple lst len =
+  let posOfLast = appendRights emptyPath (dec len)
+      t1 = (OpQuote # lst) >># (opAddress' posOfLast) >># (OpAddress # [L])
+   in OpIf # isZero (OpQuote # len) # (OpQuote # lst) # (replaceSubterm' posOfLast t1 (OpQuote # lst))
+
+argsTuplePlaceholder :: Term Natural
+argsTuplePlaceholder = nockNil'
 
 appendRights :: Path -> Term Natural -> Term Natural
 appendRights path n = dec (mul (pow2 n) (OpInc # OpQuote # path))
@@ -476,7 +513,7 @@ withTemp :: Term Natural -> Term Natural -> Term Natural
 withTemp toBePushed body =
   OpSequence # pushTemp toBePushed # body
 
-testEq :: (Members '[Reader CompilerCtx] r) => Tree.Node -> Tree.Node -> Sem r (Term Natural)
+testEq :: (Members '[Reader FunctionCtx, Reader CompilerCtx] r) => Tree.Node -> Tree.Node -> Sem r (Term Natural)
 testEq a b = do
   a' <- compile a
   b' <- compile b
@@ -488,13 +525,17 @@ nockNatLiteral = nockIntegralLiteral
 nockIntegralLiteral :: (Integral a) => a -> Term Natural
 nockIntegralLiteral = (OpQuote #) . toNock @Natural . fromIntegral
 
+appendToTuple :: Term Natural -> Term Natural -> Term Natural -> Term Natural -> Term Natural
+appendToTuple xs lenXs ys lenYs =
+  OpIf # isZero lenYs # listToTuple xs lenXs # append xs lenXs ys
+
 append :: Term Natural -> Term Natural -> Term Natural -> Term Natural
 append xs lenXs ys =
   let posOfXsNil = appendRights emptyPath lenXs
    in replaceSubterm' xs posOfXsNil ys
 
 extendClosure ::
-  (Members '[Reader CompilerCtx] r) =>
+  (Members '[Reader FunctionCtx, Reader CompilerCtx] r) =>
   Tree.NodeExtendClosure ->
   Sem r (Term Natural)
 extendClosure Tree.NodeExtendClosure {..} = do
@@ -511,7 +552,7 @@ extendClosure Tree.NodeExtendClosure {..} = do
     ClosureTotalArgsNum -> getClosureField ClosureTotalArgsNum closure
     ClosureArgsNum -> newArgsNum
     ClosureArgs -> allArgs
-    Args -> getClosureField Args closure
+    ArgsTuple -> getClosureField ArgsTuple closure
     FunctionsLibrary -> getClosureField FunctionsLibrary closure
     TempStack -> getClosureField TempStack closure
     StandardLibrary -> getClosureField StandardLibrary closure
@@ -551,13 +592,15 @@ constUnit = constVoid
 constVoid :: Term Natural
 constVoid = TermAtom nockVoid
 
-directRefPath :: Tree.DirectRef -> Path
+directRefPath :: forall r. (Members '[Reader FunctionCtx] r) => Tree.DirectRef -> Sem r Path
 directRefPath = \case
   Tree.ArgRef a -> pathToArg (fromOffsetRef a)
   Tree.TempRef Tree.RefTemp {..} ->
-    tempRefPath
-      (fromIntegral (fromJust _refTempTempHeight))
-      (fromOffsetRef _refTempOffsetRef)
+    return
+      ( tempRefPath
+          (fromIntegral (fromJust _refTempTempHeight))
+          (fromOffsetRef _refTempOffsetRef)
+      )
 
 tempRefPath :: Natural -> Natural -> Path
 tempRefPath tempHeight off = indexInStack TempStack (tempHeight - off - 1)
@@ -610,21 +653,6 @@ makeList ts = foldTerms (ts `prependList` pure (TermAtom nockNil))
 remakeList :: (Foldable l) => l (Term Natural) -> Term Natural
 remakeList ts = foldTerms (toList ts `prependList` pure (OpQuote # nockNil'))
 
-makeNockFunction :: Term Natural -> [Term Natural] -> Term Natural
-makeNockFunction funCode defs = remakeList (initSubStack <$> allElements)
-  where
-    initSubStack :: AnomaCallablePathId -> Term Natural
-    initSubStack = \case
-      WrapperCode -> funCode
-      Args -> nockNil'
-      FunctionsLibrary -> makeList defs
-      RawCode -> funCode
-      TempStack -> nockNil'
-      StandardLibrary -> stdlib
-      ClosureTotalArgsNum -> nockNil'
-      ClosureArgsNum -> nockNil'
-      ClosureArgs -> nockNil'
-
 asCell :: Term Natural -> Cell Natural
 asCell = \case
   TermCell c -> c
@@ -654,17 +682,24 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO
 
     compiledFuns :: NonEmpty (Term Natural)
     compiledFuns =
-      makeFunction'
-        <$> ( run . runReader compilerCtx . (^. compilerFunction)
-                <$> allFuns
+      makeLibraryFunction
+        <$> ( runCompilerFunction compilerCtx <$> allFuns
             )
 
     exportEnv :: Term Natural
     exportEnv = makeList (toList compiledFuns)
 
-    makeFunction' :: Term Natural -> Term Natural
-    makeFunction' c = makeFunction $ \case
-      FunctionCode -> c
+    makeLibraryFunction :: Term Natural -> Term Natural
+    makeLibraryFunction c = makeClosure $ \case
+      WrapperCode -> c
+      ArgsTuple -> argsTuplePlaceholder
+      FunctionsLibrary -> nockNil'
+      RawCode -> c
+      TempStack -> nockNil'
+      StandardLibrary -> stdlib
+      ClosureTotalArgsNum -> nockNil'
+      ClosureArgsNum -> nockNil'
+      ClosureArgs -> nockNil'
 
     functionInfos :: HashMap FunctionId FunctionInfo
     functionInfos = hashMap (run (runInputNaturals (toList <$> userFunctions)))
@@ -682,12 +717,9 @@ runCompilerWith callingConvention opts constrs libFuns mainFun = unsafePerformIO
 
     makeAnomaFun :: Sem r (Cell Natural)
     makeAnomaFun = do
-      let funCode :: Term Natural
-          funCode = head compiledFuns
-
-      return $ case makeNockFunction funCode (toList compiledFuns) of
-        TermCell c -> c
-        TermAtom {} -> impossible
+      let mainClosure :: Term Natural
+          mainClosure = head compiledFuns
+      return (asCell mainClosure)
 
     makeJuvixFun :: (Members '[Reader CompilerCtx] r) => Sem r (Cell Natural)
     makeJuvixFun = do
@@ -708,6 +740,12 @@ builtinFunction = \case
         _compilerFunction = return crash
       }
 
+closurePath :: AnomaCallablePathId -> Path
+closurePath = stackPath
+
+-- makeNockFunction :: Term Natural -> [Term Natural] -> Term Natural
+-- makeNockFunction funCode defs = callF
+
 -- | Call a function. Arguments to the function are assumed to be in the Args stack
 callFunWithEnv ::
   (Members '[Reader CompilerCtx] r) =>
@@ -716,7 +754,7 @@ callFunWithEnv ::
   Sem r (Term Natural)
 callFunWithEnv fun env = do
   fpath <- getFunctionPath fun
-  let p' = fpath ++ functionPath FunctionCode
+  let p' = fpath ++ closurePath WrapperCode
   return (OpCall # p' # (OpReplace # (stackPath FunctionsLibrary # (OpQuote # env)) # OpAddress # emptyPath))
 
 -- | Call a function. Arguments to the function are assumed to be in the Args stack
@@ -726,7 +764,7 @@ callFun ::
   Sem r (Term Natural)
 callFun fun = do
   fpath <- getFunctionPath fun
-  let p' = fpath ++ functionPath FunctionCode
+  let p' = fpath ++ closurePath WrapperCode
   return (OpCall # p' # (OpAddress # emptyPath))
 
 -- [f1_code f1_args env] / [call L [@ S]]
@@ -755,7 +793,7 @@ replaceArgsWithTerm :: Term Natural -> Term Natural
 replaceArgsWithTerm term =
   remakeList
     [ if
-          | Args == s -> term
+          | ArgsTuple == s -> term
           | otherwise -> OpAddress # stackPath s
       | s <- allElements
     ]
@@ -764,7 +802,7 @@ replaceArgs :: [Term Natural] -> Term Natural
 replaceArgs args =
   remakeList
     [ if
-          | Args == s -> remakeList args
+          | ArgsTuple == s -> foldTermsOrNil args
           | otherwise -> OpAddress # stackPath s
       | s <- allElements
     ]

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -27,7 +27,6 @@ import Juvix.Compiler.Core.Transformation
 import Juvix.Compiler.Core.Translation.Stripped.FromCore qualified as Stripped
 import Juvix.Compiler.Internal qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
-import Juvix.Compiler.Nockma.Language qualified as Nockma
 import Juvix.Compiler.Nockma.Translation.FromTree qualified as NockmaTree
 import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.EntryPoint
@@ -130,7 +129,7 @@ upToGeb spec =
 
 upToAnoma ::
   (Members '[HighlightBuilder, Reader Parser.ParserResult, Reader EntryPoint, Reader Store.ModuleTable, Files, NameIdGen, Error JuvixError, GitClone, PathResolver] r) =>
-  Sem r (Nockma.Term Natural)
+  Sem r NockmaTree.AnomaResult
 upToAnoma = upToStoredCore >>= \Core.CoreResult {..} -> storedCoreToAnoma _coreResultModule
 
 upToCoreTypecheck ::
@@ -150,7 +149,7 @@ storedCoreToTree checkId md = do
     >=> return . Tree.fromCore . Stripped.fromCore fsize . Core.computeCombinedInfoTable
     $ md
 
-storedCoreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Term Natural)
+storedCoreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r NockmaTree.AnomaResult
 storedCoreToAnoma = storedCoreToTree Core.CheckAnoma >=> treeToAnoma
 
 storedCoreToAsm :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r Asm.InfoTable
@@ -190,10 +189,7 @@ coreToReg = Core.toStored >=> storedCoreToReg
 coreToCasm :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r Casm.Result
 coreToCasm = Core.toStored >=> storedCoreToCasm
 
-coreToNockma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Term Natural)
-coreToNockma = coreToTree Core.CheckAnoma >=> treeToNockma
-
-coreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Term Natural)
+coreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r NockmaTree.AnomaResult
 coreToAnoma = coreToTree Core.CheckAnoma >=> treeToAnoma
 
 coreToMiniC :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r C.MiniCResult
@@ -221,7 +217,7 @@ treeToCairoAsm = Tree.toCairoAsm >=> return . Asm.fromTree
 treeToReg :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r Reg.InfoTable
 treeToReg = treeToAsm >=> asmToReg
 
-treeToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
+treeToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (NockmaTree.AnomaResult)
 treeToAnoma = Tree.toNockma >=> mapReader NockmaTree.fromEntryPoint . NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma
 
 treeToMiniC :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r C.MiniCResult
@@ -248,7 +244,7 @@ regToMiniC tab = do
 regToCasm :: Reg.InfoTable -> Sem r Casm.Result
 regToCasm = Reg.toCasm >=> return . Casm.fromReg
 
-treeToAnoma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
+treeToAnoma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r NockmaTree.AnomaResult
 treeToAnoma' = Tree.toNockma >=> NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma
 
 asmToMiniC' :: (Members '[Error JuvixError, Reader Asm.Options] r) => Asm.InfoTable -> Sem r C.MiniCResult

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -221,9 +221,6 @@ treeToCairoAsm = Tree.toCairoAsm >=> return . Asm.fromTree
 treeToReg :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r Reg.InfoTable
 treeToReg = treeToAsm >=> asmToReg
 
-treeToNockma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
-treeToNockma = Tree.toNockma >=> mapReader NockmaTree.fromEntryPoint . NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionJuvix
-
 treeToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
 treeToAnoma = Tree.toNockma >=> mapReader NockmaTree.fromEntryPoint . NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma
 
@@ -250,9 +247,6 @@ regToMiniC tab = do
 
 regToCasm :: Reg.InfoTable -> Sem r Casm.Result
 regToCasm = Reg.toCasm >=> return . Casm.fromReg
-
-treeToNockma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
-treeToNockma' = Tree.toNockma >=> NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionJuvix
 
 treeToAnoma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
 treeToAnoma' = Tree.toNockma >=> NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -218,7 +218,7 @@ treeToReg :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTabl
 treeToReg = treeToAsm >=> asmToReg
 
 treeToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (NockmaTree.AnomaResult)
-treeToAnoma = Tree.toNockma >=> mapReader NockmaTree.fromEntryPoint . NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma
+treeToAnoma = Tree.toNockma >=> mapReader NockmaTree.fromEntryPoint . NockmaTree.fromTreeTable
 
 treeToMiniC :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r C.MiniCResult
 treeToMiniC = treeToAsm >=> asmToMiniC
@@ -245,7 +245,7 @@ regToCasm :: Reg.InfoTable -> Sem r Casm.Result
 regToCasm = Reg.toCasm >=> return . Casm.fromReg
 
 treeToAnoma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r NockmaTree.AnomaResult
-treeToAnoma' = Tree.toNockma >=> NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma
+treeToAnoma' = Tree.toNockma >=> NockmaTree.fromTreeTable
 
 asmToMiniC' :: (Members '[Error JuvixError, Reader Asm.Options] r) => Asm.InfoTable -> Sem r C.MiniCResult
 asmToMiniC' = mapError (JuvixError @Asm.AsmError) . Asm.toReg' >=> regToMiniC' . Reg.fromAsm

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -131,7 +131,7 @@ upToGeb spec =
 upToAnoma ::
   (Members '[HighlightBuilder, Reader Parser.ParserResult, Reader EntryPoint, Reader Store.ModuleTable, Files, NameIdGen, Error JuvixError, GitClone, PathResolver] r) =>
   Sem r (Nockma.Term Natural)
-upToAnoma = upToStoredCore >>= \Core.CoreResult {..} -> Nockma.TermCell <$> storedCoreToAnoma _coreResultModule
+upToAnoma = upToStoredCore >>= \Core.CoreResult {..} -> storedCoreToAnoma _coreResultModule
 
 upToCoreTypecheck ::
   (Members '[HighlightBuilder, Reader Parser.ParserResult, Reader EntryPoint, Reader Store.ModuleTable, Files, NameIdGen, Error JuvixError, GitClone, PathResolver] r) =>
@@ -150,7 +150,7 @@ storedCoreToTree checkId md = do
     >=> return . Tree.fromCore . Stripped.fromCore fsize . Core.computeCombinedInfoTable
     $ md
 
-storedCoreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Cell Natural)
+storedCoreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Term Natural)
 storedCoreToAnoma = storedCoreToTree Core.CheckAnoma >=> treeToAnoma
 
 storedCoreToAsm :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r Asm.InfoTable
@@ -190,10 +190,10 @@ coreToReg = Core.toStored >=> storedCoreToReg
 coreToCasm :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r Casm.Result
 coreToCasm = Core.toStored >=> storedCoreToCasm
 
-coreToNockma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Cell Natural)
+coreToNockma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Term Natural)
 coreToNockma = coreToTree Core.CheckAnoma >=> treeToNockma
 
-coreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Cell Natural)
+coreToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r (Nockma.Term Natural)
 coreToAnoma = coreToTree Core.CheckAnoma >=> treeToAnoma
 
 coreToMiniC :: (Members '[Error JuvixError, Reader EntryPoint] r) => Core.Module -> Sem r C.MiniCResult
@@ -221,10 +221,10 @@ treeToCairoAsm = Tree.toCairoAsm >=> return . Asm.fromTree
 treeToReg :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r Reg.InfoTable
 treeToReg = treeToAsm >=> asmToReg
 
-treeToNockma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (Nockma.Cell Natural)
+treeToNockma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
 treeToNockma = Tree.toNockma >=> mapReader NockmaTree.fromEntryPoint . NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionJuvix
 
-treeToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (Nockma.Cell Natural)
+treeToAnoma :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
 treeToAnoma = Tree.toNockma >=> mapReader NockmaTree.fromEntryPoint . NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma
 
 treeToMiniC :: (Members '[Error JuvixError, Reader EntryPoint] r) => Tree.InfoTable -> Sem r C.MiniCResult
@@ -251,10 +251,10 @@ regToMiniC tab = do
 regToCasm :: Reg.InfoTable -> Sem r Casm.Result
 regToCasm = Reg.toCasm >=> return . Casm.fromReg
 
-treeToNockma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Cell Natural)
+treeToNockma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
 treeToNockma' = Tree.toNockma >=> NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionJuvix
 
-treeToAnoma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Cell Natural)
+treeToAnoma' :: (Members '[Error JuvixError, Reader NockmaTree.CompilerOptions] r) => Tree.InfoTable -> Sem r (Nockma.Term Natural)
 treeToAnoma' = Tree.toNockma >=> NockmaTree.fromTreeTable NockmaTree.ProgramCallingConventionAnoma
 
 asmToMiniC' :: (Members '[Error JuvixError, Reader Asm.Options] r) => Asm.InfoTable -> Sem r C.MiniCResult

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -689,6 +689,9 @@ instrAdd = "add"
 argsTag :: (IsString s) => s
 argsTag = "args@"
 
+tagTag :: (IsString s) => s
+tagTag = "tag@"
+
 stdlibTag :: (IsString s) => s
 stdlibTag = "stdlib@"
 

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -3,13 +3,13 @@ module Anoma.Compilation.Positive where
 import Base
 import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Backend (Target (TargetAnoma))
+import Juvix.Compiler.Nockma.Anoma
 import Juvix.Compiler.Nockma.Evaluator
 import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Pretty
 import Juvix.Compiler.Nockma.Translation.FromSource.QQ
 import Juvix.Compiler.Nockma.Translation.FromTree
 import Juvix.Prelude qualified as Prelude
-import Nockma.Base
 import Nockma.Eval.Positive
 
 root :: Prelude.Path Abs Dir

--- a/test/Nockma/Base.hs
+++ b/test/Nockma/Base.hs
@@ -6,19 +6,21 @@ import Juvix.Compiler.Nockma.Translation.FromTree
 
 -- | Call a function at the head of the subject using the Anoma calling convention
 anomaCall :: Term Natural -> [Term Natural] -> Term Natural
-anomaCall env args = case nonEmpty args of
-  Just args' -> helper (Just (OpReplace # (closurePath ArgsTuple # foldTerms args')))
+anomaCall functionsLib args = case nonEmpty args of
+  Just args' -> helper (Just (opReplace "anomaCall-args" (closurePath ArgsTuple) (foldTerms args')))
   Nothing -> helper Nothing
   where
     helper replaceArgs =
       opCall
         "anomaCall"
         (closurePath WrapperCode)
-        ( OpReplace
-            # (closurePath FunctionsLibrary # OpQuote # env)
-            # (repArgs (OpAddress # emptyPath))
+        ( opReplace
+            "anomaCall-functionsLibrary"
+            (closurePath FunctionsLibrary)
+            (OpQuote # functionsLib)
+            (repArgs (OpAddress # emptyPath))
         )
       where
         repArgs x = case replaceArgs of
           Nothing -> x
-          Just r -> r # x
+          Just r -> r x

--- a/test/Nockma/Base.hs
+++ b/test/Nockma/Base.hs
@@ -7,5 +7,5 @@ import Juvix.Compiler.Nockma.Translation.FromTree
 -- | Call a function at the head of the subject using the Anoma calling convention
 anomaCall :: [Term Natural] -> Term Natural
 anomaCall args = case nonEmpty args of
-  Just args' -> OpCall # [L] # OpReplace # ([R, L] # foldTerms args') # (OpAddress # emptyPath)
-  Nothing -> OpCall # [L] # (OpAddress # emptyPath)
+  Just args' -> OpCall # closurePath WrapperCode # OpReplace # (closurePath ArgsTuple # foldTerms args') # (OpAddress # emptyPath)
+  Nothing -> OpCall # closurePath WrapperCode # (OpAddress # emptyPath)

--- a/test/Nockma/Base.hs
+++ b/test/Nockma/Base.hs
@@ -11,11 +11,13 @@ anomaCall env args = case nonEmpty args of
   Nothing -> helper Nothing
   where
     helper replaceArgs =
-      OpCall
-        # closurePath WrapperCode
-        # OpReplace
-        # (closurePath FunctionsLibrary # OpQuote # env)
-        # (repArgs (OpAddress # emptyPath))
+      opCall
+        "anomaCall"
+        (closurePath WrapperCode)
+        ( OpReplace
+            # (closurePath FunctionsLibrary # OpQuote # env)
+            # (repArgs (OpAddress # emptyPath))
+        )
       where
         repArgs x = case replaceArgs of
           Nothing -> x

--- a/test/Nockma/Compile/Tree/Positive.hs
+++ b/test/Nockma/Compile/Tree/Positive.hs
@@ -22,11 +22,11 @@ runNockmaAssertion hout _main tab = do
   res <-
     runM
       . runOutputSem @(Term Natural)
-        (hPutStrLn hout . Nockma.ppPrint)
+        (hPutStrLn hout . Nockma.ppTest)
       . runReader NockmaEval.defaultEvalOptions
       $ evalCompiledNock' (anomaRes ^. anomaClosure) (anomaCall (anomaRes ^. anomaEnv) [])
   let ret = getReturn res
-  whenJust ret (hPutStrLn hout . Nockma.ppPrint)
+  whenJust ret (hPutStrLn hout . Nockma.ppTest)
   where
     opts :: CompilerOptions
     opts =

--- a/test/Nockma/Compile/Tree/Positive.hs
+++ b/test/Nockma/Compile/Tree/Positive.hs
@@ -13,11 +13,12 @@ import Tree.Eval.Positive qualified as Tree
 
 runNockmaAssertion :: Handle -> Symbol -> InfoTable -> IO ()
 runNockmaAssertion hout _main tab = do
-  Nockma.Cell nockSubject nockMain <-
+  nockMain <-
     runM
       . runErrorIO' @JuvixError
       . runReader opts
       $ treeToNockma' tab
+  let nockSubject = nockNil'
   res <-
     runM
       . runOutputSem @(Term Natural)

--- a/test/Nockma/Compile/Tree/Positive.hs
+++ b/test/Nockma/Compile/Tree/Positive.hs
@@ -8,24 +8,24 @@ import Juvix.Compiler.Nockma.Language qualified as Nockma
 import Juvix.Compiler.Nockma.Pretty qualified as Nockma
 import Juvix.Compiler.Nockma.Translation.FromTree
 import Juvix.Compiler.Tree
+import Nockma.Base
 import Tree.Eval.Base
 import Tree.Eval.Positive qualified as Tree
 
 runNockmaAssertion :: Handle -> Symbol -> InfoTable -> IO ()
 runNockmaAssertion hout _main tab = do
-  nockMain <-
+  anomaClosure <-
     runM
       . runErrorIO' @JuvixError
       . runReader opts
-      $ treeToNockma' tab
-  let nockSubject = nockNil'
+      $ treeToAnoma' tab
   res <-
     runM
       . runOutputSem @(Term Natural)
         (hPutStrLn hout . Nockma.ppPrint)
       . runReader NockmaEval.defaultEvalOptions
-      . evalCompiledNock' nockSubject
-      $ nockMain
+      . evalCompiledNock' anomaClosure
+      $ anomaCall []
   let ret = getReturn res
   whenJust ret (hPutStrLn hout . Nockma.ppPrint)
   where

--- a/test/Nockma/Compile/Tree/Positive.hs
+++ b/test/Nockma/Compile/Tree/Positive.hs
@@ -14,7 +14,7 @@ import Tree.Eval.Positive qualified as Tree
 
 runNockmaAssertion :: Handle -> Symbol -> InfoTable -> IO ()
 runNockmaAssertion hout _main tab = do
-  anomaClosure <-
+  anomaRes :: AnomaResult <-
     runM
       . runErrorIO' @JuvixError
       . runReader opts
@@ -24,8 +24,7 @@ runNockmaAssertion hout _main tab = do
       . runOutputSem @(Term Natural)
         (hPutStrLn hout . Nockma.ppPrint)
       . runReader NockmaEval.defaultEvalOptions
-      . evalCompiledNock' anomaClosure
-      $ anomaCall []
+      $ evalCompiledNock' (anomaRes ^. anomaClosure) (anomaCall (anomaRes ^. anomaEnv) [])
   let ret = getReturn res
   whenJust ret (hPutStrLn hout . Nockma.ppPrint)
   where

--- a/test/Nockma/Compile/Tree/Positive.hs
+++ b/test/Nockma/Compile/Tree/Positive.hs
@@ -1,6 +1,7 @@
 module Nockma.Compile.Tree.Positive where
 
 import Base
+import Juvix.Compiler.Nockma.Anoma
 import Juvix.Compiler.Nockma.EvalCompiled
 import Juvix.Compiler.Nockma.Evaluator qualified as NockmaEval
 import Juvix.Compiler.Nockma.Language
@@ -8,7 +9,6 @@ import Juvix.Compiler.Nockma.Language qualified as Nockma
 import Juvix.Compiler.Nockma.Pretty qualified as Nockma
 import Juvix.Compiler.Nockma.Translation.FromTree
 import Juvix.Compiler.Tree
-import Nockma.Base
 import Tree.Eval.Base
 import Tree.Eval.Positive qualified as Tree
 
@@ -24,6 +24,7 @@ runNockmaAssertion hout _main tab = do
       . runOutputSem @(Term Natural)
         (hPutStrLn hout . Nockma.ppTest)
       . runReader NockmaEval.defaultEvalOptions
+      . NockmaEval.ignoreOpCounts
       $ evalCompiledNock' (anomaRes ^. anomaClosure) (anomaCall (anomaRes ^. anomaEnv) [])
   let ret = getReturn res
   whenJust ret (hPutStrLn hout . Nockma.ppTest)

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -3,12 +3,12 @@ module Nockma.Eval.Positive where
 import Base hiding (Path, testName)
 import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Core.Language.Base (defaultSymbol)
+import Juvix.Compiler.Nockma.Anoma
 import Juvix.Compiler.Nockma.Evaluator
 import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Pretty
 import Juvix.Compiler.Nockma.Translation.FromSource.QQ
 import Juvix.Compiler.Nockma.Translation.FromTree
-import Nockma.Base
 
 type Check = Sem '[Reader [Term Natural], Reader (Term Natural), EmbedIO]
 

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -146,9 +146,8 @@ anomaCallingConventionTests =
 
 juvixCallingConventionTests :: [Test]
 juvixCallingConventionTests =
-  [True]
-    -- <**> [ compilerTest "stdlib add" (add (nockNatLiteral 1) (nockNatLiteral 2)) (eqNock [nock| 3 |]),
-    <**> [ compilerTest "blah" (add (nockNatLiteral 1) (nockNatLiteral 2)) (eqNock [nock| 3 |]),
+  [True, False]
+    <**> [ compilerTest "stdlib add" (add (nockNatLiteral 1) (nockNatLiteral 2)) (eqNock [nock| 3 |]),
            compilerTest "stdlib dec" (dec (nockNatLiteral 1)) (eqNock [nock| 0 |]),
            compilerTest "stdlib mul" (mul (nockNatLiteral 2) (nockNatLiteral 3)) (eqNock [nock| 6 |]),
            compilerTest "stdlib sub" (sub (nockNatLiteral 2) (nockNatLiteral 1)) (eqNock [nock| 1 |]),
@@ -160,7 +159,7 @@ juvixCallingConventionTests =
            compilerTest "stdlib nested" (dec (dec (nockNatLiteral 20))) (eqNock [nock| 18 |]),
            compilerTest "append rights - empty" (appendRights emptyPath (nockNatLiteral 3)) (eqNock (toNock [R, R, R])),
            compilerTest "append rights" (appendRights [L, L] (nockNatLiteral 3)) (eqNock (toNock [L, L, R, R, R])),
-           compilerTest "opAddress" ((OpQuote # (foldTerms (toNock @Natural <$> (5 :| [6, 1])))) >># opAddress' (appendRights emptyPath (nockNatLiteral 2))) (eqNock (toNock @Natural 1)),
+           compilerTest "opAddress" ((OpQuote # (foldTerms (toNock @Natural <$> (5 :| [6, 1])))) >># opAddress' (OpQuote # [R, R])) (eqNock (toNock @Natural 1)),
            compilerTest "foldTermsOrNil (empty)" (foldTermsOrNil []) (eqNock (nockNilTagged "expected-result")),
            let l :: NonEmpty Natural = 1 :| [2]
                l' :: NonEmpty (Term Natural) = nockNatLiteral <$> l

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -164,6 +164,10 @@ juvixCallingConventionTests =
            compilerTest "append rights - empty" (appendRights emptyPath (nockNatLiteral 3)) (eqNock (toNock [R, R, R])),
            compilerTest "append rights" (appendRights [L, L] (nockNatLiteral 3)) (eqNock (toNock [L, L, R, R, R])),
            compilerTest "opAddress" ((OpQuote # (foldTerms (toNock @Natural <$> (5 :| [6, 1])))) >># opAddress' (appendRights emptyPath (nockNatLiteral 2))) (eqNock (toNock @Natural 1)),
+           compilerTest "foldTermsOrNil (empty)" (foldTermsOrNil []) (eqNock nockNil'),
+           let l :: NonEmpty Natural = 1 :| [2]
+               l' :: NonEmpty (Term Natural) = nockNatLiteral <$> l
+            in compilerTest "foldTermsOrNil (non-empty)" (foldTermsOrNil (toList l')) (eqNock (foldTerms (toNock @Natural <$> l))),
            let l :: NonEmpty (Term Natural) = toNock <$> nonEmpty' [1 :: Natural .. 3]
             in compilerTest "list to tuple" (listToTuple (OpQuote # makeList (toList l)) (nockIntegralLiteral (length l))) $
                  eqNock (foldTerms l),

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -166,7 +166,31 @@ juvixCallingConventionTests =
            compilerTest "opAddress" ((OpQuote # (foldTerms (toNock @Natural <$> (5 :| [6, 1])))) >># opAddress' (appendRights emptyPath (nockNatLiteral 2))) (eqNock (toNock @Natural 1)),
            let l :: NonEmpty (Term Natural) = toNock <$> nonEmpty' [1 :: Natural .. 3]
             in compilerTest "list to tuple" (listToTuple (OpQuote # makeList (toList l)) (nockIntegralLiteral (length l))) $
-                 eqNock (foldTerms l)
+                 eqNock (foldTerms l),
+           let l :: Term Natural = OpQuote # foldTerms (toNock @Natural <$> (1 :| [2, 3]))
+            in compilerTest "replaceSubterm'" (replaceSubterm' l (OpQuote # toNock [R]) (OpQuote # (toNock @Natural 999))) (eqNock (toNock @Natural 1 # toNock @Natural 999)),
+           let lst :: [Term Natural] = toNock @Natural <$> [1, 2, 3]
+               len = nockIntegralLiteral (length lst)
+               l :: Term Natural = OpQuote # makeList lst
+            in compilerTest "append" (append l len l) (eqNock (makeList (lst ++ lst))),
+           let l :: [Natural] = [1, 2]
+               r :: NonEmpty Natural = 3 :| [4]
+               res :: Term Natural = foldTerms (toNock <$> prependList l r)
+               lenL :: Term Natural = nockIntegralLiteral (length l)
+               lenR :: Term Natural = nockIntegralLiteral (length r)
+               lstL = OpQuote # makeList (map toNock l)
+               tupR = OpQuote # foldTerms (toNock <$> r)
+            in compilerTest "appendToTuple (left non-empty, right non-empty)" (appendToTuple lstL lenL tupR lenR) (eqNock res),
+           let l :: NonEmpty Natural = 1 :| [2]
+               res :: Term Natural = foldTerms (toNock <$> l)
+               lenL :: Term Natural = nockIntegralLiteral (length l)
+               lstL = OpQuote # makeList (toNock <$> (toList l))
+            in compilerTest "appendToTuple (left non-empty, right empty)" (appendToTuple lstL lenL (OpQuote # nockNil') (nockNatLiteral 0)) (eqNock res),
+           let r :: NonEmpty Natural = 3 :| [4]
+               res :: Term Natural = foldTerms (toNock <$> r)
+               lenR :: Term Natural = nockIntegralLiteral (length r)
+               tupR = OpQuote # foldTerms (toNock <$> r)
+            in compilerTest "appendToTuple (left empty, right-nonempty)" (appendToTuple (OpQuote # nockNil') (nockNatLiteral 0) tupR lenR) (eqNock res)
          ]
 
 unitTests :: [Test]

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -26,10 +26,10 @@ makeLenses ''Test
 
 mkNockmaAssertion :: Test -> Assertion
 mkNockmaAssertion Test {..} = do
-  putStrLn (ppTrace _testProgramFormula)
-  writeFileEnsureLn
-    $(mkAbsFile "/home/jan/projects/juvix-effectful/out.nockma")
-    (ppPrint _testProgramSubject <> "\n\n" <> ppPrint _testProgramFormula)
+  -- putStrLn (ppTrace _testProgramFormula)
+  -- writeFileEnsureLn
+  --   $(mkAbsFile "/home/jan/projects/juvix-effectful/out.nockma")
+  --   (ppPrint _testProgramSubject <> "\n\n" <> ppPrint _testProgramFormula)
   let (traces, evalResult) =
         run
           . runReader _testEvalOptions

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -165,7 +165,7 @@ juvixCallingConventionTests =
            compilerTest "append rights - empty" (appendRights emptyPath (nockNatLiteral 3)) (eqNock (toNock [R, R, R])),
            compilerTest "append rights" (appendRights [L, L] (nockNatLiteral 3)) (eqNock (toNock [L, L, R, R, R])),
            compilerTest "opAddress" ((OpQuote # (foldTerms (toNock @Natural <$> (5 :| [6, 1])))) >># opAddress' (appendRights emptyPath (nockNatLiteral 2))) (eqNock (toNock @Natural 1)),
-           compilerTest "foldTermsOrNil (empty)" (foldTermsOrNil []) (eqNock nockNil'),
+           compilerTest "foldTermsOrNil (empty)" (foldTermsOrNil []) (eqNock (nockNilTagged "expected-result")),
            let l :: NonEmpty Natural = 1 :| [2]
                l' :: NonEmpty (Term Natural) = nockNatLiteral <$> l
             in compilerTest "foldTermsOrNil (non-empty)" (foldTermsOrNil (toList l')) (eqNock (foldTerms (toNock @Natural <$> l))),
@@ -190,12 +190,12 @@ juvixCallingConventionTests =
                res :: Term Natural = foldTerms (toNock <$> l)
                lenL :: Term Natural = nockIntegralLiteral (length l)
                lstL = OpQuote # makeList (toNock <$> (toList l))
-            in compilerTest "appendToTuple (left non-empty, right empty)" (appendToTuple lstL lenL (OpQuote # nockNil') (nockNatLiteral 0)) (eqNock res),
+            in compilerTest "appendToTuple (left non-empty, right empty)" (appendToTuple lstL lenL (OpQuote # nockNilTagged "appendToTuple") (nockNatLiteral 0)) (eqNock res),
            let r :: NonEmpty Natural = 3 :| [4]
                res :: Term Natural = foldTerms (toNock <$> r)
                lenR :: Term Natural = nockIntegralLiteral (length r)
                tupR = OpQuote # foldTerms (toNock <$> r)
-            in compilerTest "appendToTuple (left empty, right-nonempty)" (appendToTuple (OpQuote # nockNil') (nockNatLiteral 0) tupR lenR) (eqNock res)
+            in compilerTest "appendToTuple (left empty, right-nonempty)" (appendToTuple (OpQuote # nockNilTagged "test-appendtotuple") (nockNatLiteral 0) tupR lenR) (eqNock res)
          ]
 
 unitTests :: [Test]

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -27,7 +27,9 @@ makeLenses ''Test
 mkNockmaAssertion :: Test -> Assertion
 mkNockmaAssertion Test {..} = do
   putStrLn (ppTrace _testProgramFormula)
-  writeFileEnsureLn $(mkAbsFile "/home/jan/projects/juvix-effectful/out.nockma") (ppPrint _testProgramFormula)
+  writeFileEnsureLn
+    $(mkAbsFile "/home/jan/projects/juvix-effectful/out.nockma")
+    (ppPrint _testProgramSubject <> "\n\n" <> ppPrint _testProgramFormula)
   let (traces, evalResult) =
         run
           . runReader _testEvalOptions
@@ -89,22 +91,7 @@ eqTraces expected = do
 
 compilerTest :: Text -> Term Natural -> Check () -> Bool -> Test
 compilerTest n mainFun _testCheck _evalInterceptStdlibCalls =
-  let f =
-        CompilerFunction
-          { _compilerFunctionName = UserFunction (defaultSymbol 0),
-            _compilerFunctionArity = 0,
-            _compilerFunction = return mainFun
-          }
-      _testName :: Text
-        | _evalInterceptStdlibCalls = n <> " - intercept stdlib"
-        | otherwise = n
-      opts = CompilerOptions {_compilerOptionsEnableTrace = False}
-      _testProgramFormula = runCompilerWithJuvix opts mempty [] f
-      _testProgramSubject = nockNil'
-      _testEvalOptions = EvalOptions {..}
-      _testProgramStorage :: Storage Natural = emptyStorage
-      _testAssertEvalError :: Maybe (NockEvalError Natural -> Assertion) = Nothing
-   in Test {..}
+  anomaTest n mainFun [] _testCheck _evalInterceptStdlibCalls
 
 withAssertErrKeyNotInStorage :: Test -> Test
 withAssertErrKeyNotInStorage Test {..} =

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -117,9 +117,10 @@ anomaTest n mainFun args _testCheck _evalInterceptStdlibCalls =
 
       opts = CompilerOptions {_compilerOptionsEnableTrace = False}
 
-      _testProgramSubject = runCompilerWithAnoma opts mempty [] f
+      res :: AnomaResult = runCompilerWithAnoma opts mempty [] f
+      _testProgramSubject = res ^. anomaClosure
 
-      _testProgramFormula = anomaCall args
+      _testProgramFormula = anomaCall (res ^. anomaEnv) args
       _testProgramStorage :: Storage Natural = emptyStorage
       _testEvalOptions = EvalOptions {..}
       _testAssertEvalError :: Maybe (NockEvalError Natural -> Assertion) = Nothing

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -117,7 +117,7 @@ anomaTest n mainFun args _testCheck _evalInterceptStdlibCalls =
 
       opts = CompilerOptions {_compilerOptionsEnableTrace = False}
 
-      res :: AnomaResult = runCompilerWithAnoma opts mempty [] f
+      res :: AnomaResult = runCompilerWith opts mempty [] f
       _testProgramSubject = res ^. anomaClosure
 
       _testProgramFormula = anomaCall (res ^. anomaEnv) args

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -26,10 +26,6 @@ makeLenses ''Test
 
 mkNockmaAssertion :: Test -> Assertion
 mkNockmaAssertion Test {..} = do
-  -- putStrLn (ppTrace _testProgramFormula)
-  -- writeFileEnsureLn
-  --   $(mkAbsFile "/home/jan/projects/juvix-effectful/out.nockma")
-  --   (ppPrint _testProgramSubject <> "\n\n" <> ppPrint _testProgramFormula)
   let (traces, evalResult) =
         run
           . runReader _testEvalOptions

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -26,6 +26,8 @@ makeLenses ''Test
 
 mkNockmaAssertion :: Test -> Assertion
 mkNockmaAssertion Test {..} = do
+  putStrLn (ppTrace _testProgramFormula)
+  writeFileEnsureLn $(mkAbsFile "/home/jan/projects/juvix-effectful/out.nockma") (ppPrint _testProgramFormula)
   let (traces, evalResult) =
         run
           . runReader _testEvalOptions
@@ -160,8 +162,9 @@ anomaCallingConventionTests =
 
 juvixCallingConventionTests :: [Test]
 juvixCallingConventionTests =
-  [True, False]
-    <**> [ compilerTest "stdlib add" (add (nockNatLiteral 1) (nockNatLiteral 2)) (eqNock [nock| 3 |]),
+  [True]
+    -- <**> [ compilerTest "stdlib add" (add (nockNatLiteral 1) (nockNatLiteral 2)) (eqNock [nock| 3 |]),
+    <**> [ compilerTest "blah" (add (nockNatLiteral 1) (nockNatLiteral 2)) (eqNock [nock| 3 |]),
            compilerTest "stdlib dec" (dec (nockNatLiteral 1)) (eqNock [nock| 0 |]),
            compilerTest "stdlib mul" (mul (nockNatLiteral 2) (nockNatLiteral 3)) (eqNock [nock| 6 |]),
            compilerTest "stdlib sub" (sub (nockNatLiteral 2) (nockNatLiteral 1)) (eqNock [nock| 1 |]),
@@ -175,8 +178,8 @@ juvixCallingConventionTests =
            compilerTest "append rights" (appendRights [L, L] (nockNatLiteral 3)) (eqNock (toNock [L, L, R, R, R])),
            compilerTest "opAddress" ((OpQuote # (foldTerms (toNock @Natural <$> (5 :| [6, 1])))) >># opAddress' (appendRights emptyPath (nockNatLiteral 2))) (eqNock (toNock @Natural 1)),
            let l :: NonEmpty (Term Natural) = toNock <$> nonEmpty' [1 :: Natural .. 3]
-            in compilerTest "list to tuple" (listToTuple (OpQuote # makeList (toList l)) (nockIntegralLiteral (length l)))
-                 $ eqNock (foldTerms l)
+            in compilerTest "list to tuple" (listToTuple (OpQuote # makeList (toList l)) (nockIntegralLiteral (length l))) $
+                 eqNock (foldTerms l)
          ]
 
 unitTests :: [Test]


### PR DESCRIPTION
When we first implemented the Nockma backend we wrongly assumed that the only entry point for Juvix compiled Nockma modules would be the main function. Using this assumption we could add a setup step in the main function that put the Anoma stdlib and compiled functions from the Juvix module in a static place in the Nockma subject. References to the Anoma stdlib and functions in the module could then be resolved statically.

However, one of the use cases for Juvix -> Nockma compilation is for Anoma to run logic functions that are fields of a transaction. So the user writes a Juvix program with main function that returns a transaction. The __result__ of the main function is passed to Anoma. When Anoma calls the logic function on a field of the transaction, the setup part of the main function is not run so the subject is not in the required state. In fact, the logic function is not even callable by Anoma because non-main functions in the Juvix module use a calling convention that assumes the subject has a particular shape.

This PR solves the problem by making all functions in the Juvix module use the Anoma calling convention. The issue of setup is solved by requiring an extra Nock term, called the Juvix environment, to be injected into any Nock term arising from the compiled Juvix module at path RRL, whenever it is called. This is similar to evaluation of calls in a particular context in hoon https://anoma.github.io/anoma/calling.html#evaluating-calls-in-the-anoma-context

We also add some extra tracing. You can now annotate output cells with a tag that will be displayed in the output.

We added unittests for `listToTuple`, `appendRights` helper functions.
