### PR TITLE
Remove support for examples from judoc

### DIFF
--- a/app/Commands/Html.hs
+++ b/app/Commands/Html.hs
@@ -10,7 +10,7 @@ import Juvix.Compiler.Backend.Html.Translation.FromTyped.Source
 import Juvix.Compiler.Concrete.Pretty qualified as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
 import Juvix.Compiler.Internal.Translation
-import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context (resultInternal, resultNormalized)
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context (resultInternal)
 import Juvix.Extra.Process
 import System.Process qualified as Process
 
@@ -45,7 +45,6 @@ resultToJudocCtx :: InternalTypedResult -> Html.JudocCtx
 resultToJudocCtx res =
   Html.JudocCtx
     { _judocCtxComments = Scoper.getScoperResultComments sres,
-      _judocCtxNormalizedTable = res ^. resultNormalized,
       _judocCtxTopModules = [sres ^. Scoper.resultModule]
     }
   where

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/PrettyJudoc.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/PrettyJudoc.hs
@@ -66,7 +66,6 @@ ppJudoc (Judoc bs) = do
     ppBlock :: JudocBlock 'Scoped -> Sem r (Doc CodeAnn)
     ppBlock = \case
       JudocLines ls -> hsep <$> mapM ppLine (toList ls)
-      JudocExample {} -> return mempty
 
     ppLine :: JudocLine 'Scoped -> Sem r (Doc CodeAnn)
     ppLine (JudocLine _ as) = mconcatMapM (ppAtom . (^. withLocParam)) (toList as)

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -2031,7 +2031,6 @@ deriving stock instance Ord (JudocGroup 'Scoped)
 
 data JudocBlock (s :: Stage)
   = JudocLines (NonEmpty (JudocLine s))
-  | JudocExample (Example s)
   deriving stock (Generic)
 
 instance Serialize (JudocBlock 'Scoped)
@@ -2500,7 +2499,6 @@ instance HasLoc (JudocGroup s) where
 instance HasLoc (JudocBlock s) where
   getLoc = \case
     JudocLines ls -> getLocSpan ls
-    JudocExample e -> getLoc e
 
 instance HasLoc PatternScopedIden where
   getLoc = \case
@@ -2816,22 +2814,6 @@ instance HasAtomicity PatternArg where
     | ImplicitInstance <- p ^. patternArgIsImplicit = Atom
     | isJust (p ^. patternArgName) = Atom
     | otherwise = atomicity (p ^. patternArgPattern)
-
-judocExamples :: Judoc s -> [Example s]
-judocExamples (Judoc bs) = concatMap goGroup bs
-  where
-    goGroup :: JudocGroup s -> [Example s]
-    goGroup = \case
-      JudocGroupBlock p -> goParagraph p
-      JudocGroupLines l -> concatMap goBlock l
-
-    goParagraph :: JudocBlockParagraph s -> [Example s]
-    goParagraph l = concatMap goBlock (l ^. judocBlockParagraphBlocks)
-
-    goBlock :: JudocBlock s -> [Example s]
-    goBlock = \case
-      JudocExample e -> [e]
-      _ -> mempty
 
 instance HasNameKind ScopedIden where
   getNameKind = getNameKind . (^. scopedIdenFinal)

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -807,13 +807,6 @@ ppJudocStart = do
       | inBlock -> return Nothing
       | otherwise -> ppCode Kw.delimJudocStart $> Just ()
 
-instance (SingI s) => PrettyPrint (Example s) where
-  ppCode e =
-    ppJudocStart
-      <??+> ppCode Kw.delimJudocExample
-      <+> ppExpressionType (e ^. exampleExpression)
-        <> semicolon
-
 instance (PrettyPrint a) => PrettyPrint (WithLoc a) where
   ppCode a = morphemeM (getLoc a) (ppCode (a ^. withLocParam))
 
@@ -872,7 +865,6 @@ instance (SingI s) => PrettyPrint (JudocGroup s) where
 instance (SingI s) => PrettyPrint (JudocBlock s) where
   ppCode = \case
     JudocLines l -> vsep (ppCode <$> l)
-    JudocExample e -> ppCode e
 
 instance (SingI s) => PrettyPrint (AxiomDef s) where
   ppCode :: forall r. (Members '[ExactPrint, Reader Options] r) => AxiomDef s -> Sem r ()

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -2457,7 +2457,6 @@ checkJudocBlock ::
   Sem r (JudocBlock 'Scoped)
 checkJudocBlock = \case
   JudocLines l -> JudocLines <$> mapM checkJudocLine l
-  JudocExample e -> JudocExample <$> traverseOf exampleExpression checkParseExpressionAtoms e
 
 checkJudocBlockParagraph ::
   (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader EntryPoint] r) =>

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Lexer.hs
@@ -13,7 +13,6 @@ import Juvix.Compiler.Concrete.Extra qualified as P
 import Juvix.Compiler.Concrete.Keywords
 import Juvix.Compiler.Concrete.Translation.FromSource.ParserResultBuilder
 import Juvix.Data.Keyword
-import Juvix.Extra.Strings qualified as Str
 import Juvix.Parser.Lexer
 import Juvix.Prelude
 import Text.Megaparsec.Char.Lexer qualified as L
@@ -72,9 +71,6 @@ bracedString =
 
 string :: (Members '[ParserResultBuilder] r) => ParsecS r (Text, Interval)
 string = lexemeInterval string'
-
-judocExampleStart :: ParsecS r ()
-judocExampleStart = P.chunk Str.judocExample >> hspace_
 
 judocBlockEnd :: (Members '[ParserResultBuilder] r) => ParsecS r KeywordRef
 judocBlockEnd = kw delimJudocBlockEnd

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -111,8 +111,7 @@ genFieldProjection _funDefName _funDefBuiltin info fieldIx = do
       retTy = constrArgs !! fieldIx
   cloneFunctionDefSameName
     FunctionDef
-      { _funDefExamples = [],
-        _funDefTerminating = False,
+      { _funDefTerminating = False,
         _funDefInstance = False,
         _funDefCoercion = False,
         _funDefArgsInfo = mempty,

--- a/src/Juvix/Compiler/Internal/Extra/Base.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Base.hs
@@ -185,9 +185,6 @@ subsHoles s = leafExpressions helper
       ExpressionHole h -> clone (fromMaybe e (s ^. at h))
       _ -> return e
 
-instance HasExpressions Example where
-  leafExpressions f = traverseOf exampleExpression (leafExpressions f)
-
 instance HasExpressions ArgInfo where
   leafExpressions f ArgInfo {..} = do
     d' <- traverse (leafExpressions f) _argInfoDefault
@@ -201,13 +198,11 @@ instance HasExpressions FunctionDef where
   leafExpressions f FunctionDef {..} = do
     body' <- leafExpressions f _funDefBody
     ty' <- leafExpressions f _funDefType
-    examples' <- traverse (leafExpressions f) _funDefExamples
     infos' <- traverse (leafExpressions f) _funDefArgsInfo
     pure
       FunctionDef
         { _funDefBody = body',
           _funDefType = ty',
-          _funDefExamples = examples',
           _funDefArgsInfo = infos',
           _funDefTerminating,
           _funDefInstance,
@@ -242,13 +237,11 @@ instance HasExpressions InductiveDef where
   leafExpressions f InductiveDef {..} = do
     params' <- traverse (leafExpressions f) _inductiveParameters
     constrs' <- traverse (leafExpressions f) _inductiveConstructors
-    examples' <- traverse (leafExpressions f) _inductiveExamples
     ty' <- leafExpressions f _inductiveType
     pure
       InductiveDef
         { _inductiveParameters = params',
           _inductiveConstructors = constrs',
-          _inductiveExamples = examples',
           _inductiveType = ty',
           _inductiveName,
           _inductiveBuiltin,
@@ -260,11 +253,9 @@ instance HasExpressions InductiveDef where
 instance HasExpressions ConstructorDef where
   leafExpressions f ConstructorDef {..} = do
     ty' <- leafExpressions f _inductiveConstructorType
-    examples' <- traverse (leafExpressions f) _inductiveConstructorExamples
     pure
       ConstructorDef
-        { _inductiveConstructorExamples = examples',
-          _inductiveConstructorType = ty',
+        { _inductiveConstructorType = ty',
           _inductiveConstructorName,
           _inductiveConstructorPragmas
         }
@@ -770,7 +761,6 @@ simpleFunDef funName ty body =
   FunctionDef
     { _funDefName = funName,
       _funDefType = ty,
-      _funDefExamples = [],
       _funDefCoercion = False,
       _funDefInstance = False,
       _funDefPragmas = mempty,

--- a/src/Juvix/Compiler/Internal/Extra/Clonable.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Clonable.hs
@@ -249,8 +249,6 @@ instance Clonable FunctionDef where
             _funDefType = ty',
             _funDefBody = body',
             _funDefArgsInfo = defaultSig',
-            -- clones do not need to preserve examples
-            _funDefExamples = [],
             _funDefTerminating,
             _funDefInstance,
             _funDefCoercion,

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -37,7 +37,6 @@ data PreStatement
 data Module' stmt = Module
   { _moduleId :: ModuleId,
     _moduleName :: Name,
-    _moduleExamples :: [Example],
     _moduleBody :: ModuleBody' stmt,
     _modulePragmas :: Pragmas
   }
@@ -89,7 +88,6 @@ instance Serialize AxiomDef
 data FunctionDef = FunctionDef
   { _funDefName :: FunctionName,
     _funDefType :: Expression,
-    _funDefExamples :: [Example],
     _funDefBody :: Expression,
     _funDefTerminating :: Bool,
     _funDefInstance :: Bool,
@@ -182,16 +180,6 @@ data Expression
 instance Hashable Expression
 
 instance Serialize Expression
-
-data Example = Example
-  { _exampleId :: NameId,
-    _exampleExpression :: Expression
-  }
-  deriving stock (Eq, Generic, Data)
-
-instance Hashable Example
-
-instance Serialize Example
 
 data SimpleBinder = SimpleBinder
   { _sbinderVar :: VarName,
@@ -330,7 +318,6 @@ instance Serialize InductiveParameter
 data InductiveDef = InductiveDef
   { _inductiveName :: InductiveName,
     _inductiveBuiltin :: Maybe BuiltinInductive,
-    _inductiveExamples :: [Example],
     _inductiveType :: Expression,
     _inductiveParameters :: [InductiveParameter],
     _inductiveConstructors :: [ConstructorDef],
@@ -342,7 +329,6 @@ data InductiveDef = InductiveDef
 
 data ConstructorDef = ConstructorDef
   { _inductiveConstructorName :: ConstrName,
-    _inductiveConstructorExamples :: [Example],
     _inductiveConstructorType :: Expression,
     _inductiveConstructorPragmas :: Pragmas
   }
@@ -402,7 +388,6 @@ makeLenses ''Module'
 makeLenses ''Let
 makeLenses ''MutualBlockLet
 makeLenses ''MutualBlock
-makeLenses ''Example
 makeLenses ''PatternArg
 makeLenses ''Import
 makeLenses ''FunctionDef

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -6,7 +6,6 @@ module Juvix.Compiler.Internal.Translation.FromInternal
   )
 where
 
-import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Concrete.Data.Highlight.Input
 import Juvix.Compiler.Internal.Data.LocalVars
 import Juvix.Compiler.Internal.Language
@@ -34,7 +33,6 @@ typeCheckExpressionType exp = do
     . runNameIdGenArtifacts
     . ignoreHighlightBuilder
     . runReader table
-    . ignoreOutput @Example
     . withEmptyLocalVars
     . withEmptyInsertedArgsStack
     . mapError (JuvixError @TypeCheckerError)
@@ -57,7 +55,7 @@ typeCheckingNew ::
   Sem (Termination ': r) InternalResult ->
   Sem r InternalTypedResult
 typeCheckingNew a = do
-  (termin, (res, (normalized, (idens, (funs, r))))) <- runTermination iniTerminationState $ do
+  (termin, (res, (idens, (funs, r)))) <- runTermination iniTerminationState $ do
     res <- a
     itab <- getInternalModuleTable <$> ask
     let md :: InternalModule
@@ -67,7 +65,6 @@ typeCheckingNew a = do
         table :: InfoTable
         table = computeCombinedInfoTable itab'
     fmap (res,)
-      . runOutputList
       . runState (computeTypesTable itab')
       . runState (computeFunctionsTable itab')
       . runReader table
@@ -80,7 +77,6 @@ typeCheckingNew a = do
         _resultModule = r,
         _resultInternalModule = md,
         _resultTermination = termin,
-        _resultNormalized = HashMap.fromList [(e ^. exampleId, e ^. exampleExpression) | e <- normalized],
         _resultIdenTypes = idens,
         _resultFunctions = funs
       }

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
@@ -21,7 +21,6 @@ data InternalTypedResult = InternalTypedResult
     _resultModule :: Module,
     _resultInternalModule :: InternalModule,
     _resultTermination :: TerminationState,
-    _resultNormalized :: NormalizedTable,
     _resultIdenTypes :: TypesTable,
     _resultFunctions :: FunctionsTable
   }


### PR DESCRIPTION
The judoc examples feature is currently unused. This feature was added in https://github.com/anoma/juvix/pull/1442

Keeping support for this feature adds a cost to HTML generation. We are removing this to improve the performance of `juvix html`.

To just render the HTML documentation we only require the scoper result from the pipeline. To support the examples we need the type checking result. The cost is significant in larger projects as the pipeline is run for each import.

Part of https://github.com/anoma/juvix/issues/2744