### PR TITLE
Optional braces in case syntax

### DIFF
--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -2807,7 +2807,6 @@ instance IsApe Expression ApeLeaf where
     ExpressionParensIdentifier {} -> leaf
     ExpressionIdentifier {} -> leaf
     ExpressionList {} -> leaf
-    -- TODO: toApe?
     ExpressionCase {} -> leaf
     ExpressionIf {} -> leaf
     ExpressionLambda {} -> leaf

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -2289,7 +2289,7 @@ instance HasAtomicity (Iterator s) where
   atomicity = const Atom
 
 instance HasAtomicity (Case s) where
-  atomicity = const (Aggregate appFixity)
+  atomicity = const Atom
 
 instance HasAtomicity (If s) where
   atomicity = const Atom

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -33,7 +33,8 @@ import Juvix.Prelude.Pretty qualified as P
 
 --- An expression is `Top` if it is:
 --- * immediately at the top of a function (clause) body (including in let
----   bindings),
+---   bindings) or a lambda body
+--- * immediately inside parens or braces
 --- * the body of a `Top` let expression,
 --- * the else branch body of a `Top` if expression,
 --- * the last branch body of a `Top` case expresssion.
@@ -252,13 +253,13 @@ instance (SingI s) => PrettyPrint (ExpressionAtoms s) where
 instance (SingI s) => PrettyPrint (Initializer s) where
   ppCode Initializer {..} = do
     let n = ppPatternParensType _initializerPattern
-        e = ppTopExpressionType _initializerExpression
+        e = ppExpressionType _initializerExpression
     n <+> ppCode _initializerAssignKw <+> e
 
 instance (SingI s) => PrettyPrint (Range s) where
   ppCode Range {..} = do
     let n = ppPatternParensType _rangePattern
-        e = ppTopExpressionType _rangeExpression
+        e = ppExpressionType _rangeExpression
     n <+> ppCode _rangeInKw <+> e
 
 instance (SingI s) => PrettyPrint (Iterator s) where
@@ -268,7 +269,7 @@ instance (SingI s) => PrettyPrint (Iterator s) where
         rngs = ppCode <$> _iteratorRanges
         is' = parens . hsepSemicolon <$> nonEmpty is
         rngs' = parens . hsepSemicolon <$> nonEmpty rngs
-        b = ppTopExpressionType _iteratorBody
+        b = ppExpressionType _iteratorBody
         b'
           | _iteratorBodyBraces = braces (oneLineOrNextNoIndent b)
           | otherwise = line <> b
@@ -282,14 +283,14 @@ instance (SingI s) => PrettyPrint (List s) where
   ppCode List {..} = do
     let l = ppCode _listBracketL
         r = ppCode _listBracketR
-        es = vcatPreSemicolon (map ppTopExpressionType _listItems)
+        es = vcatPreSemicolon (map ppExpressionType _listItems)
     grouped (align (l <> spaceOrEmpty <> es <> lineOrEmpty <> r))
 
 instance (SingI s) => PrettyPrint (NamedArgument s) where
   ppCode NamedArgument {..} = do
     let s = ppCode _namedArgName
         kwassign = ppCode _namedArgAssignKw
-        val = ppTopExpressionType _namedArgValue
+        val = ppExpressionType _namedArgValue
     s <+> kwassign <+> val
 
 instance (SingI s) => PrettyPrint (ArgumentBlock s) where
@@ -329,7 +330,7 @@ instance (SingI s) => PrettyPrint (RecordStatement s) where
 
 instance (SingI s) => PrettyPrint (RecordUpdateField s) where
   ppCode RecordUpdateField {..} =
-    ppSymbolType _fieldUpdateName <+> ppCode _fieldUpdateAssignKw <+> ppTopExpressionType _fieldUpdateValue
+    ppSymbolType _fieldUpdateName <+> ppCode _fieldUpdateAssignKw <+> ppExpressionType _fieldUpdateValue
 
 instance (SingI s) => PrettyPrint (RecordUpdate s) where
   ppCode RecordUpdate {..} = do

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -32,7 +32,8 @@ import Juvix.Prelude.Pretty (annotate, pretty)
 import Juvix.Prelude.Pretty qualified as P
 
 --- An expression is `Top` if it is:
---- * immediately at the top of a function definition,
+--- * immediately at the top of a function (clause) body (including in let
+---   bindings),
 --- * the body of a `Top` let expression,
 --- * the else branch body of a `Top` if expression,
 --- * the last branch body of a `Top` case expresssion.

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -271,12 +271,11 @@ ppIterator isTop Iterator {..} = do
       rngs = ppCode <$> _iteratorRanges
       is' = parens . hsepSemicolon <$> nonEmpty is
       rngs' = parens . hsepSemicolon <$> nonEmpty rngs
-      b = ppMaybeTopExpression isTop _iteratorBody
-      b'
-        | _iteratorBodyBraces = braces (oneLineOrNextNoIndent b)
-        | otherwise = line <> b
+      b
+        | _iteratorBodyBraces = braces (oneLineOrNextNoIndent (ppTopExpressionType _iteratorBody))
+        | otherwise = line <> ppMaybeTopExpression isTop _iteratorBody
   parensIf _iteratorParens $
-    hang (n <+?> is' <+?> rngs' <> b')
+    hang (n <+?> is' <+?> rngs' <> b)
 
 instance PrettyPrint S.AName where
   ppCode n = annotated (AnnKind (S.getNameKind n)) (noLoc (pretty (n ^. S.anameVerbatim)))

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1984,21 +1984,6 @@ checkCaseBranch CaseBranch {..} = withLocalScope $ do
         ..
       }
 
-checkNewCaseBranch ::
-  forall r.
-  (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader EntryPoint] r) =>
-  NewCaseBranch 'Parsed ->
-  Sem r (NewCaseBranch 'Scoped)
-checkNewCaseBranch NewCaseBranch {..} = withLocalScope $ do
-  pattern' <- checkParsePatternAtoms _newCaseBranchPattern
-  expression' <- (checkParseExpressionAtoms _newCaseBranchExpression)
-  return $
-    NewCaseBranch
-      { _newCaseBranchPattern = pattern',
-        _newCaseBranchExpression = expression',
-        ..
-      }
-
 checkCase ::
   (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader EntryPoint] r) =>
   Case 'Parsed ->
