### PR TITLE
Report proper location for normalized types in the `WrongType` error

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -5,7 +5,6 @@ module Juvix.Compiler.Concrete.Translation.ImportScanner.FlatParse
 where
 
 import Juvix.Compiler.Concrete.Translation.ImportScanner.Base
-import Juvix.Data.Keyword (reservedSymbols)
 import Juvix.Extra.Strings qualified as Str
 import Juvix.Prelude
 import Juvix.Prelude.FlatParse hiding (Pos)

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -362,7 +362,7 @@ goType ::
   Sem r Type
 goType ty = do
   normTy <- InternalTyped.strongNormalize'' ty
-  squashApps <$> goExpression normTy
+  squashApps <$> goExpression (normTy ^. Internal.normalizedExpression)
 
 mkFunBody ::
   forall r.

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -428,6 +428,12 @@ newtype ModuleIndex = ModuleIndex
   }
   deriving stock (Data)
 
+-- | An expression that maybe has been normalized
+data NormalizedExpression = NormalizedExpression
+  { _normalizedExpression :: Expression,
+    _normalizedExpressionOriginal :: Expression
+  }
+
 makeLenses ''ModuleIndex
 makeLenses ''ArgInfo
 makeLenses ''WildcardConstructor
@@ -454,6 +460,10 @@ makeLenses ''FunctionParameter
 makeLenses ''InductiveParameter
 makeLenses ''ConstructorDef
 makeLenses ''ConstructorApp
+makeLenses ''NormalizedExpression
+
+instance HasLoc NormalizedExpression where
+  getLoc = getLoc . (^. normalizedExpressionOriginal)
 
 instance Eq ModuleIndex where
   (==) = (==) `on` (^. moduleIxModule . moduleName)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -38,7 +38,7 @@ typeCheckExpressionType exp = do
     . mapError (JuvixError @TypeCheckerError)
     . runInferenceDef
     $ inferExpression Nothing exp
-      >>= traverseOf typedType strongNormalize
+      >>= traverseOf typedType strongNormalize_
 
 typeCheckExpression ::
   (Members '[Error JuvixError, State Artifacts, Termination] r) =>

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
@@ -64,7 +64,7 @@ checkStrictlyPositiveOccurrences ::
   CheckPositivityArgs ->
   Sem r ()
 checkStrictlyPositiveOccurrences p = do
-  typeOfConstr <- strongNormalize (p ^. checkPositivityArgsTypeOfConstructor)
+  typeOfConstr <- strongNormalize_ (p ^. checkPositivityArgsTypeOfConstructor)
   go False typeOfConstr
   where
     indInfo = p ^. checkPositivityArgsInductive

--- a/src/Juvix/Data.hs
+++ b/src/Juvix/Data.hs
@@ -19,6 +19,7 @@ module Juvix.Data
     module Juvix.Data.WithLoc,
     module Juvix.Data.WithSource,
     module Juvix.Data.DependencyInfo,
+    module Juvix.Data.Keyword,
   )
 where
 
@@ -32,6 +33,7 @@ import Juvix.Data.Hole
 import Juvix.Data.InstanceHole
 import Juvix.Data.Irrelevant
 import Juvix.Data.IsImplicit
+import Juvix.Data.Keyword
 import Juvix.Data.Loc
 import Juvix.Data.NameId qualified
 import Juvix.Data.NumThreads


### PR DESCRIPTION
There is currently no automated way to test this. One can manually check that when trying to typecheck `tests/negative/issue2771/Main.juvix/` the error location is wrong:
![image](https://github.com/anoma/juvix/assets/5511599/1be986d8-a045-424e-bfdb-2ea4a695b31a)

That is now fixed:
![image](https://github.com/anoma/juvix/assets/5511599/2ee62034-6485-4c03-934b-a20f90878db3)


