### PR TITLE
Fix benchmark runtime variant

### DIFF
--- a/bench/Variants.hs
+++ b/bench/Variants.hs
@@ -198,7 +198,7 @@ runtimeWasm =
       _variantColor = getVariantColor RuntimeWasm,
       _variantRun = runWasm,
       _variantBuild = \args ->
-        command_ [] "juvix" (runtimeCommon ++ ["--target=wasm32-wasi"] ++ commonOptions args ext)
+        command_ [] "juvix" (runtimeCommon ++ ["--target=wasi"] ++ commonOptions args ext)
     }
   where
     ext :: [String]


### PR DESCRIPTION
This PR fixes the broken benchmarks build:

https://github.com/anoma/juvix-nightly-builds/actions/runs/8731798856/job/23958282008

Target `wasm32-wasi` has been renamed to `wasi`