@@ -2011,22 +1996,7 @@ checkCase Case {..} = do
       { _caseExpression = caseExpression',
         _caseBranches = caseBranches',
         _caseKw,
-        _caseParens
-      }
-
-checkNewCase ::
-  (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader EntryPoint] r) =>
-  NewCase 'Parsed ->
-  Sem r (NewCase 'Scoped)
-checkNewCase NewCase {..} = do
-  caseBranches' <- mapM checkNewCaseBranch _newCaseBranches
-  caseExpression' <- checkParseExpressionAtoms _newCaseExpression
-  return $
-    NewCase
-      { _newCaseExpression = caseExpression',
-        _newCaseBranches = caseBranches',
-        _newCaseKw,
-        _newCaseOfKw
+        _caseOfKw
       }
 
 checkIfBranch ::
@@ -2281,7 +2251,6 @@ checkExpressionAtom e = case e of
   AtomIdentifier n -> pure . AtomIdentifier <$> checkScopedIden n
   AtomLambda lam -> pure . AtomLambda <$> checkLambda lam
   AtomCase c -> pure . AtomCase <$> checkCase c
-  AtomNewCase c -> pure . AtomNewCase <$> checkNewCase c
   AtomIf c -> pure . AtomIf <$> checkIf c
   AtomLet letBlock -> pure . AtomLet <$> checkLet letBlock
   AtomUniverse uni -> return (pure (AtomUniverse uni))
@@ -2525,7 +2494,6 @@ checkParens e@(ExpressionAtoms as _) = case as of
       let scopedIdenNoFix = over scopedIdenSrcName (set S.nameFixity Nothing) scopedId
       return (ExpressionParensIdentifier scopedIdenNoFix)
     AtomIterator i -> ExpressionIterator . set iteratorParens True <$> checkIterator i
-    AtomCase c -> ExpressionCase . set caseParens True <$> checkCase c
     AtomRecordUpdate u -> ExpressionParensRecordUpdate . ParensRecordUpdate <$> checkRecordUpdate u
     _ -> checkParseExpressionAtoms e
   _ -> checkParseExpressionAtoms e
@@ -2823,7 +2791,6 @@ parseTerm =
     <|> parseFunction
     <|> parseLambda
     <|> parseCase
-    <|> parseNewCase
     <|> parseIf
     <|> parseList
     <|> parseLiteral
@@ -2872,14 +2839,6 @@ parseTerm =
         case_ :: ExpressionAtom 'Scoped -> Maybe (Case 'Scoped)
         case_ s = case s of
           AtomCase l -> Just l
-          _ -> Nothing
-
-    parseNewCase :: Parse Expression
-    parseNewCase = ExpressionNewCase <$> P.token case_ mempty
-      where
-        case_ :: ExpressionAtom 'Scoped -> Maybe (NewCase 'Scoped)
-        case_ s = case s of
-          AtomNewCase l -> Just l
           _ -> Nothing
 
     parseIf :: Parse Expression

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -720,7 +720,6 @@ goExpression = \case
   ExpressionParensIdentifier nt -> return (goIden nt)
   ExpressionApplication a -> goApplication a
   ExpressionCase a -> Internal.ExpressionCase <$> goCase a
-  ExpressionNewCase a -> Internal.ExpressionCase <$> goNewCase a
   ExpressionIf a -> goIf a
   ExpressionInfixApplication ia -> Internal.ExpressionApplication <$> goInfix ia
   ExpressionPostfixApplication pa -> Internal.ExpressionApplication <$> goPostfix pa
