### PR TITLE
justfile: use numParallelJobs in test flag

### DIFF
--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ stackArgs := stackOptFlag + ' ' + stackParallelFlag + ' ' + stackGhcParallelFlag
 
 # flags used in the stack test command
 testArgs := "--hide-successes"
-rtsFlag := if disableParallel == '' { '+RTS -N -RTS' } else { '' }
+rtsFlag := if disableParallel == '' { '+RTS -N' + numParallelJobs + ' -RTS' } else { '' }
 
 # flag used to enable tracing of bash commands
 bashDebugArg := if enableDebug == '' { '' } else { 'x' }


### PR DESCRIPTION
The numParallelJobs option on the `justfile` is used to control the total amount of concurrency when running build commands. This PR adds this number to the test runner command: `+RTS -N$numParallelJobs -RTS`. This means that `$numParallelJobs` threads will be used by the test runner.

NB: ``+RTS -N -RTS` means that tests will use the number of threads equal to the number of CPUs on the machine.