### PR TITLE
Capture scry id in the main function and use it when compiling anomaGet 

### DIFF
--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -372,4 +372,4 @@ evalProfile inistack initerm =
               Cell' typeFormula subFormula _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
               void (evalArg crumbEvalFirst stack typeFormula)
               key <- evalArg crumbEvalSecond stack subFormula
-              fromMaybeM (throwKeyNotInStorage key) (HashMap.lookup key <$> asks (^. storageKeyValueData))
+              fromMaybeM (throwKeyNotInStorage key) (HashMap.lookup (StorageKey key) <$> asks (^. storageKeyValueData))

--- a/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
@@ -146,7 +146,7 @@ instance (PrettyCode a, NockNatural a) => PrettyCode (KeyNotInStorage a) where
     hashMapKvs <- vsep <$> mapM combineKeyValue (HashMap.toList (_keyNotInStorageStorage ^. storageKeyValueData))
     return ("The key" <+> tm <+> "is not found in the storage." <> line <> "Storage contains the following key value pairs:" <> line <> hashMapKvs)
     where
-      combineKeyValue :: (Term a, Term a) -> Sem r (Doc Ann)
+      combineKeyValue :: (StorageKey a, Term a) -> Sem r (Doc Ann)
       combineKeyValue (t1, t2) = do
         pt1 <- ppCode t1
         pt2 <- ppCode t2

--- a/src/Juvix/Compiler/Nockma/Evaluator/Storage.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Storage.hs
@@ -1,12 +1,37 @@
 module Juvix.Compiler.Nockma.Evaluator.Storage where
 
 import Juvix.Compiler.Nockma.Language
+import Juvix.Compiler.Nockma.Pretty.Base
 import Juvix.Prelude.Base
 
 newtype Storage a = Storage
-  {_storageKeyValueData :: HashMap (Term a) (Term a)}
+  {_storageKeyValueData :: HashMap (StorageKey a) (Term a)}
+
+newtype StorageKey a = StorageKey {_storageKeyTerm :: Term a}
+
+makeLenses ''Storage
+makeLenses ''StorageKey
+
+stripTags :: Term a -> Term a
+stripTags = \case
+  TermAtom a -> TermAtom (set atomTag Nothing a)
+  TermCell c ->
+    TermCell
+      ( set cellTag Nothing
+          . over cellLeft stripTags
+          . over cellRight stripTags
+          . over (cellCall . _Just . stdlibCallArgs) stripTags
+          $ c
+      )
+
+instance (Eq a) => Eq (StorageKey a) where
+  s1 == s2 = stripTags (s1 ^. storageKeyTerm) == stripTags (s2 ^. storageKeyTerm)
+
+instance (Hashable a) => Hashable (StorageKey a) where
+  hashWithSalt s k = hashWithSalt s (stripTags (k ^. storageKeyTerm))
+
+instance (PrettyCode a, NockNatural a) => PrettyCode (StorageKey a) where
+  ppCode k = ppCode (stripTags (k ^. storageKeyTerm))
 
 emptyStorage :: (Hashable a) => Storage a
 emptyStorage = Storage {_storageKeyValueData = mempty}
-
-makeLenses ''Storage

--- a/src/Juvix/Compiler/Nockma/Evaluator/Storage.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Storage.hs
@@ -31,18 +31,18 @@ instance (NockmaEq a) => Eq (StorageKey a) where
   (==) = nockmaEq
 
 instance (NockmaEq a, Hashable a) => Hashable (StorageKey a) where
-  hashWithSalt salt k = goTerm salt (k ^. storageKeyTerm)
+  hashWithSalt salt k = goTerm (k ^. storageKeyTerm)
     where
-      goCell :: Int -> Cell a -> Int
-      goCell s c = hashWithSalt s (c ^. cellLeft, c ^. cellRight)
+      goCell :: Cell a -> Int
+      goCell c = hashWithSalt salt (c ^. cellLeft, c ^. cellRight)
 
-      goAtom :: Int -> Atom a -> Int
-      goAtom s a = hashWithSalt s (a ^. atom)
+      goAtom :: Atom a -> Int
+      goAtom a = hashWithSalt salt (a ^. atom)
 
