### PR TITLE
Double substitute the Nockma functions placeholder in the main function

### DIFF
--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -795,7 +795,7 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
     makeAnomaFun :: AnomaResult
     makeAnomaFun =
       AnomaResult
-        { _anomaClosure = substEnv mainClosure
+        { _anomaClosure = substEnv (substEnv mainClosure)
         }
 
 functionsLibraryPlaceHolder :: Term Natural

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -779,24 +779,24 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
             }
         )
 
+    -- Replaces all instances of functionsLibraryPlaceHolder by the actual
+    -- functions library. Note that the functions library will have
+    -- functionsLibraryPlaceHolders, but this is not an issue because they
+    -- are not directly accessible from anoma so they'll never be entrypoints.
+    substEnv :: Term Natural -> Term Natural
+    substEnv = \case
+      TermAtom a
+        | a ^. atomHint == Just AtomHintFunctionsPlaceholder -> exportEnv
+        | otherwise -> TermAtom a
+      TermCell (Cell' l r i) ->
+        -- note that we do not need to recurse into terms inside the CellInfo because those terms will never be an entry point from anoma
+        TermCell (Cell' (substEnv l) (substEnv r) i)
+
     makeAnomaFun :: AnomaResult
     makeAnomaFun =
       AnomaResult
         { _anomaClosure = substEnv mainClosure
         }
-      where
-        -- Replaces all instances of functionsLibraryPlaceHolder by the actual
-        -- functions library. Note that the functions library will have
-        -- functionsLibraryPlaceHolders, but this is not an issue because they
-        -- are not directly accessible from anoma so they'll never be entrypoints.
-        substEnv :: Term Natural -> Term Natural
-        substEnv = \case
-          TermAtom a
-            | a ^. atomHint == Just AtomHintFunctionsPlaceholder -> exportEnv
-            | otherwise -> TermAtom a
-          TermCell (Cell' l r i) ->
-            -- note that we do not need to recurse into terms inside the CellInfo because those terms will never be an entry point from anoma
-            TermCell (Cell' (substEnv l) (substEnv r) i)
 
 functionsLibraryPlaceHolder :: Term Natural
 functionsLibraryPlaceHolder =

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -728,8 +728,8 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
                <$> [(f ^. compilerFunctionName, runCompilerFunction compilerCtx f) | f <- libFuns]
            )
 
-    exportEnv :: Term Natural
-    exportEnv = Str.theFunctionsLibrary @ makeList compiledFuns
+    funcsLib :: Term Natural
+    funcsLib = Str.theFunctionsLibrary @ makeList compiledFuns
 
     makeLibraryFunction :: (Text, Term Natural) -> Term Natural
     makeLibraryFunction (funName, c) =
@@ -783,19 +783,19 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
     -- functions library. Note that the functions library will have
     -- functionsLibraryPlaceHolders, but this is not an issue because they
     -- are not directly accessible from anoma so they'll never be entrypoints.
-    substEnv :: Term Natural -> Term Natural
-    substEnv = \case
+    substFuncsLib :: Term Natural -> Term Natural
+    substFuncsLib = \case
       TermAtom a
-        | a ^. atomHint == Just AtomHintFunctionsPlaceholder -> exportEnv
+        | a ^. atomHint == Just AtomHintFunctionsPlaceholder -> funcsLib
         | otherwise -> TermAtom a
       TermCell (Cell' l r i) ->
         -- note that we do not need to recurse into terms inside the CellInfo because those terms will never be an entry point from anoma
-        TermCell (Cell' (substEnv l) (substEnv r) i)
+        TermCell (Cell' (substFuncsLib l) (substFuncsLib r) i)
 
     makeAnomaFun :: AnomaResult
     makeAnomaFun =
       AnomaResult
-        { _anomaClosure = substEnv (substEnv mainClosure)
+        { _anomaClosure = substFuncsLib (substFuncsLib mainClosure)
         }
 
 functionsLibraryPlaceHolder :: Term Natural


### PR DESCRIPTION
In the nockma compilation backend we compile functions with a an atom with hint `functionsPlaceholder` where the functions library is expected to be. After the module is compiled we now have the functions library to substitute.

The __first substitution__ replaces the `functionsPlaceholder` in the main function with the functions library.

This PR introduces a __second substitution__ that replaces the `functionsPlaceholder` atoms in the functions library that were introduced in the __first subsitution__.

This fix is sufficient to get the [transaction example](https://github.com/anoma/juvix-anoma/blob/main/examples/CounterTransaction.juvix) running in the Anoma system.