### PR TITLE
Use the justfile for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ env:
   VAMPIRVERSION: v0.1.3
   CAIRO_VM_VERSION: ae06ba04f3b6864546b6baeeebf1b0735ddccb5d
   JUST_ARGS: enableOptimized=yes runtimeCcArg=$CC runtimeLibtoolArg=$LIBTOOL
+  STACK_BUILD_ARGS: --pedantic -j4 --ghc-options=-j
 
 jobs:
   pre-commit:
@@ -183,7 +184,7 @@ jobs:
         uses: freckle/stack-action@v5
         with:
           working-directory: main
-          stack-build-arguments: -j4 --ghc-options=-j
+          stack-build-arguments: ${{ env.STACK_BUILD_ARGS }}
           test: false
 
       - name: Install and test Juvix
@@ -383,7 +384,7 @@ jobs:
         uses: freckle/stack-action@v5
         with:
           working-directory: main
-          stack-build-arguments: -j4 --ghc-options=-j
+          stack-build-arguments: ${{ env.STACK_BUILD_ARGS }}
           test: false
 
       - name: Add homebrew clang to the PATH (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ env:
   VAMPIRREPO: anoma/vamp-ir
   VAMPIRVERSION: v0.1.3
   CAIRO_VM_VERSION: ae06ba04f3b6864546b6baeeebf1b0735ddccb5d
+  JUST_ARGS: enableOptimized=yes runtimeCcArg=$CC runtimeLibtoolArg=$LIBTOOL
 
 jobs:
   pre-commit:
@@ -58,6 +59,9 @@ jobs:
   build-and-test-linux:
     runs-on: ubuntu-22.04
     steps:
+      - name: install just
+        run: sudo snap install --edge --classic just
+
       - name: Checkout our repository
         uses: actions/checkout@v3
         with:
@@ -158,7 +162,7 @@ jobs:
       - name: Make runtime
         run: |
           cd main
-          make runtime
+          just ${{ env.JUST_ARGS }} build runtime
 
       # We use the options:
       #   - -fhide-source-paths
@@ -176,9 +180,10 @@ jobs:
 
       - name: Stack setup
         id: stack
-        uses: freckle/stack-action@v4
+        uses: freckle/stack-action@v5
         with:
           working-directory: main
+          stack-build-arguments: -j4 --ghc-options=-j
           test: false
 
       - name: Install and test Juvix
@@ -186,8 +191,8 @@ jobs:
         if: ${{ success() }}
         run: |
           cd main
-          make install
-          make test
+          just ${{ env.JUST_ARGS }} install
+          just ${{ env.JUST_ARGS }} test
 
       - name: Typecheck and format Juvix examples
         if: ${{ success() }}
@@ -225,6 +230,9 @@ jobs:
   build-and-test-macos:
     runs-on: macos-12
     steps:
+      - name: Install just
+        run: brew install just
+
       - name: Checkout our repository
         uses: actions/checkout@v3
         with:
@@ -354,7 +362,7 @@ jobs:
       - name: Make runtime
         run: |
           cd main
-          make CC=$CC LIBTOOL=$LIBTOOL runtime
+          just ${{ env.JUST_ARGS }} build runtime
 
       # We use the options:
       #   - -fhide-source-paths
@@ -372,9 +380,10 @@ jobs:
 
       - name: Stack setup
         id: stack
-        uses: freckle/stack-action@v4
+        uses: freckle/stack-action@v5
         with:
           working-directory: main
+          stack-build-arguments: -j4 --ghc-options=-j
           test: false
 
       - name: Add homebrew clang to the PATH (macOS)
@@ -399,8 +408,8 @@ jobs:
         if: ${{ success() }}
         run: |
           cd main
-          make CC=$CC LIBTOOL=$LIBTOOL install
-          make CC=$CC LIBTOOL=$LIBTOOL test
+          just ${{ env.JUST_ARGS }} install
+          just ${{ env.JUST_ARGS }} test
 
       - name: Typecheck and format Juvix examples
         if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,7 @@ jobs:
   build-and-test-linux:
     runs-on: ubuntu-22.04
     steps:
-      - name: install just
-        run: sudo snap install --edge --classic just
+      - uses: extractions/setup-just@v2
 
       - name: Checkout our repository
         uses: actions/checkout@v3
@@ -231,8 +230,7 @@ jobs:
   build-and-test-macos:
     runs-on: macos-12
     steps:
-      - name: Install just
-        run: brew install just
+      - uses: extractions/setup-just@v2
 
       - name: Checkout our repository
         uses: actions/checkout@v3

--- a/justfile
+++ b/justfile
@@ -22,6 +22,17 @@ stack := "stack"
 # the command used to run ormolu
 ormolu := "ormolu"
 
+# The CC argument to the runtime Makefile
+runtimeCcArg := ''
+
+# The LIBTOOL argument to the runtime Makefile
+runtimeLibtoolArg := ''
+
+# The flags used in the runtime make commands
+runtimeCcFlag := if runtimeCcArg == '' { '' } else { "CC=" + runtimeCcArg }
+runtimeLibtoolFlag := if runtimeLibtoolArg == '' { '' } else { "LIBTOOL=" + runtimeLibtoolArg }
+runtimeArgs := trim(runtimeCcFlag + ' ' + runtimeLibtoolFlag)
+
 # flags used in the stack command
 stackOptFlag := if enableOptimized == '' { '--fast' } else { '' }
 # The ghc `-j` flag defaults to number of cpus when no argument is passed
@@ -93,7 +104,7 @@ run-profile +cmd:
 
 # Build the juvix runtime
 _buildRuntime:
-    cd runtime && make -j 4 -s
+    cd runtime && make {{ runtimeArgs }} -j 4 -s
 
 # Build the project. `build runtime` builds only the runtime.
 [no-exit-message]
@@ -104,10 +115,10 @@ build *opts:
 
     case $opts in
         runtime)
-            just _buildRuntime
+            just runtimeArgs="{{ runtimeArgs }}" _buildRuntime
             ;;
         *)
-            just _buildRuntime
+            just runtimeArgs="{{ runtimeArgs }}" _buildRuntime
             set -x
             {{ stack }} build {{ stackArgs }}
             ;;


### PR DESCRIPTION
This PR changes the CI build to use the justfile instead of the Makefile to run builds and tests. CI builds now take advantage of parallel module builds from https://github.com/anoma/juvix/pull/2729.

In order support this the runtime build target in the justfile now supports `runtimeCcArg` and `runtimeLibtoolArg` so that the `CC` and `LIBTOOL` Makefile argument can be set. This is required for the macOS build.

In addition this PR upgrades the stack setup step action. Previously the stack build flags included `--fast` which meant the whole project was rebuilt in the `test` step, this has also been fixed.

Overall this speeds up the CI:
* Linux now takes 30mins (from 40mins)
* macOS now takes 60mins (from 80mins)
