### PR TITLE
Disable macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,7 @@ jobs:
 
   build-and-test-macos:
     runs-on: macos-14
+    if: false
     steps:
       - uses: extractions/setup-just@v2
 


### PR DESCRIPTION
It's failing because of rate limits exceeded when installing RISC0 VM. We should disable the macOS CI until we figure out how to reliably get around this problem.