### PR TITLE
Support Anoma stdlib API `verifyDetached`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,7 @@ dependencies:
   - deepseq == 1.5.*
   - directory == 1.3.*
   - dlist == 1.0.*
+  - ed25519 == 0.0.*
   - edit-distance == 0.2.*
   - effectful == 2.3.*
   - effectful-core == 2.3.*

--- a/src/Juvix/Compiler/Builtins/Anoma.hs
+++ b/src/Juvix/Compiler/Builtins/Anoma.hs
@@ -43,3 +43,17 @@ registerAnomaDecode f = do
     ((ftype ==% (u <>--> nat --> decodeT)) freeVars)
     (error "anomaEncode must be of type {A : Type} -> Nat -> A")
   registerBuiltin BuiltinAnomaDecode (f ^. axiomName)
+
+registerAnomaVerifyDetached :: (Members '[Builtins, NameIdGen] r) => AxiomDef -> Sem r ()
+registerAnomaVerifyDetached f = do
+  let ftype = f ^. axiomType
+      u = ExpressionUniverse smallUniverseNoLoc
+      l = getLoc f
+  decodeT <- freshVar l "signedDataT"
+  nat <- getBuiltinName (getLoc f) BuiltinNat
+  bool_ <- getBuiltinName (getLoc f) BuiltinBool
+  let freeVars = HashSet.fromList [decodeT]
+  unless
+    ((ftype ==% (u <>--> nat --> decodeT --> nat --> bool_)) freeVars)
+    (error "anomaVerifyDetached must be of type {A : Type} -> Nat -> A -> Nat -> Bool")
+  registerBuiltin BuiltinAnomaVerifyDetached (f ^. axiomName)

--- a/src/Juvix/Compiler/Concrete/Data/Builtins.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Builtins.hs
@@ -190,6 +190,7 @@ data BuiltinAxiom
   | BuiltinAnomaGet
   | BuiltinAnomaEncode
   | BuiltinAnomaDecode
+  | BuiltinAnomaVerifyDetached
   | BuiltinPoseidon
   | BuiltinEcOp
   | BuiltinRandomEcPoint
@@ -227,6 +228,7 @@ instance Pretty BuiltinAxiom where
     BuiltinAnomaGet -> Str.anomaGet
     BuiltinAnomaEncode -> Str.anomaEncode
     BuiltinAnomaDecode -> Str.anomaDecode
+    BuiltinAnomaVerifyDetached -> Str.anomaVerifyDetached
     BuiltinPoseidon -> Str.cairoPoseidon
     BuiltinEcOp -> Str.cairoEcOp
     BuiltinRandomEcPoint -> Str.cairoRandomEcPoint

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -581,9 +581,11 @@ class CheckApplyType a t where
   checkApply :: t -> [a] -> a
 
 instance CheckApplyType a a where
-  checkApply f [] = f
-  checkApply _ _ = error "too many arguments for operator"
+  checkApply f = \case
+     [] -> f
+     _ -> error "too many arguments for operator"
 
 instance (CheckApplyType a r) => CheckApplyType a (a -> r) where
-  checkApply f (x : xs) = checkApply (f x) xs
-  checkApply _ [] = error "too few arguments for operator"
+  checkApply f = \case
+     x : xs -> checkApply (f x) xs
+    [] -> error "too few arguments for operator"

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -577,15 +577,15 @@ toCoreError loc (EvalError {..}) =
 -- | A class that provides a function `checkApply` that applies a function to a
 -- list of arguments and fails if the length of the arguments list is not equal
 -- to the arity of the function.
-class CheckApplyType a t where
+class CheckApplyType t a where
   checkApply :: t -> [a] -> a
 
 instance CheckApplyType a a where
   checkApply f = \case
-     [] -> f
-     _ -> error "too many arguments for operator"
+    [] -> f
+    _ -> error "too many arguments for operator"
 
-instance (CheckApplyType a r) => CheckApplyType a (a -> r) where
+instance (CheckApplyType r a) => CheckApplyType (a -> r) a where
   checkApply f = \case
-     x : xs -> checkApply (f x) xs
+    x : xs -> checkApply (f x) xs
     [] -> error "too few arguments for operator"

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -426,6 +426,7 @@ builtinOpArgTypes = \case
   OpAnomaGet -> [mkDynamic']
   OpAnomaEncode -> [mkDynamic']
   OpAnomaDecode -> [mkDynamic']
+  OpAnomaVerifyDetached -> [mkDynamic', mkDynamic', mkDynamic']
   OpPoseidonHash -> [mkDynamic']
   OpEc -> [mkDynamic', mkTypeField', mkDynamic']
   OpRandomEcPoint -> []

--- a/src/Juvix/Compiler/Core/Language/Builtins.hs
+++ b/src/Juvix/Compiler/Core/Language/Builtins.hs
@@ -29,6 +29,7 @@ data BuiltinOp
   | OpAnomaGet
   | OpAnomaEncode
   | OpAnomaDecode
+  | OpAnomaVerifyDetached
   | OpPoseidonHash
   | OpEc
   | OpRandomEcPoint
@@ -75,6 +76,7 @@ builtinOpArgsNum = \case
   OpAnomaGet -> 1
   OpAnomaEncode -> 1
   OpAnomaDecode -> 1
+  OpAnomaVerifyDetached -> 3
   OpPoseidonHash -> 1
   OpEc -> 3
   OpRandomEcPoint -> 0
@@ -114,6 +116,7 @@ builtinIsFoldable = \case
   OpAnomaGet -> False
   OpAnomaEncode -> False
   OpAnomaDecode -> False
+  OpAnomaVerifyDetached -> False
   OpPoseidonHash -> False
   OpEc -> False
   OpRandomEcPoint -> False
@@ -131,4 +134,4 @@ builtinsCairo :: [BuiltinOp]
 builtinsCairo = [OpPoseidonHash, OpEc, OpRandomEcPoint]
 
 builtinsAnoma :: [BuiltinOp]
-builtinsAnoma = [OpAnomaGet, OpAnomaEncode, OpAnomaDecode]
+builtinsAnoma = [OpAnomaGet, OpAnomaEncode, OpAnomaDecode, OpAnomaVerifyDetached]

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -55,6 +55,7 @@ instance PrettyCode BuiltinOp where
     OpAnomaGet -> return primAnomaGet
     OpAnomaEncode -> return primAnomaEncode
     OpAnomaDecode -> return primAnomaDecode
+    OpAnomaVerifyDetached -> return primAnomaVerifyDetached
     OpPoseidonHash -> return primPoseidonHash
     OpEc -> return primEc
     OpRandomEcPoint -> return primRandomEcPoint
@@ -808,6 +809,9 @@ primAnomaEncode = primitive Str.anomaEncode
 
 primAnomaDecode :: Doc Ann
 primAnomaDecode = primitive Str.anomaDecode
+
+primAnomaVerifyDetached :: Doc Ann
+primAnomaVerifyDetached = primitive Str.anomaVerifyDetached
 
 primPoseidonHash :: Doc Ann
 primPoseidonHash = primitive Str.cairoPoseidon

--- a/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
+++ b/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
@@ -69,6 +69,7 @@ computeNodeTypeInfo md = umapL go
           OpAnomaGet -> Info.getNodeType node
           OpAnomaEncode -> Info.getNodeType node
           OpAnomaDecode -> Info.getNodeType node
+          OpAnomaVerifyDetached -> Info.getNodeType node
           OpPoseidonHash -> case _builtinAppArgs of
             [arg] -> Info.getNodeType arg
             _ -> error "incorrect poseidon builtin application"

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -98,6 +98,7 @@ fromCore fsize tab =
         BuiltinAnomaGet -> False
         BuiltinAnomaEncode -> False
         BuiltinAnomaDecode -> False
+        BuiltinAnomaVerifyDetached -> False
         BuiltinPoseidon -> False
         BuiltinEcOp -> False
         BuiltinRandomEcPoint -> False

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -571,6 +571,7 @@ registerBuiltinAxiom d = \case
   BuiltinAnomaGet -> registerAnomaGet d
   BuiltinAnomaEncode -> registerAnomaEncode d
   BuiltinAnomaDecode -> registerAnomaDecode d
+  BuiltinAnomaVerifyDetached -> registerAnomaVerifyDetached d
   BuiltinPoseidon -> registerPoseidon d
   BuiltinEcOp -> registerEcOp d
   BuiltinRandomEcPoint -> registerRandomEcPoint d

--- a/src/Juvix/Compiler/Nockma/Encoding.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding.hs
@@ -1,8 +1,10 @@
 module Juvix.Compiler.Nockma.Encoding
   ( module Juvix.Compiler.Nockma.Encoding.Jam,
     module Juvix.Compiler.Nockma.Encoding.Cue,
+    module Juvix.Compiler.Nockma.Encoding.ByteString,
   )
 where
 
+import Juvix.Compiler.Nockma.Encoding.ByteString
 import Juvix.Compiler.Nockma.Encoding.Cue
 import Juvix.Compiler.Nockma.Encoding.Jam

--- a/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
@@ -1,9 +1,9 @@
 module Juvix.Compiler.Nockma.Encoding.ByteString where
 
-import Juvix.Prelude.Base
-import Juvix.Compiler.Nockma.Language
 import Data.Bit
 import Juvix.Compiler.Nockma.Encoding.Base
+import Juvix.Compiler.Nockma.Language
+import Juvix.Prelude.Base
 
 atomToByteString :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Atom a -> Sem r ByteString
 atomToByteString am = do

--- a/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
@@ -14,8 +14,7 @@ byteStringToAtom :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Byte
 byteStringToAtom bs = do
   a <- fromNatural . fromInteger . vectorBitsToInteger . cloneFromByteString $ bs
   return
-    ( Atom
-        { _atomInfo = emptyAtomInfo,
-          _atom = a
-        }
-    )
+    Atom
+      { _atomInfo = emptyAtomInfo,
+        _atom = a
+      }

--- a/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
@@ -1,0 +1,21 @@
+module Juvix.Compiler.Nockma.Encoding.ByteString where
+
+import Juvix.Prelude.Base
+import Juvix.Compiler.Nockma.Language
+import Data.Bit
+import Juvix.Compiler.Nockma.Encoding.Base
+
+atomToByteString :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Atom a -> Sem r ByteString
+atomToByteString am = do
+  n <- nockNatural am
+  return (cloneToByteString . integerToVectorBits . toInteger $ n)
+
+byteStringToAtom :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => ByteString -> Sem r (Atom a)
+byteStringToAtom bs = do
+  a <- fromNatural . fromInteger . vectorBitsToInteger . cloneFromByteString $ bs
+  return
+    ( Atom
+        { _atomInfo = emptyAtomInfo,
+          _atom = a
+        }
+    )

--- a/src/Juvix/Compiler/Nockma/Encoding/Cue.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Cue.hs
@@ -72,7 +72,7 @@ consumeLength = do
   if
       | lenOfLen == 0 -> return 0
       | otherwise -> do
-          -- The mist significant bit of the length is omitted
+          -- The most significant bit of the length is omitted
           let lenBits = lenOfLen - 1
           foldlM go (bit lenBits) [0 .. lenBits - 1]
   where

--- a/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
@@ -43,7 +43,7 @@ writeLength len = do
 writeAtomTag :: (Member BitWriter r) => Sem r ()
 writeAtomTag = writeZero
 
--- | Write the cell tag 0b01 to the output
+-- | Write the cell tag 0b10 to the output
 writeCellTag :: (Member BitWriter r) => Sem r ()
 writeCellTag = writeOne >> writeZero
 

--- a/src/Juvix/Compiler/Nockma/StdlibFunction.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction.hs
@@ -22,3 +22,4 @@ stdlibPath = \case
   StdlibPow2 -> [nock| [9 4 0 7] |]
   StdlibEncode -> [nock| [9 22 0 3] |]
   StdlibDecode -> [nock| [9 94 0 3] |]
+  StdlibVerifyDetached -> [nock| [9 22 0 1] |]

--- a/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
@@ -16,6 +16,7 @@ instance Pretty StdlibFunction where
     StdlibPow2 -> "pow2"
     StdlibEncode -> "encode"
     StdlibDecode -> "decode"
+    StdlibVerifyDetached -> "verify-detached"
 
 data StdlibFunction
   = StdlibDec
@@ -29,6 +30,7 @@ data StdlibFunction
   | StdlibPow2
   | StdlibEncode
   | StdlibDecode
+  | StdlibVerifyDetached
   deriving stock (Show, Lift, Eq, Bounded, Enum, Generic)
 
 instance Hashable StdlibFunction

--- a/src/Juvix/Compiler/Tree/Keywords.hs
+++ b/src/Juvix/Compiler/Tree/Keywords.hs
@@ -12,6 +12,7 @@ import Juvix.Data.Keyword.All
     kwAnomaDecode,
     kwAnomaEncode,
     kwAnomaGet,
+    kwAnomaVerifyDetached,
     kwArgsNum,
     kwAtoi,
     kwBr,
@@ -78,6 +79,7 @@ allKeywords =
          kwAnomaGet,
          kwAnomaDecode,
          kwAnomaEncode,
+         kwAnomaVerifyDetached,
          kwPoseidon,
          kwEcOp,
          kwRandomEcPoint

--- a/src/Juvix/Compiler/Tree/Language/Builtins.hs
+++ b/src/Juvix/Compiler/Tree/Language/Builtins.hs
@@ -56,4 +56,6 @@ data AnomaOp
     OpAnomaEncode
   | -- | Decode a value from an Anoma atom
     OpAnomaDecode
+  | -- | Verify a cryptogtaphic signature of an Anoma value
+    OpAnomaVerifyDetached
   deriving stock (Eq)

--- a/src/Juvix/Compiler/Tree/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Tree/Pretty/Base.hs
@@ -245,6 +245,7 @@ instance PrettyCode AnomaOp where
     OpAnomaGet -> Str.anomaGet
     OpAnomaEncode -> Str.anomaEncode
     OpAnomaDecode -> Str.anomaDecode
+    OpAnomaVerifyDetached -> Str.anomaVerifyDetached
 
 instance PrettyCode UnaryOpcode where
   ppCode = \case

--- a/src/Juvix/Compiler/Tree/Transformation/CheckNoAnoma.hs
+++ b/src/Juvix/Compiler/Tree/Transformation/CheckNoAnoma.hs
@@ -14,6 +14,7 @@ checkNoAnoma = walkT checkNode
         OpAnomaGet -> unsupportedErr "OpAnomaGet"
         OpAnomaEncode -> unsupportedErr "OpAnomaEncode"
         OpAnomaDecode -> unsupportedErr "OpAnomaDecode"
+        OpAnomaVerifyDetached -> unsupportedErr "OpAnomaVerifyDetached"
         where
           unsupportedErr :: Text -> Sem r ()
           unsupportedErr opName =

--- a/src/Juvix/Compiler/Tree/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromCore.hs
@@ -316,6 +316,7 @@ genCode infoTable fi =
       Core.OpAnomaGet -> OpAnomaGet
       Core.OpAnomaEncode -> OpAnomaEncode
       Core.OpAnomaDecode -> OpAnomaDecode
+      Core.OpAnomaVerifyDetached -> OpAnomaVerifyDetached
       _ -> impossible
 
     getArgsNum :: Symbol -> Int

--- a/src/Juvix/Compiler/Tree/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource.hs
@@ -126,6 +126,7 @@ parseAnoma =
   parseAnoma' kwAnomaGet OpAnomaGet
     <|> parseAnoma' kwAnomaDecode OpAnomaDecode
     <|> parseAnoma' kwAnomaEncode OpAnomaEncode
+    <|> parseAnoma' kwAnomaVerifyDetached OpAnomaVerifyDetached
 
 parseAnoma' ::
   (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -6,6 +6,7 @@ where
 
 import Juvix.Data.Keyword
 import Juvix.Extra.Strings qualified as Str
+import Juvix.Extra.Strings qualified as Std
 
 kwAs :: Keyword
 kwAs = asciiKw Str.as
@@ -450,6 +451,9 @@ kwAnomaDecode = asciiKw Str.anomaDecode
 
 kwAnomaEncode :: Keyword
 kwAnomaEncode = asciiKw Str.anomaEncode
+
+kwAnomaVerifyDetached :: Keyword
+kwAnomaVerifyDetached = asciiKw Std.anomaVerifyDetached
 
 delimBraceL :: Keyword
 delimBraceL = mkDelim Str.braceL

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -5,8 +5,8 @@ module Juvix.Data.Keyword.All
 where
 
 import Juvix.Data.Keyword
-import Juvix.Extra.Strings qualified as Str
 import Juvix.Extra.Strings qualified as Std
+import Juvix.Extra.Strings qualified as Str
 
 kwAs :: Keyword
 kwAs = asciiKw Str.as

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -335,6 +335,9 @@ anomaEncode = "anoma-encode"
 anomaDecode :: (IsString s) => s
 anomaDecode = "anoma-decode"
 
+anomaVerifyDetached :: (IsString s) => s
+anomaVerifyDetached = "anoma-verify-detached"
+
 builtinSeq :: (IsString s) => s
 builtinSeq = "seq"
 

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -560,5 +560,13 @@ allTests =
             [nock| [1 2 0] |],
             [nock| [1 2] |],
             [nock| false |]
+          ],
+      mkAnomaCallTest
+        "Test077: Anoma verify-detached"
+        $(mkRelDir ".")
+        $(mkRelFile "test077.juvix")
+        []
+        $ checkOutput
+          [ [nock| true |]
           ]
     ]

--- a/test/Tree/Transformation/CheckNoAnoma.hs
+++ b/test/Tree/Transformation/CheckNoAnoma.hs
@@ -71,5 +71,9 @@ tests =
     Eval.NegTest
       "anomaEncode"
       $(mkRelDir ".")
-      $(mkRelFile "test011.jvt")
+      $(mkRelFile "test011.jvt"),
+    Eval.NegTest
+      "anomaVerifyDetached"
+      $(mkRelDir ".")
+      $(mkRelFile "test012.jvt")
   ]

--- a/tests/Anoma/Compilation/positive/test077.juvix
+++ b/tests/Anoma/Compilation/positive/test077.juvix
@@ -1,0 +1,20 @@
+module test077;
+
+import Stdlib.Prelude open;
+import Stdlib.Debug.Trace open;
+
+builtin anoma-verify-detached
+axiom anomaVerifyDetached : {A : Type}
+  -> Nat
+  -> A
+  -> Nat
+  -> Bool;
+
+--- dsign privateKey (anomaEncode 1)
+sig : Nat :=
+  0x9dac7337633844c1df6af03431adec37b8b67331fbd0a36553dd11f8ac92107e58f0ca42d93d88f98a2f1181e81e1808842193af64a4abb42c6e57570fd7a5a;
+
+publicKey : Nat :=
+  0xd5d974196b220bc1fc3c11a0a04bfa46b2aba0c792daf2f3f6c2d6ac1064c463;
+
+main : Bool := anomaVerifyDetached sig 1 publicKey;

--- a/tests/Tree/negative/test012.jvt
+++ b/tests/Tree/negative/test012.jvt
@@ -1,0 +1,5 @@
+-- calling unsupported anoma-verify-detached
+
+function main() : * {
+  anoma-verify-detached(1,2,3)
+}


### PR DESCRIPTION
This PR adds support for`anomaVerifyDetached` stdlib API via a Juvix builtin.

It has signature:

```
builtin anoma-verify-detached
axiom anomaVerifyDetached : {A : Type}
   --- signature
  -> Nat 
   --- message
  -> A
   --- public key
  -> Nat
 -> Bool;
```

The [ed25519](https://hackage.haskell.org/package/ed25519) library is used in the evaluator becuase Anoma uses ed25519 signatures (https://hexdocs.pm/enacl/enacl.html).