### PR TITLE
Support Anoma stdlib APIs `sign` and `verify`

### DIFF
--- a/src/Juvix/Compiler/Builtins/Anoma.hs
+++ b/src/Juvix/Compiler/Builtins/Anoma.hs
@@ -57,3 +57,16 @@ registerAnomaVerifyDetached f = do
     ((ftype ==% (u <>--> nat --> decodeT --> nat --> bool_)) freeVars)
     (error "anomaVerifyDetached must be of type {A : Type} -> Nat -> A -> Nat -> Bool")
   registerBuiltin BuiltinAnomaVerifyDetached (f ^. axiomName)
+
+registerAnomaSign :: (Members '[Builtins, NameIdGen] r) => AxiomDef -> Sem r ()
+registerAnomaSign f = do
+  let ftype = f ^. axiomType
+      u = ExpressionUniverse smallUniverseNoLoc
+      l = getLoc f
+  dataT <- freshVar l "dataT"
+  nat <- getBuiltinName (getLoc f) BuiltinNat
+  let freeVars = HashSet.fromList [dataT]
+  unless
+    ((ftype ==% (u <>--> dataT --> nat --> nat)) freeVars)
+    (error "anomaSign must be of type {A : Type} -> A -> Nat -> Nat")
+  registerBuiltin BuiltinAnomaSign (f ^. axiomName)

--- a/src/Juvix/Compiler/Builtins/Anoma.hs
+++ b/src/Juvix/Compiler/Builtins/Anoma.hs
@@ -70,3 +70,16 @@ registerAnomaSign f = do
     ((ftype ==% (u <>--> dataT --> nat --> nat)) freeVars)
     (error "anomaSign must be of type {A : Type} -> A -> Nat -> Nat")
   registerBuiltin BuiltinAnomaSign (f ^. axiomName)
+
+registerAnomaVerify :: (Members '[Builtins, NameIdGen] r) => AxiomDef -> Sem r ()
+registerAnomaVerify f = do
+  let ftype = f ^. axiomType
+      u = ExpressionUniverse smallUniverseNoLoc
+      l = getLoc f
+  dataT <- freshVar l "dataT"
+  nat <- getBuiltinName (getLoc f) BuiltinNat
+  let freeVars = HashSet.fromList [dataT]
+  unless
+    ((ftype ==% (u <>--> nat --> nat --> dataT)) freeVars)
+    (error "anomaVerify must be of type {A : Type} -> Nat -> Nat -> A")
+  registerBuiltin BuiltinAnomaVerify (f ^. axiomName)

--- a/src/Juvix/Compiler/Concrete/Data/Builtins.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Builtins.hs
@@ -191,6 +191,7 @@ data BuiltinAxiom
   | BuiltinAnomaEncode
   | BuiltinAnomaDecode
   | BuiltinAnomaVerifyDetached
+  | BuiltinAnomaSign
   | BuiltinPoseidon
   | BuiltinEcOp
   | BuiltinRandomEcPoint
@@ -229,6 +230,7 @@ instance Pretty BuiltinAxiom where
     BuiltinAnomaEncode -> Str.anomaEncode
     BuiltinAnomaDecode -> Str.anomaDecode
     BuiltinAnomaVerifyDetached -> Str.anomaVerifyDetached
+    BuiltinAnomaSign -> Str.anomaSign
     BuiltinPoseidon -> Str.cairoPoseidon
     BuiltinEcOp -> Str.cairoEcOp
     BuiltinRandomEcPoint -> Str.cairoRandomEcPoint

--- a/src/Juvix/Compiler/Concrete/Data/Builtins.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Builtins.hs
@@ -192,6 +192,7 @@ data BuiltinAxiom
   | BuiltinAnomaDecode
   | BuiltinAnomaVerifyDetached
   | BuiltinAnomaSign
+  | BuiltinAnomaVerify
   | BuiltinPoseidon
   | BuiltinEcOp
   | BuiltinRandomEcPoint
@@ -231,6 +232,7 @@ instance Pretty BuiltinAxiom where
     BuiltinAnomaDecode -> Str.anomaDecode
     BuiltinAnomaVerifyDetached -> Str.anomaVerifyDetached
     BuiltinAnomaSign -> Str.anomaSign
+    BuiltinAnomaVerify -> Str.anomaVerify
     BuiltinPoseidon -> Str.cairoPoseidon
     BuiltinEcOp -> Str.cairoEcOp
     BuiltinRandomEcPoint -> Str.cairoRandomEcPoint

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -194,6 +194,7 @@ geval opts herr ctx env0 = eval' env0
       OpAnomaEncode -> anomaEncodeOp
       OpAnomaDecode -> anomaDecodeOp
       OpAnomaVerifyDetached -> anomaVerifyDetachedOp
+      OpAnomaSign -> anomaSignOp
       OpPoseidonHash -> poseidonHashOp
       OpEc -> ecOp
       OpRandomEcPoint -> randomEcPointOp
@@ -366,6 +367,15 @@ geval opts herr ctx env0 = eval' env0
               | otherwise ->
                   err "unsupported builtin operation: OpAnomaVerifyDetached"
         {-# INLINE anomaVerifyDetachedOp #-}
+
+        anomaSignOp :: [Node] -> Node
+        anomaSignOp = checkApply $ \arg1 arg2 ->
+          if
+              | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
+                  mkBuiltinApp' OpAnomaSign (eval' env <$> [arg1, arg2])
+              | otherwise ->
+                  err "unsupported builtin operation: OpAnomaSign"
+        {-# INLINE anomaSignOp #-}
 
         poseidonHashOp :: [Node] -> Node
         poseidonHashOp = unary $ \arg ->

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -195,6 +195,7 @@ geval opts herr ctx env0 = eval' env0
       OpAnomaDecode -> anomaDecodeOp
       OpAnomaVerifyDetached -> anomaVerifyDetachedOp
       OpAnomaSign -> anomaSignOp
+      OpAnomaVerify -> anomaVerifyOp
       OpPoseidonHash -> poseidonHashOp
       OpEc -> ecOp
       OpRandomEcPoint -> randomEcPointOp
@@ -376,6 +377,15 @@ geval opts herr ctx env0 = eval' env0
               | otherwise ->
                   err "unsupported builtin operation: OpAnomaSign"
         {-# INLINE anomaSignOp #-}
+
+        anomaVerifyOp :: [Node] -> Node
+        anomaVerifyOp = checkApply $ \arg1 arg2 ->
+          if
+              | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
+                  mkBuiltinApp' OpAnomaVerify (eval' env <$> [arg1, arg2])
+              | otherwise ->
+                  err "unsupported builtin operation: OpAnomaVerify"
+        {-# INLINE anomaVerifyOp #-}
 
         poseidonHashOp :: [Node] -> Node
         poseidonHashOp = unary $ \arg ->

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -427,6 +427,7 @@ builtinOpArgTypes = \case
   OpAnomaEncode -> [mkDynamic']
   OpAnomaDecode -> [mkDynamic']
   OpAnomaVerifyDetached -> [mkDynamic', mkDynamic', mkDynamic']
+  OpAnomaSign -> [mkDynamic', mkDynamic']
   OpPoseidonHash -> [mkDynamic']
   OpEc -> [mkDynamic', mkTypeField', mkDynamic']
   OpRandomEcPoint -> []

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -428,6 +428,7 @@ builtinOpArgTypes = \case
   OpAnomaDecode -> [mkDynamic']
   OpAnomaVerifyDetached -> [mkDynamic', mkDynamic', mkDynamic']
   OpAnomaSign -> [mkDynamic', mkDynamic']
+  OpAnomaVerify -> [mkDynamic', mkDynamic']
   OpPoseidonHash -> [mkDynamic']
   OpEc -> [mkDynamic', mkTypeField', mkDynamic']
   OpRandomEcPoint -> []

--- a/src/Juvix/Compiler/Core/Language/Builtins.hs
+++ b/src/Juvix/Compiler/Core/Language/Builtins.hs
@@ -30,6 +30,7 @@ data BuiltinOp
   | OpAnomaEncode
   | OpAnomaDecode
   | OpAnomaVerifyDetached
+  | OpAnomaSign
   | OpPoseidonHash
   | OpEc
   | OpRandomEcPoint
@@ -77,6 +78,7 @@ builtinOpArgsNum = \case
   OpAnomaEncode -> 1
   OpAnomaDecode -> 1
   OpAnomaVerifyDetached -> 3
+  OpAnomaSign -> 2
   OpPoseidonHash -> 1
   OpEc -> 3
   OpRandomEcPoint -> 0
@@ -117,6 +119,7 @@ builtinIsFoldable = \case
   OpAnomaEncode -> False
   OpAnomaDecode -> False
   OpAnomaVerifyDetached -> False
+  OpAnomaSign -> False
   OpPoseidonHash -> False
   OpEc -> False
   OpRandomEcPoint -> False
@@ -134,4 +137,10 @@ builtinsCairo :: [BuiltinOp]
 builtinsCairo = [OpPoseidonHash, OpEc, OpRandomEcPoint]
 
 builtinsAnoma :: [BuiltinOp]
-builtinsAnoma = [OpAnomaGet, OpAnomaEncode, OpAnomaDecode, OpAnomaVerifyDetached]
+builtinsAnoma =
+  [ OpAnomaGet,
+    OpAnomaEncode,
+    OpAnomaDecode,
+    OpAnomaVerifyDetached,
+    OpAnomaSign
+  ]

--- a/src/Juvix/Compiler/Core/Language/Builtins.hs
+++ b/src/Juvix/Compiler/Core/Language/Builtins.hs
@@ -31,6 +31,7 @@ data BuiltinOp
   | OpAnomaDecode
   | OpAnomaVerifyDetached
   | OpAnomaSign
+  | OpAnomaVerify
   | OpPoseidonHash
   | OpEc
   | OpRandomEcPoint
@@ -79,6 +80,7 @@ builtinOpArgsNum = \case
   OpAnomaDecode -> 1
   OpAnomaVerifyDetached -> 3
   OpAnomaSign -> 2
+  OpAnomaVerify -> 2
   OpPoseidonHash -> 1
   OpEc -> 3
   OpRandomEcPoint -> 0
@@ -120,6 +122,7 @@ builtinIsFoldable = \case
   OpAnomaDecode -> False
   OpAnomaVerifyDetached -> False
   OpAnomaSign -> False
+  OpAnomaVerify -> False
   OpPoseidonHash -> False
   OpEc -> False
   OpRandomEcPoint -> False
@@ -142,5 +145,6 @@ builtinsAnoma =
     OpAnomaEncode,
     OpAnomaDecode,
     OpAnomaVerifyDetached,
-    OpAnomaSign
+    OpAnomaSign,
+    OpAnomaVerify
   ]

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -56,6 +56,7 @@ instance PrettyCode BuiltinOp where
     OpAnomaEncode -> return primAnomaEncode
     OpAnomaDecode -> return primAnomaDecode
     OpAnomaVerifyDetached -> return primAnomaVerifyDetached
+    OpAnomaSign -> return primAnomaSign
     OpPoseidonHash -> return primPoseidonHash
     OpEc -> return primEc
     OpRandomEcPoint -> return primRandomEcPoint
@@ -812,6 +813,9 @@ primAnomaDecode = primitive Str.anomaDecode
 
 primAnomaVerifyDetached :: Doc Ann
 primAnomaVerifyDetached = primitive Str.anomaVerifyDetached
+
+primAnomaSign :: Doc Ann
+primAnomaSign = primitive Str.anomaSign
 
 primPoseidonHash :: Doc Ann
 primPoseidonHash = primitive Str.cairoPoseidon

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -57,6 +57,7 @@ instance PrettyCode BuiltinOp where
     OpAnomaDecode -> return primAnomaDecode
     OpAnomaVerifyDetached -> return primAnomaVerifyDetached
     OpAnomaSign -> return primAnomaSign
+    OpAnomaVerify -> return primAnomaVerify
     OpPoseidonHash -> return primPoseidonHash
     OpEc -> return primEc
     OpRandomEcPoint -> return primRandomEcPoint
@@ -816,6 +817,9 @@ primAnomaVerifyDetached = primitive Str.anomaVerifyDetached
 
 primAnomaSign :: Doc Ann
 primAnomaSign = primitive Str.anomaSign
+
+primAnomaVerify :: Doc Ann
+primAnomaVerify = primitive Str.anomaVerify
 
 primPoseidonHash :: Doc Ann
 primPoseidonHash = primitive Str.cairoPoseidon

--- a/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
+++ b/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
@@ -70,6 +70,7 @@ computeNodeTypeInfo md = umapL go
           OpAnomaEncode -> Info.getNodeType node
           OpAnomaDecode -> Info.getNodeType node
           OpAnomaVerifyDetached -> Info.getNodeType node
+          OpAnomaSign -> Info.getNodeType node
           OpPoseidonHash -> case _builtinAppArgs of
             [arg] -> Info.getNodeType arg
             _ -> error "incorrect poseidon builtin application"

--- a/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
+++ b/src/Juvix/Compiler/Core/Transformation/ComputeTypeInfo.hs
@@ -71,6 +71,7 @@ computeNodeTypeInfo md = umapL go
           OpAnomaDecode -> Info.getNodeType node
           OpAnomaVerifyDetached -> Info.getNodeType node
           OpAnomaSign -> Info.getNodeType node
+          OpAnomaVerify -> Info.getNodeType node
           OpPoseidonHash -> case _builtinAppArgs of
             [arg] -> Info.getNodeType arg
             _ -> error "incorrect poseidon builtin application"

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -580,6 +580,7 @@ goAxiomInductive a = whenJust (a ^. Internal.axiomBuiltin) builtinInductive
       Internal.BuiltinAnomaEncode -> return ()
       Internal.BuiltinAnomaDecode -> return ()
       Internal.BuiltinAnomaVerifyDetached -> return ()
+      Internal.BuiltinAnomaSign -> return ()
       Internal.BuiltinPoseidon -> return ()
       Internal.BuiltinEcOp -> return ()
       Internal.BuiltinRandomEcPoint -> return ()
@@ -713,7 +714,6 @@ goAxiomDef a = maybe goAxiomNotBuiltin builtinBody (a ^. Internal.axiomBuiltin)
               mkSmallUniv
               (mkLambda' natType (mkBuiltinApp' OpAnomaDecode [mkVar' 0]))
           )
-      -- ((ftype ==% (u <>--> nat --> decodeT --> nat --> bool_)) freeVars)
       Internal.BuiltinAnomaVerifyDetached -> do
         natType <- getNatType
         registerAxiomDef
@@ -727,6 +727,19 @@ goAxiomDef a = maybe goAxiomNotBuiltin builtinBody (a ^. Internal.axiomBuiltin)
                           natType
                           (mkBuiltinApp' OpAnomaVerifyDetached [mkVar' 2, mkVar' 1, mkVar' 0])
                       )
+                  )
+              )
+          )
+      Internal.BuiltinAnomaSign -> do
+        natType <- getNatType
+        registerAxiomDef
+          ( mkLambda'
+              mkSmallUniv
+              ( mkLambda'
+                  (mkVar' 0)
+                  ( mkLambda'
+                      natType
+                      (mkBuiltinApp' OpAnomaSign [mkVar' 1, mkVar' 0])
                   )
               )
           )
@@ -1137,6 +1150,7 @@ goApplication a = do
         Just Internal.BuiltinAnomaEncode -> app
         Just Internal.BuiltinAnomaDecode -> app
         Just Internal.BuiltinAnomaVerifyDetached -> app
+        Just Internal.BuiltinAnomaSign -> app
         Just Internal.BuiltinPoseidon -> app
         Just Internal.BuiltinEcOp -> app
         Just Internal.BuiltinRandomEcPoint -> app

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -581,6 +581,7 @@ goAxiomInductive a = whenJust (a ^. Internal.axiomBuiltin) builtinInductive
       Internal.BuiltinAnomaDecode -> return ()
       Internal.BuiltinAnomaVerifyDetached -> return ()
       Internal.BuiltinAnomaSign -> return ()
+      Internal.BuiltinAnomaVerify -> return ()
       Internal.BuiltinPoseidon -> return ()
       Internal.BuiltinEcOp -> return ()
       Internal.BuiltinRandomEcPoint -> return ()
@@ -740,6 +741,19 @@ goAxiomDef a = maybe goAxiomNotBuiltin builtinBody (a ^. Internal.axiomBuiltin)
                   ( mkLambda'
                       natType
                       (mkBuiltinApp' OpAnomaSign [mkVar' 1, mkVar' 0])
+                  )
+              )
+          )
+      Internal.BuiltinAnomaVerify -> do
+        natType <- getNatType
+        registerAxiomDef
+          ( mkLambda'
+              mkSmallUniv
+              ( mkLambda'
+                  natType
+                  ( mkLambda'
+                      natType
+                      (mkBuiltinApp' OpAnomaVerify [mkVar' 1, mkVar' 0])
                   )
               )
           )
@@ -1151,6 +1165,7 @@ goApplication a = do
         Just Internal.BuiltinAnomaDecode -> app
         Just Internal.BuiltinAnomaVerifyDetached -> app
         Just Internal.BuiltinAnomaSign -> app
+        Just Internal.BuiltinAnomaVerify -> app
         Just Internal.BuiltinPoseidon -> app
         Just Internal.BuiltinEcOp -> app
         Just Internal.BuiltinRandomEcPoint -> app

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -100,6 +100,7 @@ fromCore fsize tab =
         BuiltinAnomaDecode -> False
         BuiltinAnomaVerifyDetached -> False
         BuiltinAnomaSign -> False
+        BuiltinAnomaVerify -> False
         BuiltinPoseidon -> False
         BuiltinEcOp -> False
         BuiltinRandomEcPoint -> False

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -99,6 +99,7 @@ fromCore fsize tab =
         BuiltinAnomaEncode -> False
         BuiltinAnomaDecode -> False
         BuiltinAnomaVerifyDetached -> False
+        BuiltinAnomaSign -> False
         BuiltinPoseidon -> False
         BuiltinEcOp -> False
         BuiltinRandomEcPoint -> False

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -573,6 +573,7 @@ registerBuiltinAxiom d = \case
   BuiltinAnomaDecode -> registerAnomaDecode d
   BuiltinAnomaVerifyDetached -> registerAnomaVerifyDetached d
   BuiltinAnomaSign -> registerAnomaSign d
+  BuiltinAnomaVerify -> registerAnomaVerify d
   BuiltinPoseidon -> registerPoseidon d
   BuiltinEcOp -> registerEcOp d
   BuiltinRandomEcPoint -> registerRandomEcPoint d

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -572,6 +572,7 @@ registerBuiltinAxiom d = \case
   BuiltinAnomaEncode -> registerAnomaEncode d
   BuiltinAnomaDecode -> registerAnomaDecode d
   BuiltinAnomaVerifyDetached -> registerAnomaVerifyDetached d
+  BuiltinAnomaSign -> registerAnomaSign d
   BuiltinPoseidon -> registerPoseidon d
   BuiltinEcOp -> registerEcOp d
   BuiltinRandomEcPoint -> registerRandomEcPoint d

--- a/src/Juvix/Compiler/Nockma/Encoding/Ed25519.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Ed25519.hs
@@ -1,0 +1,9 @@
+module Juvix.Compiler.Nockma.Encoding.Ed25519 where
+
+import Data.ByteString qualified as BS
+import Juvix.Prelude.Base
+
+-- | Remove the Ed25519 signature from a signed message.
+-- The signaure of an Ed25519 message is the first 64 bytes of the signed message.
+removeSignature :: ByteString -> ByteString
+removeSignature = BS.drop 64

--- a/src/Juvix/Compiler/Nockma/StdlibFunction.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction.hs
@@ -23,3 +23,4 @@ stdlibPath = \case
   StdlibEncode -> [nock| [9 22 0 3] |]
   StdlibDecode -> [nock| [9 94 0 3] |]
   StdlibVerifyDetached -> [nock| [9 22 0 1] |]
+  StdlibSign -> [nock| [9 10 0 1] |]

--- a/src/Juvix/Compiler/Nockma/StdlibFunction.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction.hs
@@ -24,3 +24,4 @@ stdlibPath = \case
   StdlibDecode -> [nock| [9 94 0 3] |]
   StdlibVerifyDetached -> [nock| [9 22 0 1] |]
   StdlibSign -> [nock| [9 10 0 1] |]
+  StdlibVerify -> [nock| [9 4 0 1] |]

--- a/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
@@ -17,6 +17,7 @@ instance Pretty StdlibFunction where
     StdlibEncode -> "encode"
     StdlibDecode -> "decode"
     StdlibVerifyDetached -> "verify-detached"
+    StdlibSign -> "sign"
 
 data StdlibFunction
   = StdlibDec
@@ -31,6 +32,7 @@ data StdlibFunction
   | StdlibEncode
   | StdlibDecode
   | StdlibVerifyDetached
+  | StdlibSign
   deriving stock (Show, Lift, Eq, Bounded, Enum, Generic)
 
 instance Hashable StdlibFunction

--- a/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
@@ -18,6 +18,7 @@ instance Pretty StdlibFunction where
     StdlibDecode -> "decode"
     StdlibVerifyDetached -> "verify-detached"
     StdlibSign -> "sign"
+    StdlibVerify -> "verify"
 
 data StdlibFunction
   = StdlibDec
@@ -33,6 +34,7 @@ data StdlibFunction
   | StdlibDecode
   | StdlibVerifyDetached
   | StdlibSign
+  | StdlibVerify
   deriving stock (Show, Lift, Eq, Bounded, Enum, Generic)
 
 instance Hashable StdlibFunction

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -428,6 +428,7 @@ compile = \case
         Tree.OpAnomaDecode -> return (goAnomaDecode args)
         Tree.OpAnomaVerifyDetached -> return (goAnomaVerifyDetached args)
         Tree.OpAnomaSign -> return (goAnomaSign args)
+        Tree.OpAnomaVerify -> return (goAnomaVerify args)
 
     goUnop :: Tree.NodeUnop -> Sem r (Term Natural)
     goUnop Tree.NodeUnop {..} = do
@@ -466,6 +467,11 @@ compile = \case
     goAnomaSign :: [Term Natural] -> Term Natural
     goAnomaSign = \case
       [message, privKey] -> callStdlib StdlibSign [goAnomaEncode [message], privKey]
+      _ -> impossible
+
+    goAnomaVerify :: [Term Natural] -> Term Natural
+    goAnomaVerify = \case
+      [signedMessage, pubKey] -> callStdlib StdlibDecode [callStdlib StdlibVerify [signedMessage, pubKey]]
       _ -> impossible
 
     goTrace :: Term Natural -> Sem r (Term Natural)

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -427,6 +427,7 @@ compile = \case
         Tree.OpAnomaEncode -> return (goAnomaEncode args)
         Tree.OpAnomaDecode -> return (goAnomaDecode args)
         Tree.OpAnomaVerifyDetached -> return (goAnomaVerifyDetached args)
+        Tree.OpAnomaSign -> return (goAnomaSign args)
 
     goUnop :: Tree.NodeUnop -> Sem r (Term Natural)
     goUnop Tree.NodeUnop {..} = do
@@ -460,6 +461,11 @@ compile = \case
     goAnomaVerifyDetached :: [Term Natural] -> Term Natural
     goAnomaVerifyDetached = \case
       [sig, message, pubKey] -> callStdlib StdlibVerifyDetached [sig, goAnomaEncode [message], pubKey]
+      _ -> impossible
+
+    goAnomaSign :: [Term Natural] -> Term Natural
+    goAnomaSign = \case
+      [message, privKey] -> callStdlib StdlibSign [goAnomaEncode [message], privKey]
       _ -> impossible
 
     goTrace :: Term Natural -> Sem r (Term Natural)

--- a/src/Juvix/Compiler/Tree/Keywords.hs
+++ b/src/Juvix/Compiler/Tree/Keywords.hs
@@ -13,6 +13,7 @@ import Juvix.Data.Keyword.All
     kwAnomaEncode,
     kwAnomaGet,
     kwAnomaSign,
+    kwAnomaVerify,
     kwAnomaVerifyDetached,
     kwArgsNum,
     kwAtoi,
@@ -82,6 +83,7 @@ allKeywords =
          kwAnomaEncode,
          kwAnomaVerifyDetached,
          kwAnomaSign,
+         kwAnomaVerify,
          kwPoseidon,
          kwEcOp,
          kwRandomEcPoint

--- a/src/Juvix/Compiler/Tree/Keywords.hs
+++ b/src/Juvix/Compiler/Tree/Keywords.hs
@@ -12,6 +12,7 @@ import Juvix.Data.Keyword.All
     kwAnomaDecode,
     kwAnomaEncode,
     kwAnomaGet,
+    kwAnomaSign,
     kwAnomaVerifyDetached,
     kwArgsNum,
     kwAtoi,
@@ -80,6 +81,7 @@ allKeywords =
          kwAnomaDecode,
          kwAnomaEncode,
          kwAnomaVerifyDetached,
+         kwAnomaSign,
          kwPoseidon,
          kwEcOp,
          kwRandomEcPoint

--- a/src/Juvix/Compiler/Tree/Language/Builtins.hs
+++ b/src/Juvix/Compiler/Tree/Language/Builtins.hs
@@ -58,4 +58,6 @@ data AnomaOp
     OpAnomaDecode
   | -- | Verify a cryptogtaphic signature of an Anoma value
     OpAnomaVerifyDetached
+  | -- | Cryptographically sign an Anoma value using a secret key
+    OpAnomaSign
   deriving stock (Eq)

--- a/src/Juvix/Compiler/Tree/Language/Builtins.hs
+++ b/src/Juvix/Compiler/Tree/Language/Builtins.hs
@@ -60,4 +60,6 @@ data AnomaOp
     OpAnomaVerifyDetached
   | -- | Cryptographically sign an Anoma value using a secret key
     OpAnomaSign
+  | -- | Verify a signature obtained from OpAnomaSign using a public key
+    OpAnomaVerify
   deriving stock (Eq)

--- a/src/Juvix/Compiler/Tree/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Tree/Pretty/Base.hs
@@ -246,6 +246,7 @@ instance PrettyCode AnomaOp where
     OpAnomaEncode -> Str.anomaEncode
     OpAnomaDecode -> Str.anomaDecode
     OpAnomaVerifyDetached -> Str.anomaVerifyDetached
+    OpAnomaSign -> Str.anomaSign
 
 instance PrettyCode UnaryOpcode where
   ppCode = \case

--- a/src/Juvix/Compiler/Tree/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Tree/Pretty/Base.hs
@@ -247,6 +247,7 @@ instance PrettyCode AnomaOp where
     OpAnomaDecode -> Str.anomaDecode
     OpAnomaVerifyDetached -> Str.anomaVerifyDetached
     OpAnomaSign -> Str.anomaSign
+    OpAnomaVerify -> Str.anomaVerify
 
 instance PrettyCode UnaryOpcode where
   ppCode = \case

--- a/src/Juvix/Compiler/Tree/Transformation/CheckNoAnoma.hs
+++ b/src/Juvix/Compiler/Tree/Transformation/CheckNoAnoma.hs
@@ -16,6 +16,7 @@ checkNoAnoma = walkT checkNode
         OpAnomaDecode -> unsupportedErr "OpAnomaDecode"
         OpAnomaVerifyDetached -> unsupportedErr "OpAnomaVerifyDetached"
         OpAnomaSign -> unsupportedErr "OpAnomaSign"
+        OpAnomaVerify -> unsupportedErr "OpAnomaVerify"
         where
           unsupportedErr :: Text -> Sem r ()
           unsupportedErr opName =

--- a/src/Juvix/Compiler/Tree/Transformation/CheckNoAnoma.hs
+++ b/src/Juvix/Compiler/Tree/Transformation/CheckNoAnoma.hs
@@ -15,6 +15,7 @@ checkNoAnoma = walkT checkNode
         OpAnomaEncode -> unsupportedErr "OpAnomaEncode"
         OpAnomaDecode -> unsupportedErr "OpAnomaDecode"
         OpAnomaVerifyDetached -> unsupportedErr "OpAnomaVerifyDetached"
+        OpAnomaSign -> unsupportedErr "OpAnomaSign"
         where
           unsupportedErr :: Text -> Sem r ()
           unsupportedErr opName =

--- a/src/Juvix/Compiler/Tree/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromCore.hs
@@ -318,6 +318,7 @@ genCode infoTable fi =
       Core.OpAnomaDecode -> OpAnomaDecode
       Core.OpAnomaVerifyDetached -> OpAnomaVerifyDetached
       Core.OpAnomaSign -> OpAnomaSign
+      Core.OpAnomaVerify -> OpAnomaVerify
       _ -> impossible
 
     getArgsNum :: Symbol -> Int

--- a/src/Juvix/Compiler/Tree/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromCore.hs
@@ -317,6 +317,7 @@ genCode infoTable fi =
       Core.OpAnomaEncode -> OpAnomaEncode
       Core.OpAnomaDecode -> OpAnomaDecode
       Core.OpAnomaVerifyDetached -> OpAnomaVerifyDetached
+      Core.OpAnomaSign -> OpAnomaSign
       _ -> impossible
 
     getArgsNum :: Symbol -> Int

--- a/src/Juvix/Compiler/Tree/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource.hs
@@ -128,6 +128,7 @@ parseAnoma =
     <|> parseAnoma' kwAnomaEncode OpAnomaEncode
     <|> parseAnoma' kwAnomaVerifyDetached OpAnomaVerifyDetached
     <|> parseAnoma' kwAnomaSign OpAnomaSign
+    <|> parseAnoma' kwAnomaVerify OpAnomaVerify
 
 parseAnoma' ::
   (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>

--- a/src/Juvix/Compiler/Tree/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource.hs
@@ -127,6 +127,7 @@ parseAnoma =
     <|> parseAnoma' kwAnomaDecode OpAnomaDecode
     <|> parseAnoma' kwAnomaEncode OpAnomaEncode
     <|> parseAnoma' kwAnomaVerifyDetached OpAnomaVerifyDetached
+    <|> parseAnoma' kwAnomaSign OpAnomaSign
 
 parseAnoma' ::
   (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -5,7 +5,6 @@ module Juvix.Data.Keyword.All
 where
 
 import Juvix.Data.Keyword
-import Juvix.Extra.Strings qualified as Std
 import Juvix.Extra.Strings qualified as Str
 
 kwAs :: Keyword
@@ -453,7 +452,10 @@ kwAnomaEncode :: Keyword
 kwAnomaEncode = asciiKw Str.anomaEncode
 
 kwAnomaVerifyDetached :: Keyword
-kwAnomaVerifyDetached = asciiKw Std.anomaVerifyDetached
+kwAnomaVerifyDetached = asciiKw Str.anomaVerifyDetached
+
+kwAnomaSign :: Keyword
+kwAnomaSign = asciiKw Str.anomaSign
 
 delimBraceL :: Keyword
 delimBraceL = mkDelim Str.braceL

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -457,6 +457,9 @@ kwAnomaVerifyDetached = asciiKw Str.anomaVerifyDetached
 kwAnomaSign :: Keyword
 kwAnomaSign = asciiKw Str.anomaSign
 
+kwAnomaVerify :: Keyword
+kwAnomaVerify = asciiKw Str.anomaVerify
+
 delimBraceL :: Keyword
 delimBraceL = mkDelim Str.braceL
 

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -338,6 +338,9 @@ anomaDecode = "anoma-decode"
 anomaVerifyDetached :: (IsString s) => s
 anomaVerifyDetached = "anoma-verify-detached"
 
+anomaSign :: (IsString s) => s
+anomaSign = "anoma-sign"
+
 builtinSeq :: (IsString s) => s
 builtinSeq = "seq"
 

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -341,6 +341,9 @@ anomaVerifyDetached = "anoma-verify-detached"
 anomaSign :: (IsString s) => s
 anomaSign = "anoma-sign"
 
+anomaVerify :: (IsString s) => s
+anomaVerify = "anoma-verify"
+
 builtinSeq :: (IsString s) => s
 builtinSeq = "seq"
 

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -568,5 +568,13 @@ allTests =
         []
         $ checkOutput
           [ [nock| true |]
-          ]
+          ],
+      let toSignAndVerify :: Term Natural = [nock| [1 2 nil] |]
+       in mkAnomaCallTest
+            "Test078: Anoma sign and verify"
+            $(mkRelDir ".")
+            $(mkRelFile "test078.juvix")
+            [OpQuote # toSignAndVerify]
+            $ checkOutput
+              [toSignAndVerify]
     ]

--- a/test/Tree/Transformation/CheckNoAnoma.hs
+++ b/test/Tree/Transformation/CheckNoAnoma.hs
@@ -75,5 +75,9 @@ tests =
     Eval.NegTest
       "anomaVerifyDetached"
       $(mkRelDir ".")
-      $(mkRelFile "test012.jvt")
+      $(mkRelFile "test012.jvt"),
+    Eval.NegTest
+      "anomaSign"
+      $(mkRelDir ".")
+      $(mkRelFile "test013.jvt")
   ]

--- a/test/Tree/Transformation/CheckNoAnoma.hs
+++ b/test/Tree/Transformation/CheckNoAnoma.hs
@@ -79,5 +79,9 @@ tests =
     Eval.NegTest
       "anomaSign"
       $(mkRelDir ".")
-      $(mkRelFile "test013.jvt")
+      $(mkRelFile "test013.jvt"),
+    Eval.NegTest
+      "anomaVerify"
+      $(mkRelDir ".")
+      $(mkRelFile "test014.jvt")
   ]

--- a/tests/Anoma/Compilation/positive/test078.juvix
+++ b/tests/Anoma/Compilation/positive/test078.juvix
@@ -1,0 +1,17 @@
+module test078;
+
+import Stdlib.Prelude open;
+
+builtin anoma-sign
+axiom anomaSign : {A : Type} -> A -> Nat -> Nat;
+
+builtin anoma-verify
+axiom anomaVerify : {A : Type} -> Nat -> Nat -> A;
+
+privKey : Nat :=
+  0x3181f891cd2323ffe802dd8f36f7e77cd072e3bd8f49884e8b38a297646351e9015535fa1125ec092c85758756d51bf29eed86a118942135c1657bf4cb5c6fc9;
+
+pubKey : Nat :=
+  0x3181f891cd2323ffe802dd8f36f7e77cd072e3bd8f49884e8b38a297646351e9;
+
+main (input : List Nat) : List Nat := anomaVerify (anomaSign input privKey) pubKey;

--- a/tests/Tree/negative/test013.jvt
+++ b/tests/Tree/negative/test013.jvt
@@ -1,5 +1,5 @@
 -- calling unsupported anoma-sign
 
 function main() : * {
-  anoma-verify-sign(1,2)
+  anoma-sign(1,2)
 }

--- a/tests/Tree/negative/test013.jvt
+++ b/tests/Tree/negative/test013.jvt
@@ -1,0 +1,5 @@
+-- calling unsupported anoma-sign
+
+function main() : * {
+  anoma-verify-sign(1,2)
+}

--- a/tests/Tree/negative/test014.jvt
+++ b/tests/Tree/negative/test014.jvt
@@ -1,0 +1,5 @@
+-- calling unsupported anoma-verify
+
+function main() : * {
+  anoma-verify(1,2)
+}


### PR DESCRIPTION
This PR adds support for the Anoma stdlib `sign` and `verify` APIs.

```
builtin anoma-sign
axiom anomaSign : {A : Type}
  -- message to sign
  -> A
  -- secret key
  -> Nat
  -- signed message
  -> Nat;

builtin anoma-verify
axiom anomaVerify : {A : Type}
  -- signed message to verify 
  -> Nat 
  -- public key
  -> Nat 
  -- message with signature removed
  -> A;
```

These correspond to the [`sign`](https://hexdocs.pm/enacl/enacl.html#sign-2) and [`sign_open`](https://hexdocs.pm/enacl/enacl.html#sign_open-2) APIs from libsodium respectively.

If signature verification fails in `anomaVerify`, the Anoma program exits. We copy this behaviour in the evaluator by throwing an error in this case.

## Notes

The Haskell Ed25519 library does not support `sign_open`. Its verification function returns Bool, i.e it checks that the signature is valid. The signed message is simply the concatenation of the signature (64 bytes) and the original message so I added a function to remove the signature from a signed message.