@@ -1054,7 +1053,7 @@ goCase :: forall r. (Members '[Reader DefaultArgsStack, Builtins, NameIdGen, Err
 goCase c = do
   _caseExpression <- goExpression (c ^. caseExpression)
   _caseBranches <- mapM goBranch (c ^. caseBranches)
-  let _caseParens = c ^. caseParens
+  let _caseParens = False
       _caseExpressionType :: Maybe Internal.Expression = Nothing
       _caseExpressionWholeType :: Maybe Internal.Expression = Nothing
   return Internal.Case {..}
@@ -1063,21 +1062,6 @@ goCase c = do
     goBranch b = do
       _caseBranchPattern <- goPatternArg (b ^. caseBranchPattern)
       _caseBranchExpression <- goExpression (b ^. caseBranchExpression)
-      return Internal.CaseBranch {..}
-
-goNewCase :: forall r. (Members '[Reader DefaultArgsStack, Builtins, NameIdGen, Error ScoperError, Reader Pragmas, Reader S.InfoTable] r) => NewCase 'Scoped -> Sem r Internal.Case
-goNewCase c = do
-  _caseExpression <- goExpression (c ^. newCaseExpression)
-  _caseBranches <- mapM goBranch (c ^. newCaseBranches)
-  let _caseParens = False
-      _caseExpressionType :: Maybe Internal.Expression = Nothing
-      _caseExpressionWholeType :: Maybe Internal.Expression = Nothing
-  return Internal.Case {..}
-  where
-    goBranch :: NewCaseBranch 'Scoped -> Sem r Internal.CaseBranch
-    goBranch b = do
-      _caseBranchPattern <- goPatternArg (b ^. newCaseBranchPattern)
-      _caseBranchExpression <- goExpression (b ^. newCaseBranchExpression)
       return Internal.CaseBranch {..}
 
 goLambda :: forall r. (Members '[Reader DefaultArgsStack, Builtins, NameIdGen, Error ScoperError, Reader Pragmas, Reader S.InfoTable] r) => Lambda 'Scoped -> Sem r Internal.Lambda

--- a/tests/Anoma/Compilation/positive/test026.juvix
+++ b/tests/Anoma/Compilation/positive/test026.juvix
@@ -18,58 +18,51 @@ last {A} : List A -> Maybe A
 
 front : {A : Type} → Queue A → Maybe A
   | q :=
-    case qfst q of {
+    case qfst q of
       | nil := last (qsnd q)
-      | x :: _ := just x
-    };
+      | x :: _ := just x;
 
 drop_front : {A : Type} → Queue A → Queue A
   | {A} q :=
     let
       q' : Queue A := queue (tail (qfst q)) (qsnd q);
-    in case qfst q' of {
+    in case qfst q' of
          | nil := queue (reverse (qsnd q')) nil
-         | _ := q'
-       };
+         | _ := q';
 
 pop_front {A} : Queue A -> Maybe (A × Queue A)
   | (queue xs ys) :=
-    case xs of {
+    case xs of
       | h :: t := just (h, queue t ys)
       | [] :=
-        case reverse ys of {
+        case reverse ys of
           | h :: t := just (h, queue t [])
-          | [] := nothing
-        }
-    };
+          | [] := nothing;
 
 push_back : {A : Type} → Queue A → A → Queue A
   | q x :=
-    case qfst q of {
+    case qfst q of
       | nil := queue (x :: nil) (qsnd q)
-      | q' := queue q' (x :: qsnd q)
-    };
+      | q' := queue q' (x :: qsnd q);
 
 is_empty : {A : Type} → Queue A → Bool
   | q :=
-    case qfst q of {
+    case qfst q of
       | nil :=
         case qsnd q of {
           | nil := true
           | _ := false
         }
-      | _ := false
-    };
+      | _ := false;
 
 empty : {A : Type} → Queue A := queue nil nil;
 
 terminating
 g : List Nat → Queue Nat → List Nat
   | acc q :=
-    case pop_front q of {
+    case pop_front q of
       | nothing := acc
-      | just (h, q') := g (h :: acc) q'
-    };
+      | just (h, q') := g (h :: acc) q';
 
 f : Nat → Queue Nat → List Nat
   | zero q := g nil q

--- a/tests/Anoma/Compilation/positive/test028.juvix
+++ b/tests/Anoma/Compilation/positive/test028.juvix
@@ -13,8 +13,8 @@ force : (Unit → Stream) → Stream
 terminating
 sfilter : (Nat → Bool) → (Unit → Stream) → Unit → Stream
   | p s unit :=
-    case force s
-      | cons h t :=
+    case force s of
+      cons h t :=
         if (p h) (cons h (sfilter p t)) (force (sfilter p t));
 
 shead : Stream → Nat
@@ -37,8 +37,8 @@ indivisible : Nat → Nat → Bool
 terminating
 eratostenes : (Unit → Stream) → Unit → Stream
   | s unit :=
-    case force s
-      | cons n t :=
+    case force s of
+      cons n t :=
         cons n (eratostenes (sfilter (indivisible n) t));
 
 primes : Unit → Stream := eratostenes (numbers 2);

--- a/tests/Anoma/Compilation/positive/test035.juvix
+++ b/tests/Anoma/Compilation/positive/test035.juvix
@@ -25,13 +25,12 @@ terminating
 f : Tree → Nat
   | leaf := 1
   | (node l r) :=
-    case g l, g r of {
+    case g l, g r of
       | leaf, leaf := 3
       | node l r, leaf := mod ((f l + f r) * 2) 20000
       | node l1 r1, node l2 r2 :=
         mod ((f l1 + f r1) * (f l2 + f r2)) 20000
-      | _, node l r := mod (f l + f r) 20000
-    };
+      | _, node l r := mod (f l + f r) 20000;
 
 g : Tree → Tree
   | leaf := leaf

--- a/tests/Anoma/Compilation/positive/test038.juvix
+++ b/tests/Anoma/Compilation/positive/test038.juvix
@@ -4,8 +4,7 @@ module test038;
 import Stdlib.Prelude open;
 
 main : Nat :=
-  case 1, 2 of {
+  case 1, 2 of
     | suc _, zero := 0
     | suc _, suc x := x
-    | _ := 19
-  };
+    | _ := 19;

--- a/tests/Anoma/Compilation/positive/test052.juvix
+++ b/tests/Anoma/Compilation/positive/test052.juvix
@@ -148,9 +148,8 @@ res : Either Error Val := eval (double+1 # num 7);
 -- TODO: Use Partial or failwith in left branches when anoma backend supports
 -- strings
 main : List Nat :=
-  case res >>= getNat of {
+  case res >>= getNat of
     | left (ScopeError n ctx) := []
     | left (ExpectedNat e) := []
     | left ExpectedLambda := []
-    | right r := [r]
-  };
+    | right r := [r];

--- a/tests/Anoma/Compilation/positive/test057.juvix
+++ b/tests/Anoma/Compilation/positive/test057.juvix
@@ -5,7 +5,7 @@ import Stdlib.Prelude open;
 
 myfun : {A : Type} -> (A -> A -> A) -> A -> List A -> A
   | f x xs :=
-    case x :: xs
+    case x :: xs of
       | nil := x
       | y :: nil := y
       | y :: z :: _ := f y z;

--- a/tests/Casm/Compilation/positive/test024.juvix
+++ b/tests/Casm/Compilation/positive/test024.juvix
@@ -27,13 +27,13 @@ f : Tree → Nat
       terminating
       a :
         Nat :=
-          case l
+          case l of
             | leaf := 1
             | node l r := f l + f r;
       terminating
       b :
         Nat :=
-          case r
+          case r of
             | node l r := f l + f r
             | _ := 2;
     in a * b;

--- a/tests/Casm/Compilation/positive/test026.juvix
+++ b/tests/Casm/Compilation/positive/test026.juvix
@@ -3,8 +3,7 @@ module test026;
 
 import Stdlib.Prelude open;
 
-type Queue (A : Type) :=
-  | queue : List A → List A → Queue A;
+type Queue (A : Type) := queue : List A → List A → Queue A;
 
 qfst : {A : Type} → Queue A → List A
   | (queue x _) := x;
@@ -19,9 +18,9 @@ pop_front : {A : Type} → Queue A → Queue A
   | {A} q :=
     let
       q' : Queue A := queue (tail (qfst q)) (qsnd q);
-    in case qfst q'
-      | nil := queue (reverse (qsnd q')) nil
-      | _ := q';
+    in case qfst q' of
+         | nil := queue (reverse (qsnd q')) nil
+         | _ := q';
 
 push_back : {A : Type} → Queue A → A → Queue A
   | q x :=
@@ -33,9 +32,10 @@ is_empty : {A : Type} → Queue A → Bool
   | q :=
     case qfst q of
       | nil :=
-        (case qsnd q
+        case qsnd q of {
           | nil := true
-          | _ := false)
+          | _ := false
+        }
       | _ := false;
 
 empty : {A : Type} → Queue A := queue nil nil;
@@ -45,8 +45,6 @@ g {{Partial}} : List Nat → Queue Nat → List Nat
   | acc q :=
     if (is_empty q) acc (g (front q :: acc) (pop_front q));
 
--- TODO: remove `terminating` after fixing https://github.com/anoma/juvix/issues/2414
-terminating
 f {{Partial}} : Nat → Queue Nat → List Nat
   | zero q := g nil q
   | n@(suc n') q := f n' (push_back q n);
@@ -55,4 +53,4 @@ sum : List Nat → Nat
   | nil := 0
   | (h :: t) := h + sum t;
 
-main : Nat := sum (runPartial (λ {{{_}} := f 100 empty}));
+main : Nat := sum (runPartial λ {{{_}} := f 100 empty});

--- a/tests/Casm/Compilation/positive/test026.juvix
+++ b/tests/Casm/Compilation/positive/test026.juvix
@@ -25,13 +25,13 @@ pop_front : {A : Type} → Queue A → Queue A
 
 push_back : {A : Type} → Queue A → A → Queue A
   | q x :=
-    case qfst q
+    case qfst q of
       | nil := queue (x :: nil) (qsnd q)
       | q' := queue q' (x :: qsnd q);
 
 is_empty : {A : Type} → Queue A → Bool
   | q :=
-    case qfst q
+    case qfst q of
       | nil :=
         (case qsnd q
           | nil := true

--- a/tests/Casm/Compilation/positive/test057.juvix
+++ b/tests/Casm/Compilation/positive/test057.juvix
@@ -5,7 +5,7 @@ import Stdlib.Prelude open;
 
 myfun : {A : Type} -> (A -> A -> A) -> A -> List A -> A
   | f x xs :=
-    case x :: xs
+    case x :: xs of
       | nil := x
       | y :: nil := y
       | y :: z :: _ := f y z;

--- a/tests/Compilation/negative/test002.juvix
+++ b/tests/Compilation/negative/test002.juvix
@@ -4,7 +4,7 @@ module test002;
 import Stdlib.Prelude open;
 
 f (x : List Nat) : Nat :=
-  case x
+  case x of
     | nil := 0
     | x :: y :: _ := x + y;
 

--- a/tests/Compilation/positive/test012.juvix
+++ b/tests/Compilation/positive/test012.juvix
@@ -14,12 +14,9 @@ gen : Nat → Tree
   | zero := leaf
   | n :=
     if
-      (mod n 3 == 0)
-      (node1 (gen (sub n 1)))
-      (if
-        (mod n 3 == 1)
-        (node2 (gen (sub n 1)) (gen (sub n 1)))
-        (node3 (gen (sub n 1)) (gen (sub n 1)) (gen (sub n 1))));
+      | mod n 3 == 0 := node1 (gen (sub n 1))
+      | mod n 3 == 1 := node2 (gen (sub n 1)) (gen (sub n 1))
+      | else := node3 (gen (sub n 1)) (gen (sub n 1)) (gen (sub n 1));
 
 preorder : Tree → IO
   | leaf := printNat 0

--- a/tests/Compilation/positive/test015.juvix
+++ b/tests/Compilation/positive/test015.juvix
@@ -5,25 +5,34 @@ import Stdlib.Prelude open;
 
 terminating
 f : Nat → Nat → Nat
-| x :=
-    let g (y : Nat) : Nat := x + y in
-    if (x == 0)
-       (f 10)
-       (if (x < 10)
-           λ{y := g (f (sub x 1) y)}
-           g);
+  | x :=
+    let
+      g (y : Nat) : Nat := x + y;
+    in if
+      | x == 0 := f 10
+      | else := if (x < 10) λ {y := g (f (sub x 1) y)} g;
 
 g (x : Nat) (h : Nat → Nat) : Nat := x + h x;
 
 terminating
 h : Nat → Nat
-| zero := 0
-| (suc x) := g x h;
+  | zero := 0
+  | (suc x) := g x h;
 
 main : IO :=
-    printNatLn (f 100 500) >> -- 600
-    printNatLn (f 5 0) >> -- 25
-    printNatLn (f 5 5) >> -- 30
-    printNatLn (h 10) >> -- 45
-    printNatLn (g 10 h) >> -- 55
-    printNatLn (g 3 (f 10));
+  printNatLn (f 100 500)
+    >> -- 600
+      printNatLn
+      (f 5 0)
+    >> -- 25
+      printNatLn
+      (f 5 5)
+    >> -- 30
+      printNatLn
+      (h 10)
+    >> -- 45
+      printNatLn
+      (g 10 h)
+    >> -- 55
+      printNatLn
+      (g 3 (f 10));

--- a/tests/Compilation/positive/test021.juvix
+++ b/tests/Compilation/positive/test021.juvix
@@ -7,12 +7,9 @@ terminating
 power' : Nat → Nat → Nat → Nat
   | acc a b :=
     if
-      (b == 0)
-      acc
-      (if
-        (mod b 2 == 0)
-        (power' acc (a * a) (div b 2))
-        (power' (acc * a) (a * a) (div b 2)));
+      | b == 0 := acc
+      | mod b 2 == 0 := power' acc (a * a) (div b 2)
+      | else := power' (acc * a) (a * a) (div b 2);
 
 power : Nat → Nat → Nat := power' 1;
 
@@ -20,4 +17,3 @@ main : IO :=
   printNatLn (power 2 3)
     >> printNatLn (power 3 7)
     >> printNatLn (power 5 11);
-

--- a/tests/Compilation/positive/test024.juvix
+++ b/tests/Compilation/positive/test024.juvix
@@ -13,7 +13,6 @@ gen : Nat → Tree
   | (suc (suc n')) := node (gen n') (gen (suc n'));
 
 g : Tree → Tree
-  
   | leaf := leaf
   | (node l r) := if (isNode l) r (node r l);
 
@@ -25,17 +24,15 @@ f : Tree → Nat
       l : Tree := g l';
       r : Tree := g r';
       terminating
-      a :
-        Nat :=
-          case l
-            | leaf := 1
-            | node l r := f l + f r;
+      a : Nat :=
+        case l of
+          | leaf := 1
+          | node l r := f l + f r;
       terminating
-      b :
-        Nat :=
-          case r
-            | node l r := f l + f r
-            | _ := 2;
+      b : Nat :=
+        case r of
+          | node l r := f l + f r
+          | _ := 2;
     in a * b;
 
 isNode : Tree → Bool
@@ -43,4 +40,3 @@ isNode : Tree → Bool
   | leaf := false;
 
 main : IO := printNatLn (f (gen 10));
-

--- a/tests/Compilation/positive/test025.juvix
+++ b/tests/Compilation/positive/test025.juvix
@@ -6,7 +6,10 @@ import Stdlib.Prelude open;
 terminating
 gcd : Nat → Nat → Nat
   | a b :=
-    if (a > b) (gcd b a) (if (a == 0) b (gcd (mod b a) a));
+    if
+      | a > b := gcd b a
+      | a == 0 := b
+      | else := gcd (mod b a) a;
 
 main : IO :=
   printNatLn (gcd (3 * 7 * 2) (7 * 2 * 11))

--- a/tests/Compilation/positive/test026.juvix
+++ b/tests/Compilation/positive/test026.juvix
@@ -3,8 +3,7 @@ module test026;
 
 import Stdlib.Prelude open;
 
-type Queue (A : Type) :=
-  | queue : List A → List A → Queue A;
+type Queue (A : Type) := queue : List A → List A → Queue A;
 
 qfst : {A : Type} → Queue A → List A
   | (queue x _) := x;
@@ -20,8 +19,8 @@ pop_front : {A : Type} → Queue A → Queue A
     let
       q' : Queue A := queue (tail (qfst q)) (qsnd q);
     in case qfst q' of
-      | nil := queue (reverse (qsnd q')) nil
-      | _ := q';
+         | nil := queue (reverse (qsnd q')) nil
+         | _ := q';
 
 push_back : {A : Type} → Queue A → A → Queue A
   | q x :=
@@ -55,5 +54,6 @@ printListNatLn : List Nat → IO
   | (h :: t) :=
     printNat h >> printString " :: " >> printListNatLn t;
 
-main : IO := printListNatLn (runPartial (λ {{{_}} := f 100 empty}));
+main : IO :=
+  printListNatLn (runPartial λ {{{_}} := f 100 empty});
 -- list of numbers from 1 to 100

--- a/tests/Compilation/positive/test026.juvix
+++ b/tests/Compilation/positive/test026.juvix
@@ -19,23 +19,24 @@ pop_front : {A : Type} → Queue A → Queue A
   | {A} q :=
     let
       q' : Queue A := queue (tail (qfst q)) (qsnd q);
-    in case qfst q'
+    in case qfst q' of
       | nil := queue (reverse (qsnd q')) nil
       | _ := q';
 
 push_back : {A : Type} → Queue A → A → Queue A
   | q x :=
-    case qfst q
+    case qfst q of
       | nil := queue (x :: nil) (qsnd q)
       | q' := queue q' (x :: qsnd q);
 
 is_empty : {A : Type} → Queue A → Bool
   | q :=
-    case qfst q
+    case qfst q of
       | nil :=
-        (case qsnd q
+        case qsnd q of {
           | nil := true
-          | _ := false)
+          | _ := false
+        }
       | _ := false;
 
 empty : {A : Type} → Queue A := queue nil nil;
@@ -45,8 +46,6 @@ g {{Partial}} : List Nat → Queue Nat → List Nat
   | acc q :=
     if (is_empty q) acc (g (front q :: acc) (pop_front q));
 
--- TODO: remove `terminating` after fixing https://github.com/anoma/juvix/issues/2414
-terminating
 f {{Partial}} : Nat → Queue Nat → List Nat
   | zero q := g nil q
   | n@(suc n') q := f n' (push_back q n);
@@ -58,4 +57,3 @@ printListNatLn : List Nat → IO
 
 main : IO := printListNatLn (runPartial (λ {{{_}} := f 100 empty}));
 -- list of numbers from 1 to 100
-

--- a/tests/Compilation/positive/test028.juvix
+++ b/tests/Compilation/positive/test028.juvix
@@ -3,8 +3,7 @@ module test028;
 
 import Stdlib.Prelude open;
 
-type Stream :=
-  | cons : Nat → (Unit → Stream) → Stream;
+type Stream := cons : Nat → (Unit → Stream) → Stream;
 
 force : (Unit → Stream) → Stream
   | f := f unit;
@@ -47,4 +46,3 @@ main : IO :=
     >> printNatLn (snth 50 primes)
     >> printNatLn (snth 100 primes)
     >> printNatLn (snth 200 primes);
-

--- a/tests/Compilation/positive/test028.juvix
+++ b/tests/Compilation/positive/test028.juvix
@@ -12,8 +12,8 @@ force : (Unit → Stream) → Stream
 terminating
 sfilter : (Nat → Bool) → (Unit → Stream) → Unit → Stream
   | p s unit :=
-    case force s
-      | cons h t :=
+    case force s of
+      cons h t :=
         if (p h) (cons h (sfilter p t)) (force (sfilter p t));
 
 shead : Stream → Nat
@@ -36,8 +36,8 @@ indivisible : Nat → Nat → Bool
 terminating
 eratostenes : (Unit → Stream) → Unit → Stream
   | s unit :=
-    case force s
-      | cons n t :=
+    case force s of
+      cons n t :=
         cons n (eratostenes (sfilter (indivisible n) t));
 
 primes : Unit → Stream := eratostenes (numbers 2);

--- a/tests/Compilation/positive/test029.juvix
+++ b/tests/Compilation/positive/test029.juvix
@@ -15,4 +15,3 @@ main : IO :=
     >> printNatLn (ack 2 7)
     >> printNatLn (ack 2 13)
     >> printNatLn (ack 3 7);
-

--- a/tests/Compilation/positive/test032.juvix
+++ b/tests/Compilation/positive/test032.juvix
@@ -7,8 +7,7 @@ split : {A : Type} → Nat → List A → List A × List A
   | zero xs := nil, xs
   | (suc n) nil := nil, nil
   | (suc n) (x :: xs) :=
-    case split n xs of
-      l1, l2 := x :: l1, l2;
+    case split n xs of l1, l2 := x :: l1, l2;
 
 terminating
 merge' : List Nat → List Nat → List Nat

--- a/tests/Compilation/positive/test032.juvix
+++ b/tests/Compilation/positive/test032.juvix
@@ -7,8 +7,8 @@ split : {A : Type} → Nat → List A → List A × List A
   | zero xs := nil, xs
   | (suc n) nil := nil, nil
   | (suc n) (x :: xs) :=
-    case split n xs
-      | l1, l2 := x :: l1, l2;
+    case split n xs of
+      l1, l2 := x :: l1, l2;
 
 terminating
 merge' : List Nat → List Nat → List Nat
@@ -23,10 +23,10 @@ sort : List Nat → List Nat
     let
       n : Nat := length xs;
     in if
-      (n <= 1)
-      xs
-      (case split (div n 2) xs
-        | l1, l2 := merge' (sort l1) (sort l2));
+      | n <= 1 := xs
+      | else :=
+        case split (div n 2) xs of
+          l1, l2 := merge' (sort l1) (sort l2);
 
 terminating
 uniq : List Nat → List Nat

--- a/tests/Compilation/positive/test035.juvix
+++ b/tests/Compilation/positive/test035.juvix
@@ -24,7 +24,7 @@ terminating
 f : Tree → Nat
   | leaf := 1
   | (node l r) :=
-    case g l, g r
+    case g l, g r of
       | leaf, leaf := 3
       | node l r, leaf := mod ((f l + f r) * 2) 20000
       | node l1 r1, node l2 r2 :=

--- a/tests/Compilation/positive/test037.juvix
+++ b/tests/Compilation/positive/test037.juvix
@@ -12,10 +12,9 @@ f (l : List ((Nat → Nat) → Nat → Nat)) : Nat :=
       y : Nat → Nat := id;
     in (let
          z : (Nat → Nat) → Nat → Nat := id;
-       in case l of {
+       in case l of
             | _ :: _ := id
             | _ := id
-          }
          z)
       y)
     7;

--- a/tests/Compilation/positive/test052.juvix
+++ b/tests/Compilation/positive/test052.juvix
@@ -180,7 +180,7 @@ double+1 : Expr := Λ (compose # +1 # double # ! 0);
 res : Either Error Val := eval (double+1 # num 7);
 
 main : IO :=
-  case res
+  case res of
     | left (ScopeError n ctx) :=
       printStringLn
         ("ScopeError: "

--- a/tests/Compilation/positive/test057.juvix
+++ b/tests/Compilation/positive/test057.juvix
@@ -5,7 +5,7 @@ import Stdlib.Prelude open;
 
 myfun : {A : Type} -> (A -> A -> A) -> A -> List A -> A
   | f x xs :=
-    case x :: xs
+    case x :: xs of
       | nil := x
       | y :: nil := y
       | y :: z :: _ := f y z;

--- a/tests/Compilation/positive/test060.juvix
+++ b/tests/Compilation/positive/test060.juvix
@@ -19,7 +19,7 @@ type Pair (A B : Type) :=
 mf : Pair (Pair Bool (List Nat)) (List Nat) → Bool
   | mkPair@{fst := mkPair@{fst; snd := nil};
            snd := zero :: _} := fst
-  | x := case x of {_ := false};
+  | x := case x of _ := false;
 
 main : Triple Nat Nat Nat :=
   let
@@ -32,14 +32,15 @@ main : Triple Nat Nat Nat :=
     f : Triple Nat Nat Nat -> Triple Nat Nat Nat :=
       (@Triple{fst := fst * 10});
   in if
-    (mf
-      mkPair@{
-        fst := mkPair true nil;
-        snd := 0 :: nil
-      })
-    (f p')
-    mkTriple@{
-      fst := 0;
-      thd := 0;
-      snd := 0
-    };
+    | mf
+        mkPair@{
+          fst := mkPair true nil;
+          snd := 0 :: nil
+        } :=
+      (f p')
+    | else :=
+      mkTriple@{
+        fst := 0;
+        thd := 0;
+        snd := 0
+      };

--- a/tests/Compilation/positive/test064.juvix
+++ b/tests/Compilation/positive/test064.juvix
@@ -36,7 +36,6 @@ even' : Nat -> Bool := even;
 
 main : Nat :=
   sum 3
-    + case even' 6 || g true || h true of {
+    + case even' 6 || g true || h true of
         | true := if (g false) (f 1 2 + sum 7 + j 0) 0
-        | false := f (3 + 4) (f 0 8) + loop
-      };
+        | false := f (3 + 4) (f 0 8) + loop;

--- a/tests/Geb/positive/Compilation/test007.juvix
+++ b/tests/Geb/positive/Compilation/test007.juvix
@@ -10,6 +10,6 @@ type Box :=
   | box : Box2 -> Box;
 
 main : Nat :=
-  case box (box2 3 5)
-    | box (box2 x y) := x + y;
+  case box (box2 3 5) of
+    box (box2 x y) := x + y;
 -- result: 8

--- a/tests/Geb/positive/Compilation/test008.juvix
+++ b/tests/Geb/positive/Compilation/test008.juvix
@@ -10,7 +10,7 @@ type enum :=
   | opt3 : Bool -> (Bool -> Bool -> Bool) -> Bool -> enum;
 
 main : Bool :=
-  case opt3 true λ {x y := if y false x} false
+  case opt3 true λ {x y := if y false x} false of
     | opt0 := false
     | opt1 b := b
     | opt2 b f := f b

--- a/tests/Geb/positive/Compilation/test011.juvix
+++ b/tests/Geb/positive/Compilation/test011.juvix
@@ -17,14 +17,14 @@ id''' : ((Nat → Nat) → Nat → Nat) → (Nat → Nat) → Nat → Nat
 
 f : Pair → Nat
   | l :=
-    (case l
+    (case l of
         | pair x zero := x
         | _ := id'')
       (let
         y : Nat → Nat := id';
       in (let
           z : (Nat → Nat) → Nat → Nat := id'';
-        in (case l
+        in (case l of
             | pair _ zero := id'''
             | _ := id''')
           z)

--- a/tests/Geb/positive/Compilation/test027.juvix
+++ b/tests/Geb/positive/Compilation/test027.juvix
@@ -7,7 +7,7 @@ type Pair :=
   | pair : Nat -> Nat -> Pair;
 
 main : Nat :=
-  case pair 1 2
+  case pair 1 2 of
     | pair (suc _) zero := 0
     | pair (suc _) (suc x) := x
     | _ := 19;

--- a/tests/Internal/positive/Case.juvix
+++ b/tests/Internal/positive/Case.juvix
@@ -4,18 +4,16 @@ import Stdlib.Prelude open;
 
 not' : Bool → Bool
   | b :=
-    case b of {
+    case b of
       | true := false
-      | false := true
-    };
+      | false := true;
 
 terminating
 andList : List Bool → Bool
   | l :=
-    case l of {
+    case l of
       | nil := true
-      | x :: xs := x && andList xs
-    };
+      | x :: xs := x && andList xs;
 
 main : IO :=
   printBoolLn (not' false)

--- a/tests/VampIR/positive/Compilation/test005.juvix
+++ b/tests/VampIR/positive/Compilation/test005.juvix
@@ -11,6 +11,6 @@ type Box :=
 
 main : Nat -> Nat -> Nat
   | x y :=
-    case box (box2 x y)
+    case box (box2 x y) of
       | box (box2 x y) := x + y;
 -- result: 8

--- a/tests/VampIR/positive/Compilation/test017.juvix
+++ b/tests/VampIR/positive/Compilation/test017.juvix
@@ -7,26 +7,23 @@ import Stdlib.Prelude open;
 terminating
 f : Nat → Nat
   | x :=
-    case x of {
+    case x of
       | zero := 1
-      | suc y := 2 * x + g y
-    };
+      | suc y := 2 * x + g y;
 
 terminating
 g : Nat → Nat
   | x :=
-    case x of {
+    case x of
       | zero := 1
-      | suc y := x + h y
-    };
+      | suc y := x + h y;
 
 terminating
 h : Nat → Nat
   | x :=
-    case x of {
+    case x of
       | zero := 1
-      | suc y := x * f y
-    };
+      | suc y := x * f y;
 
 main : Nat → Nat
   | x := f x + f (2 * x);

--- a/tests/VampIR/positive/Compilation/test018.juvix
+++ b/tests/VampIR/positive/Compilation/test018.juvix
@@ -10,9 +10,8 @@ pow : Nat -> Nat
 hash' : Nat -> Nat -> Nat
   | (suc n@(suc (suc m))) x :=
     if
-      (x < pow n)
-      (hash' n x)
-      (mod (div (x * x) (pow m)) (pow 6))
+      | x < pow n := hash' n x
+      | else := mod (div (x * x) (pow m)) (pow 6)
   | _ x := x * x;
 
 hash : Nat -> Nat := hash' 16;

--- a/tests/VampIR/positive/Compilation/test019.juvix
+++ b/tests/VampIR/positive/Compilation/test019.juvix
@@ -3,9 +3,7 @@ module test019;
 
 import Stdlib.Prelude open;
 
-main : Nat -> Nat -> Nat
-  | x y :=
-    case tail (id (x :: y :: nil)) of {
-      | nil := 0
-      | h :: _ := h
-    };
+main (x y : Nat) : Nat :=
+  case tail (id (x :: y :: nil)) of
+    | nil := 0
+    | h :: _ := h;

--- a/tests/VampIR/positive/Compilation/test021.juvix
+++ b/tests/VampIR/positive/Compilation/test021.juvix
@@ -9,12 +9,9 @@ power : Nat → Nat → Nat :=
     terminating
     power' (acc a b : Nat) : Nat :=
       if
-        (b == 0)
-        acc
-        (if
-          (mod b 2 == 0)
-          (power' acc (a * a) (div b 2))
-          (power' (acc * a) (a * a) (div b 2)));
+        | b == 0 := acc
+        | mod b 2 == 0 := power' acc (a * a) (div b 2)
+        | else := power' (acc * a) (a * a) (div b 2);
   in power' 1;
 
 main : Nat -> Nat -> Nat := power;

--- a/tests/VampIR/positive/Compilation/test023.juvix
+++ b/tests/VampIR/positive/Compilation/test023.juvix
@@ -3,8 +3,6 @@ module test023;
 
 import Stdlib.Prelude open;
 
-main : Nat → Nat → Nat
-  | x y :=
-    case λ {z := if (x == z) (x, 0) (x, z)} (y + x) of {
-      a, b := a + b
-    };
+main (x y : Nat) : Nat :=
+    case λ {z := if (x == z) (x, 0) (x, z)} (y + x) of
+      a, b := a + b;

--- a/tests/negative/issue1337/DoubleBraces.juvix
+++ b/tests/negative/issue1337/DoubleBraces.juvix
@@ -4,4 +4,4 @@ type Nat :=
   | O : Nat
   | S : Nat -> Nat;
 
-fun (n : Nat) : Nat := case n of {S {{y}} := O};
+fun (n : Nat) : Nat := case n of S {{y}} := O;

--- a/tests/positive/Alias.juvix
+++ b/tests/positive/Alias.juvix
@@ -20,10 +20,9 @@ not2 (b : Boolean) : Boolean :=
   let
     syntax alias yes := ⊤;
     syntax alias no := ⊥;
-  in case b of {
+  in case b of
        | no := yes
-       | yes := no
-     };
+       | yes := no;
 
 module ExportAlias;
   syntax alias Binary := Bool;

--- a/tests/positive/AliasRecordConstructor.juvix
+++ b/tests/positive/AliasRecordConstructor.juvix
@@ -12,7 +12,7 @@ t : T :=
   };
 
 t1 : T -> A
- | mkT'@{ field := x } := x;
+  | mkT'@{field := x} := x;
 
 syntax iterator it {init := 0; range := 1};
 it : (A → A) → T → A

--- a/tests/positive/Format.juvix
+++ b/tests/positive/Format.juvix
@@ -30,31 +30,28 @@ M;
 end;
 
 -- case with single branch
-case1 (n : Nat) : Nat := case n of {x := zero};
+case1 (n : Nat) : Nat := case n of x := zero;
 
 -- case with multiple branches
 case2 (n : Nat) : Nat :=
-  case n of {
+  case n of
     | zero := zero
-    | _ := zero
-  };
+    | _ := zero;
 
 -- case on nested case
 case3 (n : Nat) : Nat :=
-  case case n of {_ := zero} of {
+  case case n of {_ := zero} of
     | zero := zero
-    | _ := zero
-  };
+    | _ := zero;
 
 -- case on nested case expression
 case4 (n : Nat) : Nat :=
-  case n of {
+  case n of
     | zero := case n of {x := zero}
-    | _ := zero
-  };
+    | _ := zero;
 
 -- -- case with application subject
-case5 (n : Nat) : Nat := case id n of {x := zero};
+case5 (n : Nat) : Nat := case id n of x := zero;
 
 -- qualified commas
 t4 : String := "a" M., "b" M., "c" M., "d";

--- a/tests/positive/ImportShadow/Main.juvix
+++ b/tests/positive/ImportShadow/Main.juvix
@@ -4,13 +4,12 @@ import Nat open;
 
 type Unit := unit : Unit;
 
-f : Nat := case unit of {is-zero := zero};
+f : Nat := case unit of is-zero := zero;
 
 f2 : Nat :=
-  case suc zero of {
+  case suc zero of
     | suc is-zero := zero
-    | _ := zero
-  };
+    | _ := zero;
 
 f3 : Nat → Nat
   | (suc is-zero) := is-zero

--- a/tests/positive/ImportShadow/Nat.juvix
+++ b/tests/positive/ImportShadow/Nat.juvix
@@ -10,7 +10,6 @@ type Nat :=
 
 is-zero : Nat → Bool
   | n :=
-    case n of {
+    case n of
       | zero := true
-      | suc _ := false
-    };
+      | suc _ := false;

--- a/tests/positive/InstanceImport/Main.juvix
+++ b/tests/positive/InstanceImport/Main.juvix
@@ -10,4 +10,4 @@ type Bool :=
 instance
 boolI : T Bool := mkT λ {x := x};
 
-main : Bool := case T.pp unit of {unit := T.pp true};
+main : Bool := case T.pp unit of unit := T.pp true;

--- a/tests/positive/Internal/Case.juvix
+++ b/tests/positive/Internal/Case.juvix
@@ -4,43 +4,38 @@ import Stdlib.Prelude open;
 
 isZero : Nat → Bool
   | n :=
-    case n of {
+    case n of
       | zero := true
-      | k@(suc _) := false
-    };
+      | k@(suc _) := false;
 
 id' : Bool → {A : Type} → A → A
   | b :=
-    case b of {
+    case b of
       | true := id
-      | false := id
-    };
+      | false := id;
 
 pred : Nat → Nat
   | n :=
-    case n of {
+    case n of
       | zero := zero
-      | suc n := n
-    };
+      | suc n := n;
 
 appIf : {A : Type} → Bool → (A → A) → A → A
   | b f :=
-    case b of {
+    case b of
       | true := f
-      | false := id
-    };
+      | false := id;
 
 appIf2 : {A : Type} → Bool → (A → A) → A → A
   | b f a :=
-    (case b of {
+    case b of {
       | true := f
       | false := id
-    })
+    }
       a;
 
 nestedCase1 : {A : Type} → Bool → (A → A) → A → A
   | b f :=
-    case b of {
+    case b of
       | true := case b of {_ := id}
-      | false := id
-    };
+      | false := id;

--- a/tests/positive/Internal/Case.juvix
+++ b/tests/positive/Internal/Case.juvix
@@ -32,10 +32,10 @@ appIf : {A : Type} → Bool → (A → A) → A → A
 
 appIf2 : {A : Type} → Bool → (A → A) → A → A
   | b f a :=
-    case b of {
+    (case b of {
       | true := f
       | false := id
-    }
+    })
       a;
 
 nestedCase1 : {A : Type} → Bool → (A → A) → A → A

--- a/tests/positive/Iterators.juvix
+++ b/tests/positive/Iterators.juvix
@@ -19,7 +19,6 @@ main : Bool :=
     z : Bool := false;
   in itconst (a := true; b := false) (c in false; d in false)
        for (x := true) (y in false)
-         case x of {
+         case x of
            | true := y
-           | false := z
-         };
+           | false := z;

--- a/tests/positive/LetShadow.juvix
+++ b/tests/positive/LetShadow.juvix
@@ -7,9 +7,8 @@ type Nat :=
 type Unit := unit : Unit;
 
 t : Nat :=
-  case unit of {
+  case unit of
     x :=
       let
         x : Nat := suc zero;
-      in x
-  };
+      in x;

--- a/tests/positive/NestedPatterns.juvix
+++ b/tests/positive/NestedPatterns.juvix
@@ -9,7 +9,6 @@ toList : {A : Type} -> MyList A -> List A
 
 f : MyList Nat -> Nat
   | xs :=
-    case toList xs of {
+    case toList xs of
       | suc n :: nil := n
-      | _ := zero
-    };
+      | _ := zero;

--- a/tests/positive/Traits2.juvix
+++ b/tests/positive/Traits2.juvix
@@ -79,7 +79,7 @@ import Stdlib.Data.Product open;
   {{Semigroup A}}
   {B C : Type}
   : A × B -> (B -> A × C) -> A × C
-  | (a, b) f := case f b of {a', b' := a <> a', b'};
+  | (a, b) f := case f b of a', b' := a <> a', b';
 
 instance
 ×-Monad


### PR DESCRIPTION
* Closes #2769 
* Removes old case syntax
* Pretty printing doesn't print braces in `case` if the `case` is a "top" expression in a definition. 