-      goTerm :: Int -> Term a -> Int
-      goTerm s = \case
-        TermAtom a -> goAtom s a
-        TermCell c -> goCell s c
+      goTerm :: Term a -> Int
+      goTerm = \case
+        TermAtom a -> goAtom a
+        TermCell c -> goCell c
 
 instance (PrettyCode a, NockNatural a) => PrettyCode (StorageKey a) where
   ppCode k = ppCode (stripTags (k ^. storageKeyTerm))

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -304,6 +304,16 @@ anomaCallableClosureWrapper =
 
 mainFunctionWrapper :: Term Natural
 mainFunctionWrapper =
+  -- 1. The Anoma system expects to receive a function of type `ScryId -> Transaction`
+  --
+  -- 2. The ScryId is only used to construct the argument to the Scry operation (i.e the anomaGet builtin in the Juvix frontend),
+  --
+  -- 3. When the Juvix developer writes a function to submit to Anoma they use
+  -- type `() -> Transaction`, this wrapper is used to capture the ScryId
+  -- argument into the subject which is then used to construct OpScry arguments
+  -- when anomaGet is compiled.
+  --
+  -- 4. If the Anoma system expectation changes then this code must be changed.
   let captureAnomaGetOrder :: Term Natural
       captureAnomaGetOrder = replaceSubject $ \case
         AnomaGetOrder -> Just (getClosureFieldInSubject ArgsTuple)

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -526,12 +526,16 @@ allTests =
           v1 :: Term Natural = [nock| 222 |]
           k2 :: Term Natural = [nock| [1 2 3 nil] |]
           v2 :: Term Natural = [nock| [4 5 6 nil] |]
+          -- The keys of the storage are of the form [id key nil].
+          -- The id is captured from the arguments tuple of the function.
+          sk1 :: Term Natural = [nock| [[333 1 2 3 nil] 333 nil] |]
+          sk2 :: Term Natural = [nock| [[333 1 2 3 nil] [1 2 3 nil] nil] |]
        in mkAnomaCallTest'
             True
             ( Storage
                 ( HashMap.fromList
-                    [ (k1, v1),
-                      (k2, v2)
+                    [ (sk1, v1),
+                      (sk2, v2)
                     ]
                 )
             )

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -534,8 +534,8 @@ allTests =
             True
             ( Storage
                 ( HashMap.fromList
-                    [ (sk1, v1),
-                      (sk2, v2)
+                    [ (StorageKey sk1, v1),
+                      (StorageKey sk2, v2)
                     ]
                 )
             )

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -123,7 +123,7 @@ anomaTest n mainFun args _testCheck _evalInterceptStdlibCalls =
    in Test {..}
 
 testWithStorage :: [(Term Natural, Term Natural)] -> Text -> Term Natural -> Term Natural -> Check () -> Test
-testWithStorage s = Test defaultEvalOptions Nothing (Storage (HashMap.fromList s))
+testWithStorage s = Test defaultEvalOptions Nothing (Storage (HashMap.fromList (first StorageKey <$> s)))
 
 test :: Text -> Term Natural -> Term Natural -> Check () -> Test
 test = testWithStorage []


### PR DESCRIPTION
The purpose of this PR is to wrap the compiled main function with Nockma code that captures the argument tuple for use when compiling `anomaGet` calls. 


* The [Anoma system expects](https://github.com/anoma/anoma/blob/c7f2d69d1efe2e5516a65b8f4af6576e0703dc87/lib/anoma/node/executor/worker.ex#L20) to receive a function of type `ScryId -> Transaction`
 
* The ScryId is only used to construct the argument to the Scry operation (i.e the anomaGet builtin in the Juvix frontend),
 
 * When the Juvix developer writes a function to submit to Anoma they use type `() -> Transaction`, the main function wrapper is used to capture the ScryId argument into the subject which is then used to construct OpScry arguments when anomaGet is compiled.
 
 * If the Anoma system expectation changes then the wrapper code must be changed.

We could add a transformation that checks that the main function in the Anoma target has no arguments. However it is convenient to be able to write functions with arguments for testing and debugging (for example compiling directly to a logic function).