### PR TITLE
Fix casm test failures due to concurrent calls to setCurrentDir

### DIFF
--- a/test/Casm/Run/Base.hs
+++ b/test/Casm/Run/Base.hs
@@ -14,10 +14,7 @@ import Runtime.Base qualified as R
 
 casmRunVM' :: Path Abs Dir -> Path Abs File -> IO Text
 casmRunVM' dirPath outputFile = do
-  dir <- getCurrentDir
-  setCurrentDir dirPath
-  out0 <- R.readProcess "run_cairo_vm.sh" [toFilePath outputFile] ""
-  setCurrentDir dir
+  out0 <- R.readProcessCwd (toFilePath dirPath) "run_cairo_vm.sh" [toFilePath outputFile] ""
   return $ fromString $ unlines $ drop 1 $ lines (fromText out0)
 
 casmRunVM :: LabelInfo -> Code -> Path Abs File -> (String -> IO ()) -> Assertion


### PR DESCRIPTION
See test failure: https://github.com/anoma/juvix/actions/runs/8466758094/job/23196216342

```
          Test030: Ackermann function (higher-order definition):                           FAIL (7.40s)
            Translate to JuvixCore                     (6.92s)
            Translate to CASM                          (0.06s)
            Pretty print                               (0.15s)
            Interpret                                  (0.12s)
            Compare expected and actual program output
            Check run_cairo_vm.sh is on path
            Serialize to Cairo bytecode
            Run Cairo VM                               (0.14s)
              /tmp/tmp-60ba562ca9d8f9b5: changeWorkingDirectory: does not exist (No such file or directory)
            
            Use -p '/Juvix to CASM positive tests (no optimization).Test030: Ackermann function (higher-order definition)/' to rerun this test only.
```

`setCurrentDir` cannot be used because tests are run at the same time on different threads.

This PR removes `setCurrentDir` and instead passes the CWD directly to the `proc` call.
