### PR TITLE
Rename `Dynamic'` to `DynamicTy'`

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -195,7 +195,7 @@ mkTypeField' :: Type
 mkTypeField' = mkTypeField Info.empty
 
 mkDynamic :: Info -> Type
-mkDynamic i = NDyn (Dynamic i)
+mkDynamic i = NDyn (DynamicTy i)
 
 mkDynamic' :: Type
 mkDynamic' = mkDynamic Info.empty
@@ -728,7 +728,7 @@ destruct = \case
         _nodeChildren = [],
         _nodeReassemble = noChildren $ \i' -> mkTypePrim i' prim
       }
-  NDyn (Dynamic i) ->
+  NDyn (DynamicTy i) ->
     NodeDetails
       { _nodeInfo = i,
         _nodeSubinfos = [],

--- a/src/Juvix/Compiler/Core/Language.hs
+++ b/src/Juvix/Compiler/Core/Language.hs
@@ -59,7 +59,7 @@ type TypeConstr = TypeConstr' Info Node
 
 type TypePrim = TypePrim' Info
 
-type Dynamic = Dynamic' Info
+type DynamicTy = DynamicTy' Info
 
 type Bottom = Bottom' Info Node
 
@@ -83,7 +83,7 @@ data Node
   | NUniv {-# UNPACK #-} !Univ
   | NTyp {-# UNPACK #-} !TypeConstr
   | NPrim {-# UNPACK #-} !TypePrim
-  | NDyn !Dynamic -- Dynamic is already a newtype, so it's unpacked.
+  | NDyn !DynamicTy -- Dynamic is already a newtype, so it's unpacked.
   | NBot {-# UNPACK #-} !Bottom
   | -- Evaluation only: `Closure env node`.
     Closure
@@ -137,5 +137,5 @@ emptyBinder =
   Binder
     { _binderName = "?",
       _binderLocation = Nothing,
-      _binderType = NDyn (Dynamic mempty)
+      _binderType = NDyn (DynamicTy mempty)
     }

--- a/src/Juvix/Compiler/Core/Language/Nodes.hs
+++ b/src/Juvix/Compiler/Core/Language/Nodes.hs
@@ -243,8 +243,8 @@ data TypePrim' i = TypePrim
 -- | Dynamic type. A Node with a dynamic type has an unknown type. Useful
 -- for transformations that introduce partial type information, e.g., one can
 -- have types `* -> *` and `* -> * -> Nat` where `*` is the dynamic type.
-newtype Dynamic' i = Dynamic
-  { _dynamicInfo :: i
+newtype DynamicTy' i = DynamicTy
+  { _dynamicTyInfo :: i
   }
   deriving stock (Generic)
 
@@ -294,7 +294,7 @@ instance (Serialize i) => Serialize (TypePrim' i)
 
 instance (Serialize i, Serialize a) => Serialize (TypeConstr' i a)
 
-instance (Serialize i) => Serialize (Dynamic' i)
+instance (Serialize i) => Serialize (DynamicTy' i)
 
 instance (Serialize i, Serialize a) => Serialize (Bottom' i a)
 
@@ -366,7 +366,7 @@ instance HasAtomicity (TypePrim' i) where
 instance HasAtomicity (TypeConstr' i a) where
   atomicity _ = Aggregate lambdaFixity
 
-instance HasAtomicity (Dynamic' i) where
+instance HasAtomicity (DynamicTy' i) where
   atomicity _ = Atom
 
 instance HasAtomicity (Bottom' i a) where
@@ -401,7 +401,7 @@ makeLenses ''Pi'
 makeLenses ''Lambda'
 makeLenses ''Univ'
 makeLenses ''TypeConstr'
-makeLenses ''Dynamic'
+makeLenses ''DynamicTy'
 makeLenses ''LetItem'
 
 instance (Eq ty) => Eq (Binder' ty) where
@@ -457,8 +457,8 @@ instance (Eq a) => Eq (TypeConstr' i a) where
 instance Eq (TypePrim' i) where
   (TypePrim _ p1) == (TypePrim _ p2) = p1 == p2
 
-instance Eq (Dynamic' i) where
-  (Dynamic _) == (Dynamic _) = True
+instance Eq (DynamicTy' i) where
+  DynamicTy {} == DynamicTy {} = True
 
 instance Eq (Bottom' i a) where
   Bottom {} == Bottom {} = True

--- a/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
+++ b/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
@@ -96,7 +96,7 @@ computeNodeTypeInfo md = umapL go
         mkUniv' 0
       NPrim TypePrim {} ->
         mkUniv' 0
-      NDyn Dynamic {} ->
+      NDyn DynamicTy {} ->
         mkUniv' 0
       NBot Bottom {..} ->
         _bottomType

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -288,7 +288,7 @@ translateType node = case node of
         }
   NPrim TypePrim {..} ->
     Stripped.TyPrim _typePrimPrimitive
-  NDyn Dynamic {} ->
+  NDyn DynamicTy {} ->
     Stripped.TyDynamic
   _ ->
     Stripped.TyDynamic

--- a/src/Juvix/Compiler/Store/Core/Extra.hs
+++ b/src/Juvix/Compiler/Store/Core/Extra.hs
@@ -80,7 +80,7 @@ toCore InfoTable {..} =
       NUniv Univ {..} -> Core.mkUniv' _univLevel
       NTyp TypeConstr {..} -> Core.mkTypeConstr' _typeConstrSymbol (map goNode _typeConstrArgs)
       NPrim TypePrim {..} -> Core.mkTypePrim' _typePrimPrimitive
-      NDyn Dynamic {} -> Core.mkDynamic'
+      NDyn DynamicTy {} -> Core.mkDynamic'
       NBot Bottom {..} -> Core.mkBottom mempty (goNode _bottomType)
 
     goBinder :: Binder -> Core.Binder
@@ -167,7 +167,7 @@ fromCore Core.InfoTable {..} =
       Core.NUniv Core.Univ {..} -> NUniv $ Univ () _univLevel
       Core.NTyp Core.TypeConstr {..} -> NTyp $ TypeConstr () _typeConstrSymbol (map goNode _typeConstrArgs)
       Core.NPrim Core.TypePrim {..} -> NPrim $ TypePrim () _typePrimPrimitive
-      Core.NDyn Core.Dynamic {} -> NDyn $ Dynamic ()
+      Core.NDyn Core.DynamicTy {} -> NDyn $ DynamicTy ()
       Core.NBot Core.Bottom {..} -> NBot $ Bottom () (goNode _bottomType)
       Core.NMatch {} -> impossible
       Core.Closure {} -> impossible

--- a/src/Juvix/Compiler/Store/Core/Language.hs
+++ b/src/Juvix/Compiler/Store/Core/Language.hs
@@ -45,7 +45,7 @@ type TypeConstr = TypeConstr' () Node
 
 type TypePrim = TypePrim' ()
 
-type Dynamic = Dynamic' ()
+type Dynamic = DynamicTy' ()
 
 type Bottom = Bottom' () Node
 


### PR DESCRIPTION
1. Rename `Dynamic'` to `DynamicTy'` in the Core language.

It helps minimizing conflicts with effectful's [Dynamic](https://www.stackage.org/haddock/nightly-2024-02-06/effectful-core-2.3.0.1/Effectful.html#v:Dynamic)