### PR TITLE
Fix Rust toolchain caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,27 +135,18 @@ jobs:
           path: ${{ env.HOME }}/.local/bin/juvix-cairo-vm
           key: ${{ runner.os }}-cairo-vm-${{ env.CAIRO_VM_VERSION }}
 
-      - name: Cache RISC0 VM
-        id: cache-risc0-vm
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.HOME }}/.local/bin/r0vm
-          key: ${{ runner.os }}-risc0-vm-${{ env.RISC0_VM_VERSION }}
-
       - name: Install Rust toolchain
-        if: steps.cache-cairo-vm.outputs.cache-hit != 'true' || steps.cache-risc0-vm.outputs.cache-hit != 'true'
+        if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-on-failure: false
 
       - name: Install RISC0 VM
-        if: steps.cache-risc0-vm.outputs.cache-hit != 'true'
         shell: bash
         run: |
           cargo install cargo-binstall --force
           cargo binstall cargo-risczero@1.0.1 --no-confirm --force
           cargo risczero install
-          cp `which r0vm` $HOME/.local/bin/r0vm
 
       - name: Checkout CairoVM
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the error in the Rust toolchain caching by setting `cache-on-failure` to false for the `setup-rust-toolchain` action.
