### PR TITLE
Cache cairo-vm-cli in the CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ env:
   SKIP: ormolu,format-juvix-files,typecheck-juvix-examples
   VAMPIRREPO: anoma/vamp-ir
   VAMPIRVERSION: v0.1.3
+  CAIRO_VM_VERSION: 42e04161de82d7e5381258def4b65087c8944660
 
 jobs:
   pre-commit:
@@ -95,6 +96,9 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - run: echo "HOME=$HOME" >> $GITHUB_ENV
+        shell: bash
+
       - name: Install the latest Wasmer version
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -119,17 +123,36 @@ jobs:
         run: |
           vamp-ir --version
 
+      - name: Cache CairoVM
+        id: cache-cairo-vm
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HOME }}/.local/bin/cairo-vm-cli
+          key: ${{ runner.os }}-cairo-vm-${{ env.CAIRO_VM_VERSION }}
+
       - name: Install Rust toolchain
+        if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Checkout CairoVM
+        uses: actions/checkout@v4
+        if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
+        with:
+          repository: lambdaclass/cairo-vm
+          path: cairo-vm
+          ref: ${{ env.CAIRO_VM_VERSION }}
+
       - name: Install Cairo VM
+        if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          git clone https://github.com/lambdaclass/cairo-vm.git
           cd cairo-vm
           cargo build --release
           cp target/release/cairo-vm-cli $HOME/.local/bin/cairo-vm-cli
-          cd -
+
+      - name: Install run_cairo_vm.sh
+        shell: bash
+        run: |
           cp main/scripts/run_cairo_vm.sh $HOME/.local/bin/run_cairo_vm.sh
 
       - name: Make runtime
@@ -293,18 +316,40 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - run: echo "HOME=$HOME" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Cache CairoVM
+        id: cache-cairo-vm
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HOME }}/.local/bin/cairo-vm-cli
+          key: ${{ runner.os }}-cairo-vm-${{ env.CAIRO_VM_VERSION }}
+
       - name: Install Rust toolchain
+        if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Checkout CairoVM
+        uses: actions/checkout@v4
+        if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
+        with:
+          repository: lambdaclass/cairo-vm
+          path: cairo-vm
+          ref: ${{ env.CAIRO_VM_VERSION }}
+
       - name: Install Cairo VM
+        if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          git clone https://github.com/lambdaclass/cairo-vm.git
           cd cairo-vm
           cargo build --release
           cp -a target/release/cairo-vm-cli $HOME/.local/bin/cairo-vm-cli
           chmod a+x $HOME/.local/bin/cairo-vm-cli
-          cd -
+
+      - name: Install run_cairo_vm.sh
+        shell: bash
+        run: |
           cp -a main/scripts/run_cairo_vm.sh $HOME/.local/bin/run_cairo_vm.sh
           chmod a+x $HOME/.local/bin/run_cairo_vm.sh
 


### PR DESCRIPTION
This PR modifies the CI manifest to cache the `cairo-vm-cli` executable so we don't have to rebuild it on each run.

The ref of the cairo-vm repo is pinned to `42e04161de82d7e5381258def4b65087c8944660` which is currently the HEAD ref of the repository. This can be changed in the CI manifest by editing the `CAIRO_VM_VERSION` variable. Doing so will trigger a rebuild of `cairo-vm-cli`.