### PR TITLE
Deduplicate project remote dependencies

### DIFF
--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -34,6 +34,7 @@ import Juvix.Compiler.Pipeline.Artifacts
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.ImportParents
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
+import Juvix.Compiler.Pipeline.Loader.PathResolver.DependencyResolver
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
 import Juvix.Compiler.Pipeline.ModuleInfoCache
 import Juvix.Compiler.Pipeline.Package.Loader.Error
@@ -51,7 +52,7 @@ import Juvix.Data.Field
 
 type PipelineAppEffects = '[TaggedLock, EmbedIO]
 
-type PipelineLocalEff = '[ModuleInfoCache, Reader ImportParents, PathResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
+type PipelineLocalEff = '[ModuleInfoCache, Reader ImportParents, PathResolver, DependencyResolver, EvalFileEff, Error PackageLoaderError, Error DependencyError, GitClone, Error GitProcessError, Process, Log, Reader EntryPoint, Files, Error JuvixError, HighlightBuilder, Internet]
 
 type PipelineEff' r = PipelineLocalEff ++ r
 

--- a/src/Juvix/Compiler/Pipeline/Artifacts/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Artifacts/PathResolver.hs
@@ -5,12 +5,11 @@ import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Loader.PathResolver
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Compiler.Pipeline.Package.Loader.PathResolver
-import Juvix.Data.Effect.Git
 import Juvix.Data.Effect.TaggedLock
 import Juvix.Prelude
 
-runPathResolverArtifacts :: (Members '[TaggedLock, Files, Reader EntryPoint, State Artifacts, Error DependencyError, GitClone, Error JuvixError, EvalFileEff] r) => Sem (PathResolver ': r) a -> Sem r a
+runPathResolverArtifacts :: (Members '[TaggedLock, Files, Reader EntryPoint, State Artifacts, Error DependencyError, DependencyResolver, Error JuvixError, EvalFileEff] r) => Sem (PathResolver ': r) a -> Sem r a
 runPathResolverArtifacts = runStateLikeArtifacts runPathResolverPipe' artifactResolver
 
-runPackagePathResolverArtifacts :: (Members '[TaggedLock, Files, Reader EntryPoint, State Artifacts, Error DependencyError, GitClone, Error JuvixError, EvalFileEff] r) => Path Abs Dir -> Sem (PathResolver ': r) a -> Sem r a
+runPackagePathResolverArtifacts :: (Members '[TaggedLock, Files, Reader EntryPoint, State Artifacts, Error DependencyError, DependencyResolver, Error JuvixError, EvalFileEff] r) => Path Abs Dir -> Sem (PathResolver ': r) a -> Sem r a
 runPackagePathResolverArtifacts root = runStateLikeArtifacts (runPackagePathResolver'' root) artifactResolver

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver.hs
@@ -203,7 +203,7 @@ addRootDependency conf e root = do
   resolvedDependency <- resolveDependency d
   checkRemoteDependency resolvedDependency
   let p = resolvedDependency ^. resolvedDependencyPath
-  withEnvProjectRoot p $ do
+  withEnvInitialRoot p $ do
     pkg <- mkPackage (Just e) p
     shouldUpdateLockfile' <- shouldUpdateLockfile pkg
     when shouldUpdateLockfile' setShouldUpdateLockfile
@@ -406,7 +406,7 @@ runPathResolver2 st topEnv arg = do
               env' =
                 ResolverEnv
                   { _envRoot = root',
-                    _envProjectRoot = root',
+                    _envInitialRoot = root',
                     _envLockfileInfo = Nothing,
                     _envSingleFile
                   }
@@ -430,7 +430,7 @@ runPathResolver' st root x = do
       env =
         ResolverEnv
           { _envRoot = root,
-            _envProjectRoot = root,
+            _envInitialRoot = root,
             _envLockfileInfo = Nothing,
             _envSingleFile
           }

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver.hs
@@ -4,6 +4,7 @@ module Juvix.Compiler.Pipeline.Loader.PathResolver
     module Juvix.Compiler.Pipeline.Loader.PathResolver.Error,
     module Juvix.Compiler.Pipeline.Loader.PathResolver.Data,
     module Juvix.Compiler.Pipeline.Loader.PathResolver.PackageInfo,
