### PR TITLE
Fix benchmarks suite `juvix compile` variants

### DIFF
--- a/bench/Variants.hs
+++ b/bench/Variants.hs
@@ -147,7 +147,7 @@ juvixExe =
       _variantColor = getVariantColor JuvixExe,
       _variantRun = runExe,
       _variantBuild = \args ->
-        command_ [] "juvix" (juvixCommon ++ commonOptions args ext)
+        command_ [] "juvix" (juvixCommon ++ ["native"] ++ commonOptions args ext)
     }
   where
     ext :: [String]
@@ -165,7 +165,7 @@ juvixWasm =
       _variantColor = getVariantColor JuvixWasm,
       _variantRun = runWasm,
       _variantBuild = \args ->
-        command_ [] "juvix" (juvixCommon ++ ["--target=wasm32-wasi"] ++ commonOptions args ext)
+        command_ [] "juvix" (juvixCommon ++ ["wasi"] ++ commonOptions args ext)
     }
   where
     ext :: [String]


### PR DESCRIPTION
The `--target` flag was replaced by subcommands in https://github.com/anoma/juvix/pull/2700

This PR fixes the benchmark suite to use `juvix compile native` and `juvix compile wasi`.

In addition this PR adds as `compile-only` target to `juvix-bench`

The compile-only target only compiles the executable for each variant of each suite. It doesn't actually run the benchmarks. This is useful when checking that the variant build steps are correct before committing.

Example to run with stack:

```
stack bench --ba 'compile-only'
```