### PR TITLE
Effects for finite and infinite supplies

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -239,7 +239,7 @@ runMarkdownModuleParser fpath mk =
 
     parseRestBlocks ::
       forall r'.
-      (Members '[ParserResultBuilder, Error ParserError, Input (Maybe MK.JuvixCodeBlock), State MdModuleBuilder] r') =>
+      (Members '[ParserResultBuilder, Error ParserError, Input MK.JuvixCodeBlock, State MdModuleBuilder] r') =>
       Sem r' ()
     parseRestBlocks = whenJustM input $ \x -> do
       stmts <- parseHelper parseTopStatements x

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -31,7 +31,7 @@ scanner :: Path Abs File -> ByteString -> Result e ScanResult
 scanner fp bs = do
   spansToLocs <$> runParser pPreScanResult bs
   where
-    getInterval :: (Members '[Input (Maybe FileLoc)] r) => Sem r Interval
+    getInterval :: (Members '[Input FileLoc] r) => Sem r Interval
     getInterval = do
       _intervalStart <- inputJust
       _intervalEnd <- inputJust

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -100,7 +100,7 @@ data FunctionInfo = FunctionInfo
     _functionInfoName :: Text
   }
 
-data FunctionCtx = FunctionCtx
+newtype FunctionCtx = FunctionCtx
   { _functionCtxArity :: Natural
   }
 
@@ -520,7 +520,7 @@ compile = \case
                 ClosureTotalArgsNum -> Nothing
                 ClosureArgsNum -> Nothing
                 AnomaGetOrder -> Nothing
-          return $ (opCall "callClosure" (closurePath WrapperCode) newSubject)
+          return (opCall "callClosure" (closurePath WrapperCode) newSubject)
 
 isZero :: Term Natural -> Term Natural
 isZero a = OpEq # a # nockNatLiteral 0
@@ -773,11 +773,11 @@ runCompilerWith opts constrs moduleFuns mainFun = makeAnomaFun
             AnomaGetOrder -> nockNilHere
 
     functionInfos :: HashMap FunctionId FunctionInfo
-    functionInfos = hashMap (run (runInputNaturals (toList <$> userFunctions)))
+    functionInfos = hashMap (run (runStreamOfNaturals (toList <$> userFunctions)))
 
-    userFunctions :: (Members '[Input Natural] r) => Sem r (NonEmpty (FunctionId, FunctionInfo))
+    userFunctions :: (Members '[StreamOf Natural] r) => Sem r (NonEmpty (FunctionId, FunctionInfo))
     userFunctions = forM allFuns $ \CompilerFunction {..} -> do
-      i <- input
+      i <- yield
       return
         ( _compilerFunctionId,
           FunctionInfo

--- a/src/Juvix/Prelude/Effects.hs
+++ b/src/Juvix/Prelude/Effects.hs
@@ -3,6 +3,7 @@ module Juvix.Prelude.Effects
     module Juvix.Prelude.Effects.Base,
     module Juvix.Prelude.Effects.Accum,
     module Juvix.Prelude.Effects.Input,
+    module Juvix.Prelude.Effects.StreamOf,
     module Juvix.Prelude.Effects.Bracket,
   )
 where
@@ -12,3 +13,4 @@ import Juvix.Prelude.Effects.Base
 import Juvix.Prelude.Effects.Bracket
 import Juvix.Prelude.Effects.Input
 import Juvix.Prelude.Effects.Output
+import Juvix.Prelude.Effects.StreamOf

--- a/src/Juvix/Prelude/Effects/Input.hs
+++ b/src/Juvix/Prelude/Effects/Input.hs
@@ -1,37 +1,38 @@
-{-# OPTIONS_GHC -Wno-unused-type-patterns #-}
+module Juvix.Prelude.Effects.Input
+  ( Input,
+    input,
+    inputJust,
+    peekInput,
+    runInputList,
+  )
+where
 
-module Juvix.Prelude.Effects.Input where
-
-import Data.Stream qualified as Stream
 import Juvix.Prelude.Base.Foundation
 import Juvix.Prelude.Effects.Base
-import Juvix.Prelude.Stream
+import Safe
 
--- TODO make static versions. Finite and infinite.
-data Input (i :: GHCType) :: Effect where
-  Input :: Input i m i
+data Input (i :: GHCType) :: Effect
 
-makeEffect ''Input
+type instance DispatchOf (Input _) = 'Static 'NoSideEffects
 
-runInputList :: forall i r a. [i] -> Sem (Input (Maybe i) ': r) a -> Sem r a
-runInputList s = reinterpret (evalState s) $ \case
-  Input -> do
-    x <- gets @[i] nonEmpty
-    case x of
-      Nothing -> return Nothing
-      Just (a :| as) -> do
-        put as
-        return (Just a)
+newtype instance StaticRep (Input i) = Input
+  { _unInput :: [i]
+  }
 
-runInputStream :: forall i r a. Stream i -> Sem (Input i ': r) a -> Sem r a
-runInputStream s = reinterpret (evalState s) $ \case
-  Input -> do
-    Stream.Cons a as <- get @(Stream i)
-    put as
-    return a
+input :: (Member (Input i) r) => Sem r (Maybe i)
+input =
+  stateStaticRep $
+    \case
+      Input [] -> (Nothing, Input [])
+      Input (i : is) -> (Just i, Input is)
 
-runInputNaturals :: Sem (Input Natural ': r) a -> Sem r a
-runInputNaturals = runInputStream allNaturals
+peekInput :: (Member (Input i) r) => Sem r (Maybe i)
+peekInput = do
+  Input l <- getStaticRep
+  return (headMay l)
 
-inputJust :: (Members '[Input (Maybe i)] r) => Sem r i
+runInputList :: [i] -> Sem (Input i ': r) a -> Sem r a
+runInputList = evalStaticRep . Input
+
+inputJust :: (Members '[Input i] r) => Sem r i
 inputJust = fromMaybe (error "inputJust") <$> input

--- a/src/Juvix/Prelude/Effects/StreamOf.hs
+++ b/src/Juvix/Prelude/Effects/StreamOf.hs
@@ -1,0 +1,30 @@
+module Juvix.Prelude.Effects.StreamOf
+  ( StreamOf,
+    yield,
+    runStreamOf,
+    runStreamOfNaturals,
+  )
+where
+
+import Data.Stream
+import Juvix.Prelude.Base.Foundation
+import Juvix.Prelude.Effects.Base
+import Juvix.Prelude.Stream
+
+data StreamOf (i :: GHCType) :: Effect
+
+type instance DispatchOf (StreamOf _) = 'Static 'NoSideEffects
+
+newtype instance StaticRep (StreamOf i) = StreamOf
+  { _unStreamOf :: Stream i
+  }
+
+yield :: (Member (StreamOf i) r) => Sem r i
+yield = stateStaticRep $ \case
+  StreamOf (Cons i is) -> (i, StreamOf is)
+
+runStreamOf :: Stream i -> Sem (StreamOf i ': r) a -> Sem r a
+runStreamOf = evalStaticRep . StreamOf
+
+runStreamOfNaturals :: Sem (StreamOf Natural ': r) a -> Sem r a
+runStreamOfNaturals = runStreamOf allNaturals


### PR DESCRIPTION
This pr refactors the `Input` effect. It is now meant to be used with finite input lists.

It also introduces the `StreamOf` effect, which is meant to be used for infinite supplies.

Both have static implementations so they should add negligible overhead when used.