### PR TITLE
Support sharing ModuleInfoCache between pipeline runs

### DIFF
--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -34,6 +34,7 @@ import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
+import Juvix.Compiler.Pipeline.MCache
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Compiler.Pipeline.Result
@@ -49,7 +50,7 @@ import Juvix.Data.Field
 
 type PipelineAppEffects = '[TaggedLock, EmbedIO]
 
-type PipelineLocalEff = '[PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
+type PipelineLocalEff = '[MCache, PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
 
 type PipelineEff' r = PipelineLocalEff ++ r
 

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -34,7 +34,7 @@ import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
-import Juvix.Compiler.Pipeline.MCache
+import Juvix.Compiler.Pipeline.ModuleInfoCache
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Compiler.Pipeline.Result
@@ -50,7 +50,7 @@ import Juvix.Data.Field
 
 type PipelineAppEffects = '[TaggedLock, EmbedIO]
 
-type PipelineLocalEff = '[MCache, PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
+type PipelineLocalEff = '[ModuleInfoCache, PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
 
 type PipelineEff' r = PipelineLocalEff ++ r
 

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -32,6 +32,7 @@ import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Che
 import Juvix.Compiler.Nockma.Translation.FromTree qualified as NockmaTree
 import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.EntryPoint
+import Juvix.Compiler.Pipeline.ImportParents
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
 import Juvix.Compiler.Pipeline.ModuleInfoCache
@@ -50,7 +51,7 @@ import Juvix.Data.Field
 
 type PipelineAppEffects = '[TaggedLock, EmbedIO]
 
-type PipelineLocalEff = '[ModuleInfoCache, PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
+type PipelineLocalEff = '[ModuleInfoCache, Reader ImportParents, PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
 
 type PipelineEff' r = PipelineLocalEff ++ r
 

--- a/src/Juvix/Compiler/Pipeline/Driver.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver.hs
@@ -70,9 +70,7 @@ processFileToStoredCore ::
   EntryPoint ->
   Sem r (PipelineResult Core.CoreResult)
 processFileToStoredCore entry =
-  runReader @ImportParents mempty
-  -- . evalCacheEmpty processModule'
-  $
+  runReader @ImportParents mempty $
     processFileToStoredCore' entry
 
 processFileUpTo ::