+    module Juvix.Compiler.Pipeline.Loader.PathResolver.DependencyResolver,
     runPathResolver,
     runPathResolverPipe,
     runPathResolverPipe',
@@ -13,11 +14,11 @@ where
 
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
-import Data.Text qualified as T
 import Juvix.Compiler.Concrete.Data.Name
 import Juvix.Compiler.Pipeline.EntryPoint
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Data
+import Juvix.Compiler.Pipeline.Loader.PathResolver.DependencyResolver
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
 import Juvix.Compiler.Pipeline.Loader.PathResolver.PackageInfo
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Paths
@@ -25,7 +26,6 @@ import Juvix.Compiler.Pipeline.Lockfile
 import Juvix.Compiler.Pipeline.Package
 import Juvix.Compiler.Pipeline.Package.Loader.EvalEff
 import Juvix.Compiler.Pipeline.Root.Base (PackageType (..))
-import Juvix.Data.Effect.Git
 import Juvix.Data.Effect.TaggedLock
 import Juvix.Data.SHA256 qualified as SHA256
 import Juvix.Extra.PackageFiles
@@ -35,7 +35,7 @@ import Juvix.Prelude
 
 mkPackage ::
   forall r.
-  (Members '[Files, Error JuvixError, Reader ResolverEnv, GitClone, EvalFileEff] r) =>
+  (Members '[Files, Error JuvixError, Reader ResolverEnv, DependencyResolver, EvalFileEff] r) =>
   Maybe EntryPoint ->
   Path Abs Dir ->
   Sem r Package
@@ -47,7 +47,7 @@ mkPackage mpackageEntry _packageRoot = do
 
 mkPackageInfo ::
   forall r.
-  (Members '[TaggedLock, Files, Error JuvixError, Reader ResolverEnv, Error DependencyError, GitClone] r) =>
+  (Members '[TaggedLock, Files, Error JuvixError, Error DependencyError, Reader ResolverEnv, DependencyResolver] r) =>
   Maybe EntryPoint ->
   Path Abs Dir ->
   Package ->
@@ -121,57 +121,8 @@ mkPackageInfo mpackageEntry _packageRoot pkg = do
                       }
                 )
 
-lookupCachedDependency :: (Members '[State ResolverState, Reader ResolverEnv, Files, GitClone] r) => Path Abs Dir -> Sem r (Maybe LockfileDependency)
+lookupCachedDependency :: (Members '[State ResolverState, Reader ResolverEnv, Files, DependencyResolver] r) => Path Abs Dir -> Sem r (Maybe LockfileDependency)
 lookupCachedDependency p = fmap (^. resolverCacheItemDependency) . HashMap.lookup p <$> gets (^. resolverCache)
-
-resolveDependency :: forall r. (Members '[Reader ResolverEnv, Files, Error DependencyError, GitClone] r) => PackageDependencyInfo -> Sem r ResolvedDependency
-resolveDependency i = case i ^. packageDepdendencyInfoDependency of
-  DependencyPath p -> do
-    r <- asks (^. envRoot)
-    p' <- canonicalDir r (p ^. pathDependencyPath)
-    return
-      ResolvedDependency
-        { _resolvedDependencyPath = p',
-          _resolvedDependencyDependency = i ^. packageDepdendencyInfoDependency
-        }
-  DependencyGit g -> do
-    r <- rootBuildDir <$> asks (^. envProjectRoot)
-    gitCacheDir <- globalGitCache
-    let cloneRelDir :: Path Rel Dir
-        cloneRelDir = relDir (T.unpack (SHA256.digestText (g ^. gitDependencyUrl)))
-        cloneDir = gitCacheDir <//> cloneRelDir
-        cloneArgs =
-          CloneArgs
-            { _cloneArgsCloneDir = cloneDir,
-              _cloneArgsRepoUrl = g ^. gitDependencyUrl
-            }
-    provideWith_ cloneArgs $ do
-      fetchOnNoSuchRefAndRetry (errorHandler cloneDir) (`checkout` (g ^. gitDependencyRef))
-      resolvedRef <- headRef (errorHandler cloneDir)
-      let destDir =
-            r
-              <//> relDependenciesDir
-              <//> relDir (T.unpack (SHA256.digestText (g ^. gitDependencyUrl <> resolvedRef)))
-      unlessM (directoryExists' destDir) (replaceDirectory cloneDir destDir)
-      return
-        ResolvedDependency
-          { _resolvedDependencyPath = destDir,
-            _resolvedDependencyDependency =
-              DependencyGit (set gitDependencyRef resolvedRef g)
-          }
-    where
-      errorHandler :: Path Abs Dir -> GitError -> Sem (Git ': r) a
-      errorHandler p c =
-        throw
-          DependencyError
-            { _dependencyErrorCause =
-                GitDependencyError
-                  DependencyErrorGit
-                    { _dependencyErrorGitCloneDir = p,
-                      _dependencyErrorGitError = c
-                    },
-              _dependencyErrorPackageFile = i ^. packageDependencyInfoPackageFile
-            }
 
 registerPackageBase ::
   forall r.
@@ -204,7 +155,7 @@ registerPackageBase = do
 
 registerDependencies' ::
   forall r.
-  (Members '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, GitClone, EvalFileEff] r) =>
+  (Members '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, DependencyResolver, EvalFileEff] r) =>
   DependenciesConfig ->
   Sem (Reader ResolverEnv ': State ResolverState ': r) ()
 registerDependencies' conf = do
@@ -241,7 +192,7 @@ registerDependencies' conf = do
 
 addRootDependency ::
   forall r.
-  (Members '[TaggedLock, State ResolverState, Reader ResolverEnv, Files, Error JuvixError, Error DependencyError, GitClone, EvalFileEff] r) =>
+  (Members '[TaggedLock, State ResolverState, Reader ResolverEnv, Files, Error JuvixError, Error DependencyError, DependencyResolver, EvalFileEff] r) =>
   DependenciesConfig ->
   EntryPoint ->
   Path Abs Dir ->
@@ -270,7 +221,7 @@ addRootDependency conf e root = do
 
 addDependency ::
   forall r.
-  (Members '[TaggedLock, State ResolverState, Reader ResolverEnv, Files, Error JuvixError, Error DependencyError, GitClone, EvalFileEff] r) =>
+  (Members '[TaggedLock, State ResolverState, Reader ResolverEnv, Files, Error JuvixError, Error DependencyError, DependencyResolver, EvalFileEff] r) =>
   Maybe EntryPoint ->
   PackageDependencyInfo ->
   Sem r LockfileDependency
@@ -287,7 +238,7 @@ addDependency me d = do
 
 addDependency' ::
   forall r.
-  (Members '[TaggedLock, State ResolverState, Reader ResolverEnv, Files, Error JuvixError, Error DependencyError, GitClone, EvalFileEff] r) =>
+  (Members '[TaggedLock, State ResolverState, Reader ResolverEnv, Files, Error JuvixError, Error DependencyError, DependencyResolver, EvalFileEff] r) =>
   Package ->
   Maybe EntryPoint ->
   ResolvedDependency ->
@@ -411,7 +362,7 @@ expectedPath' m = do
 
 runPathResolver2 ::
   forall r a v.
-  (v ~ '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, GitClone, EvalFileEff], Members v r) =>
+  (v ~ '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, DependencyResolver, EvalFileEff], Members v r) =>
   ResolverState ->
   ResolverEnv ->
   Sem (PathResolver ': r) a ->
@@ -465,10 +416,10 @@ runPathResolver2 st topEnv arg = do
             put oldState
             return res
 
-runPathResolver :: (Members '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, GitClone, EvalFileEff] r) => Path Abs Dir -> Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
+runPathResolver :: (Members '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, DependencyResolver, EvalFileEff] r) => Path Abs Dir -> Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
 runPathResolver = runPathResolver' iniResolverState
 
-runPathResolver' :: (Members '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, GitClone, EvalFileEff] r) => ResolverState -> Path Abs Dir -> Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
+runPathResolver' :: (Members '[TaggedLock, Reader EntryPoint, Files, Error JuvixError, Error DependencyError, DependencyResolver, EvalFileEff] r) => ResolverState -> Path Abs Dir -> Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
 runPathResolver' st root x = do
   e <- ask
   let _envSingleFile :: Maybe (Path Abs File)
@@ -485,15 +436,15 @@ runPathResolver' st root x = do
           }
   runPathResolver2 st env x
 
-runPathResolverPipe' :: (Members '[TaggedLock, Files, Reader EntryPoint, Error DependencyError, GitClone, Error JuvixError, EvalFileEff] r) => ResolverState -> Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
+runPathResolverPipe' :: (Members '[TaggedLock, Files, Reader EntryPoint, DependencyResolver, Error JuvixError, Error DependencyError, EvalFileEff] r) => ResolverState -> Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
 runPathResolverPipe' iniState a = do
   r <- asks (^. entryPointResolverRoot)
   runPathResolver' iniState r a
 
-runPathResolverPipe :: (Members '[TaggedLock, Files, Reader EntryPoint, Error DependencyError, GitClone, Error JuvixError, EvalFileEff] r) => Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
+runPathResolverPipe :: (Members '[TaggedLock, Files, Reader EntryPoint, DependencyResolver, Error JuvixError, Error DependencyError, EvalFileEff] r) => Sem (PathResolver ': r) a -> Sem r (ResolverState, a)
 runPathResolverPipe a = do
   r <- asks (^. entryPointResolverRoot)
   runPathResolver r a
 
-evalPathResolverPipe :: (Members '[TaggedLock, Files, Reader EntryPoint, Error DependencyError, GitClone, Error JuvixError, EvalFileEff] r) => Sem (PathResolver ': r) a -> Sem r a
+evalPathResolverPipe :: (Members '[TaggedLock, Files, Reader EntryPoint, DependencyResolver, Error JuvixError, Error DependencyError, EvalFileEff] r) => Sem (PathResolver ': r) a -> Sem r a
 evalPathResolverPipe = fmap snd . runPathResolverPipe

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Data.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Data.hs
@@ -6,8 +6,10 @@ import Juvix.Compiler.Pipeline.Package.Base
 import Juvix.Prelude
 
 data ResolverEnv = ResolverEnv
-  { _envRoot :: Path Abs Dir,
-    _envProjectRoot :: Path Abs Dir,
+  { -- | The root path of the current project being resolved
+    _envRoot :: Path Abs Dir,
+    -- | The root path of the initial project (i.e the first project considered in the resolution)
+    _envInitialRoot :: Path Abs Dir,
     -- | The path of the input file *if* we are using the global project
     _envSingleFile :: Maybe (Path Abs File),
     _envLockfileInfo :: Maybe LockfileInfo
@@ -62,8 +64,8 @@ checkRemoteDependency d = case d ^. resolvedDependencyDependency of
 withEnvRoot :: (Members '[Reader ResolverEnv] r) => Path Abs Dir -> Sem r a -> Sem r a
 withEnvRoot root' = local (set envRoot root')
 
-withEnvProjectRoot :: (Members '[Reader ResolverEnv] r) => Path Abs Dir -> Sem r a -> Sem r a
-withEnvProjectRoot projectRoot = local (set envProjectRoot projectRoot) . local (set envRoot projectRoot)
+withEnvInitialRoot :: (Members '[Reader ResolverEnv] r) => Path Abs Dir -> Sem r a -> Sem r a
+withEnvInitialRoot projectRoot = local (set envInitialRoot projectRoot) . local (set envRoot projectRoot)
 
 withLockfile :: (Members '[Reader ResolverEnv] r) => LockfileInfo -> Sem r a -> Sem r a
 withLockfile f = local (set envLockfileInfo (Just f))

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Data.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Data.hs
@@ -7,6 +7,7 @@ import Juvix.Prelude
 
 data ResolverEnv = ResolverEnv
   { _envRoot :: Path Abs Dir,
+    _envProjectRoot :: Path Abs Dir,
     -- | The path of the input file *if* we are using the global project
     _envSingleFile :: Maybe (Path Abs File),
     _envLockfileInfo :: Maybe LockfileInfo
@@ -60,6 +61,9 @@ checkRemoteDependency d = case d ^. resolvedDependencyDependency of
 
 withEnvRoot :: (Members '[Reader ResolverEnv] r) => Path Abs Dir -> Sem r a -> Sem r a
 withEnvRoot root' = local (set envRoot root')
+
+withEnvProjectRoot :: (Members '[Reader ResolverEnv] r) => Path Abs Dir -> Sem r a -> Sem r a
+withEnvProjectRoot projectRoot = local (set envProjectRoot projectRoot) . local (set envRoot projectRoot)
 
 withLockfile :: (Members '[Reader ResolverEnv] r) => LockfileInfo -> Sem r a -> Sem r a
 withLockfile f = local (set envLockfileInfo (Just f))

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/DependencyResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/DependencyResolver.hs
@@ -36,7 +36,7 @@ runDependencyResolver = runProvider_ helper
                   _resolvedDependencyDependency = i ^. packageDepdendencyInfoDependency
                 }
           DependencyGit g -> do
-            let r = rootBuildDir (env ^. envProjectRoot)
+            let r = rootBuildDir (env ^. envInitialRoot)
             gitCacheDir <- globalGitCache
             let cloneRelDir :: Path Rel Dir
                 cloneRelDir = mkSafeDir (g ^. gitDependencyUrl)

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/DependencyResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/DependencyResolver.hs
@@ -1,0 +1,86 @@
+module Juvix.Compiler.Pipeline.Loader.PathResolver.DependencyResolver where
+
+import Data.Text qualified as T
+import Juvix.Compiler.Pipeline.Loader.PathResolver.Data
+import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
+import Juvix.Compiler.Pipeline.Package.Dependency
+import Juvix.Data.Effect.Git
+import Juvix.Data.SHA256 qualified as SHA256
+import Juvix.Extra.Paths.Base
+import Juvix.Prelude
+
+data DependencyResolver' :: Effect where
+  ResolveDependency' :: PackageDependencyInfo -> DependencyResolver' m ResolvedDependency
+
+makeSem ''DependencyResolver'
+
+type DependencyResolver = Provider_ DependencyResolver' ResolverEnv
+
+runDependencyResolver ::
+  forall r a.
+  (Members '[Files, Error DependencyError, GitClone] r) =>
+  Sem (DependencyResolver ': r) a ->
+  Sem r a
+runDependencyResolver = runProvider_ helper
+  where
+    helper :: forall x. ResolverEnv -> Sem (DependencyResolver' ': r) x -> Sem r x
+    helper env m = do
+      (`interpret` m) $ \case
+        ResolveDependency' i -> case i ^. packageDepdendencyInfoDependency of
+          DependencyPath p -> do
+            let r = env ^. envRoot
+            p' <- canonicalDir r (p ^. pathDependencyPath)
+            return
+              ResolvedDependency
+                { _resolvedDependencyPath = p',
+                  _resolvedDependencyDependency = i ^. packageDepdendencyInfoDependency
+                }
+          DependencyGit g -> do
+            let r = rootBuildDir (env ^. envProjectRoot)
+            gitCacheDir <- globalGitCache
+            let cloneRelDir :: Path Rel Dir
+                cloneRelDir = mkSafeDir (g ^. gitDependencyUrl)
+                cloneDir = gitCacheDir <//> cloneRelDir
+                cloneArgs =
+                  CloneArgs
+                    { _cloneArgsCloneDir = cloneDir,
+                      _cloneArgsRepoUrl = g ^. gitDependencyUrl
+                    }
+            provideWith_ cloneArgs $ do
+              fetchOnNoSuchRefAndRetry (errorHandler cloneDir) (`checkout` (g ^. gitDependencyRef))
+              resolvedRef <- headRef (errorHandler cloneDir)
+              let destDir =
+                    r
+                      <//> relDependenciesDir
+                      <//> mkSafeDir (g ^. gitDependencyUrl <> resolvedRef)
+              unlessM (directoryExists' destDir) (replaceDirectory cloneDir destDir)
+              return
+                ResolvedDependency
+                  { _resolvedDependencyPath = destDir,
+                    _resolvedDependencyDependency =
+                      DependencyGit (set gitDependencyRef resolvedRef g)
+                  }
+            where
+              errorHandler :: forall b. Path Abs Dir -> GitError -> Sem (Git ': r) b
+              errorHandler p c =
+                throw
+                  DependencyError
+                    { _dependencyErrorCause =
+                        GitDependencyError
+                          DependencyErrorGit
+                            { _dependencyErrorGitCloneDir = p,
+                              _dependencyErrorGitError = c
+                            },
+                      _dependencyErrorPackageFile = i ^. packageDependencyInfoPackageFile
+                    }
+
+              mkSafeDir :: Text -> Path Rel Dir
+              mkSafeDir = relDir . T.unpack . SHA256.digestText
+
+resolveDependency ::
+  (Members '[Reader ResolverEnv, DependencyResolver] r) =>
+  PackageDependencyInfo ->
+  Sem r ResolvedDependency
+resolveDependency i = do
+  env <- ask @ResolverEnv
+  provideWith_ @DependencyResolver' env (resolveDependency' i)

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Error.hs
@@ -61,7 +61,7 @@ instance PrettyCodeAnn DependencyErrorGit where
         <+> "is not a valid git clone."
           <> line
           <> "Try running"
-        <+> code "juvix clean"
+        <+> code "juvix clean --global"
     NoSuchRef ref ->
       prefix
         <> "The git ref:"

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -15,6 +15,7 @@ import Juvix.Compiler.Pipeline.Artifacts.PathResolver
 import Juvix.Compiler.Pipeline.Driver (evalModuleInfoCache)
 import Juvix.Compiler.Pipeline.Driver qualified as Driver
 import Juvix.Compiler.Pipeline.EntryPoint
+import Juvix.Compiler.Pipeline.Loader.PathResolver (runDependencyResolver)
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Base
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
 import Juvix.Compiler.Pipeline.ModuleInfoCache
@@ -164,6 +165,7 @@ compileReplInputIO fp txt = do
     . mapError (JuvixError @DependencyError)
     . mapError (JuvixError @PackageLoaderError)
     . runEvalFileEffIO
+    . runDependencyResolver
     . runPathResolverArtifacts
     . evalModuleInfoCache
     $ do

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -81,6 +81,7 @@ runIOEitherPipeline' entry a = do
     . mapError (JuvixError @DependencyError)
     . mapError (JuvixError @PackageLoaderError)
     . runEvalFileEffIO
+    . runDependencyResolver
     . runPathResolver'
     . evalModuleInfoCache
     $ a
@@ -150,6 +151,7 @@ runReplPipelineIOEither' lockMode entry = do
       . mapError (JuvixError @DependencyError)
       . mapError (JuvixError @PackageLoaderError)
       . runEvalFileEffIO
+      . runDependencyResolver
       . runPathResolver'
       . evalModuleInfoCache
       $ entrySetup defaultDependenciesConfig >> processFileToStoredCore entry

--- a/src/Juvix/Data/Effect/Files.hs
+++ b/src/Juvix/Data/Effect/Files.hs
@@ -18,6 +18,11 @@ import Juvix.Prelude.Path
 equalPaths :: Path Abs File -> Path Abs File -> Sem r Bool
 equalPaths a b = return (a == b)
 
+replaceDirectory :: (Member Files r) => Path Abs Dir -> Path Abs Dir -> Sem r ()
+replaceDirectory source target = do
+  whenM (directoryExists' target) (removeDirectoryRecursive' target)
+  copyDirectory source target
+
 walkDirRelAccum ::
   forall acc r.
   (Member Files r) =>
@@ -115,3 +120,6 @@ globalPackageDescriptionRoot = (<//> $(mkRelDir "package")) <$> juvixConfigDir
 
 globalPackageBaseRoot :: (Members '[Files] r) => Sem r (Path Abs Dir)
 globalPackageBaseRoot = (<//> $(mkRelDir "package-base")) <$> juvixConfigDir
+
+globalGitCache :: (Members '[Files] r) => Sem r (Path Abs Dir)
+globalGitCache = (<//> $(mkRelDir "git-cache")) <$> juvixConfigDir

--- a/src/Juvix/Data/Effect/Files/Base.hs
+++ b/src/Juvix/Data/Effect/Files/Base.hs
@@ -41,6 +41,7 @@ data Files :: Effect where
   RemoveFile' :: Path Abs File -> Files m ()
   RenameFile' :: Path Abs File -> Path Abs File -> Files m ()
   CopyFile' :: Path Abs File -> Path Abs File -> Files m ()
+  CopyDirectory :: Path Abs Dir -> Path Abs Dir -> Files m ()
   JuvixConfigDir :: Files m (Path Abs Dir)
   CanonicalDir :: Path Abs Dir -> Prepath Dir -> Files m (Path Abs Dir)
   NormalizeDir :: Path b Dir -> Files m (Path Abs Dir)

--- a/src/Juvix/Data/Effect/Files/IO.hs
+++ b/src/Juvix/Data/Effect/Files/IO.hs
@@ -47,6 +47,7 @@ runFilesIO = interpret helper
       RemoveFile' f -> Path.removeFile f
       RenameFile' p1 p2 -> Path.renameFile p1 p2
       CopyFile' p1 p2 -> Path.copyFile p1 p2
+      CopyDirectory p1 p2 -> Path.copyDirRecur p1 p2
       JuvixConfigDir -> juvixConfigDirIO
       CanonicalDir root d -> prepathToAbsDir root d
       NormalizeDir p -> canonicalizePath p

--- a/src/Juvix/Data/SHA256.hs
+++ b/src/Juvix/Data/SHA256.hs
@@ -4,6 +4,13 @@ import Crypto.Hash.SHA256 qualified as SHA256
 import Data.ByteString.Base16 qualified as Base16
 import Juvix.Prelude
 
+digestText :: Text -> Text
+digestText =
+  decodeUtf8Lenient
+    . Base16.encode
+    . SHA256.hash
+    . encodeUtf8
+
 -- | Create a HEX encoded, SHA256 digest of the contents of a file.
 digestFile :: (Member Files r) => Path Abs File -> Sem r Text
 digestFile = fmap (decodeUtf8Lenient . Base16.encode . SHA256.hash) . readFileBS'

--- a/tests/smoke/Commands/compile-dependencies-package-juvix.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies-package-juvix.smoke.yaml
@@ -930,7 +930,7 @@ tests:
         # compile project
         juvix --offline compile native HelloWorld.juvix
     stderr:
-      contains: dep1
+      contains: Failed to obtain remote dependencies
     stdout:
       matches:
         # compile should not attempt to clone the dependency
@@ -952,6 +952,9 @@ tests:
         mkdir $temp/dep
         cd $temp/dep
         git init
+
+        mkdir $temp/config
+        export XDG_CONFIG_HOME=$temp/config
 
         cat <<-EOF > HelloDep.juvix
         module HelloDep;
@@ -999,7 +1002,7 @@ tests:
         juvix compile native HelloWorld.juvix
 
         # corrupt the clone
-        rm -rf ./.juvix-build/deps/dep1/.git
+        find $XDG_CONFIG_HOME -type d -name '.git' -exec rm -rf {} +
 
         # compile project
         juvix compile native HelloWorld.juvix

--- a/tests/smoke/Commands/compile-dependencies.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies.smoke.yaml
@@ -866,7 +866,7 @@ tests:
         # compile project
         juvix --offline compile native HelloWorld.juvix
     stderr:
-      contains: dep1
+      contains: Failed to obtain remote dependencies
     stdout:
       matches:
         # compile should not attempt to clone the dependency
@@ -905,6 +905,9 @@ tests:
         mkdir $temp/base
         cd $temp/base
 
+        mkdir $temp/config
+        export XDG_CONFIG_HOME=$temp/config
+
         cat <<-EOF > juvix.yaml
         name: HelloWorld
         main: HelloWorld.juvix
@@ -931,7 +934,7 @@ tests:
         juvix compile native HelloWorld.juvix
 
         # corrupt the clone
-        rm -rf ./.juvix-build/deps/dep1/.git
+        find $XDG_CONFIG_HOME -type d -name '.git' -exec rm -rf {} +
 
         # compile project
         juvix compile native HelloWorld.juvix
@@ -1049,14 +1052,14 @@ tests:
         git commit -m "commit2"
 
         cd $temp/base
-        juvix clean
+        juvix clean --global
         juvix compile native HelloWorld.juvix
         ./HelloWorld
 
         # Update the Package file and recompile
         # it should use the latest commit
         echo "-- comment" >> Package.juvix
-        juvix clean
+        juvix clean --global
         juvix compile native HelloWorld.juvix
         ./HelloWorld
 


### PR DESCRIPTION
## Goal

The goal of this PR is to deduplicate all dependencies in a Juvix project. 

Two dependencies are __identical__ when:

* For path dependencies, their paths are equal
* For git dependencies, their URL and their resolved revision (i.e the git revision hash after resolving a tag) are equal

For example in the following dependency tree, where each of the named dependencies represent identical git dependencies.

```
MyPkg
|
|-- Dep1-hash1
|   |
|   |-- Dep2-hash2
|   |   |
|   |   `-- Stdlib-hash3
|   |
|   `-- Stdlib-hash3
|
|-- Dep2-hash2
|   |
|   `-- Stdlib-hash3
|
`-- Stdlib-hash3
```

The project `MyPkg` should just contain the following dependencies: `Dep1-hash1, Dep2-hash2, Stdlib-hash3`.

## Design

### Storage of transitive dependencies

Currently the transitive dependencies of a project are fetched/stored in `.juvix-build` directories of the corresponding dependencies. After this PR all dependencies, including transitive ones are stored in the `.juvix-build` directory of the root project.

Again, assuming that all the transitive dependencies have the same git hash, in the file system we label the dependencies with their git hash.

```
MyPkg
|
`- .juvix-build
          |- Dep1-hash1
          |- Dep2-hash2
          `- Stdlib-hash3
```

Say we have two versions of `Dep2` in the transitive dependency graph:

```
MyPkg
|
|-- Dep1-hash1
|   |
|   |-- Dep2-hash2
|   |   |
|   |   `-- Stdlib-hash3
|   |
|   `-- Stdlib-hash3
|
|-- Dep2-hash4
|   |
|   `-- Stdlib-hash3
|
`-- Stdlib-hash3
```

we would have two copies of `Dep2` in the `.juvix-build` directory with different hashes:

```
MyPkg
|
`- .juvix-build
          |- Dep1-hash1
          |- Dep2-hash2
          |- Dep2-hash4
          `- Stdlib-hash3
```

### Storage of git clones

As a consequence of this design we cannot store the git clones for each dependency in the `.juvix-build` directory as we do now.

We now store the git clones in a global directory `~/.config/juvix/0.6.1/git-cache`.

When a dependency at a particular revision is required, the global git clone is fetched/checked out at the required revision and copied into the `.juvix-build` directory of the relevant project.

### Naming of git clones

The requirement for the naming of the global git clones is that they can be identified by URL.

In this PR the name of a clone is formed by taking the SHA256 hash of the dependency git URL. This is to avoid issues with file-system safe escaping of characters.

### Naming of dependency directories

The requirement for the naming of the dependency directories is that they can be identified by URL.
 / revision in accordance with our definition of identical dependencies.

In this PR the name of a clone is formed by taking the SHA256 hash of the concatenation of the dependency git URL and git revision. This is to avoid issues with file-system safe escaping of characters.

The downside of this approach is that it's hard to see which directories correspond to which dependencies when navigating the filesystem. However, navigating using the Juvix tooling by using go-to-definition etc. will continue to work as before.

## Benchmarks

I tested using [`juvix-containers` test `Main.juvix`](https://github.com/anoma/juvix-containers/blob/ebe8d2a8739ad1a3c2d05a3884b5f6111190e135/test/Main.juvix).

The following benchmarks show timings excluding the initial clone of dependencies (which happens in the warmup run).

Before:
```
$ juvix clean && juvix clean -g
$ hyperfine -w 1 'juvix compile native Main.juvix'
Benchmark 1: juvix compile native Main.juvix
  Time (mean ± σ):      5.598 s ±  0.410 s    [User: 5.020 s, System: 0.586 s]
  Range (min … max):    5.106 s …  6.382 s    10 runs
```

After:
```
$ juvix clean && juvix clean -g
$ hyperfine -w 1 'juvix compile native Main.juvix'
Benchmark 1: juvix compile native Main.juvix
  Time (mean ± σ):      4.418 s ±  0.241 s    [User: 4.083 s, System: 0.343 s]
  Range (min … max):    4.237 s …  4.927 s    10 runs
```

The time saved is due to the fact that before the project depends on 2 copies of the stdlib and after the project depends on 1 copy of the stdlib.

Time is also saved in the initial run because the stdlib is only cloned once instead of twice. The cached stdlib clone is also shared between all project which will improve the performance of all projects that use the stdlib.

Closes
* https://github.com/anoma/juvix/issues/2760