### PR TITLE
Miscellaneous improvements for Nockma debugging

### DIFF
--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -290,9 +290,6 @@ nockBool = \case
 nockNilTagged :: Text -> Term Natural
 nockNilTagged txt = TermAtom (set atomTag (Just (Tag txt)) nockNil)
 
-nockNilUntagged :: Term Natural
-nockNilUntagged = TermAtom nockNil
-
 data NockNaturalNaturalError
   = NaturalInvalidPath (Atom Natural)
   | NaturalInvalidOp (Atom Natural)

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -101,9 +101,9 @@ unfoldCell c = c ^. cellLeft :| reverse (go [] (c ^. cellRight))
     go :: [Term a] -> Term a -> [Term a]
     go acc t = case t of
       TermAtom {} -> t : acc
-      TermCell (Cell' l r i) -> case i ^. cellInfoCall of
-        Nothing -> go (l : acc) r
-        Just {} -> t : acc
+      TermCell (Cell' l r i)
+        | isNothing (i ^. cellInfoCall) && isNothing (i ^. cellInfoTag) -> go (l : acc) r
+        | otherwise -> t : acc
 
 instance (PrettyCode a, NockNatural a) => PrettyCode (Term a) where
   ppCode = \case

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -3,6 +3,7 @@ module Juvix.Compiler.Nockma.Translation.FromTree
     fromTreeTable,
     AnomaResult (..),
     anomaClosure,
+    compilerFunctionId,
     compilerFunctionName,
     AnomaCallablePathId (..),
     CompilerOptions (..),
@@ -94,7 +95,8 @@ fromEntryPoint EntryPoint {..} =
 
 data FunctionInfo = FunctionInfo
   { _functionInfoPath :: Path,
-    _functionInfoArity :: Natural
+    _functionInfoArity :: Natural,
+    _functionInfoName :: Text
   }
 
 data FunctionCtx = FunctionCtx
@@ -115,7 +117,8 @@ data ConstructorInfo = ConstructorInfo
 type ConstructorInfos = HashMap Tree.Tag ConstructorInfo
 
 data CompilerFunction = CompilerFunction
-  { _compilerFunctionName :: FunctionId,
+  { _compilerFunctionId :: FunctionId,
+    _compilerFunctionName :: Text,
     _compilerFunctionArity :: Natural,
     _compilerFunction :: Sem '[Reader CompilerCtx, Reader FunctionCtx] (Term Natural)
   }
@@ -271,7 +274,8 @@ fromTreeTable t = case t ^. Tree.infoMainFunction of
         compileFunction :: Tree.FunctionInfo -> CompilerFunction
         compileFunction Tree.FunctionInfo {..} =
           CompilerFunction
-            { _compilerFunctionName = UserFunction _functionSymbol,
+            { _compilerFunctionId = UserFunction _functionSymbol,
+              _compilerFunctionName = _functionName,
               _compilerFunctionArity = fromIntegral _functionArgsNum,
               _compilerFunction = compile _functionCode
             }
@@ -477,10 +481,10 @@ compile = \case
       return . makeClosure $ \case
         WrapperCode -> OpQuote # anomaCallableClosureWrapper
         ArgsTuple -> OpQuote # argsTuplePlaceholder "goAllocClosure"
+        FunctionsLibrary -> OpQuote # functionsLibraryPlaceHolder
         RawCode -> opAddress "allocClosureFunPath" (fpath <> closurePath RawCode)
         TempStack -> remakeList []
         StandardLibrary -> OpQuote # stdlib
-        FunctionsLibrary -> OpQuote # functionsLibraryPlaceHolder
         ClosureTotalArgsNum -> nockNatLiteral farity
         ClosureArgsNum -> nockIntegralLiteral (length args)
         ClosureArgs -> remakeList args
@@ -720,27 +724,29 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
     compiledFuns =
       mainClosure
         :| ( makeLibraryFunction
-               <$> ( runCompilerFunction compilerCtx <$> libFuns
-                   )
+               <$> [(f ^. compilerFunctionName, runCompilerFunction compilerCtx f) | f <- libFuns]
            )
 
     exportEnv :: Term Natural
-    exportEnv = makeList compiledFuns
+    exportEnv = "exportEnv" @ makeList compiledFuns
 
-    makeLibraryFunction :: Term Natural -> Term Natural
-    makeLibraryFunction c = makeClosure $ \p ->
-      let nockNilHere = nockNilTagged ("makeLibraryFunction-" <> show p)
-       in case p of
-            WrapperCode -> c
-            ArgsTuple -> argsTuplePlaceholder "libraryFunction"
-            FunctionsLibrary -> functionsLibraryPlaceHolder
-            RawCode -> c
-            TempStack -> nockNilHere
-            StandardLibrary -> stdlib
-            ClosureTotalArgsNum -> nockNilHere
-            ClosureArgsNum -> nockNilHere
-            ClosureArgs -> nockNilHere
-            AnomaGetOrder -> nockNilHere
+    makeLibraryFunction :: (Text, Term Natural) -> Term Natural
+    makeLibraryFunction (funName, c) =
+      ("def-" <> funName)
+        @ ( makeClosure $ \p ->
+              let nockNilHere = nockNilTagged ("makeLibraryFunction-" <> show p)
+               in case p of
+                    WrapperCode -> ("wrapperCode-" <> funName) @ c
+                    ArgsTuple -> ("argsTuple-" <> funName) @ argsTuplePlaceholder "libraryFunction"
+                    FunctionsLibrary -> ("functionsLibrary-" <> funName) @ functionsLibraryPlaceHolder
+                    RawCode -> ("rawCode-" <> funName) @ c
+                    TempStack -> ("tempStack-" <> funName) @ nockNilHere
+                    StandardLibrary -> ("stdlib-" <> funName) @ stdlib
+                    ClosureTotalArgsNum -> ("closureTotalArgsNum-" <> funName) @ nockNilHere
+                    ClosureArgsNum -> ("closureArgsNum-" <> funName) @ nockNilHere
+                    ClosureArgs -> ("closureArgs-" <> funName) @ nockNilHere
+                    AnomaGetOrder -> ("anomaGetOrder-" <> funName) @ nockNilHere
+          )
 
     makeMainFunction :: Term Natural -> Term Natural
     makeMainFunction c = makeClosure $ \p ->
@@ -764,10 +770,11 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
     userFunctions = forM allFuns $ \CompilerFunction {..} -> do
       i <- input
       return
-        ( _compilerFunctionName,
+        ( _compilerFunctionId,
           FunctionInfo
             { _functionInfoPath = indexInStack FunctionsLibrary i,
-              _functionInfoArity = _compilerFunctionArity
+              _functionInfoArity = _compilerFunctionArity,
+              _functionInfoName = _compilerFunctionName
             }
         )
 
@@ -807,9 +814,10 @@ builtinFunction :: BuiltinFunctionId -> CompilerFunction
 builtinFunction = \case
   BuiltinPlaceholder ->
     CompilerFunction
-      { _compilerFunctionName = BuiltinFunction BuiltinPlaceholder,
+      { _compilerFunctionId = BuiltinFunction BuiltinPlaceholder,
         _compilerFunctionArity = 0,
-        _compilerFunction = return crash
+        _compilerFunction = return crash,
+        _compilerFunctionName = "builtinPlaceholderName"
       }
 
 closurePath :: AnomaCallablePathId -> Path
@@ -823,8 +831,9 @@ callFun ::
   Sem r (Term Natural)
 callFun fun = do
   fpath <- getFunctionPath fun
+  fname <- getFunctionName fun
   let p' = fpath ++ closurePath WrapperCode
-  return (opCall "callFun" p' (opAddress "callFunSubject" emptyPath))
+  return (opCall ("callFun-" <> fname) p' (opAddress "callFunSubject" emptyPath))
 
 -- | Call a function with the passed arguments
 callFunWithArgs ::
@@ -855,8 +864,14 @@ replaceArgsWithTerm tag term =
 replaceArgs :: [Term Natural] -> Term Natural
 replaceArgs = replaceArgsWithTerm "replaceArgs" . foldTermsOrNil
 
+getFunctionInfo :: (Members '[Reader CompilerCtx] r) => FunctionId -> Sem r FunctionInfo
+getFunctionInfo funId = asks (^?! compilerFunctionInfos . at funId . _Just)
+
 getFunctionPath :: (Members '[Reader CompilerCtx] r) => FunctionId -> Sem r Path
-getFunctionPath funName = asks (^?! compilerFunctionInfos . at funName . _Just . functionInfoPath)
+getFunctionPath funId = (^. functionInfoPath) <$> getFunctionInfo funId
+
+getFunctionName :: (Members '[Reader CompilerCtx] r) => FunctionId -> Sem r Text
+getFunctionName funId = (^. functionInfoName) <$> getFunctionInfo funId
 
 evaluated :: Term Natural -> Term Natural
 evaluated t = OpApply # (opAddress "evaluated" emptyPath) # t

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -41,6 +41,7 @@ import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Tree.Data.InfoTable qualified as Tree
 import Juvix.Compiler.Tree.Language qualified as Tree
 import Juvix.Compiler.Tree.Language.Rep
+import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude hiding (Atom, Path)
 
 newtype AnomaResult = AnomaResult
@@ -728,7 +729,7 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
            )
 
     exportEnv :: Term Natural
-    exportEnv = "exportEnv" @ makeList compiledFuns
+    exportEnv = Str.theFunctionsLibrary @ makeList compiledFuns
 
     makeLibraryFunction :: (Text, Term Natural) -> Term Natural
     makeLibraryFunction (funName, c) =

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -983,7 +983,7 @@ getConstructorMemRep :: (Members '[Reader CompilerCtx] r) => Tree.Tag -> Sem r N
 getConstructorMemRep tag = (^. constructorInfoMemRep) <$> getConstructorInfo tag
 
 crash :: Term Natural
-crash = ("crash" @ OpAddress #. OpAddress # OpAddress)
+crash = ("crash" @ OpAddress # OpAddress # OpAddress)
 
 mul :: Term Natural -> Term Natural -> Term Natural
 mul a b = callStdlib StdlibMul [a, b]

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -987,4 +987,7 @@ version :: (IsString s) => s
 version = "version"
 
 functionsPlaceholder :: (IsString s) => s
-functionsPlaceholder = "functions_placeholder"
+functionsPlaceholder = "functionsLibrary_placeholder"
+
+theFunctionsLibrary :: (IsString s) => s
+theFunctionsLibrary = "the_functionsLibrary"

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -105,7 +105,8 @@ anomaTest n mainFun args _testCheck _evalInterceptStdlibCalls =
         CompilerFunction
           { _compilerFunctionId = UserFunction (defaultSymbol 0),
             _compilerFunctionArity = fromIntegral (length args),
-            _compilerFunction = return mainFun
+            _compilerFunction = return mainFun,
+            _compilerFunctionName = "main"
           }
       _testName :: Text
         | _evalInterceptStdlibCalls = n <> " - intercept stdlib"

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -103,7 +103,7 @@ anomaTest :: Text -> Term Natural -> [Term Natural] -> Check () -> Bool -> Test
 anomaTest n mainFun args _testCheck _evalInterceptStdlibCalls =
   let f =
         CompilerFunction
-          { _compilerFunctionName = UserFunction (defaultSymbol 0),
+          { _compilerFunctionId = UserFunction (defaultSymbol 0),
             _compilerFunctionArity = fromIntegral (length args),
             _compilerFunction = return mainFun
           }


### PR DESCRIPTION
Each commit in this PR is a separate improvement.

* Tag any Term with a string instead of just cells using `@`. e.g `"myTag" @ opCall ...`
* `:dump FILE` in the nockma REPL to dump the last REPL result to a file.
* More tagging in the pretty nockma output.