### PR TITLE
Support parallel module compilation in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# set to non-empty string to disable parallel tests
+# set to non-empty string to disable parallel builds and tests
 #
 # e.g:
 #   just disableParallel=yes test
@@ -13,6 +13,9 @@ enableOptimized := ''
 # set to non-empty string to enable command debugging
 enableDebug := ''
 
+# set to number of parallel jobs
+numParallelJobs := ''
+
 # the command used to run stack
 stack := "stack"
 
@@ -21,7 +24,12 @@ ormolu := "ormolu"
 
 # flags used in the stack command
 stackOptFlag := if enableOptimized == '' { '--fast' } else { '' }
-stackArgs := stackOptFlag + " -j" + num_cpus()
+# The ghc `-j` flag defaults to number of cpus when no argument is passed
+stackGhcParallelFlag := if disableParallel == '' { "--ghc-options=-j" + numParallelJobs } else { '' }
+# The stack `-j` options requires an argument
+stackParallelFlagJobs := if numParallelJobs == '' { num_cpus() } else { numParallelJobs }
+stackParallelFlag := if disableParallel == '' { '-j' + stackParallelFlagJobs } else { '' }
+stackArgs := stackOptFlag + ' ' + stackParallelFlag + ' ' + stackGhcParallelFlag
 
 # flags used in the stack test command
 testArgs := "--hide-successes"

--- a/justfile
+++ b/justfile
@@ -76,6 +76,7 @@ test *filter:
     if [ -n "$filter" ]; then
       filter="-p \"$filter\""
     fi
+    set -x
     {{ stack }} test {{ stackArgs }} --ta "{{ testArgs }} {{ rtsFlag }} $filter"
 
 # Run a juvix command and profile it
@@ -99,6 +100,7 @@ build *opts:
             ;;
         *)
             just _buildRuntime
+            set -x
             {{ stack }} build {{ stackArgs }}
             ;;
     esac


### PR DESCRIPTION
Thanks to @janmasrovira for figuring out that the stack `--ghc-options=-j` flag enables [parallel module compilation in GHC](https://downloads.haskell.org/ghc/latest/docs/users_guide/using.html#using-ghc-make).

This PR adds support for this in the project justfile.

You can configure the argument to `-j` using the `numParallelJobs` option, for example:

```
just numParallelJobs=24 build
+ stack build --fast -j24 --ghc-options=-j24
```

If `numParallelJobs` is not set then `-j` is passed with no arguments in `--ghc-options` (this is equivalent to passing the number of cpus of the machine.) and is passed with the number of cpus of the machine for the stack `-j` option (the stack `-j` option requires an argument). 

The `numParallelJobs` option also sets the argument to the [stack `-j` option](https://docs.haskellstack.org/en/stable/global_flags/#-jobs-or-j-option).

To disable build parallelism set the `disableParallel` flag:

```
just disableParallel=yes build
+ stack build --fast
```