### PR TITLE
Use aarch64 macOS agent for CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           make smoke-only
 
   build-and-test-macos:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: extractions/setup-just@v2
 
@@ -237,6 +237,10 @@ jobs:
         with:
           path: main
           submodules: true
+
+      - name: install stack
+        run: |
+          brew install haskell-stack
 
       - name: Install Sed
         run: |
@@ -310,7 +314,7 @@ jobs:
           test: false
           stack-arguments: --copy-bins
           working-directory: smoke-repo
-          cache-prefix: ${{ steps.icuversion.outputs.version }}
+          cache-prefix: ${{ runner.arch }}-${{ steps.icuversion.outputs.version }}
           pedantic: false
 
       - name: Set homebrew LLVM CC and LIBTOOL vars (macOS)
@@ -331,7 +335,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.HOME }}/.local/bin/juvix-cairo-vm
-          key: ${{ runner.os }}-cairo-vm-${{ env.CAIRO_VM_VERSION }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cairo-vm-${{ env.CAIRO_VM_VERSION }}
 
       - name: Install Rust toolchain
         if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
@@ -375,7 +379,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: main/.hie
-          key: ${{ runner.os }}-stack-hie
+          key: ${{ runner.os }}-${{ runner.arch }}-stack-hie
 
       - name: Stack setup
         id: stack
@@ -384,6 +388,7 @@ jobs:
           working-directory: main
           stack-build-arguments: ${{ env.STACK_BUILD_ARGS }}
           test: false
+          cache-prefix: ${{ runner.arch }}
 
       - name: Add homebrew clang to the PATH (macOS)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
 
       - name: Install the latest Wasmer version
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: wasmerio/wasmer
           binaries-location: bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,10 +395,11 @@ jobs:
           echo "$(brew --prefix llvm@15)/bin" >> $GITHUB_PATH
 
       - name: Install VampIR for testing
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: ${{ env.VAMPIRREPO }}
           platform: darwin
+          arch: x86_64
           tag: ${{ env.VAMPIRVERSION }}
           chmod: 0755
           rename-to: vamp-ir


### PR DESCRIPTION
This PR updates the macOS CI build to use the `macos-14` build agent. This uses the M series aarch64 chips.

* The M1 macOS agent does not have stack preinstalled so we must install it using brew before building anything.
* The cache keys must have the `runner.arch` prefix to avoid building with the x86_64 cache.

The macOS build / test run in about the same time as the linux build / test, i.e significantly faster than on the x86 macOS agents.

## Notes

* We use the x86_64 binary of vamp-ir because the vamp-ir aarch64 releases do not have names that are compatible with the GitHub action we are using to download the binary releases. The x86_64 binary works fine for the purposes of testing.