### PR TITLE
Add support for Strings in the Anoma backend

### DIFF
--- a/src/Juvix/Compiler/Core/Transformation/Check/Anoma.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Check/Anoma.hs
@@ -10,4 +10,4 @@ checkAnoma md = do
   checkMainExists md
   checkNoAxioms md
   mapAllNodesM checkNoIO md
-  mapAllNodesM (checkBuiltins' (builtinsString ++ builtinsCairo) [PrimString, PrimField]) md
+  mapAllNodesM (checkBuiltins' ([OpStrToInt, OpShow] ++ builtinsCairo) [PrimField]) md

--- a/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
@@ -6,15 +6,43 @@ import Juvix.Compiler.Nockma.Language
 import Juvix.Prelude.Base
 
 atomToByteString :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Atom a -> Sem r ByteString
-atomToByteString am = do
-  n <- nockNatural am
-  return (cloneToByteString . integerToVectorBits . toInteger $ n)
+atomToByteString = fmap naturalToByteString . nockNatural
 
 byteStringToAtom :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => ByteString -> Sem r (Atom a)
-byteStringToAtom bs = do
-  a <- fromNatural . fromInteger . vectorBitsToInteger . cloneFromByteString $ bs
-  return
-    Atom
-      { _atomInfo = emptyAtomInfo,
-        _atom = a
-      }
+byteStringToAtom = fmap mkEmptyAtom . fromNatural . byteStringToNatural
+
+byteStringToNatural :: ByteString -> Natural
+byteStringToNatural = bitsToNatural . cloneFromByteString
+
+naturalToByteString :: Natural -> ByteString
+naturalToByteString = cloneToByteString . naturalToBits
+
+textToNatural :: Text -> Natural
+textToNatural = byteStringToNatural . encodeUtf8
+
+bitsToNatural :: Vector Bit -> Natural
+bitsToNatural = fromInteger . vectorBitsToInteger
+
+naturalToBits :: Natural -> Vector Bit
+naturalToBits = integerToVectorBits . toInteger
+
+atomToText :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Atom a -> Sem r Text
+atomToText = fmap decodeUtf8Lenient . atomToByteString
+
+-- | Construct an atom formed by concatenating the bits of two atoms, where each atom represents a sequence of bytes
+atomConcatenateBytes :: forall a r. (NockNatural a, Member (Error (ErrNockNatural a)) r) => Atom a -> Atom a -> Sem r (Atom a)
+atomConcatenateBytes l r = do
+  -- cloneToByteString ensures that the bytestring is zero-padded up to the byte boundary
+  lBs <- cloneToByteString <$> atomToBits l
+  rBs <- cloneToByteString <$> atomToBits r
+  byteStringToAtom (lBs <> rBs)
+  where
+    atomToBits :: Atom a -> Sem r (Vector Bit)
+    atomToBits = fmap naturalToBits . nockNatural
+
+mkEmptyAtom :: a -> Atom a
+mkEmptyAtom x =
+  Atom
+    { _atomInfo = emptyAtomInfo,
+      _atom = x
+    }

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -247,7 +247,13 @@ evalProfile inistack initerm =
             StdlibVerify -> case args' of
               TCell (TermAtom signedMessage) (TermAtom pubKey) -> goVerify signedMessage pubKey
               _ -> error "expected a term of the form [signedMessage (atom) public_key (atom)]"
+            StdlibCatBytes -> case args' of
+              TCell (TermAtom arg1) (TermAtom arg2) -> goCat arg1 arg2
+              _ -> error "expected a term with two atoms"
           where
+            goCat :: Atom a -> Atom a -> Sem r (Term a)
+            goCat arg1 arg2 = TermAtom . setAtomHint AtomHintString <$> atomConcatenateBytes arg1 arg2
+
             goVerifyDetached :: Atom a -> Atom a -> Atom a -> Sem r (Term a)
             goVerifyDetached sigT messageT pubKeyT = do
               sig <- Signature <$> atomToByteString sigT

--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -122,6 +122,7 @@ data AtomHint
   | AtomHintNil
   | AtomHintVoid
   | AtomHintFunctionsPlaceholder
+  | AtomHintString
   deriving stock (Show, Eq, Lift, Generic)
 
 instance Hashable AtomHint
@@ -345,6 +346,9 @@ atomHintInfo h =
   emptyAtomInfo
     { _atomInfoHint = Just h
     }
+
+setAtomHint :: AtomHint -> Atom a -> Atom a
+setAtomHint h = set (atomInfo . atomInfoHint) (Just h)
 
 class IsNock nock where
   toNock :: nock -> Term Natural

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -5,6 +5,7 @@ module Juvix.Compiler.Nockma.Pretty.Base
   )
 where
 
+import Juvix.Compiler.Nockma.Encoding.ByteString (atomToText)
 import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Pretty.Options
 import Juvix.Data.CodeAnn
@@ -23,7 +24,7 @@ class PrettyCode c where
 runPrettyCode :: (PrettyCode c) => Options -> c -> Doc Ann
 runPrettyCode opts = run . runReader opts . ppCode
 
-instance (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
+instance forall a. (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
   ppCode atm = do
     t <- runFail $ do
       failWhenM (asks (^. optIgnoreTags))
@@ -43,6 +44,10 @@ instance (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
           AtomHintNil -> return (annotate (AnnKind KNameConstructor) Str.nil)
           AtomHintVoid -> return (annotate (AnnKind KNameAxiom) Str.void)
           AtomHintFunctionsPlaceholder -> return (annotate (AnnKind KNameAxiom) Str.functionsPlaceholder)
+          AtomHintString -> atomToText atm >>= ppCode
+
+instance PrettyCode Text where
+  ppCode = return . dquotes . pretty
 
 instance PrettyCode Interval where
   ppCode = return . pretty

--- a/src/Juvix/Compiler/Nockma/StdlibFunction.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction.hs
@@ -25,3 +25,10 @@ stdlibPath = \case
   StdlibVerifyDetached -> [nock| [9 22 0 1] |]
   StdlibSign -> [nock| [9 10 0 1] |]
   StdlibVerify -> [nock| [9 4 0 1] |]
+  -- Obtained from the urbit dojo using:
+  --
+  -- =>  anoma  !=(~(cat block 3))
+  --
+  -- The `3` here is because we want to treat each atom as sequences of 2^3
+  -- bits, i.e bytes.
+  StdlibCatBytes -> [nock| [8 [9 10 0 7] 9 4 10 [6 7 [0 3] 1 3] 0 2] |]

--- a/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
@@ -19,6 +19,7 @@ instance Pretty StdlibFunction where
     StdlibVerifyDetached -> "verify-detached"
     StdlibSign -> "sign"
     StdlibVerify -> "verify"
+    StdlibCatBytes -> "cat"
 
 data StdlibFunction
   = StdlibDec
@@ -35,6 +36,7 @@ data StdlibFunction
   | StdlibVerifyDetached
   | StdlibSign
   | StdlibVerify
+  | StdlibCatBytes
   deriving stock (Show, Lift, Eq, Bounded, Enum, Generic)
 
 instance Hashable StdlibFunction

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -576,5 +576,12 @@ allTests =
             $(mkRelFile "test078.juvix")
             [OpQuote # toSignAndVerify]
             $ checkOutput
-              [toSignAndVerify]
+              [toSignAndVerify],
+      let inputStr :: Term Natural = [nock| "Juvix!" |]
+       in mkAnomaCallTest
+            "Test079: Strings"
+            $(mkRelDir ".")
+            $(mkRelFile "test079.juvix")
+            [OpQuote # inputStr]
+            $ checkOutput [[nock| "Juvix! ✨ héllo world ✨" |]]
     ]

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -268,7 +268,8 @@ juvixCallingConventionTests =
                res :: Term Natural = foldTerms (toNock <$> r)
                lenR :: Term Natural = nockIntegralLiteral (length r)
                tupR = OpQuote # foldTerms (toNock <$> r)
-            in compilerTest "appendToTuple (left empty, right-nonempty)" (appendToTuple (OpQuote # nockNilTagged "test-appendtotuple") (nockNatLiteral 0) tupR lenR) (eqNock res)
+            in compilerTest "appendToTuple (left empty, right-nonempty)" (appendToTuple (OpQuote # nockNilTagged "test-appendtotuple") (nockNatLiteral 0) tupR lenR) (eqNock res),
+           compilerTest "stdlib cat" (callStdlib StdlibCatBytes [nockNatLiteral 2, nockNatLiteral 1]) (eqNock [nock| 258 |])
          ]
 
 unitTests :: [Test]

--- a/tests/Anoma/Compilation/negative/String.juvix
+++ b/tests/Anoma/Compilation/negative/String.juvix
@@ -2,4 +2,4 @@ module String;
 
 import Stdlib.Prelude open;
 
-main : String := "boom";
+main : String := intToString 1;

--- a/tests/Anoma/Compilation/positive/test079.juvix
+++ b/tests/Anoma/Compilation/positive/test079.juvix
@@ -1,0 +1,6 @@
+module test079;
+
+import Stdlib.Prelude open;
+
+main (s : String) : String :=
+  s ++str " " ++str "✨ héllo" ++str " " ++str "world ✨";


### PR DESCRIPTION
This PR adds support for the `String` type, String literals and string concatenation to the Nockma backend. Support for the builtins `show` and `intToString` is not supported.

### Example

test079.juvix
```
module test079;

import Stdlib.Prelude open;

main (s : String) : String :=
  s ++str " " ++str "✨ héllo" ++str " " ++str "world ✨";
```

args.nockma
```
[quote "Juvix!"]
```

```
$ juvix compile anoma test079.juvix
$ juvix dev nockma run test079.pretty.nockma --args args.nockma
"Juvix! ✨ héllo world ✨"
```

### String representation

A String is a sequence of UTF-8 encoded bytes. We interpret these bytes as a sequence of bits to represent the string as an integer atom in nockma.

For example:

The string `"a"` is UTF-8 encoded as `97` which is `0b1100001` in bits.

The string `"ab"` is UTF-8 encoded at the pair of bytes: `97 98` which is `0b1100001 0b1100010`. 

When we combine the bytes into a single sequence of bits we must take care to pad each binary representation with zeros to each byte boundary.

So the binary representation of `"ab"` as an atom is `0b110000101100010` or `24930` as an integer atom.

### String concatenation

We use the [cat](https://github.com/anoma/anoma/blob/ea25f88cea52226d77c8392ae16bbfc5a7ffccee/hoon/anoma.hoon#L215) function in the Anoma stdlib to concatenate the bytes representing two strings.

We need to use the block parameter `3` in the Anoma call because we want to treat the atoms representing the strings as sequences of bytes (= 2^3 bits).

To find the relevant Nock code to call `cat` with block parameter `3` we use the urbit dojo as follows:

```
 =>  anoma  !=(~(cat block 3))
[8 [9 10 0 7] 9 4 10 [6 7 [0 3] 1 3] 0 2]
```

### Stdlib intercept in Evaluator

The evaluator has support for strings using `AtomHint`s, so strings can be printed and traced. The stdlib `cat` call is also intercepted because evaluating the unjetted hoon version is slow.  

### String support in pretty nockma

In a pretty nockma file or `nock` quasi-quote you can write double quoted string literals, e.g "abc". These are automatically translated to UTF-8 integer atoms as in the previous section.