--- a/src/Juvix/Compiler/Pipeline/Driver.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver.hs
@@ -41,9 +41,9 @@ import Path.Posix qualified as Path
 evalModuleInfoCache ::
   forall r a.
   (Members '[TaggedLock, Error JuvixError, Files, PathResolver] r) =>
-  Sem (ModuleInfoCache ': r) a ->
+  Sem (ModuleInfoCache ': Reader ImportParents ': r) a ->
   Sem r a
-evalModuleInfoCache = evalCacheEmpty (runReader @ImportParents mempty . processModule')
+evalModuleInfoCache = runReader @ImportParents mempty . evalCacheEmpty processModule'
 
 processFileUpToParsing ::
   forall r.

--- a/src/Juvix/Compiler/Pipeline/ImportParents.hs
+++ b/src/Juvix/Compiler/Pipeline/ImportParents.hs
@@ -1,0 +1,11 @@
+module Juvix.Compiler.Pipeline.ImportParents where
+
+import Juvix.Compiler.Concrete.Data
+import Juvix.Prelude.Base
+
+newtype ImportParents = ImportParents
+  { _importParents :: [TopModulePath]
+  }
+  deriving newtype (Semigroup, Monoid)
+
+makeLenses ''ImportParents

--- a/src/Juvix/Compiler/Pipeline/ImportParents.hs
+++ b/src/Juvix/Compiler/Pipeline/ImportParents.hs
@@ -3,9 +3,23 @@ module Juvix.Compiler.Pipeline.ImportParents where
 import Juvix.Compiler.Concrete.Data
 import Juvix.Prelude.Base
 
-newtype ImportParents = ImportParents
-  { _importParents :: [TopModulePath]
+data ImportParents = ImportParents
+  { _importParents :: [TopModulePath],
+    _importParentsSeenModules :: HashSet TopModulePath
   }
-  deriving newtype (Semigroup, Monoid)
 
 makeLenses ''ImportParents
+
+instance Semigroup ImportParents where
+  s1 <> s2 =
+    ImportParents
+      { _importParents = s1 ^. importParents <> s2 ^. importParents,
+        _importParentsSeenModules = s1 ^. importParentsSeenModules <> s2 ^. importParentsSeenModules
+      }
+
+instance Monoid ImportParents where
+  mempty =
+    ImportParents
+      { _importParents = mempty,
+        _importParentsSeenModules = mempty
+      }

--- a/src/Juvix/Compiler/Pipeline/ImportParents.hs
+++ b/src/Juvix/Compiler/Pipeline/ImportParents.hs
@@ -3,23 +3,9 @@ module Juvix.Compiler.Pipeline.ImportParents where
 import Juvix.Compiler.Concrete.Data
 import Juvix.Prelude.Base
 
-data ImportParents = ImportParents
-  { _importParents :: [TopModulePath],
-    _importParentsSeenModules :: HashSet TopModulePath
+newtype ImportParents = ImportParents
+  { _importParents :: [TopModulePath]
   }
+  deriving newtype (Semigroup, Monoid)
 
 makeLenses ''ImportParents
-
-instance Semigroup ImportParents where
-  s1 <> s2 =
-    ImportParents
-      { _importParents = s1 ^. importParents <> s2 ^. importParents,
-        _importParentsSeenModules = s1 ^. importParentsSeenModules <> s2 ^. importParentsSeenModules
-      }
-
-instance Monoid ImportParents where
-  mempty =
-    ImportParents
-      { _importParents = mempty,
-        _importParentsSeenModules = mempty
-      }

--- a/src/Juvix/Compiler/Pipeline/MCache.hs
+++ b/src/Juvix/Compiler/Pipeline/MCache.hs
@@ -1,0 +1,23 @@
+module Juvix.Compiler.Pipeline.MCache where
+
+import Juvix.Compiler.Pipeline.EntryPoint
+import Juvix.Compiler.Pipeline.Result
+import Juvix.Compiler.Store.Language qualified as Store
+import Juvix.Data.Effect.Cache
+import Juvix.Prelude.Base
+
+newtype EntryIndex = EntryIndex
+  { _entryIxEntry :: EntryPoint
+  }
+
+makeLenses ''EntryIndex
+
+instance Eq EntryIndex where
+  (==) = (==) `on` (^. entryIxEntry . entryPointModulePath)
+
+instance Hashable EntryIndex where
+  hashWithSalt s = hashWithSalt s . (^. entryIxEntry . entryPointModulePath)
+
+type MCache' a = Cache EntryIndex a
+
+type MCache = MCache' (PipelineResult Store.ModuleInfo)

--- a/src/Juvix/Compiler/Pipeline/ModuleInfoCache.hs
+++ b/src/Juvix/Compiler/Pipeline/ModuleInfoCache.hs
@@ -1,4 +1,4 @@
-module Juvix.Compiler.Pipeline.MCache where
+module Juvix.Compiler.Pipeline.ModuleInfoCache where
 
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Result
@@ -18,6 +18,6 @@ instance Eq EntryIndex where
 instance Hashable EntryIndex where
   hashWithSalt s = hashWithSalt s . (^. entryIxEntry . entryPointModulePath)
 
-type MCache' a = Cache EntryIndex a
+type ModuleInfoCache' a = Cache EntryIndex a
 
-type MCache = MCache' (PipelineResult Store.ModuleInfo)
+type ModuleInfoCache = ModuleInfoCache' (PipelineResult Store.ModuleInfo)

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
@@ -12,7 +12,7 @@ import Juvix.Compiler.Core.Evaluator
 import Juvix.Compiler.Core.Extra.Value
 import Juvix.Compiler.Core.Language
 import Juvix.Compiler.Pipeline
-import Juvix.Compiler.Pipeline.Driver (evalMCache, processFileToStoredCore)
+import Juvix.Compiler.Pipeline.Driver (evalModuleInfoCache, processFileToStoredCore)
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Compiler.Pipeline.Package.Loader.PathResolver
@@ -139,7 +139,7 @@ loadPackage' packagePath = do
       . mapError (JuvixError @GitProcessError)
       . runGitProcess
       . runPackagePathResolver rootPath
-      . evalMCache
+      . evalModuleInfoCache
       $ (^. pipelineResult) <$> processFileToStoredCore packageEntryPoint
     )
   where

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
@@ -12,7 +12,7 @@ import Juvix.Compiler.Core.Evaluator
 import Juvix.Compiler.Core.Extra.Value
 import Juvix.Compiler.Core.Language
 import Juvix.Compiler.Pipeline
-import Juvix.Compiler.Pipeline.Driver (processFileToStoredCore)
+import Juvix.Compiler.Pipeline.Driver (evalMCache, processFileToStoredCore)
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Compiler.Pipeline.Package.Loader.PathResolver
@@ -139,6 +139,7 @@ loadPackage' packagePath = do
       . mapError (JuvixError @GitProcessError)
       . runGitProcess
       . runPackagePathResolver rootPath
+      . evalMCache
       $ (^. pipelineResult) <$> processFileToStoredCore packageEntryPoint
     )
   where

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -15,7 +15,6 @@ import Juvix.Compiler.Pipeline.Artifacts.PathResolver
 import Juvix.Compiler.Pipeline.Driver (evalModuleInfoCache)
 import Juvix.Compiler.Pipeline.Driver qualified as Driver
 import Juvix.Compiler.Pipeline.EntryPoint
-import Juvix.Compiler.Pipeline.ImportParents
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
 import Juvix.Compiler.Pipeline.ModuleInfoCache

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -12,10 +12,12 @@ import Juvix.Compiler.Internal qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.Artifacts.PathResolver
+import Juvix.Compiler.Pipeline.Driver (evalMCache)
 import Juvix.Compiler.Pipeline.Driver qualified as Driver
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
+import Juvix.Compiler.Pipeline.MCache
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff.IO
 import Juvix.Compiler.Pipeline.Result
@@ -111,7 +113,7 @@ compileExpression p =
     >>= fromInternalExpression
 
 registerImport ::
-  (Members '[TaggedLock, Error JuvixError, State Artifacts, Reader EntryPoint, Files, GitClone, PathResolver] r) =>
+  (Members '[TaggedLock, Error JuvixError, State Artifacts, Reader EntryPoint, Files, GitClone, PathResolver, MCache] r) =>
   Import 'Parsed ->
   Sem r ()
 registerImport i = do
@@ -163,6 +165,7 @@ compileReplInputIO fp txt = do
     . mapError (JuvixError @PackageLoaderError)
     . runEvalFileEffIO
     . runPathResolverArtifacts
+    . evalMCache
     $ do
       p <- parseReplInput fp txt
       case p of

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -12,12 +12,12 @@ import Juvix.Compiler.Internal qualified as Internal
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.Termination.Checker
 import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.Artifacts.PathResolver
-import Juvix.Compiler.Pipeline.Driver (evalMCache)
+import Juvix.Compiler.Pipeline.Driver (evalModuleInfoCache)
 import Juvix.Compiler.Pipeline.Driver qualified as Driver
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
-import Juvix.Compiler.Pipeline.MCache
+import Juvix.Compiler.Pipeline.ModuleInfoCache
 import Juvix.Compiler.Pipeline.Package.Loader.Error
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff.IO
 import Juvix.Compiler.Pipeline.Result
@@ -113,7 +113,7 @@ compileExpression p =
     >>= fromInternalExpression
 
 registerImport ::
-  (Members '[TaggedLock, Error JuvixError, State Artifacts, Reader EntryPoint, Files, GitClone, PathResolver, MCache] r) =>
+  (Members '[TaggedLock, Error JuvixError, State Artifacts, Reader EntryPoint, Files, GitClone, PathResolver, ModuleInfoCache] r) =>
   Import 'Parsed ->
   Sem r ()
 registerImport i = do
@@ -165,7 +165,7 @@ compileReplInputIO fp txt = do
     . mapError (JuvixError @PackageLoaderError)
     . runEvalFileEffIO
     . runPathResolverArtifacts
-    . evalMCache
+    . evalModuleInfoCache
     $ do
       p <- parseReplInput fp txt
       case p of

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -15,6 +15,7 @@ import Juvix.Compiler.Pipeline.Artifacts.PathResolver
 import Juvix.Compiler.Pipeline.Driver (evalModuleInfoCache)
 import Juvix.Compiler.Pipeline.Driver qualified as Driver
 import Juvix.Compiler.Pipeline.EntryPoint
+import Juvix.Compiler.Pipeline.ImportParents
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
 import Juvix.Compiler.Pipeline.ModuleInfoCache

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -82,6 +82,7 @@ runIOEitherPipeline' entry a = do
     . mapError (JuvixError @PackageLoaderError)
     . runEvalFileEffIO
     . runPathResolver'
+    . evalMCache
     $ a
 
 mainIsPackageFile :: EntryPoint -> Bool
@@ -150,6 +151,7 @@ runReplPipelineIOEither' lockMode entry = do
       . mapError (JuvixError @PackageLoaderError)
       . runEvalFileEffIO
       . runPathResolver'
+      . evalMCache
       $ entrySetup defaultDependenciesConfig >> processFileToStoredCore entry
   return $ case eith of
     Left err -> Left err

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -82,7 +82,7 @@ runIOEitherPipeline' entry a = do
     . mapError (JuvixError @PackageLoaderError)
     . runEvalFileEffIO
     . runPathResolver'
-    . evalMCache
+    . evalModuleInfoCache
     $ a
 
 mainIsPackageFile :: EntryPoint -> Bool
@@ -151,7 +151,7 @@ runReplPipelineIOEither' lockMode entry = do
       . mapError (JuvixError @PackageLoaderError)
       . runEvalFileEffIO
       . runPathResolver'
-      . evalMCache
+      . evalModuleInfoCache
       $ entrySetup defaultDependenciesConfig >> processFileToStoredCore entry
   return $ case eith of
     Left err -> Left err


### PR DESCRIPTION
This PR delays running of the pipeline `MCache` (renamed to `ModuleInfoCache`) to allow this cache to be shared between pipeline runs in `processRecursiveUpToTyped`. `processRecursiveUpToTyped` is used by the `juvix html` command to recursively build HTML for modules in a project.

* Closes https://github.com/anoma/juvix/issues/2744

## Performance

The docs build is now much faster and takes much less memory:

Before:

```
$ /usr/bin/time -lh juvix html docs/index.juvix.md	
1m17.41s real		35.39s user		11.42s sys
          5918703616  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
             3665213  page reclaims
                 697  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
              114533  voluntary context switches
               81450  involuntary context switches
        595152097097  instructions retired
        143688878963  cycles elapsed
         19323983744  peak memory footprint
```

After:

```
$ /usr/bin/time -lh juvix html docs/index.juvix.md
	8.35s real		5.76s user		0.62s sys
          2992160768  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              221870  page reclaims
                 719  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1965  voluntary context switches
                1962  involuntary context switches
         93909891240  instructions retired
         19317129226  cycles elapsed
          2963053632  peak memory footprint
```

## Notes

* `MCache` is renamed to `ModuleInfoCache`

* `ModuleInfoCache` must be defined in a separate module instead of being defined in `Compiler.Pipeline.Driver` to avoid a cyclic dependency. `ModuleInfoCache` is now used used in `Juvix.Compiler.Pipeline` (in `PipelineEff`) and this module is imported by `Juvix.Compiler.Pipeline.Driver`).

