### PR TITLE
Update ormolu to 0.7.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: mrkkrp/ormolu-action@v11
+      - uses: mrkkrp/ormolu-action@v15
         with:
-          version: 0.5.3.0
+          version: 0.7.4.0
           extra-args: >-
             --ghc-opt -XDerivingStrategies
             --ghc-opt -XImportQualifiedPost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,6 @@ jobs:
       - uses: mrkkrp/ormolu-action@v15
         with:
           version: 0.7.4.0
-          extra-args: >-
-            --ghc-opt -XDerivingStrategies
-            --ghc-opt -XImportQualifiedPost
-            --ghc-opt -XMultiParamTypeClasses
-            --ghc-opt -XPatternSynonyms
-            --ghc-opt -XStandaloneDeriving
-            --ghc-opt -XTemplateHaskell
-            --ghc-opt -XUnicodeSyntax
-            --ghc-opt -XBangPatterns
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install hpack
-        run: sudo apt install -y haskell-hpack
+        run: sudo apt install -y hpack
 
       - name: Generate juvix.cabal
         run: hpack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install hpack
+        run: sudo apt install -y haskell-hpack
+
+      - name: Generate juvix.cabal
+        run: hpack
+
       - uses: mrkkrp/ormolu-action@v15
         with:
           version: 0.7.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: mrkkrp/ormolu-action@v15
         with:
           version: 0.7.4.0
+          respect-cabal-files: true
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/app/App.hs
+++ b/app/App.hs
@@ -156,8 +156,8 @@ getEntryPoint' RunAppIOArgs {..} inputFile = do
       root = _runAppIOArgsRoot
   estdin <-
     if
-        | opts ^. globalStdin -> Just <$> liftIO getContents
-        | otherwise -> return Nothing
+      | opts ^. globalStdin -> Just <$> liftIO getContents
+      | otherwise -> return Nothing
   mainFile <- getMainAppFileMaybe inputFile
   set entryPointStdin estdin <$> entryPointFromGlobalOptionsPre root ((^. pathPath) <$> mainFile) opts
 
@@ -178,8 +178,8 @@ getEntryPointStdin' RunAppIOArgs {..} = do
       root = _runAppIOArgsRoot
   estdin <-
     if
-        | opts ^. globalStdin -> Just <$> liftIO getContents
-        | otherwise -> return Nothing
+      | opts ^. globalStdin -> Just <$> liftIO getContents
+      | otherwise -> return Nothing
   set entryPointStdin estdin <$> entryPointFromGlobalOptionsNoFile root opts
 
 fromRightGenericError :: (Members '[App] r, ToGenericError err, Typeable err) => Either err a -> Sem r a
@@ -237,8 +237,8 @@ appRunProgressLog m = do
             _progressLogOptionsShowThreadId = g ^. globalDevShowThreadIds
           }
   if
-      | g ^. globalOnlyErrors -> ignoreProgressLog m
-      | otherwise -> runProgressLogIO opts m
+    | g ^. globalOnlyErrors -> ignoreProgressLog m
+    | otherwise -> runProgressLogIO opts m
 
 runPipelineNoOptions ::
   (Members '[App, EmbedIO, TaggedLock] r) =>
@@ -274,15 +274,15 @@ runPipelineHtml ::
   Maybe (AppPath File) ->
   Sem r (InternalTypedResult, [InternalTypedResult])
 runPipelineHtml bNonRecursive input_ =
-  appRunProgressLog $
-    if
-        | bNonRecursive -> do
-            r <- runPipelineNoOptions input_ upToInternalTyped
-            return (r, [])
-        | otherwise -> do
-            args <- askArgs
-            entry <- getEntryPoint' args input_
-            runReader defaultPipelineOptions (runPipelineHtmlEither entry) >>= fromRightJuvixError
+  appRunProgressLog
+    $ if
+      | bNonRecursive -> do
+          r <- runPipelineNoOptions input_ upToInternalTyped
+          return (r, [])
+      | otherwise -> do
+          args <- askArgs
+          entry <- getEntryPoint' args input_
+          runReader defaultPipelineOptions (runPipelineHtmlEither entry) >>= fromRightJuvixError
 
 runPipelineOptions :: (Members '[App] r) => Sem (Reader PipelineOptions ': r) a -> Sem r a
 runPipelineOptions m = do

--- a/app/Commands/Compile/Anoma.hs
+++ b/app/Commands/Compile/Anoma.hs
@@ -20,7 +20,8 @@ runCommand opts = do
     runReader entryPoint
       . runError @JuvixError
       . coreToAnoma
-      $ coreRes ^. coreResultModule
+      $ coreRes
+      ^. coreResultModule
   res <- getRight r
   outputAnomaResult nockmaFile res
 

--- a/app/Commands/Compile/CStage.hs
+++ b/app/Commands/Compile/CStage.hs
@@ -87,14 +87,14 @@ parseCStage = do
                 <> toPlainString (itemize ["'" <> Juvix.show s <> "'" <> ": " <> cstageHelp s | s <- allElements @CStage])
             )
       )
-  pure $
-    if
-        | onlySource -> CSource
-        | onlyPreprocess -> CPreprocess
-        | onlyAssemble -> CAssembly
-        | otherwise -> case mcstage of
-            Nothing -> defaultCStage
-            Just x -> x
+  pure
+    $ if
+      | onlySource -> CSource
+      | onlyPreprocess -> CPreprocess
+      | onlyAssemble -> CAssembly
+      | otherwise -> case mcstage of
+          Nothing -> defaultCStage
+          Just x -> x
 
 defaultCStage :: CStage
 defaultCStage = CExecutable

--- a/app/Commands/Compile/Cairo.hs
+++ b/app/Commands/Compile/Cairo.hs
@@ -19,6 +19,7 @@ runCommand opts = do
     runReader entryPoint
       . runError @JuvixError
       . coreToCairo
-      $ coreRes ^. coreResultModule
+      $ coreRes
+      ^. coreResultModule
   res <- getRight r
   liftIO (JSON.encodeFile (toFilePath cairoFile) res)

--- a/app/Commands/Compile/CommonOptions.hs
+++ b/app/Commands/Compile/CommonOptions.hs
@@ -92,10 +92,10 @@ parseCompileCommonOptions' allowOutputFile = do
       )
   _compileOutputFile <-
     if
-        | allowOutputFile ->
-            optional parseGenericOutputFile
-        | otherwise ->
-            pure Nothing
+      | allowOutputFile ->
+          optional parseGenericOutputFile
+      | otherwise ->
+          pure Nothing
   _compileInputFile <- parseInputFileType @k
   pure CompileCommonOptions {..}
 

--- a/app/Commands/Compile/Vampir.hs
+++ b/app/Commands/Compile/Vampir.hs
@@ -19,6 +19,7 @@ runCommand opts = do
     runReader entryPoint
       . runError @JuvixError
       . coreToVampIR
-      $ coreRes ^. coreResultModule
+      $ coreRes
+      ^. coreResultModule
   VampIR.Result {..} <- getRight r
   writeFileEnsureLn vampirFile _resultCode

--- a/app/Commands/Dependencies/Options.hs
+++ b/app/Commands/Dependencies/Options.hs
@@ -11,7 +11,7 @@ parseDependenciesCommand = hsubparser commandUpdate
 
 commandUpdate :: Mod CommandFields DependenciesCommand
 commandUpdate =
-  command "update" $
-    info
+  command "update"
+    $ info
       (pure Update)
       (progDesc "Fetch package dependencies and update the lock file")

--- a/app/Commands/Dev/Asm/Options.hs
+++ b/app/Commands/Dev/Asm/Options.hs
@@ -13,8 +13,8 @@ data AsmCommand
 
 parseAsmCommand :: Parser AsmCommand
 parseAsmCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandRun,
         commandValidate,
         commandCompile

--- a/app/Commands/Dev/Asm/Validate.hs
+++ b/app/Commands/Dev/Asm/Validate.hs
@@ -18,11 +18,11 @@ runCommand opts = do
           exitJuvixError (JuvixError err)
         Nothing ->
           if
-              | opts ^. asmValidateNoPrint ->
-                  exitMsg ExitSuccess "validation succeeded"
-              | otherwise -> do
-                  renderStdOut (Asm.ppOutDefault tab tab)
-                  exitMsg ExitSuccess ""
+            | opts ^. asmValidateNoPrint ->
+                exitMsg ExitSuccess "validation succeeded"
+            | otherwise -> do
+                renderStdOut (Asm.ppOutDefault tab tab)
+                exitMsg ExitSuccess ""
   where
     file :: AppPath File
     file = opts ^. asmValidateInputFile

--- a/app/Commands/Dev/Casm/Options.hs
+++ b/app/Commands/Dev/Casm/Options.hs
@@ -15,8 +15,8 @@ data CasmCommand
 
 parseCasmCommand :: Parser CasmCommand
 parseCasmCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandCompile,
         commandRun,
         commandRead,

--- a/app/Commands/Dev/Casm/Read.hs
+++ b/app/Commands/Dev/Casm/Read.hs
@@ -27,8 +27,8 @@ runCommand opts = do
           case r of
             Left err -> exitJuvixError (JuvixError err)
             Right code' -> do
-              unless (project opts ^. casmReadNoPrint) $
-                renderStdOut (Casm.Pretty.ppProgram code')
+              unless (project opts ^. casmReadNoPrint)
+                $ renderStdOut (Casm.Pretty.ppProgram code')
               doRun code'
   where
     file :: AppPath File

--- a/app/Commands/Dev/Core/Asm.hs
+++ b/app/Commands/Dev/Core/Asm.hs
@@ -19,9 +19,9 @@ runCommand opts = do
   r <- runReader ep . runError @JuvixError $ coreToAsm (Core.moduleFromInfoTable tab)
   tab' <- getRight r
   if
-      | project opts ^. coreAsmPrint ->
-          renderStdOut (Asm.ppOutDefault tab' tab')
-      | otherwise -> runAsm True tab'
+    | project opts ^. coreAsmPrint ->
+        renderStdOut (Asm.ppOutDefault tab' tab')
+    | otherwise -> runAsm True tab'
   where
     sinputFile :: AppPath File
     sinputFile = project opts ^. coreAsmInputFile

--- a/app/Commands/Dev/Core/FromConcrete.hs
+++ b/app/Commands/Dev/Core/FromConcrete.hs
@@ -86,6 +86,6 @@ runCommand coreOpts = do
       err = error "function not found"
 
   if
-      | coreOpts ^. coreFromConcreteEval -> goEval
-      | coreOpts ^. coreFromConcreteNormalize -> goNormalize
-      | otherwise -> goPrint
+    | coreOpts ^. coreFromConcreteEval -> goEval
+    | coreOpts ^. coreFromConcreteNormalize -> goNormalize
+    | otherwise -> goPrint

--- a/app/Commands/Dev/Core/FromConcrete/Options.hs
+++ b/app/Commands/Dev/Core/FromConcrete/Options.hs
@@ -69,8 +69,8 @@ parseCoreFromConcreteOptions = do
       )
   _coreFromConcreteInputFile <- parseInputFile FileExtJuvixCore
   _coreFromConcreteSymbolName <-
-    optional $
-      strOption
+    optional
+      $ strOption
         ( long "symbol-name"
             <> short 's'
             <> help "Print/eval a specific function identifier (default for eval: main)"

--- a/app/Commands/Dev/Core/Options.hs
+++ b/app/Commands/Dev/Core/Options.hs
@@ -23,8 +23,8 @@ data CoreCommand
 
 parseCoreCommand :: Parser CoreCommand
 parseCoreCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandRepl,
         commandEval,
         commandNormalize,

--- a/app/Commands/Dev/Core/Repl.hs
+++ b/app/Commands/Dev/Core/Repl.hs
@@ -118,12 +118,12 @@ runRepl opts tab = do
       let md' = Core.moduleFromInfoTable tab'
           node' = normalize (maximum allowedFieldSizes) md' node
        in if
-              | Info.member Info.kNoDisplayInfo (Core.getInfo node') ->
-                  runRepl opts tab'
-              | otherwise -> do
-                  renderStdOut (Core.ppOut opts (Core.disambiguateNodeNames md' node'))
-                  putStrLn ""
-                  runRepl opts tab'
+            | Info.member Info.kNoDisplayInfo (Core.getInfo node') ->
+                runRepl opts tab'
+            | otherwise -> do
+                renderStdOut (Core.ppOut opts (Core.disambiguateNodeNames md' node'))
+                putStrLn ""
+                runRepl opts tab'
 
     replType :: Core.InfoTable -> Core.Node -> Sem r ()
     replType tab' node = do

--- a/app/Commands/Dev/Core/Strip.hs
+++ b/app/Commands/Dev/Core/Strip.hs
@@ -20,8 +20,8 @@ runCommand opts = do
           . runError @JuvixError
           $ Core.toStripped Core.IdentityTrans (Core.moduleFromInfoTable tab)
   tab' <-
-    getRight $
-      mapRight (Stripped.fromCore (project gopts ^. Core.optFieldSize) . Core.computeCombinedInfoTable) r
+    getRight
+      $ mapRight (Stripped.fromCore (project gopts ^. Core.optFieldSize) . Core.computeCombinedInfoTable) r
   unless (project opts ^. coreStripNoPrint) $ do
     renderStdOut (Core.ppOut opts tab')
   where

--- a/app/Commands/Dev/DevCompile/NativeRust.hs
+++ b/app/Commands/Dev/DevCompile/NativeRust.hs
@@ -71,5 +71,5 @@ writeRuntime ::
   Sem r ()
 writeRuntime runtime = do
   buildDir <- askBuildDir
-  liftIO $
-    BS.writeFile (toFilePath (buildDir <//> $(mkRelFile "libjuvix.rlib"))) runtime
+  liftIO
+    $ BS.writeFile (toFilePath (buildDir <//> $(mkRelFile "libjuvix.rlib"))) runtime

--- a/app/Commands/Dev/DevCompile/Options.hs
+++ b/app/Commands/Dev/DevCompile/Options.hs
@@ -35,49 +35,49 @@ parseDevCompileCommand =
 
 commandCore :: Mod CommandFields DevCompileCommand
 commandCore =
-  command "core" $
-    info
+  command "core"
+    $ info
       (Core <$> parseCore)
       (progDesc "Compile to Juvix Core")
 
 commandReg :: Mod CommandFields DevCompileCommand
 commandReg =
-  command "reg" $
-    info
+  command "reg"
+    $ info
       (Reg <$> parseReg)
       (progDesc "Compile to Juvix Reg")
 
 commandTree :: Mod CommandFields DevCompileCommand
 commandTree =
-  command "tree" $
-    info
+  command "tree"
+    $ info
       (Tree <$> parseTree)
       (progDesc "Compile to Juvix Tree")
 
 commandCasm :: Mod CommandFields DevCompileCommand
 commandCasm =
-  command "casm" $
-    info
+  command "casm"
+    $ info
       (Casm <$> parseCasm)
       (progDesc "Compile to Juvix Casm")
 
 commandAsm :: Mod CommandFields DevCompileCommand
 commandAsm =
-  command "asm" $
-    info
+  command "asm"
+    $ info
       (Asm <$> parseAsm)
       (progDesc "Compile to Juvix ASM")
 
 commandRust :: Mod CommandFields DevCompileCommand
 commandRust =
-  command "rust" $
-    info
+  command "rust"
+    $ info
       (Rust <$> parseRust)
       (progDesc "Compile to Rust")
 
 commandNativeRust :: Mod CommandFields DevCompileCommand
 commandNativeRust =
-  command "native-rust" $
-    info
+  command "native-rust"
+    $ info
       (NativeRust <$> parseNativeRust)
       (progDesc "Compile to native executable through Rust")

--- a/app/Commands/Dev/ImportTree/Options.hs
+++ b/app/Commands/Dev/ImportTree/Options.hs
@@ -20,14 +20,14 @@ parseImportTree =
 
 commandScanFile :: Mod CommandFields ImportTreeCommand
 commandScanFile =
-  command "scan" $
-    info
+  command "scan"
+    $ info
       (ScanFile <$> parseScanFile)
       (progDesc "Scan a single Juvix file and print its imports")
 
 commandPrint :: Mod CommandFields ImportTreeCommand
 commandPrint =
-  command "print" $
-    info
+  command "print"
+    $ info
       (Print <$> parsePrint)
       (progDesc "Print the import tree for the current package")

--- a/app/Commands/Dev/Internal/Options.hs
+++ b/app/Commands/Dev/Internal/Options.hs
@@ -11,8 +11,8 @@ data InternalCommand
 
 parseInternalCommand :: Parser InternalCommand
 parseInternalCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandPretty,
         commandTypeCheck
       ]

--- a/app/Commands/Dev/MigrateJuvixYaml.hs
+++ b/app/Commands/Dev/MigrateJuvixYaml.hs
@@ -13,8 +13,8 @@ runCommand MigrateJuvixYamlOptions {..} = do
   pkgFileExists <- fileExists' pkgFilePath
   pkg <- askPackage
   if
-      | isGlobalPackage -> exitMsg (ExitFailure 1) "No Package file found"
-      | not pkgFileExists || _migrateJuvixYamlOptionsForce -> do
-          writePackageFile pkgDir pkg
-          removeFile' (pkgDir <//> juvixYamlFile)
-      | otherwise -> exitMsg (ExitFailure 1) (show pkgFilePath <> " already exists.")
+    | isGlobalPackage -> exitMsg (ExitFailure 1) "No Package file found"
+    | not pkgFileExists || _migrateJuvixYamlOptionsForce -> do
+        writePackageFile pkgDir pkg
+        removeFile' (pkgDir <//> juvixYamlFile)
+    | otherwise -> exitMsg (ExitFailure 1) (show pkgFilePath <> " already exists.")

--- a/app/Commands/Dev/Nockma/Options.hs
+++ b/app/Commands/Dev/Nockma/Options.hs
@@ -15,8 +15,8 @@ data NockmaCommand
 
 parseNockmaCommand :: Parser NockmaCommand
 parseNockmaCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandRepl,
         commandFromAsm,
         commandFormat,

--- a/app/Commands/Dev/Options.hs
+++ b/app/Commands/Dev/Options.hs
@@ -77,99 +77,99 @@ parseDevCommand =
 
 commandImportTree :: Mod CommandFields DevCommand
 commandImportTree =
-  command "import-tree" $
-    info
+  command "import-tree"
+    $ info
       (ImportTree <$> parseImportTree)
       (progDesc "Subcommands related to the import dependency tree")
 
 commandDevCompile :: Mod CommandFields DevCommand
 commandDevCompile =
-  command "compile" $
-    info
+  command "compile"
+    $ info
       (DevCompile <$> parseDevCompileCommand)
       (progDesc "Compile a Juvix file to an internal language")
 
 commandHighlight :: Mod CommandFields DevCommand
 commandHighlight =
-  command "highlight" $
-    info
+  command "highlight"
+    $ info
       (Highlight <$> parseHighlight)
       (progDesc "Highlight a Juvix file")
 
 commandInternal :: Mod CommandFields DevCommand
 commandInternal =
-  command "internal" $
-    info
+  command "internal"
+    $ info
       (Internal <$> parseInternalCommand)
       (progDesc "Subcommands related to Internal")
 
 commandCore :: Mod CommandFields DevCommand
 commandCore =
-  command "core" $
-    info
+  command "core"
+    $ info
       (Core <$> parseCoreCommand)
       (progDesc "Subcommands related to JuvixCore")
 
 commandAsm :: Mod CommandFields DevCommand
 commandAsm =
-  command "asm" $
-    info
+  command "asm"
+    $ info
       (Asm <$> parseAsmCommand)
       (progDesc "Subcommands related to JuvixAsm")
 
 commandReg :: Mod CommandFields DevCommand
 commandReg =
-  command "reg" $
-    info
+  command "reg"
+    $ info
       (Reg <$> parseRegCommand)
       (progDesc "Subcommands related to JuvixReg")
 
 commandTree :: Mod CommandFields DevCommand
 commandTree =
-  command "tree" $
-    info
+  command "tree"
+    $ info
       (Tree <$> parseTreeCommand)
       (progDesc "Subcommands related to JuvixTree")
 
 commandCasm :: Mod CommandFields DevCommand
 commandCasm =
-  command "casm" $
-    info
+  command "casm"
+    $ info
       (Casm <$> parseCasmCommand)
       (progDesc "Subcommands related to Cairo Assembly")
 
 commandRuntime :: Mod CommandFields DevCommand
 commandRuntime =
-  command "runtime" $
-    info
+  command "runtime"
+    $ info
       (Runtime <$> parseRuntimeCommand)
       (progDesc "Subcommands related to the Juvix runtime")
 
 commandParse :: Mod CommandFields DevCommand
 commandParse =
-  command "parse" $
-    info
+  command "parse"
+    $ info
       (Parse <$> parseParse)
       (progDesc "Parse a Juvix file")
 
 commandScope :: Mod CommandFields DevCommand
 commandScope =
-  command "scope" $
-    info
+  command "scope"
+    $ info
       (Scope <$> parseScope)
       (progDesc "Parse and scope a Juvix file")
 
 commandShowRoot :: Mod CommandFields DevCommand
 commandShowRoot =
-  command "root" $
-    info
+  command "root"
+    $ info
       (DisplayRoot <$> parseRoot)
       (progDesc "Show the root path for a Juvix project")
 
 commandTermination :: Mod CommandFields DevCommand
 commandTermination =
-  command "termination" $
-    info
+  command "termination"
+    $ info
       (Termination <$> parseTerminationCommand)
       (progDesc "Subcommands related to termination checking")
 
@@ -184,14 +184,14 @@ commandJuvixDevRepl =
 
 commandMigrateJuvixYaml :: Mod CommandFields DevCommand
 commandMigrateJuvixYaml =
-  command "migrate-juvix-yaml" $
-    info
+  command "migrate-juvix-yaml"
+    $ info
       (MigrateJuvixYaml <$> parseMigrateJuvixYaml)
       (progDesc "Migrate juvix.yaml to Package.juvix in the current project")
 
 commandNockma :: Mod CommandFields DevCommand
 commandNockma =
-  command "nockma" $
-    info
+  command "nockma"
+    $ info
       (Nockma <$> parseNockmaCommand)
       (progDesc "Subcommands related to the nockma backend")

--- a/app/Commands/Dev/Reg/Options.hs
+++ b/app/Commands/Dev/Reg/Options.hs
@@ -13,8 +13,8 @@ data RegCommand
 
 parseRegCommand :: Parser RegCommand
 parseRegCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandCompile,
         commandRun,
         commandRead

--- a/app/Commands/Dev/Reg/Read.hs
+++ b/app/Commands/Dev/Reg/Read.hs
@@ -22,8 +22,8 @@ runCommand opts = do
       case r of
         Left err -> exitJuvixError (JuvixError err)
         Right tab' -> do
-          unless (project opts ^. regReadNoPrint) $
-            renderStdOut (Reg.ppOutDefault tab' tab')
+          unless (project opts ^. regReadNoPrint)
+            $ renderStdOut (Reg.ppOutDefault tab' tab')
           doRun tab'
   where
     file :: AppPath File

--- a/app/Commands/Dev/Repl/Options.hs
+++ b/app/Commands/Dev/Repl/Options.hs
@@ -11,10 +11,10 @@ parseDevRepl = do
   _replInputFile <- optional (parseInputFile FileExtJuvix)
   _replTransformations <- do
     ts <- optCoreTransformationIds
-    pure $
-      if
-          | null ts -> toStoredTransformations
-          | otherwise -> ts
+    pure
+      $ if
+        | null ts -> toStoredTransformations
+        | otherwise -> ts
   _replNoDisambiguate <- optNoDisambiguate
   _replShowDeBruijn <-
     switch

--- a/app/Commands/Dev/Runtime/Options.hs
+++ b/app/Commands/Dev/Runtime/Options.hs
@@ -21,8 +21,8 @@ parseRuntimeOptions =
 
 parseRuntimeCommand :: Parser RuntimeCommand
 parseRuntimeCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandCompile
       ]
   where

--- a/app/Commands/Dev/Scope.hs
+++ b/app/Commands/Dev/Scope.hs
@@ -13,10 +13,10 @@ runCommand opts = do
   res :: Scoper.ScoperResult <- runPipelineNoOptions (opts ^. scopeInputFile) upToScopingEntry
   let m :: Module 'Scoped 'ModuleTop = res ^. Scoper.resultModule
   if
-      | opts ^. scopeWithComments ->
-          renderStdOut (Print.ppOut (globalOpts, opts) (Scoper.getScoperResultComments res) m)
-      | otherwise ->
-          renderStdOut (Print.ppOutNoComments (globalOpts, opts) m)
+    | opts ^. scopeWithComments ->
+        renderStdOut (Print.ppOut (globalOpts, opts) (Scoper.getScoperResultComments res) m)
+    | otherwise ->
+        renderStdOut (Print.ppOutNoComments (globalOpts, opts) m)
   when (opts ^. scopeListComments) $ do
     newline
     newline

--- a/app/Commands/Dev/Termination/CallGraph.hs
+++ b/app/Commands/Dev/Termination/CallGraph.hs
@@ -18,7 +18,9 @@ runCommand CallGraphOptions {..} = do
       toAnsiText' = toAnsiText (not (globalOpts ^. globalNoColors))
       infotable =
         Internal.computeCombinedInfoTable (Stored.getInternalModuleTable _pipelineResultImports)
-          <> _pipelineResult ^. Internal.resultInternalModule . Internal.internalModuleInfoTable
+          <> _pipelineResult
+          ^. Internal.resultInternalModule
+          . Internal.internalModuleInfoTable
       callMap = Termination.buildCallMap mainModule
       completeGraph = Termination.completeCallGraph callMap
       filteredGraph =
@@ -42,11 +44,11 @@ runCommand CallGraphOptions {..} = do
     renderStdOut (Internal.ppOut globalOpts r)
     newline
     if
-        | markedTerminating ->
-            printSuccessExit (n <> " Terminates by assumption")
-        | otherwise ->
-            case Termination.findOrder r of
-              Nothing ->
-                exitFailMsg (n <> " Fails the termination checking")
-              Just (Termination.LexOrder k) ->
-                printSuccessExit (n <> " Terminates with order " <> show (toList k))
+      | markedTerminating ->
+          printSuccessExit (n <> " Terminates by assumption")
+      | otherwise ->
+          case Termination.findOrder r of
+            Nothing ->
+              exitFailMsg (n <> " Fails the termination checking")
+            Just (Termination.LexOrder k) ->
+              printSuccessExit (n <> " Terminates with order " <> show (toList k))

--- a/app/Commands/Dev/Termination/CallGraph/Options.hs
+++ b/app/Commands/Dev/Termination/CallGraph/Options.hs
@@ -14,13 +14,15 @@ makeLenses ''CallGraphOptions
 parseCallGraph :: Parser CallGraphOptions
 parseCallGraph = do
   _graphFunctionNameFilter <-
-    fmap msum . optional $
-      nonEmpty . Text.words
-        <$> option
-          str
-          ( long "function"
-              <> short 'f'
-              <> help "Only shows the specified function"
-          )
+    fmap msum
+      . optional
+      $ nonEmpty
+      . Text.words
+      <$> option
+        str
+        ( long "function"
+            <> short 'f'
+            <> help "Only shows the specified function"
+        )
   _graphInputFile <- optional (parseInputFile FileExtJuvix)
   pure CallGraphOptions {..}

--- a/app/Commands/Dev/Termination/Calls/Options.hs
+++ b/app/Commands/Dev/Termination/Calls/Options.hs
@@ -17,15 +17,17 @@ makeLenses ''CallsOptions
 parseCalls :: Parser CallsOptions
 parseCalls = do
   _callsFunctionNameFilter <-
-    fmap msum . optional $
-      nonEmpty . Text.words
-        <$> option
-          str
-          ( long "function"
-              <> short 'f'
-              <> metavar "fun1 fun2 ..."
-              <> help "Only shows the specified functions"
-          )
+    fmap msum
+      . optional
+      $ nonEmpty
+      . Text.words
+      <$> option
+        str
+        ( long "function"
+            <> short 'f'
+            <> metavar "fun1 fun2 ..."
+            <> help "Only shows the specified functions"
+        )
   _callsShowDecreasingArgs <-
     option
       decrArgsParser

--- a/app/Commands/Dev/Termination/Options.hs
+++ b/app/Commands/Dev/Termination/Options.hs
@@ -17,8 +17,8 @@ data TerminationCommand
 
 parseTerminationCommand :: Parser TerminationCommand
 parseTerminationCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandCalls,
         commandGraph
       ]

--- a/app/Commands/Dev/Tree/Options.hs
+++ b/app/Commands/Dev/Tree/Options.hs
@@ -19,8 +19,8 @@ data TreeCommand
 
 parseTreeCommand :: Parser TreeCommand
 parseTreeCommand =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandRepl,
         commandEval,
         commandCompileOld,

--- a/app/Commands/Dev/Tree/Read.hs
+++ b/app/Commands/Dev/Tree/Read.hs
@@ -19,8 +19,8 @@ runCommand opts = do
       case r of
         Left err -> exitJuvixError (JuvixError err)
         Right tab' -> do
-          unless (project opts ^. treeReadNoPrint) $
-            renderStdOut (Tree.ppOutDefault tab' tab')
+          unless (project opts ^. treeReadNoPrint)
+            $ renderStdOut (Tree.ppOutDefault tab' tab')
           doEval tab'
   where
     file :: AppPath File

--- a/app/Commands/Dev/Tree/Repl.hs
+++ b/app/Commands/Dev/Tree/Repl.hs
@@ -106,8 +106,8 @@ evalNode node = do
   case et of
     Left e -> error (show e)
     Right v ->
-      liftIO $
-        putStrLn (ppPrint tab v)
+      liftIO
+        $ putStrLn (ppPrint tab v)
 
 replCommand :: String -> Repl ()
 replCommand input_ = Repline.dontCrash $ do

--- a/app/Commands/Eval/Options.hs
+++ b/app/Commands/Eval/Options.hs
@@ -34,8 +34,8 @@ parseEvalOptions :: Parser EvalOptions
 parseEvalOptions = do
   _evalInputFile <- optional (parseInputFiles (FileExtJuvix :| [FileExtJuvixMarkdown]))
   _evalSymbolName <-
-    optional $
-      strOption
+    optional
+      $ strOption
         ( long "symbol-name"
             <> short 's'
             <> help "Evaluate a specific function identifier (default: main)"

--- a/app/Commands/Extra/Clang.hs
+++ b/app/Commands/Extra/Clang.hs
@@ -96,10 +96,10 @@ commonArgs buildDir ClangArgs {..} = run . execAccumList $ do
     CPreprocess -> addArg "-E"
     CAssembly -> addArg "-S"
     CExecutable -> return ()
-  addArg $
-    if
-        | _clangDebug -> "-DDEBUG"
-        | otherwise -> "-DNDEBUG"
+  addArg
+    $ if
+      | _clangDebug -> "-DDEBUG"
+      | otherwise -> "-DNDEBUG"
   addArg "-W"
   addArg "-Wall"
   addArg "-Wno-unused-parameter"

--- a/app/Commands/Extra/Compile.hs
+++ b/app/Commands/Extra/Compile.hs
@@ -134,10 +134,10 @@ clangNativeCompile o = do
   outputFile' <- outputFile o
   buildDir <- askBuildDir
   if
-      | o ^. compileCOutput ->
-          copyFile inputFile outputFile'
-      | otherwise ->
-          runClang (native64Args buildDir o outputFile' inputFile)
+    | o ^. compileCOutput ->
+        copyFile inputFile outputFile'
+    | otherwise ->
+        runClang (native64Args buildDir o outputFile' inputFile)
 
 clangWasmWasiCompile ::
   forall r.
@@ -149,11 +149,11 @@ clangWasmWasiCompile o = do
   outputFile' <- outputFile o
   buildDir <- askBuildDir
   if
-      | o ^. compileCOutput ->
-          copyFile inputFile outputFile'
-      | otherwise -> do
-          clangArgs <- wasiArgs buildDir o outputFile' inputFile <$> sysrootEnvVar
-          runClang clangArgs
+    | o ^. compileCOutput ->
+        copyFile inputFile outputFile'
+    | otherwise -> do
+        clangArgs <- wasiArgs buildDir o outputFile' inputFile <$> sysrootEnvVar
+        runClang clangArgs
   where
     sysrootEnvVar :: Sem r (Path Abs Dir)
     sysrootEnvVar =
@@ -180,11 +180,11 @@ commonArgs buildDir o outfile =
          toFilePath outfile
        ]
     <> ( if
-             | not (o ^. compilePreprocess || o ^. compileAssembly) ->
-                 [ "-L",
-                   toFilePath buildDir
-                 ]
-             | otherwise -> []
+           | not (o ^. compilePreprocess || o ^. compileAssembly) ->
+               [ "-L",
+                 toFilePath buildDir
+               ]
+           | otherwise -> []
        )
 
 optimizationOption :: CompileOptions -> String
@@ -206,9 +206,9 @@ native64Args buildDir o outfile inputFile =
          toFilePath inputFile
        ]
     <> ( if
-             | not (o ^. compilePreprocess || o ^. compileAssembly) ->
-                 ["-ljuvix"]
-             | otherwise -> []
+           | not (o ^. compilePreprocess || o ^. compileAssembly) ->
+               ["-ljuvix"]
+           | otherwise -> []
        )
 
 wasiArgs :: Path Abs Dir -> CompileOptions -> Path Abs File -> Path Abs File -> Path Abs Dir -> [String]
@@ -224,9 +224,9 @@ wasiArgs buildDir o outfile inputFile sysrootPath =
          toFilePath inputFile
        ]
     <> ( if
-             | not (o ^. compilePreprocess || o ^. compileAssembly) ->
-                 ["-ljuvix"]
-             | otherwise -> []
+           | not (o ^. compilePreprocess || o ^. compileAssembly) ->
+               ["-ljuvix"]
+           | otherwise -> []
        )
 
 findClangOnPath :: (Member EmbedIO r) => Sem r (Maybe (Path Abs File))

--- a/app/Commands/Extra/Compile/Options.hs
+++ b/app/Commands/Extra/Compile/Options.hs
@@ -132,13 +132,13 @@ parseCompileOptions' supportedTargets parserFile = do
       )
   _compileUnsafe <-
     if
-        | elem AppTargetVampIR supportedTargets ->
-            switch
-              ( long "unsafe"
-                  <> help "Disable range and error checking (for targets: vampir)"
-              )
-        | otherwise ->
-            pure False
+      | elem AppTargetVampIR supportedTargets ->
+          switch
+            ( long "unsafe"
+                <> help "Disable range and error checking (for targets: vampir)"
+            )
+      | otherwise ->
+          pure False
   _compileOptimizationLevel <-
     optional
       ( option
@@ -178,8 +178,8 @@ optCompileTarget supportedTargets =
 
     parseTarget :: String -> Either String CompileTarget
     parseTarget txt =
-      maybe err return $
-        lookup
+      maybe err return
+        $ lookup
           (map toLower txt)
           [(Prelude.show t, t) | t <- listTargets]
       where

--- a/app/Commands/Extra/NewCompile.hs
+++ b/app/Commands/Extra/NewCompile.hs
@@ -55,8 +55,8 @@ commandTargetHelper t parseCommand =
 
 commandTargetsHelper :: [(CompileTarget, Parser a)] -> Parser a
 commandTargetsHelper supportedTargets =
-  hsubparser $
-    mconcat
+  hsubparser
+    $ mconcat
       [ commandTargetHelper backend parser
         | (backend, parser) <- supportedTargets
       ]

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -37,14 +37,14 @@ targetFromOptions opts = do
     Nothing -> do
       isPackageGlobal <- askPackageGlobal
       if
-          | isStdin -> return TargetStdin
-          | not isPackageGlobal -> return TargetProject
-          | otherwise -> do
-              exitFailMsg $
-                Text.unlines
-                  [ "juvix format error: either 'JUVIX_FILE_OR_PROJECT' or '--stdin' option must be specified",
-                    "Use the --help option to display more usage information."
-                  ]
+        | isStdin -> return TargetStdin
+        | not isPackageGlobal -> return TargetProject
+        | otherwise -> do
+            exitFailMsg
+              $ Text.unlines
+                [ "juvix format error: either 'JUVIX_FILE_OR_PROJECT' or '--stdin' option must be specified",
+                  "Use the --help option to display more usage information."
+                ]
 
 -- | Formats the project on the root
 formatProject ::

--- a/app/Commands/Html.hs
+++ b/app/Commands/Html.hs
@@ -19,8 +19,8 @@ runGenOnlySourceHtml HtmlOptions {..} = do
   res <- runPipelineNoOptions _htmlInputFile upToScopingEntry
   let m = res ^. Scoper.resultModule
   outputDir <- fromAppPathDir _htmlOutputDir
-  liftIO $
-    Html.genSourceHtml
+  liftIO
+    $ Html.genSourceHtml
       GenSourceHtmlArgs
         { _genSourceHtmlArgsAssetsDir = _htmlAssetsPrefix,
           _genSourceHtmlArgsHtmlKind = Html.HtmlOnly,

--- a/app/Commands/Init.hs
+++ b/app/Commands/Init.hs
@@ -29,21 +29,21 @@ init opts = do
   cwd <- getCurrentDir
   when isInteractive (say ("creating " <> pack (toFilePath packageFilePath)))
   if
-      | opts ^. initOptionsBasic -> writeBasicPackage cwd
-      | otherwise -> do
-          pkg <-
-            if
-                | isInteractive -> do
-                    say "✨ Your next Juvix adventure is about to begin! ✨"
-                    say "I will help you set it up"
-                    getPackage
-                | otherwise -> do
-                    projectName <- getDefaultProjectName
-                    let emptyPkg = emptyPackage DefaultBuildDir (cwd <//> packageFilePath)
-                    return $ case projectName of
-                      Nothing -> emptyPkg
-                      Just n -> emptyPkg {_packageName = n}
-          writePackageFile cwd pkg
+    | opts ^. initOptionsBasic -> writeBasicPackage cwd
+    | otherwise -> do
+        pkg <-
+          if
+            | isInteractive -> do
+                say "✨ Your next Juvix adventure is about to begin! ✨"
+                say "I will help you set it up"
+                getPackage
+            | otherwise -> do
+                projectName <- getDefaultProjectName
+                let emptyPkg = emptyPackage DefaultBuildDir (cwd <//> packageFilePath)
+                return $ case projectName of
+                  Nothing -> emptyPkg
+                  Just n -> emptyPkg {_packageName = n}
+        writePackageFile cwd pkg
   checkPackage
   when isInteractive (say "you are all set")
   where
@@ -112,17 +112,17 @@ getProjName = do
         go = do
           txt <- getLine
           if
-              | Text.null txt, Just def' <- def -> return def'
-              | otherwise ->
-                  case parse projectNameParser txt of
-                    Right p
-                      | Text.length p <= projextNameMaxLength -> return p
-                      | otherwise -> do
-                          say ("The project name cannot exceed " <> prettyText projextNameMaxLength <> " characters")
-                          retry
-                    Left err -> do
-                      say err
-                      retry
+            | Text.null txt, Just def' <- def -> return def'
+            | otherwise ->
+                case parse projectNameParser txt of
+                  Right p
+                    | Text.length p <= projextNameMaxLength -> return p
+                    | otherwise -> do
+                        say ("The project name cannot exceed " <> prettyText projextNameMaxLength <> " characters")
+                        retry
+                  Left err -> do
+                    say err
+                    retry
           where
             retry :: Sem r Text
             retry = do
@@ -139,13 +139,13 @@ getVersion :: forall r. (Members '[EmbedIO] r) => Sem r SemVer
 getVersion = do
   txt <- getLine
   if
-      | Text.null txt -> return defaultVersion
-      | otherwise -> case parse semver' txt of
-          Right r -> return r
-          Left err -> do
-            say err
-            say "The version must follow the 'Semantic Versioning 2.0.0' specification"
-            retry
+    | Text.null txt -> return defaultVersion
+    | otherwise -> case parse semver' txt of
+        Right r -> return r
+        Left err -> do
+          say err
+          say "The version must follow the 'Semantic Versioning 2.0.0' specification"
+          retry
   where
     retry :: Sem r SemVer
     retry = do

--- a/app/Commands/Isabelle.hs
+++ b/app/Commands/Isabelle.hs
@@ -16,17 +16,17 @@ runCommand opts = do
   let thy = res ^. resultTheory
   outputDir <- fromAppPathDir (opts ^. isabelleOutputDir)
   if
-      | opts ^. isabelleStdout -> do
-          renderStdOut (ppOutDefault thy)
-          putStrLn ""
-      | otherwise -> do
-          ensureDir outputDir
-          let file :: Path Rel File
-              file =
-                relFile
-                  ( unpack (thy ^. theoryName . namePretty)
-                      <.> isabelleFileExt
-                  )
-              absPath :: Path Abs File
-              absPath = outputDir <//> file
-          writeFileEnsureLn absPath (ppPrint thy <> "\n")
+    | opts ^. isabelleStdout -> do
+        renderStdOut (ppOutDefault thy)
+        putStrLn ""
+    | otherwise -> do
+        ensureDir outputDir
+        let file :: Path Rel File
+            file =
+              relFile
+                ( unpack (thy ^. theoryName . namePretty)
+                    <.> isabelleFileExt
+                )
+            absPath :: Path Abs File
+            absPath = outputDir <//> file
+        writeFileEnsureLn absPath (ppPrint thy <> "\n")

--- a/app/Commands/Markdown.hs
+++ b/app/Commands/Markdown.hs
@@ -45,9 +45,9 @@ runCommand opts = do
       | opts ^. markdownStdout -> liftIO . putStrLn $ md
       | otherwise -> do
           ensureDir outputDir
-          when (opts ^. markdownWriteAssets) $
-            liftIO $
-              writeAssets outputDir
+          when (opts ^. markdownWriteAssets)
+            $ liftIO
+            $ writeAssets outputDir
 
           let mdFile :: Path Rel File
               mdFile =

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -157,10 +157,10 @@ replCommand opts input_ = catchAll $ do
   evalRes <- compileThenEval ctx input_
   whenJust evalRes $ \n ->
     if
-        | Info.member Info.kNoDisplayInfo (Core.getInfo n) -> return ()
-        | opts ^. replPrintValues ->
-            renderOutLn (Core.ppOut opts (toValue tab n))
-        | otherwise -> renderOutLn (Core.ppOut opts n)
+      | Info.member Info.kNoDisplayInfo (Core.getInfo n) -> return ()
+      | opts ^. replPrintValues ->
+          renderOutLn (Core.ppOut opts (toValue tab n))
+      | otherwise -> renderOutLn (Core.ppOut opts n)
   where
     compileThenEval :: ReplContext -> String -> Repl (Maybe Core.Node)
     compileThenEval ctx s = compileString >>= mapM eval
@@ -207,15 +207,15 @@ dev :: String -> Repl ()
 dev input_ = do
   ctx <- replGetContext
   if
-      | input_ == scoperStateCmd -> do
-          renderOutLn (Concrete.ppTrace (ctx ^. replContextArtifacts . artifactScoperState))
-      | otherwise ->
-          renderOutLn
-            ( "Unrecognized command "
-                <> input_
-                <> "\nAvailable commands: "
-                <> unwords cmds
-            )
+    | input_ == scoperStateCmd -> do
+        renderOutLn (Concrete.ppTrace (ctx ^. replContextArtifacts . artifactScoperState))
+    | otherwise ->
+        renderOutLn
+          ( "Unrecognized command "
+              <> input_
+              <> "\nAvailable commands: "
+              <> unwords cmds
+          )
   where
     cmds :: [String]
     cmds = [scoperStateCmd]

--- a/app/TopCommand/Options.hs
+++ b/app/TopCommand/Options.hs
@@ -132,8 +132,8 @@ parseUtility =
 
     commandFormat :: Mod CommandFields TopCommand
     commandFormat =
-      command "format" $
-        info
+      command "format"
+        $ info
           (JuvixFormat <$> parseFormat)
           ( headerDoc
               ( Just
@@ -163,50 +163,50 @@ parseUtility =
 
 commandCheck :: Mod CommandFields TopCommand
 commandCheck =
-  command "typecheck" $
-    info
+  command "typecheck"
+    $ info
       (Typecheck <$> parseTypecheck)
       (progDesc "Typecheck a Juvix file")
 
 commandCompile :: Mod CommandFields TopCommand
 commandCompile =
-  command "compile" $
-    info
+  command "compile"
+    $ info
       (Compile <$> parseCompileCommand)
       (progDesc "Compile a Juvix file")
 
 commandEval :: Mod CommandFields TopCommand
 commandEval =
-  command "eval" $
-    info
+  command "eval"
+    $ info
       (Eval <$> parseEvalOptions)
       (progDesc "Evaluate a Juvix file")
 
 commandHtml :: Mod CommandFields TopCommand
 commandHtml =
-  command "html" $
-    info
+  command "html"
+    $ info
       (Html <$> parseHtml)
       (progDesc "Generate HTML for a Juvix file")
 
 commandMarkdown :: Mod CommandFields TopCommand
 commandMarkdown =
-  command "markdown" $
-    info
+  command "markdown"
+    $ info
       (Markdown <$> parseJuvixMarkdown)
       (progDesc "Translate Juvix code blocks in a Markdown file to Markdown")
 
 commandIsabelle :: Mod CommandFields TopCommand
 commandIsabelle =
-  command "isabelle" $
-    info
+  command "isabelle"
+    $ info
       (Isabelle <$> parseIsabelle)
       (progDesc "Generate Isabelle/HOL types for a Juvix file")
 
 commandDev :: Mod CommandFields TopCommand
 commandDev =
-  command "dev" $
-    info
+  command "dev"
+    $ info
       (Dev <$> Dev.parseDevCommand)
       (progDesc "Commands for the developers")
 

--- a/src/Juvix/Compiler/Asm/Data/Stack.hs
+++ b/src/Juvix/Compiler/Asm/Data/Stack.hs
@@ -44,12 +44,12 @@ push a s =
 pop :: Stack a -> Stack a
 pop s =
   if
-      | null s -> error "popping an empty stack"
-      | otherwise ->
-          Stack
-            { _stackValues = IntMap.delete (s ^. stackHeight - 1) (s ^. stackValues),
-              _stackHeight = s ^. stackHeight - 1
-            }
+    | null s -> error "popping an empty stack"
+    | otherwise ->
+        Stack
+          { _stackValues = IntMap.delete (s ^. stackHeight - 1) (s ^. stackValues),
+            _stackHeight = s ^. stackHeight - 1
+          }
 
 top :: Stack a -> Maybe a
 top s = IntMap.lookup (s ^. stackHeight - 1) (s ^. stackValues)

--- a/src/Juvix/Compiler/Asm/Extra/Memory.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Memory.hs
@@ -14,8 +14,8 @@ type Arguments = HashMap Offset Type
 
 argumentsFromFunctionInfo :: FunctionInfo -> Arguments
 argumentsFromFunctionInfo fi =
-  HashMap.fromList $
-    zip [0 ..] (take (fi ^. functionArgsNum) (typeArgs (fi ^. functionType)))
+  HashMap.fromList
+    $ zip [0 ..] (take (fi ^. functionArgsNum) (typeArgs (fi ^. functionType)))
 
 -- | A static representation of JuvixAsm memory providing type information for
 -- memory locations.
@@ -61,8 +61,8 @@ topValueStack n mem = Stack.nthFromTop n (mem ^. memoryValueStack)
 
 topValueStack' :: Int -> Memory -> Type
 topValueStack' n mem =
-  fromMaybe (error "invalid value stack access") $
-    topValueStack n mem
+  fromMaybe (error "invalid value stack access")
+    $ topValueStack n mem
 
 -- | Values from top of the value stack, in order from top to bottom.
 topValuesFromValueStack :: Int -> Memory -> Maybe [Type]
@@ -71,8 +71,8 @@ topValuesFromValueStack n mem = Stack.topValues n (mem ^. memoryValueStack)
 -- | Values from top of the value stack, in order from top to bottom.
 topValuesFromValueStack' :: Int -> Memory -> [Type]
 topValuesFromValueStack' n mem =
-  fromMaybe (error "invalid value stack access") $
-    Stack.topValues n (mem ^. memoryValueStack)
+  fromMaybe (error "invalid value stack access")
+    $ Stack.topValues n (mem ^. memoryValueStack)
 
 -- | Read temporary stack at index `n` from the bottom.
 bottomTempStack :: Int -> Memory -> Maybe Type
@@ -80,8 +80,8 @@ bottomTempStack n mem = Stack.nthFromBottom n (mem ^. memoryTempStack)
 
 bottomTempStack' :: Int -> Memory -> Type
 bottomTempStack' n mem =
-  fromMaybe (error "invalid temporary stack access") $
-    bottomTempStack n mem
+  fromMaybe (error "invalid temporary stack access")
+    $ bottomTempStack n mem
 
 getArgumentType :: Offset -> Memory -> Maybe Type
 getArgumentType off mem = HashMap.lookup off (mem ^. memoryArgumentArea)
@@ -129,16 +129,16 @@ getValueType tab mem val =
 -- | Check if the value stack has at least the given height
 checkValueStackHeight' :: (Member (Error AsmError) r) => Maybe Location -> Int -> Memory -> Sem r ()
 checkValueStackHeight' loc n mem = do
-  unless (length (mem ^. memoryValueStack) >= n) $
-    throw $
-      AsmError
-        loc
-        ( fromString $
-            "wrong value stack height: expected at least "
-              ++ show n
-              ++ ", but the height is "
-              ++ show (length (mem ^. memoryValueStack))
-        )
+  unless (length (mem ^. memoryValueStack) >= n)
+    $ throw
+    $ AsmError
+      loc
+      ( fromString
+          $ "wrong value stack height: expected at least "
+          ++ show n
+          ++ ", but the height is "
+          ++ show (length (mem ^. memoryValueStack))
+      )
 
 -- | Check if the values on top of the value stack have the given types (the
 -- first element of the list corresponds to the top of the stack)
@@ -148,15 +148,15 @@ checkValueStack' loc tab tys mem = do
   mapM_
     ( \(ty, idx) -> do
         let ty' = fromJust $ topValueStack idx mem
-        unless (isSubtype' ty' ty) $
-          throw $
-            AsmError loc $
-              "type mismatch on value stack cell "
-                <> show idx
-                <> " from top: expected "
-                <> ppTrace tab ty
-                <> " but got "
-                <> ppTrace tab ty'
+        unless (isSubtype' ty' ty)
+          $ throw
+          $ AsmError loc
+          $ "type mismatch on value stack cell "
+          <> show idx
+          <> " from top: expected "
+          <> ppTrace tab ty
+          <> " but got "
+          <> ppTrace tab ty'
     )
     (zip tys [0 ..])
 
@@ -166,17 +166,21 @@ checkValueStack' loc tab tys mem = do
 -- of the argument areas don't match.
 unifyMemory' :: (Member (Error AsmError) r) => Maybe Location -> InfoTable -> Memory -> Memory -> Sem r Memory
 unifyMemory' loc tab mem1 mem2 = do
-  unless (length (mem1 ^. memoryValueStack) == length (mem2 ^. memoryValueStack)) $
-    throw $
-      AsmError loc "value stack height mismatch"
+  unless (length (mem1 ^. memoryValueStack) == length (mem2 ^. memoryValueStack))
+    $ throw
+    $ AsmError loc "value stack height mismatch"
   vs <- zipWithM (unifyTypes'' loc tab) (toList (mem1 ^. memoryValueStack)) (toList (mem2 ^. memoryValueStack))
-  unless (length (mem1 ^. memoryTempStack) == length (mem2 ^. memoryTempStack)) $
-    throw $
-      AsmError loc "temporary stack height mismatch"
+  unless (length (mem1 ^. memoryTempStack) == length (mem2 ^. memoryTempStack))
+    $ throw
+    $ AsmError loc "temporary stack height mismatch"
   ts <- zipWithM (unifyTypes'' loc tab) (toList (mem1 ^. memoryTempStack)) (toList (mem2 ^. memoryTempStack))
   unless
-    ( length (mem1 ^. memoryArgumentArea) == length (mem2 ^. memoryArgumentArea)
-        && mem1 ^. memoryArgsNum == mem2 ^. memoryArgsNum
+    ( length (mem1 ^. memoryArgumentArea)
+        == length (mem2 ^. memoryArgumentArea)
+        && mem1
+        ^. memoryArgsNum
+        == mem2
+        ^. memoryArgsNum
     )
     $ throw
     $ AsmError loc "argument area size mismatch"
@@ -191,8 +195,8 @@ unifyMemory' loc tab mem1 mem2 = do
             (fromJust $ HashMap.lookup off (mem1 ^. memoryArgumentArea))
       )
       [0 .. n - 1]
-  return $
-    Memory
+  return
+    $ Memory
       { _memoryValueStack = Stack.fromList vs,
         _memoryTempStack = Stack.fromList ts,
         _memoryArgumentArea = HashMap.fromList (zipExact [0 .. n - 1] args),

--- a/src/Juvix/Compiler/Asm/Extra/Recursors.hs
+++ b/src/Juvix/Compiler/Asm/Extra/Recursors.hs
@@ -52,9 +52,9 @@ recurse' sig = go True
     goNextCmd :: Bool -> Maybe Location -> Sem r (Memory, a) -> Code -> Sem r (Memory, [a])
     goNextCmd isTail loc mp t = do
       (mem', r) <- mp
-      when (isTail && null t && length (mem' ^. memoryValueStack) /= 1) $
-        throw $
-          AsmError loc "expected value stack height 1 on function exit"
+      when (isTail && null t && length (mem' ^. memoryValueStack) /= 1)
+        $ throw
+        $ AsmError loc "expected value stack height 1 on function exit"
       (mem'', rs) <- go isTail mem' t
       return (mem'', r : rs)
 
@@ -88,9 +88,9 @@ recurse' sig = go True
               ty <- getValueType' loc (sig ^. recursorInfoTable) mem val
               return (pushValueStack ty mem)
             Pop -> do
-              when (null (mem ^. memoryValueStack)) $
-                throw $
-                  AsmError loc "popping empty value stack"
+              when (null (mem ^. memoryValueStack))
+                $ throw
+                $ AsmError loc "popping empty value stack"
               return (popValueStack 1 mem)
             Trace ->
               return mem
@@ -110,16 +110,16 @@ recurse' sig = go True
                   (\ty idx -> unifyTypes'' loc (sig ^. recursorInfoTable) ty (topValueStack' idx mem))
                   tyargs
                   [0 ..]
-              return $
-                pushValueStack (mkTypeConstr (ci ^. constructorInductive) tag tys) $
-                  popValueStack n mem
+              return
+                $ pushValueStack (mkTypeConstr (ci ^. constructorInductive) tag tys)
+                $ popValueStack n mem
             AllocClosure InstrAllocClosure {..} -> do
               let fi = lookupFunInfo (sig ^. recursorInfoTable) _allocClosureFunSymbol
                   (tyargs, tgt) = unfoldType (fi ^. functionType)
               checkValueStack' loc (sig ^. recursorInfoTable) (take _allocClosureArgsNum tyargs) mem
-              return $
-                pushValueStack (mkTypeFun (drop _allocClosureArgsNum tyargs) tgt) $
-                  popValueStack _allocClosureArgsNum mem
+              return
+                $ pushValueStack (mkTypeFun (drop _allocClosureArgsNum tyargs) tgt)
+                $ popValueStack _allocClosureArgsNum mem
             ExtendClosure x ->
               fixMemExtendClosure mem x
             Call x ->
@@ -180,9 +180,9 @@ recurse' sig = go True
           OpStrToInt ->
             checkUnop TyString mkTypeInteger
           OpArgsNum -> do
-            when (null (mem ^. memoryValueStack)) $
-              throw $
-                AsmError loc "empty value stack"
+            when (null (mem ^. memoryValueStack))
+              $ throw
+              $ AsmError loc "empty value stack"
             checkFunType (topValueStack' 0 mem)
             return $ pushValueStack mkTypeInteger (popValueStack 1 mem)
           OpIntToField ->
@@ -201,70 +201,70 @@ recurse' sig = go True
 
         fixMemExtendClosure :: Memory -> InstrExtendClosure -> Sem r Memory
         fixMemExtendClosure mem InstrExtendClosure {..} = do
-          when (length (mem ^. memoryValueStack) < _extendClosureArgsNum + 1) $
-            throw $
-              AsmError loc "invalid closure extension: not enough values on the stack"
+          when (length (mem ^. memoryValueStack) < _extendClosureArgsNum + 1)
+            $ throw
+            $ AsmError loc "invalid closure extension: not enough values on the stack"
           let ty = topValueStack' 0 mem
           checkFunType ty
-          when (ty /= TyDynamic && length (typeArgs ty) < _extendClosureArgsNum) $
-            throw $
-              AsmError loc "invalid closure extension: too many supplied arguments"
+          when (ty /= TyDynamic && length (typeArgs ty) < _extendClosureArgsNum)
+            $ throw
+            $ AsmError loc "invalid closure extension: too many supplied arguments"
           fixMemValueStackArgs mem 1 _extendClosureArgsNum ty
 
         fixMemCall :: Memory -> InstrCall -> Sem r Memory
         fixMemCall mem InstrCall {..} = do
           let k = if _callType == CallClosure then 1 else 0
-          when (length (mem ^. memoryValueStack) < _callArgsNum + k) $
-            throw $
-              AsmError loc "invalid call: not enough values on the stack"
+          when (length (mem ^. memoryValueStack) < _callArgsNum + k)
+            $ throw
+            $ AsmError loc "invalid call: not enough values on the stack"
           let ty = case _callType of
                 CallClosure -> topValueStack' 0 mem
                 CallFun sym -> lookupFunInfo (sig ^. recursorInfoTable) sym ^. functionType
           let argsNum = case _callType of
                 CallClosure -> length (typeArgs ty)
                 CallFun sym -> lookupFunInfo (sig ^. recursorInfoTable) sym ^. functionArgsNum
-          when (argsNum /= 0) $
-            checkFunType ty
-          when (ty /= TyDynamic && argsNum /= _callArgsNum) $
-            throw $
-              AsmError loc "invalid call: the number of supplied arguments doesn't match the number of expected arguments"
+          when (argsNum /= 0)
+            $ checkFunType ty
+          when (ty /= TyDynamic && argsNum /= _callArgsNum)
+            $ throw
+            $ AsmError loc "invalid call: the number of supplied arguments doesn't match the number of expected arguments"
           fixMemValueStackArgs mem k _callArgsNum ty
 
         fixMemCallClosures :: Memory -> InstrCallClosures -> Sem r Memory
         fixMemCallClosures mem InstrCallClosures {..} = do
-          when (_callClosuresArgsNum < 1) $
-            throw $
-              AsmError loc "invalid closure call: expected at least one supplied argument"
-          when (null (mem ^. memoryValueStack)) $
-            throw $
-              AsmError loc "invalid closure call: value stack is empty"
+          when (_callClosuresArgsNum < 1)
+            $ throw
+            $ AsmError loc "invalid closure call: expected at least one supplied argument"
+          when (null (mem ^. memoryValueStack))
+            $ throw
+            $ AsmError loc "invalid closure call: value stack is empty"
           let ty = topValueStack' 0 mem
           checkFunType ty
           if
-              | ty == TyDynamic -> do
-                  let mem' = popValueStack 1 mem
-                  return $ pushValueStack TyDynamic (popValueStack _callClosuresArgsNum mem')
-              | length (typeArgs ty) < _callClosuresArgsNum -> do
-                  let n = length (typeArgs ty)
-                  mem' <- fixMemCall mem (InstrCall CallClosure n)
-                  fixMemCallClosures mem' (InstrCallClosures (_callClosuresArgsNum - n))
-              | length (typeArgs ty) > _callClosuresArgsNum ->
-                  fixMemExtendClosure mem (InstrExtendClosure _callClosuresArgsNum)
-              | otherwise ->
-                  fixMemCall mem (InstrCall CallClosure (length (typeArgs ty)))
+            | ty == TyDynamic -> do
+                let mem' = popValueStack 1 mem
+                return $ pushValueStack TyDynamic (popValueStack _callClosuresArgsNum mem')
+            | length (typeArgs ty) < _callClosuresArgsNum -> do
+                let n = length (typeArgs ty)
+                mem' <- fixMemCall mem (InstrCall CallClosure n)
+                fixMemCallClosures mem' (InstrCallClosures (_callClosuresArgsNum - n))
+            | length (typeArgs ty) > _callClosuresArgsNum ->
+                fixMemExtendClosure mem (InstrExtendClosure _callClosuresArgsNum)
+            | otherwise ->
+                fixMemCall mem (InstrCall CallClosure (length (typeArgs ty)))
 
         fixMemValueStackArgs :: Memory -> Int -> Int -> Type -> Sem r Memory
         fixMemValueStackArgs mem k argsNum ty = do
           checkValueStackHeight' loc (argsNum + k) mem
           let mem' = popValueStack k mem
-          unless (ty == TyDynamic) $
-            checkValueStack' loc (sig ^. recursorInfoTable) (take argsNum (typeArgs ty)) mem'
+          unless (ty == TyDynamic)
+            $ checkValueStack' loc (sig ^. recursorInfoTable) (take argsNum (typeArgs ty)) mem'
           let tyargs = topValuesFromValueStack' argsNum mem'
           -- `typeArgs ty` may be shorter than `tyargs` only if `ty` is dynamic
           zipWithM_ (unifyTypes'' loc (sig ^. recursorInfoTable)) tyargs (typeArgs ty)
-          return $
-            pushValueStack (mkTypeFun (drop argsNum (typeArgs ty)) (typeTarget ty)) $
-              popValueStack argsNum mem'
+          return
+            $ pushValueStack (mkTypeFun (drop argsNum (typeArgs ty)) (typeTarget ty))
+            $ popValueStack argsNum mem'
 
         dropTempStack :: Memory -> Memory
         dropTempStack mem = mem {_memoryTempStack = Stack.empty}
@@ -274,8 +274,8 @@ recurse' sig = go True
           TyDynamic -> return ()
           TyFun {} -> return ()
           ty ->
-            throw $
-              AsmError
+            throw
+              $ AsmError
                 loc
                 ( "expected a function, got value of type "
                     <> ppTrace (sig ^. recursorInfoTable) ty
@@ -316,33 +316,34 @@ recurse' sig = go True
 
     goSave :: Bool -> Memory -> CmdSave -> Sem r (Memory, a)
     goSave isTail mem cmd@CmdSave {..} = do
-      when (null (mem ^. memoryValueStack)) $
-        throw $
-          AsmError loc "popping empty value stack"
+      when (null (mem ^. memoryValueStack))
+        $ throw
+        $ AsmError loc "popping empty value stack"
       let mem1 = pushTempStack (topValueStack' 0 mem) (popValueStack 1 mem)
       (mem2, a) <- go isTail mem1 _cmdSaveCode
       a' <- (sig ^. recurseSave) mem cmd a
-      when (not isTail && _cmdSaveIsTail) $
-        throw $
-          AsmError loc "'tsave' not in tail position"
-      when (isTail && not _cmdSaveIsTail) $
-        throw $
-          AsmError loc "'save' in tail position"
-      when (not isTail && null (mem2 ^. memoryTempStack)) $
-        throw $
-          AsmError loc "popping empty temporary stack"
+      when (not isTail && _cmdSaveIsTail)
+        $ throw
+        $ AsmError loc "'tsave' not in tail position"
+      when (isTail && not _cmdSaveIsTail)
+        $ throw
+        $ AsmError loc "'save' in tail position"
+      when (not isTail && null (mem2 ^. memoryTempStack))
+        $ throw
+        $ AsmError loc "popping empty temporary stack"
       return (if isTail then mem2 else popTempStack 1 mem2, a')
       where
         loc = _cmdSaveInfo ^. commandInfoLocation
 
     checkBranchInvariant :: Int -> Maybe Location -> Memory -> Memory -> Sem r ()
     checkBranchInvariant k loc mem mem' = do
-      unless (length (mem' ^. memoryValueStack) == length (mem ^. memoryValueStack) + k) $
-        throw $
-          AsmError loc ("wrong value stack height after branching (must increase by " <> show k <> ")")
+      unless (length (mem' ^. memoryValueStack) == length (mem ^. memoryValueStack) + k)
+        $ throw
+        $ AsmError loc ("wrong value stack height after branching (must increase by " <> show k <> ")")
       unless
         ( null (mem' ^. memoryTempStack)
-            || length (mem' ^. memoryTempStack) == length (mem ^. memoryTempStack)
+            || length (mem' ^. memoryTempStack)
+            == length (mem ^. memoryTempStack)
         )
         $ throw
         $ AsmError loc "temporary stack height changed after branching"
@@ -419,14 +420,14 @@ recurseS' sig = go True
             AllocConstr tag -> do
               let ci = lookupConstrInfo (sig ^. recursorInfoTable) tag
                   n = ci ^. constructorArgsNum
-              return $
-                stackInfoPopValueStack (n - 1) si
+              return
+                $ stackInfoPopValueStack (n - 1) si
             AllocClosure InstrAllocClosure {..} -> do
-              return $
-                stackInfoPopValueStack (_allocClosureArgsNum - 1) si
+              return
+                $ stackInfoPopValueStack (_allocClosureArgsNum - 1) si
             ExtendClosure InstrExtendClosure {..} ->
-              return $
-                stackInfoPopValueStack _extendClosureArgsNum si
+              return
+                $ stackInfoPopValueStack _extendClosureArgsNum si
             Call x ->
               fixStackCall si x
             TailCall x ->
@@ -488,9 +489,9 @@ recurseS' sig = go True
 
     checkStackInfo :: Maybe Location -> StackInfo -> StackInfo -> Sem r ()
     checkStackInfo loc si1 si2 =
-      when (si1 /= si2) $
-        throw $
-          AsmError loc "stack height mismatch"
+      when (si1 /= si2)
+        $ throw
+        $ AsmError loc "stack height mismatch"
 
     stackInfoPushValueStack :: Int -> StackInfo -> StackInfo
     stackInfoPushValueStack n si = si {_stackInfoValueStackHeight = si ^. stackInfoValueStackHeight + n}

--- a/src/Juvix/Compiler/Asm/Interpreter.hs
+++ b/src/Juvix/Compiler/Asm/Interpreter.hs
@@ -66,10 +66,10 @@ runCodeR infoTable funInfo = goCode (funInfo ^. functionCode) >> popLastValueSta
         v <- popValueStack
         pushTempStack v
         if
-            | _cmdSaveIsTail ->
-                goCode _cmdSaveCode
-            | otherwise ->
-                goCode _cmdSaveCode >> popTempStack >> goCode cont
+          | _cmdSaveIsTail ->
+              goCode _cmdSaveCode
+          | otherwise ->
+              goCode _cmdSaveCode >> popTempStack >> goCode cont
 
     goInstr :: (Member Runtime r) => Maybe Location -> Instruction -> Code -> Sem r ()
     goInstr loc instr cont = case instr of
@@ -107,8 +107,8 @@ runCodeR infoTable funInfo = goCode (funInfo ^. functionCode) >> popLastValueSta
         v <- popValueStack
         case v of
           ValClosure cl -> do
-            unless (_extendClosureArgsNum > 0) $
-              runtimeError "invalid closure extension: the number of supplied arguments must be greater than 0"
+            unless (_extendClosureArgsNum > 0)
+              $ runtimeError "invalid closure extension: the number of supplied arguments must be greater than 0"
             extendClosure cl _extendClosureArgsNum
             goCode cont
           _ -> runtimeError "invalid closure extension: expected closure on top of value stack"
@@ -130,13 +130,13 @@ runCodeR infoTable funInfo = goCode (funInfo ^. functionCode) >> popLastValueSta
         unless (null cont) (runtimeError "invalid return")
         isToplevel <- fmap not hasCaller
         if
-            | isToplevel -> return ()
-            | otherwise -> do
-                v <- popLastValueStack
-                cont' <- popCallStack
-                replaceFrame (cont' ^. contFrame)
-                pushValueStack v
-                goCode (cont' ^. contCode)
+          | isToplevel -> return ()
+          | otherwise -> do
+              v <- popLastValueStack
+              cont' <- popCallStack
+              replaceFrame (cont' ^. contFrame)
+              pushValueStack v
+              goCode (cont' ^. contCode)
 
     goBinOp' :: (Member Runtime r) => (Val -> Val -> Sem r Val) -> Sem r ()
     goBinOp' op = do
@@ -168,10 +168,10 @@ runCodeR infoTable funInfo = goCode (funInfo ^. functionCode) >> popLastValueSta
       ConstrRef cr -> do
         ctr <- getDirectRef (cr ^. fieldRef) >>= getConstr
         if
-            | cr ^. fieldOffset < length (ctr ^. constrArgs) ->
-                return $ (ctr ^. constrArgs) !! (cr ^. fieldOffset)
-            | otherwise ->
-                runtimeError "invalid constructor field access"
+          | cr ^. fieldOffset < length (ctr ^. constrArgs) ->
+              return $ (ctr ^. constrArgs) !! (cr ^. fieldOffset)
+          | otherwise ->
+              runtimeError "invalid constructor field access"
         where
           getConstr :: Val -> Sem r Constr
           getConstr = \case
@@ -246,28 +246,28 @@ runCodeR infoTable funInfo = goCode (funInfo ^. functionCode) >> popLastValueSta
             (n < 0)
             (runtimeError "invalid closure: too many arguments")
           if
-              | n > argsNum -> do
-                  extendClosure cl argsNum
-                  if
-                      | isTail -> goInstr loc Return cont
-                      | otherwise -> goCode cont
-              | n == argsNum -> do
-                  frm <- getCallFrame loc cl fi n
-                  if
-                      | isTail -> do
-                          unless (null cont) $
-                            runtimeError "invalid tail call"
-                          replaceTailFrame frm
-                      | otherwise -> do
-                          pushCallStack cont
-                          replaceFrame frm
-                  goCode (fi ^. functionCode)
-              | otherwise -> do
-                  let instr = mkInstr ((if isTail then TailCallClosures else CallClosures) (InstrCallClosures (argsNum - n)))
-                  frm <- getCallFrame loc cl fi n
-                  pushCallStack (instr : cont)
-                  replaceFrame frm
-                  goCode (fi ^. functionCode)
+            | n > argsNum -> do
+                extendClosure cl argsNum
+                if
+                  | isTail -> goInstr loc Return cont
+                  | otherwise -> goCode cont
+            | n == argsNum -> do
+                frm <- getCallFrame loc cl fi n
+                if
+                  | isTail -> do
+                      unless (null cont)
+                        $ runtimeError "invalid tail call"
+                      replaceTailFrame frm
+                  | otherwise -> do
+                      pushCallStack cont
+                      replaceFrame frm
+                goCode (fi ^. functionCode)
+            | otherwise -> do
+                let instr = mkInstr ((if isTail then TailCallClosures else CallClosures) (InstrCallClosures (argsNum - n)))
+                frm <- getCallFrame loc cl fi n
+                pushCallStack (instr : cont)
+                replaceFrame frm
+                goCode (fi ^. functionCode)
         _ -> runtimeError "invalid indirect call: expected closure on top of value stack"
 
     eitherToError :: (Member Runtime r) => Either Text Val -> Sem r Val

--- a/src/Juvix/Compiler/Asm/Interpreter/Runtime.hs
+++ b/src/Juvix/Compiler/Asm/Interpreter/Runtime.hs
@@ -85,14 +85,14 @@ runRuntime tab = interp
         modify' (set runtimeFrame frm {_frameCallLocation = s ^. runtimeFrame . frameCallLocation})
       ReadArg off -> do
         s <- get
-        return $
-          fromMaybe
+        return
+          $ fromMaybe
             (throwRuntimeError s "invalid argument area read")
             (HashMap.lookup off (s ^. runtimeFrame . frameArgs . argumentArea))
       ReadTemp r -> do
         s <- get
-        return $
-          fromMaybe
+        return
+          $ fromMaybe
             (throwRuntimeError s "invalid temporary stack read")
             (Stack.nthFromBottom (r ^. refTempOffsetRef . offsetRefOffset) (s ^. runtimeFrame . frameTemp . temporaryStack))
       PushTempStack val ->
@@ -114,8 +114,8 @@ runRuntime tab = interp
 
     throwRuntimeError :: forall b. RuntimeState -> Text -> b
     throwRuntimeError s msg =
-      doFlushLogs s `GHC.seq`
-        throwRunError s msg
+      doFlushLogs s
+        `GHC.seq` throwRunError s msg
 
     doFlushLogs :: RuntimeState -> ()
     doFlushLogs s =

--- a/src/Juvix/Compiler/Asm/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Asm/Pretty/Base.hs
@@ -52,19 +52,19 @@ instance PrettyCode Frame where
     let header =
           pretty (Str.function :: String)
             <+> n
-              <> maybe mempty (\loc -> pretty (" called at" :: String) <+> pretty loc) _frameCallLocation
+            <> maybe mempty (\loc -> pretty (" called at" :: String) <+> pretty loc) _frameCallLocation
     args <- ppCode _frameArgs
     temp <- ppCode _frameTemp
     stack <- ppCode _frameStack
-    return $
-      header
-        <> line
-        <> indent' (pretty ("arguments = " :: String) <> args)
-        <> line
-        <> indent' (pretty ("temporaries = " :: String) <> temp)
-        <> line
-        <> indent' (pretty ("value stack = " :: String) <> stack)
-        <> line
+    return
+      $ header
+      <> line
+      <> indent' (pretty ("arguments = " :: String) <> args)
+      <> line
+      <> indent' (pretty ("temporaries = " :: String) <> temp)
+      <> line
+      <> indent' (pretty ("value stack = " :: String) <> stack)
+      <> line
 
 instance PrettyCode RuntimeState where
   ppCode :: (Member (Reader Options) r) => RuntimeState -> Sem r (Doc Ann)
@@ -136,17 +136,19 @@ instance PrettyCode Command where
     Branch CmdBranch {..} -> do
       br1 <- ppCodeCode _cmdBranchTrue
       br2 <- ppCodeCode _cmdBranchFalse
-      return $
-        primitive Str.instrBr
-          <+> braces'
-            ( constr Str.true_ <> colon
-                <+> braces' br1
-                  <> semi
-                  <> line
-                  <> constr Str.false_
-                  <> colon
-                <+> braces' br2 <> semi
-            )
+      return
+        $ primitive Str.instrBr
+        <+> braces'
+          ( constr Str.true_
+              <> colon
+              <+> braces' br1
+              <> semi
+              <> line
+              <> constr Str.false_
+              <> colon
+              <+> braces' br2
+              <> semi
+          )
     Case CmdCase {..} -> do
       name <- Tree.ppIndName _cmdCaseInductive
       brs <- mapM ppCode _cmdCaseBranches

--- a/src/Juvix/Compiler/Asm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource.hs
@@ -152,8 +152,8 @@ parseSave loc isTail = do
   let updateNames :: LocalNameMap DirectRef -> LocalNameMap DirectRef
       updateNames mp = maybe mp (\n -> HashMap.insert n (mkTempRef (OffsetRef tmpNum (Just n))) mp) mn
   c <- braces (localS @LocalParams (over localParamsTempIndex (+ 1)) $ localS @LocalParams (over localParamsNameMap updateNames) parseCode)
-  return $
-    Save
+  return
+    $ Save
       ( CmdSave
           { _cmdSaveInfo = CommandInfo loc,
             _cmdSaveIsTail = isTail,

--- a/src/Juvix/Compiler/Asm/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromTree.hs
@@ -61,8 +61,8 @@ genCode fi =
               (go isTail _nodeBinopArg2)
           )
       Tree.PrimBinop op ->
-        snocReturn isTail $
-          DL.append
+        snocReturn isTail
+          $ DL.append
             (go False _nodeBinopArg2)
             ( DL.snoc
                 (go False _nodeBinopArg1)
@@ -71,59 +71,59 @@ genCode fi =
 
     goUnop :: Bool -> Tree.NodeUnop -> Code'
     goUnop isTail Tree.NodeUnop {..} =
-      snocReturn isTail $
-        DL.snoc (go False _nodeUnopArg) (genUnOp _nodeUnopOpcode)
+      snocReturn isTail
+        $ DL.snoc (go False _nodeUnopArg) (genUnOp _nodeUnopOpcode)
 
     goCairo :: Bool -> Tree.NodeCairo -> Code'
     goCairo isTail Tree.NodeCairo {..} =
-      snocReturn isTail $
-        DL.snoc (goArgs _nodeCairoArgs) (mkInstr $ Cairo _nodeCairoOpcode)
+      snocReturn isTail
+        $ DL.snoc (goArgs _nodeCairoArgs) (mkInstr $ Cairo _nodeCairoOpcode)
 
     goConstant :: Bool -> Tree.NodeConstant -> Code'
     goConstant isTail Tree.NodeConstant {..} =
-      snocReturn isTail $
-        DL.singleton $
-          mkInstr $
-            Push (Constant _nodeConstant)
+      snocReturn isTail
+        $ DL.singleton
+        $ mkInstr
+        $ Push (Constant _nodeConstant)
 
     goMemRef :: Bool -> Tree.NodeMemRef -> Code'
     goMemRef isTail Tree.NodeMemRef {..} =
-      snocReturn isTail $
-        DL.singleton $
-          mkInstr (Push (Ref _nodeMemRef))
+      snocReturn isTail
+        $ DL.singleton
+        $ mkInstr (Push (Ref _nodeMemRef))
 
     goAllocConstr :: Bool -> Tree.NodeAllocConstr -> Code'
     goAllocConstr isTail Tree.NodeAllocConstr {..} =
-      snocReturn isTail $
-        DL.snoc
+      snocReturn isTail
+        $ DL.snoc
           (goArgs _nodeAllocConstrArgs)
           (mkInstr (AllocConstr _nodeAllocConstrTag))
 
     goAllocClosure :: Bool -> Tree.NodeAllocClosure -> Code'
     goAllocClosure isTail Tree.NodeAllocClosure {..} =
-      snocReturn isTail $
-        DL.snoc
+      snocReturn isTail
+        $ DL.snoc
           (goArgs _nodeAllocClosureArgs)
-          ( mkInstr $
-              AllocClosure $
-                InstrAllocClosure
-                  { _allocClosureFunSymbol = _nodeAllocClosureFunSymbol,
-                    _allocClosureArgsNum = length _nodeAllocClosureArgs
-                  }
+          ( mkInstr
+              $ AllocClosure
+              $ InstrAllocClosure
+                { _allocClosureFunSymbol = _nodeAllocClosureFunSymbol,
+                  _allocClosureArgsNum = length _nodeAllocClosureArgs
+                }
           )
 
     goExtendClosure :: Bool -> Tree.NodeExtendClosure -> Code'
     goExtendClosure isTail Tree.NodeExtendClosure {..} =
-      snocReturn isTail $
-        DL.append
+      snocReturn isTail
+        $ DL.append
           (goArgs (toList _nodeExtendClosureArgs))
           ( DL.snoc
               (go False _nodeExtendClosureFun)
-              ( mkInstr $
-                  ExtendClosure $
-                    InstrExtendClosure
-                      { _extendClosureArgsNum = length _nodeExtendClosureArgs
-                      }
+              ( mkInstr
+                  $ ExtendClosure
+                  $ InstrExtendClosure
+                    { _extendClosureArgsNum = length _nodeExtendClosureArgs
+                    }
               )
           )
 
@@ -132,24 +132,24 @@ genCode fi =
       Tree.CallFun sym ->
         DL.snoc
           (goArgs _nodeCallArgs)
-          ( mkInstr $
-              (if isTail then TailCall else Call) $
-                InstrCall
-                  { _callType = CallFun sym,
-                    _callArgsNum = length _nodeCallArgs
-                  }
+          ( mkInstr
+              $ (if isTail then TailCall else Call)
+              $ InstrCall
+                { _callType = CallFun sym,
+                  _callArgsNum = length _nodeCallArgs
+                }
           )
       Tree.CallClosure arg ->
         DL.append
           (goArgs _nodeCallArgs)
           ( DL.snoc
               (go False arg)
-              ( mkInstr $
-                  (if isTail then TailCall else Call) $
-                    InstrCall
-                      { _callType = CallClosure,
-                        _callArgsNum = length _nodeCallArgs
-                      }
+              ( mkInstr
+                  $ (if isTail then TailCall else Call)
+                  $ InstrCall
+                    { _callType = CallClosure,
+                      _callArgsNum = length _nodeCallArgs
+                    }
               )
           )
 
@@ -157,12 +157,12 @@ genCode fi =
     goCallClosures isTail Tree.NodeCallClosures {..} =
       DL.append
         (goArgs (toList _nodeCallClosuresArgs))
-        ( DL.snoc (go False _nodeCallClosuresFun) $
-            mkInstr $
-              (if isTail then TailCallClosures else CallClosures) $
-                InstrCallClosures
-                  { _callClosuresArgsNum = length _nodeCallClosuresArgs
-                  }
+        ( DL.snoc (go False _nodeCallClosuresFun)
+            $ mkInstr
+            $ (if isTail then TailCallClosures else CallClosures)
+            $ InstrCallClosures
+              { _callClosuresArgsNum = length _nodeCallClosuresArgs
+              }
         )
 
     goBranch :: Bool -> Tree.NodeBranch -> Code'
@@ -197,8 +197,8 @@ genCode fi =
           CaseBranch
             { _caseBranchTag,
               _caseBranchCode =
-                [ Save $
-                    CmdSave
+                [ Save
+                    $ CmdSave
                       { _cmdSaveInfo = emptyInfo,
                         _cmdSaveName = Nothing,
                         _cmdSaveIsTail = isTail,

--- a/src/Juvix/Compiler/Backend/Cairo/Translation/FromCasm.hs
+++ b/src/Juvix/Compiler/Backend/Cairo/Translation/FromCasm.hs
@@ -208,8 +208,8 @@ fromCasm instrs0 =
 
         goReturn :: [Element]
         goReturn =
-          [ ElementInstruction $
-              Instruction
+          [ ElementInstruction
+              $ Instruction
                 { _instrOffDst = -2,
                   _instrOffOp0 = -1,
                   _instrOffOp1 = -1,

--- a/src/Juvix/Compiler/Backend/Html/Extra.hs
+++ b/src/Juvix/Compiler/Backend/Html/Extra.hs
@@ -36,19 +36,19 @@ livejs =
 cssLink :: (Members '[Reader HtmlOptions] r) => AttributeValue -> Sem r Html
 cssLink css = do
   assetsPrefix <- textValue <$> asks (^. htmlOptionsAssetsPrefix)
-  return $
-    link
-      ! Attr.href (assetsPrefix <> "assets/css/" <> css)
-      ! Attr.rel "stylesheet"
-      ! Attr.type_ "text/css"
+  return
+    $ link
+    ! Attr.href (assetsPrefix <> "assets/css/" <> css)
+    ! Attr.rel "stylesheet"
+    ! Attr.type_ "text/css"
 
 jsLink :: (Members '[Reader HtmlOptions] r) => AttributeValue -> Sem r Html
 jsLink js = do
   assetsPrefix <- textValue <$> asks (^. htmlOptionsAssetsPrefix)
   return
     $ script
-      ! Attr.src (assetsPrefix <> "assets/js/" <> js)
-      ! Attr.type_ "text/javascript"
+    ! Attr.src (assetsPrefix <> "assets/js/" <> js)
+    ! Attr.type_ "text/javascript"
     $ mempty
 
 toggleJs :: (Members '[Reader HtmlOptions] r) => Sem r Html
@@ -83,12 +83,13 @@ metaUtf8 = meta ! Attr.charset "UTF-8"
 taraSmiling :: (Members '[Reader HtmlOptions] r) => Sem r Html
 taraSmiling = do
   assetsPrefix <- textValue <$> asks (^. htmlOptionsAssetsPrefix)
-  return $
-    Html.a ! Attr.href Str.juvixDotOrg $
-      Html.img
-        ! Attr.id "tara"
-        ! Attr.src (assetsPrefix <> "assets/images/tara-smiling.svg")
-        ! Attr.alt "Tara"
+  return
+    $ Html.a
+    ! Attr.href Str.juvixDotOrg
+    $ Html.img
+    ! Attr.id "tara"
+    ! Attr.src (assetsPrefix <> "assets/images/tara-smiling.svg")
+    ! Attr.alt "Tara"
 
 htmlJuvixFooter ::
   (Members '[Reader HtmlOptions] r) =>
@@ -98,30 +99,32 @@ htmlJuvixFooter = do
   htmlKind <- asks (^. htmlOptionsKind)
   tara <- taraSmiling
   if
-      | noFooter -> return mempty
-      | otherwise -> do
-          let juvixLinkOrg :: Html
-              juvixLinkOrg =
-                a ! Attr.href Str.juvixDotOrg $
-                  toHtml ("Juvix " :: Text)
+    | noFooter -> return mempty
+    | otherwise -> do
+        let juvixLinkOrg :: Html
+            juvixLinkOrg =
+              a
+                ! Attr.href Str.juvixDotOrg
+                $ toHtml ("Juvix " :: Text)
 
-              commitInfo :: Html
-              commitInfo =
-                a
-                  ! Attr.href
-                    (textValue ("https://github.com/anoma/juvix/commit/" <> shortHash))
-                  $ toHtml versionTag
+            commitInfo :: Html
+            commitInfo =
+              a
+                ! Attr.href
+                  (textValue ("https://github.com/anoma/juvix/commit/" <> shortHash))
+                $ toHtml versionTag
 
-              juvixVersion :: Html
-              juvixVersion =
-                toHtml ("Powered by " :: Text)
-                  <> juvixLinkOrg
-                  <> commitInfo
+            juvixVersion :: Html
+            juvixVersion =
+              toHtml ("Powered by " :: Text)
+                <> juvixLinkOrg
+                <> commitInfo
 
-          return $
-            case htmlKind of
-              HtmlDoc ->
-                Html.div ! Attr.id "footer" $
-                  p juvixVersion
-                    <> tara
-              _ -> footer . pre $ juvixVersion
+        return
+          $ case htmlKind of
+            HtmlDoc ->
+              Html.div
+                ! Attr.id "footer"
+                $ p juvixVersion
+                <> tara
+            _ -> footer . pre $ juvixVersion

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -104,20 +104,20 @@ createIndexFile ps = do
       tree' <- root tree
       return
         $ Html.div
-          ! Attr.id "content"
+        ! Attr.id "content"
         $ Html.div
-          ! Attr.id "module-list"
+        ! Attr.id "module-list"
         $ (p ! Attr.class_ "caption" $ "Modules")
-          <> ( button
-                 ! Attr.id "toggle-all-button"
-                 ! Attr.class_ "toggle-button opened"
-                 ! Attr.onclick "toggle()"
-                 $ Html.span
-                   ! Attr.id "toggle-button-text"
-                   ! Attr.class_ "toggle-icon"
-                 $ "▼ Hide all modules"
-             )
-          <> tree'
+        <> ( button
+               ! Attr.id "toggle-all-button"
+               ! Attr.class_ "toggle-button opened"
+               ! Attr.onclick "toggle()"
+               $ Html.span
+               ! Attr.id "toggle-button-text"
+               ! Attr.class_ "toggle-icon"
+               $ "▼ Hide all modules"
+           )
+        <> tree'
 
     tree :: ModuleTree
     tree = indexTree ps
@@ -135,13 +135,13 @@ createIndexFile ps = do
           Nothing ->
             return
               $ Html.span
-                ! Attr.class_ attrBare
+              ! Attr.class_ attrBare
               $ toHtml (prettyText sym)
           Just lbl' -> do
             lnk <- nameIdAttrRef lbl' Nothing
             return
               $ Html.span
-                ! Attr.class_ attrBare
+              ! Attr.class_ attrBare
               $ (a ! Attr.href lnk $ toHtml (prettyText lbl'))
 
         attrBase :: Html.AttributeValue
@@ -160,9 +160,9 @@ createIndexFile ps = do
                   c' <- mapM (uncurry goChild) (HashMap.toList children)
                   return
                     $ details
-                      ! Attr.open "open"
+                    ! Attr.open "open"
                     $ summary row'
-                      <> ul (mconcatMap li c')
+                    <> ul (mconcatMap li c')
 
 writeHtml :: (Members '[EmbedIO] r) => Path Abs File -> Html -> Sem r ()
 writeHtml f h = liftIO $ do
@@ -227,19 +227,19 @@ topTemplate rightMenu' content' = do
   toggle <- toggleJs
   let mhead :: Html
       mhead =
-        Html.head $
-          title titleStr
-            <> Html.meta
-              ! Attr.httpEquiv "Content-Type"
-              ! Attr.content "text/html; charset=UTF-8"
-            <> Html.meta
-              ! Attr.name "viewport"
-              ! Attr.content "width=device-width, initial-scale=1"
-            <> mathJax
-            <> livejs
-            <> ayuTheme
-            <> judocTheme
-            <> toggle
+        Html.head
+          $ title titleStr
+          <> Html.meta
+          ! Attr.httpEquiv "Content-Type"
+          ! Attr.content "text/html; charset=UTF-8"
+          <> Html.meta
+          ! Attr.name "viewport"
+          ! Attr.content "width=device-width, initial-scale=1"
+          <> mathJax
+          <> livejs
+          <> ayuTheme
+          <> judocTheme
+          <> toggle
 
       titleStr :: Html
       titleStr = "Juvix Documentation"
@@ -250,14 +250,14 @@ topTemplate rightMenu' content' = do
         version' <- toHtml <$> asks (^. entryPointPackage . packageVersion . to prettySemVer)
         return
           $ Html.div
-            ! Attr.id "package-header"
+          ! Attr.id "package-header"
           $ ( Html.span
                 ! Attr.class_ "caption"
                 $ pkgName'
-                  <> " - "
-                  <> version'
+                <> " - "
+                <> version'
             )
-            <> rightMenu'
+          <> rightMenu'
 
       mbody :: Sem r Html
       mbody = do
@@ -265,10 +265,10 @@ topTemplate rightMenu' content' = do
         footer' <- htmlJuvixFooter
         return
           $ body
-            ! Attr.class_ "js-enabled"
+          ! Attr.class_ "js-enabled"
           $ bodyHeader'
-            <> content'
-            <> footer'
+          <> content'
+          <> footer'
 
   body' <- mbody
   return $ docTypeHtml (mhead <> body')
@@ -316,10 +316,10 @@ goTopModule cs m = do
           sourceRef' <- local (set htmlOptionsKind HtmlSrc) (nameIdAttrRef tmp Nothing)
           return
             $ ul
-              ! Attr.id "page-menu"
-              ! Attr.class_ "links"
+            ! Attr.id "page-menu"
+            ! Attr.class_ "links"
             $ li (a ! Attr.href sourceRef' $ "Source")
-              <> li (a ! Attr.href (fromString (toFilePath indexFileName)) $ "Index")
+            <> li (a ! Attr.href (fromString (toFilePath indexFileName)) $ "Index")
 
         content :: Sem s Html
         content = do
@@ -327,46 +327,46 @@ goTopModule cs m = do
           interface' <- moduleInterface
           return
             $ Html.div
-              ! Attr.id "content"
+            ! Attr.id "content"
             $ moduleHeader
-              <> toc
-              <> preface'
-              -- <> synopsis
-              <> interface'
+            <> toc
+            <> preface'
+            -- <> synopsis
+            <> interface'
 
         docPreface :: Sem s Html
         docPreface = do
           pref <- goJudocMay (m ^. moduleDoc)
           return
             $ Html.div
-              ! Attr.id "description"
+            ! Attr.id "description"
             $ Html.div
-              ! Attr.class_ "doc"
+            ! Attr.class_ "doc"
             $ ( a
                   ! Attr.id "sec:description"
                   ! Attr.href "sec:description"
                   $ h1 "Description"
               )
-              <> pref
+            <> pref
 
         toc :: Html
         toc =
           Html.div
             ! Attr.id "table-of-contents"
             $ Html.div
-              ! Attr.id "contents-list"
+            ! Attr.id "contents-list"
             $ ( p
                   ! Attr.class_ "caption"
                   ! Attr.onclick "window.scrollTo(0,0)"
                   $ "Contents"
               )
-              <> tocEntries
+            <> tocEntries
           where
             tocEntries :: Html
             tocEntries =
-              ul $
-                li (a ! Attr.href "#sec:description" $ "Description")
-                  <> li (a ! Attr.href "#sec:interface" $ "Definitions")
+              ul
+                $ li (a ! Attr.href "#sec:description" $ "Description")
+                <> li (a ! Attr.href "#sec:interface" $ "Definitions")
 
         moduleHeader :: Html
         moduleHeader =
@@ -379,13 +379,13 @@ goTopModule cs m = do
           sigs' <- mconcatMapM goStatement (m ^. moduleBody)
           return
             $ Html.div
-              ! Attr.id "interface"
+            ! Attr.id "interface"
             $ ( a
                   ! Attr.id "sec:interface"
                   ! Attr.href "sec:interface"
                   $ h1 "Definitions"
               )
-              <> sigs'
+            <> sigs'
 
 goJudocMay :: (Members '[Reader HtmlOptions] r) => Maybe (Judoc 'Scoped) -> Sem r Html
 goJudocMay = maybe (return mempty) goJudoc
@@ -437,13 +437,13 @@ goFixity def = do
   header' <- defHeader (def ^. fixitySymbol) sig' (def ^. fixityDoc)
   prec' <- mkPrec
   let tbl' = table . tbody $ ari <> prec'
-  return $
-    header'
-      <> ( Html.div
-             ! Attr.class_ "subs"
-             $ (p ! Attr.class_ "caption" $ "Fixity details")
-               <> tbl'
-         )
+  return
+    $ header'
+    <> ( Html.div
+           ! Attr.class_ "subs"
+           $ (p ! Attr.class_ "caption" $ "Fixity details")
+           <> tbl'
+       )
   where
     info :: ParsedFixityInfo 'Scoped
     info = def ^. fixityInfo
@@ -474,9 +474,9 @@ goFixity def = do
             AssocNone -> ""
             AssocRight -> ", right-associative"
             AssocLeft -> ", left-associative"
-       in row $
-            arit
-              <> assoc
+       in row
+            $ arit
+            <> assoc
 
 goAlias :: forall r. (Members '[Reader HtmlOptions] r) => AliasDef 'Scoped -> Sem r Html
 goAlias def = do
@@ -551,9 +551,9 @@ goConstructors cc = do
   tbl' <- table . tbody <$> mconcatMapM goConstructor cc
   return
     $ Html.div
-      ! Attr.class_ "subs constructors"
+    ! Attr.class_ "subs constructors"
     $ (p ! Attr.class_ "caption" $ "Constructors")
-      <> tbl'
+    <> tbl'
   where
     goConstructor :: ConstructorDef 'Scoped -> Sem r Html
     goConstructor c = do
@@ -572,7 +572,7 @@ goConstructors cc = do
           sig' <- ppHelper (ppConstructorDef False (set constructorDoc Nothing c))
           return
             $ td
-              ! Attr.class_ "src"
+            ! Attr.class_ "src"
             $ sig'
 
 noDefHeader :: Html -> Html
@@ -590,9 +590,9 @@ defHeader name sig mjudoc = do
   judoc' <- judoc
   return
     $ Html.div
-      ! Attr.class_ "top"
+    ! Attr.class_ "top"
     $ funHeader'
-      <> judoc'
+    <> judoc'
   where
     uid :: NameId
     uid = name ^. S.nameId
@@ -613,17 +613,17 @@ defHeader name sig mjudoc = do
 sourceAndSelfLink :: (Members '[Reader HtmlOptions] r) => TopModulePath -> NameId -> Sem r Html
 sourceAndSelfLink tmp name = do
   ref' <- local (set htmlOptionsKind HtmlSrc) (nameIdAttrRef tmp (Just name))
-  return $
-    ( a
-        ! Attr.href ref'
-        ! Attr.class_ "link"
-        $ "Source"
-    )
-      <> ( a
-             ! Attr.href (selfLinkName name)
-             ! Attr.class_ "selflink"
-             $ "#"
-         )
+  return
+    $ ( a
+          ! Attr.href ref'
+          ! Attr.class_ "link"
+          $ "Source"
+      )
+    <> ( a
+           ! Attr.href (selfLinkName name)
+           ! Attr.class_ "selflink"
+           $ "#"
+       )
 
 tagIden :: (IsString c) => NameId -> c
 tagIden = fromText . prettyText

--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped/Source.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped/Source.hs
@@ -148,8 +148,8 @@ genModuleText ::
   Sem r Text
 genModuleText GenModuleTextArgs {..} = do
   outputHtml <-
-    genModuleHtml $
-      GenModuleHtmlArgs
+    genModuleHtml
+      $ GenModuleHtmlArgs
         { _genModuleHtmlArgsConcreteOpts = _genModuleTextArgsConcreteOpts,
           _genModuleHtmlArgsUTC = _genModuleTextArgsUTC,
           _genModuleHtmlArgsComments = _genModuleTextArgsComments,
@@ -165,22 +165,24 @@ genModuleHtml ::
 genModuleHtml o = do
   onlyCode <- asks (^. htmlOptionsOnlyCode)
   if
-      | onlyCode -> justCode
-      | otherwise -> do
-          hd <- mhead
-          bd <- mbody
-          return $
-            docTypeHtml ! Attr.xmlns "http://www.w3.org/1999/xhtml" $
-              hd <> bd
+    | onlyCode -> justCode
+    | otherwise -> do
+        hd <- mhead
+        bd <- mbody
+        return
+          $ docTypeHtml
+          ! Attr.xmlns "http://www.w3.org/1999/xhtml"
+          $ hd
+          <> bd
   where
     mhead :: Sem r Html
     mhead = do
       css <- themeCss
       js <- highlightJs
-      return $
-        metaUtf8
-          <> css
-          <> js
+      return
+        $ metaUtf8
+        <> css
+        <> js
 
     mbody :: Sem r Html
     mbody =
@@ -193,13 +195,14 @@ genModuleHtml o = do
 
     formattedTime :: Sem r Html
     formattedTime =
-      return $
-        Html.span . toHtml $
-          "Last modified on "
-            <> formatTime
-              defaultTimeLocale
-              "%Y-%m-%d %-H:%M %Z"
-              (o ^. genModuleHtmlArgsUTC)
+      return
+        $ Html.span
+        . toHtml
+        $ "Last modified on "
+        <> formatTime
+          defaultTimeLocale
+          "%Y-%m-%d %-H:%M %Z"
+          (o ^. genModuleHtmlArgsUTC)
 
     justCode :: Sem r Html
     justCode =
@@ -213,9 +216,10 @@ genModuleHtml o = do
 
     mheader :: Sem r Html
     mheader =
-      return $
-        Html.div ! Attr.id "package-header" $
-          (Html.span ! Attr.class_ "caption" $ "")
+      return
+        $ Html.div
+        ! Attr.id "package-header"
+        $ (Html.span ! Attr.class_ "caption" $ "")
 
 renderTree :: (Members '[Reader HtmlOptions] r) => SimpleDocTree Ann -> Sem r Html
 renderTree = go
@@ -344,10 +348,12 @@ putTag ann x = case ann of
     tagRef :: TopModulePath -> S.NameId -> Sem r Html
     tagRef tmp ni = do
       pth <- nameIdAttrRef tmp (Just ni)
-      return $
-        Html.span ! Attr.class_ "annot" $
-          a ! Attr.href pth $
-            x
+      return
+        $ Html.span
+        ! Attr.class_ "annot"
+        $ a
+        ! Attr.href pth
+        $ x
 
     tagKind k =
       Html.span
@@ -370,12 +376,12 @@ moduleDocRelativePath m = do
         | otherwise = topModulePathToRelativePathDot ext suff
   let relpath :: Path Rel File = pathgen m
   if
-      | null fixPrefix -> return relpath
-      | otherwise -> do
-          return $
-            fromMaybe
-              relpath
-              (stripProperPrefix (fromJust (parseRelDir fixPrefix)) relpath)
+    | null fixPrefix -> return relpath
+    | otherwise -> do
+        return
+          $ fromMaybe
+            relpath
+            (stripProperPrefix (fromJust (parseRelDir fixPrefix)) relpath)
 
 nameIdAttrRef :: (Members '[Reader HtmlOptions] r) => TopModulePath -> Maybe S.NameId -> Sem r AttributeValue
 nameIdAttrRef tp mid = do

--- a/src/Juvix/Compiler/Backend/Isabelle/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Backend/Isabelle/Pretty/Base.hs
@@ -117,20 +117,20 @@ instance PrettyCode Theory where
   ppCode Theory {..} = do
     n <- ppCode _theoryName
     stmts <- mapM ppCode _theoryStatements
-    return $
-      kwTheory
-        <+> n
-          <> line
-          <> kwImports
-        <+> "Main"
-          <> line
-          <> kwBegin
-          <> line
-          <> line
-          <> vsep (punctuate line stmts)
-          <> line
-          <> line
-          <> kwEnd
+    return
+      $ kwTheory
+      <+> n
+      <> line
+      <> kwImports
+      <+> "Main"
+      <> line
+      <> kwBegin
+      <> line
+      <> line
+      <> vsep (punctuate line stmts)
+      <> line
+      <> line
+      <> kwEnd
 
 ppRightExpression ::
   (PrettyCode a, HasAtomicity a, Member (Reader Options) r) =>

--- a/src/Juvix/Compiler/Backend/Isabelle/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Isabelle/Translation/FromTyped.hs
@@ -31,8 +31,8 @@ fromInternal Internal.InternalTypedResult {..} = do
   where
     go :: Bool -> Internal.InfoTable -> Internal.Module -> Sem r Result
     go onlyTypes tab md =
-      return $
-        Result
+      return
+        $ Result
           { _resultTheory = goModule onlyTypes tab md,
             _resultModuleId = md ^. Internal.moduleId
           }
@@ -60,8 +60,8 @@ goModule onlyTypes infoTable Internal.Module {..} =
 
     goMutualBlock :: Internal.MutualBlock -> [Statement]
     goMutualBlock Internal.MutualBlock {..} =
-      filter (\stmt -> not onlyTypes || isTypeDef stmt) $
-        map goMutualStatement (toList _mutualStatements)
+      filter (\stmt -> not onlyTypes || isTypeDef stmt)
+        $ map goMutualStatement (toList _mutualStatements)
 
     goMutualStatement :: Internal.MutualStatement -> Statement
     goMutualStatement = \case
@@ -71,8 +71,10 @@ goModule onlyTypes infoTable Internal.Module {..} =
 
     goInductiveDef :: Internal.InductiveDef -> Statement
     goInductiveDef Internal.InductiveDef {..}
-      | length _inductiveConstructors == 1
-          && head' _inductiveConstructors ^. Internal.inductiveConstructorIsRecord =
+      | length _inductiveConstructors
+          == 1
+          && head' _inductiveConstructors
+          ^. Internal.inductiveConstructorIsRecord =
           let tyargs = fst $ Internal.unfoldFunType $ head' _inductiveConstructors ^. Internal.inductiveConstructorType
            in StmtRecord
                 Record

--- a/src/Juvix/Compiler/Backend/Markdown/Translation/FromTyped/Source.hs
+++ b/src/Juvix/Compiler/Backend/Markdown/Translation/FromTyped/Source.hs
@@ -72,8 +72,8 @@ fromJuvixMarkdown opts = do
       let mk :: Mk = mkInfo ^. Concrete.markdownInfo
           sepr :: [Int] = mkInfo ^. Concrete.markdownInfoBlockLengths
 
-      when (nullMk mk || null sepr) $
-        throw
+      when (nullMk mk || null sepr)
+        $ throw
           ( ErrNoJuvixCodeBlocks
               NoJuvixCodeBlocksError
                 { _noJuvixCodeBlocksErrorFilepath = fname
@@ -164,10 +164,10 @@ go fname = do
                     let m' = set Concrete.moduleBody stmts' m
                     goRender m'
                   else
-                    return $
-                      Html.preEscapedText $
-                        Text.intercalate "\n\n" $
-                          map (toStrict . Html.renderHtml) htmlStatements
+                    return
+                      $ Html.preEscapedText
+                      $ Text.intercalate "\n\n"
+                      $ map (toStrict . Html.renderHtml) htmlStatements
 
           let _processingStateMk = case opts of
                 MkJuvixBlockOptionsHide -> MkNull

--- a/src/Juvix/Compiler/Backend/Rust/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Backend/Rust/Pretty/Base.hs
@@ -12,9 +12,9 @@ class PrettyCode c where
 
 doc :: (PrettyCode c) => Options -> c -> Doc Ann
 doc opts x =
-  run $
-    runReader opts $
-      ppCode x
+  run
+    $ runReader opts
+    $ ppCode x
 
 ampersand :: Doc Ann
 ampersand = "&"

--- a/src/Juvix/Compiler/Backend/Rust/Translation/FromReg.hs
+++ b/src/Juvix/Compiler/Backend/Rust/Translation/FromReg.hs
@@ -71,8 +71,8 @@ fromReg backend lims tab =
       where
         mkFunConstDecl :: Reg.FunctionInfo -> Statement
         mkFunConstDecl funInfo =
-          StatementConst $
-            ConstDecl
+          StatementConst
+            $ ConstDecl
               { _constVariable = getFunctionIdent info (funInfo ^. Reg.functionSymbol),
                 _constType = Word,
                 _constValue = mkInteger (getFUID info (funInfo ^. Reg.functionSymbol))
@@ -80,12 +80,12 @@ fromReg backend lims tab =
 
     juvixFunctions :: [Statement]
     juvixFunctions =
-      [ StatementLoop $
-          Loop
+      [ StatementLoop
+          $ Loop
             { _loopLabel = Just "'program",
               _loopBody =
-                [ StatementMatch $
-                    Match
+                [ StatementMatch
+                    $ Match
                       { _matchValue = mkVar "funid",
                         _matchBranches = map (fromRegFunction info) funs ++ [errBranch]
                       }
@@ -342,8 +342,8 @@ fromRegInstr info = \case
 
     fromTailCallClosures :: Reg.InstrTailCallClosures -> [Statement]
     fromTailCallClosures Reg.InstrTailCallClosures {..} =
-      [ StatementExpression $
-          mkCall
+      [ StatementExpression
+          $ mkCall
             "tapply!"
             [ mkVar "'program",
               mkVar "program",
@@ -383,8 +383,8 @@ fromRegInstr info = \case
     fromCase Reg.InstrCase {..} = do
       case _instrCaseIndRep of
         Reg.IndRepStandard ->
-          [ StatementMatch $
-              Match
+          [ StatementMatch
+              $ Match
                 { _matchValue = mkCall "mem.get_constr_tag" [fromValue _instrCaseValue],
                   _matchBranches = brs'
                 }

--- a/src/Juvix/Compiler/Backend/Rust/Translation/FromReg/Base.hs
+++ b/src/Juvix/Compiler/Backend/Rust/Translation/FromReg/Base.hs
@@ -57,8 +57,8 @@ stmtsBlock stmts = [StatementExpression (ExprBlock (Block stmts))]
 
 stmtLet :: IsMut -> Text -> Expression -> Statement
 stmtLet isMut result value =
-  StatementLet $
-    Let
+  StatementLet
+    $ Let
       { _letMutable = isMut,
         _letVariable = result,
         _letType = Nothing,
@@ -67,8 +67,8 @@ stmtLet isMut result value =
 
 stmtDecl :: IsMut -> Text -> Type -> Statement
 stmtDecl isMut var ty =
-  StatementLet $
-    Let
+  StatementLet
+    $ Let
       { _letMutable = isMut,
         _letVariable = var,
         _letType = Just ty,

--- a/src/Juvix/Compiler/Backend/VampIR/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Backend/VampIR/Pretty/Base.hs
@@ -12,9 +12,9 @@ class PrettyCode c where
 
 doc :: (PrettyCode c) => Options -> c -> Doc Ann
 doc opts x =
-  run $
-    runReader opts $
-      ppCode x
+  run
+    $ runReader opts
+    $ ppCode x
 
 ppName :: NameKind -> Text -> Sem r (Doc Ann)
 ppName k n = return $ annotate (AnnKind k) (pretty n)
@@ -102,10 +102,10 @@ vampIRDefs bits unsafe =
     <> show bits
     <> ";\n\n"
     <> if
-        | unsafe ->
-            UTF8.toString $(FE.makeRelativeToProject ("runtime/vampir/stdlib_unsafe" <> vampIRFileExt) >>= FE.embedFile)
-        | otherwise ->
-            UTF8.toString $(FE.makeRelativeToProject ("runtime/vampir/stdlib" <> vampIRFileExt) >>= FE.embedFile)
+      | unsafe ->
+          UTF8.toString $(FE.makeRelativeToProject ("runtime/vampir/stdlib_unsafe" <> vampIRFileExt) >>= FE.embedFile)
+      | otherwise ->
+          UTF8.toString $(FE.makeRelativeToProject ("runtime/vampir/stdlib" <> vampIRFileExt) >>= FE.embedFile)
 
 --------------------------------------------------------------------------------
 -- helper functions

--- a/src/Juvix/Compiler/Builtins/Effect.hs
+++ b/src/Juvix/Compiler/Builtins/Effect.hs
@@ -36,8 +36,8 @@ runBuiltins ini = reinterpret (runState ini) $ \case
     where
       notDefined :: Sem (State BuiltinsState ': r) x
       notDefined =
-        throw $
-          JuvixError
+        throw
+          $ JuvixError
             NotDefined
               { _notDefinedBuiltin = b,
                 _notDefinedLoc = i
@@ -51,8 +51,8 @@ runBuiltins ini = reinterpret (runState ini) $ \case
     where
       alreadyDefined :: Sem (State BuiltinsState ': r) x
       alreadyDefined =
-        throw $
-          JuvixError
+        throw
+          $ JuvixError
             AlreadyDefined
               { _alreadyDefinedBuiltin = b,
                 _alreadyDefinedLoc = getLoc n

--- a/src/Juvix/Compiler/Casm/Extra/Stdlib.hs
+++ b/src/Juvix/Compiler/Casm/Extra/Stdlib.hs
@@ -28,9 +28,9 @@ makeLenses ''StdlibBuiltins
 addStdlibBuiltins :: (Member LabelInfoBuilder r) => Address -> Sem r (StdlibBuiltins, [Instruction])
 addStdlibBuiltins addr = do
   instrs <-
-    fmap (fromRight impossible) $
-      runParser' addr "stdlib.casm" $
-        decodeUtf8 $(FE.makeRelativeToProject "runtime/casm/stdlib.casm" >>= FE.embedFile)
+    fmap (fromRight impossible)
+      $ runParser' addr "stdlib.casm"
+      $ decodeUtf8 $(FE.makeRelativeToProject "runtime/casm/stdlib.casm" >>= FE.embedFile)
   let _stdlibGetRegsName :: Text = "juvix_get_regs"
       _stdlibCallClosureName :: Text = "juvix_call_closure"
       _stdlibExtendClosureName :: Text = "juvix_extend_closure"

--- a/src/Juvix/Compiler/Casm/Interpreter.hs
+++ b/src/Juvix/Compiler/Casm/Interpreter.hs
@@ -104,14 +104,14 @@ hRunCode hout inputInfo (LabelInfo labelInfo) instrs0 = runST goCode
       let len = MV.length mem
       mem' <-
         if
-            | addr >= len -> do
-                mem' <- MV.grow mem (max (addr + initialMemSize - len) len)
-                mapM_ (\i -> MV.write mem' i Nothing) [len .. MV.length mem' - 1]
-                return mem'
-            | otherwise ->
-                return mem
-      whenJustM (MV.read mem' addr) $
-        throwRunError ("double memory write at address " <> show addr)
+          | addr >= len -> do
+              mem' <- MV.grow mem (max (addr + initialMemSize - len) len)
+              mapM_ (\i -> MV.write mem' i Nothing) [len .. MV.length mem' - 1]
+              return mem'
+          | otherwise ->
+              return mem
+      whenJustM (MV.read mem' addr)
+        $ throwRunError ("double memory write at address " <> show addr)
       MV.write mem' addr (Just v)
       return mem'
 
@@ -129,10 +129,10 @@ hRunCode hout inputInfo (LabelInfo labelInfo) instrs0 = runST goCode
 
     readLabel :: LabelRef -> FField
     readLabel LabelRef {..} =
-      fieldFromInteger fsize $
-        fromIntegral $
-          fromMaybe (throwRunError "invalid label") $
-            HashMap.lookup _labelRefSymbol labelInfo
+      fieldFromInteger fsize
+        $ fromIntegral
+        $ fromMaybe (throwRunError "invalid label")
+        $ HashMap.lookup _labelRefSymbol labelInfo
 
     readValue' :: Bool -> Address -> Address -> Address -> Memory s -> Value -> ST s FField
     readValue' isRel pc ap fp mem = \case
@@ -200,8 +200,8 @@ hRunCode hout inputInfo (LabelInfo labelInfo) instrs0 = runST goCode
           IntDiv -> fieldFromInteger fsize (fieldToInt x `quot` fieldToInt y)
           IntMod -> fieldFromInteger fsize (fieldToInt x `rem` fieldToInt y)
           IntLt ->
-            fieldFromInteger fsize $
-              if fieldToInt x < fieldToInt y then 0 else 1
+            fieldFromInteger fsize
+              $ if fieldToInt x < fieldToInt y then 0 else 1
 
         fieldToInt :: FField -> Integer
         fieldToInt f
@@ -254,8 +254,8 @@ hRunCode hout inputInfo (LabelInfo labelInfo) instrs0 = runST goCode
     goHint hint pc ap fp mem = case hint of
       HintInput var -> do
         let val =
-              fromMaybe (throwRunError "invalid input") $
-                HashMap.lookup var (inputInfo ^. inputInfoMap)
+              fromMaybe (throwRunError "invalid input")
+                $ HashMap.lookup var (inputInfo ^. inputInfoMap)
         mem' <- writeMem mem ap val
         go (pc + 1) ap fp mem'
       HintAlloc size -> do
@@ -269,8 +269,8 @@ hRunCode hout inputInfo (LabelInfo labelInfo) instrs0 = runST goCode
     goFinish :: Address -> Memory s -> ST s FField
     goFinish ap mem = do
       checkGaps mem
-      when (ap == 0) $
-        throwRunError "nothing to return"
+      when (ap == 0)
+        $ throwRunError "nothing to return"
       readMem mem (ap - 1)
 
 catchRunErrorIO :: a -> IO (Either CasmError a)

--- a/src/Juvix/Compiler/Casm/Transformation/Optimize/Peephole.hs
+++ b/src/Juvix/Compiler/Casm/Transformation/Optimize/Peephole.hs
@@ -19,20 +19,20 @@ peephole = mapT go
         | _instrCallRel,
           Imm 3 <- _instrCallTarget,
           Just k1 <- getAssignApFp a1 ->
-            fixAssignAp $
-              mkAssignAp (Val (Ref (MemRef Ap k1)))
-                : Return
-                : is
+            fixAssignAp
+              $ mkAssignAp (Val (Ref (MemRef Ap k1)))
+              : Return
+              : is
       Call InstrCall {..} : Return : Assign a1 : Assign a2 : Return : is
         | _instrCallRel,
           Imm 3 <- _instrCallTarget,
           Just k1 <- getAssignApFp a1,
           Just k2 <- getAssignApFp a2 ->
-            fixAssignAp $
-              mkAssignAp (Val (Ref (MemRef Ap k1)))
-                : mkAssignAp (Val (Ref (MemRef Ap (k2 - 1))))
-                : Return
-                : is
+            fixAssignAp
+              $ mkAssignAp (Val (Ref (MemRef Ap k1)))
+              : mkAssignAp (Val (Ref (MemRef Ap (k2 - 1))))
+              : Return
+              : is
       Call InstrCall {..} : Return : Jump InstrJump {..} : is
         | _instrCallRel,
           Imm 3 <- _instrCallTarget,

--- a/src/Juvix/Compiler/Casm/Translation/FromCairo.hs
+++ b/src/Juvix/Compiler/Casm/Translation/FromCairo.hs
@@ -64,9 +64,12 @@ fromCairo elems0 =
         goCall :: Cairo.Instruction -> [Cairo.Element] -> (Instruction, Int)
         goCall i@Cairo.Instruction {..} elems
           | (_instrPcUpdate == Cairo.PcUpdateJump || _instrPcUpdate == Cairo.PcUpdateJumpRel)
-              && _instrApUpdate == Cairo.ApUpdateRegular
-              && _instrDstReg == Ap
-              && _instrOffDst == 0 =
+              && _instrApUpdate
+              == Cairo.ApUpdateRegular
+              && _instrDstReg
+              == Ap
+              && _instrOffDst
+              == 0 =
               (call, delta)
           | otherwise =
               errorMsg addr ("invalid call: " <> show i)
@@ -84,13 +87,20 @@ fromCairo elems0 =
 
         goRet :: Cairo.Instruction -> [Cairo.Element] -> (Instruction, Int)
         goRet i@Cairo.Instruction {..} _
-          | _instrApUpdate == Cairo.ApUpdateRegular
-              && _instrPcUpdate == Cairo.PcUpdateJump
-              && _instrResLogic == Cairo.ResOp1
-              && _instrOp1Src == Cairo.Op1SrcFp
-              && _instrOffOp1 == -1
-              && _instrDstReg == Fp
-              && _instrOffDst == -2 =
+          | _instrApUpdate
+              == Cairo.ApUpdateRegular
+              && _instrPcUpdate
+              == Cairo.PcUpdateJump
+              && _instrResLogic
+              == Cairo.ResOp1
+              && _instrOp1Src
+              == Cairo.Op1SrcFp
+              && _instrOffOp1
+              == -1
+              && _instrDstReg
+              == Fp
+              && _instrOffDst
+              == -2 =
               (Return, 0)
           | otherwise =
               errorMsg addr ("invalid ret: " <> show i)
@@ -98,7 +108,8 @@ fromCairo elems0 =
         goAssertEq :: Cairo.Instruction -> [Cairo.Element] -> (Instruction, Int)
         goAssertEq i@Cairo.Instruction {..} elems
           | (_instrApUpdate == Cairo.ApUpdateInc || _instrApUpdate == Cairo.ApUpdateRegular)
-              && _instrPcUpdate == Cairo.PcUpdateRegular =
+              && _instrPcUpdate
+              == Cairo.PcUpdateRegular =
               (asng, delta)
           | otherwise =
               errorMsg addr ("invalid assignment: " <> show i)

--- a/src/Juvix/Compiler/Casm/Translation/FromReg.hs
+++ b/src/Juvix/Compiler/Casm/Translation/FromReg.hs
@@ -49,10 +49,10 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
           : Label startLab
           : initBuiltinsInstr
           : loadInputArgsInstrs
-          ++ callMainInstr
+            ++ callMainInstr
           : bltsRet
-          ++ resRetInstrs
-          ++ [Return]
+            ++ resRetInstrs
+            ++ [Return]
   (blts, binstrs) <- addStdlibBuiltins (length pinstrs)
   let cinstrs = concatMap (mkFunCall . fst) $ sortOn snd $ HashMap.toList (info ^. Reg.extraInfoFUIDs)
   (addr, instrs) <- second (concat . reverse) <$> foldM (goFun blts endLab) (length pinstrs + length binstrs + length cinstrs, []) (tab ^. Reg.infoFunctions)
@@ -153,8 +153,8 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
           addr1 = addr0 + length pre
           n = funInfo ^. Reg.functionArgsNum
       let vars =
-            HashMap.fromList $
-              map (\k -> (Reg.VarRef Reg.VarGroupArgs k Nothing, -argsOffset - k)) [0 .. n - 1]
+            HashMap.fromList
+              $ map (\k -> (Reg.VarRef Reg.VarGroupArgs k Nothing, -argsOffset - k)) [0 .. n - 1]
       instrs <-
         fmap fst
           . runCasmBuilder addr1 vars (-argsOffset - n)
@@ -208,16 +208,16 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
               n = length liveVars'
               bltOff =
                 if
-                    | updatedBuiltins ->
-                        -argsOffset - n - fromEnum (isJust outVar)
-                    | otherwise ->
-                        -argsOffset - n
+                  | updatedBuiltins ->
+                      -argsOffset - n - fromEnum (isJust outVar)
+                  | otherwise ->
+                      -argsOffset - n
               vars =
-                HashMap.fromList $
-                  maybe [] (\var -> [(var, -argsOffset - n - if updatedBuiltins then 0 else 1)]) outVar
-                    ++ zipWithExact (\var k -> (var, -argsOffset - k)) liveVars' [0 .. n - 1]
-          unless updatedBuiltins $
-            goAssignApBuiltins
+                HashMap.fromList
+                  $ maybe [] (\var -> [(var, -argsOffset - n - if updatedBuiltins then 0 else 1)]) outVar
+                  ++ zipWithExact (\var k -> (var, -argsOffset - k)) liveVars' [0 .. n - 1]
+          unless updatedBuiltins
+            $ goAssignApBuiltins
           mapM_ (mkMemRef >=> goAssignAp . Val . Ref) (reverse liveVars')
           output'' (mkCallRel $ Imm 3)
           output'' Return
@@ -324,8 +324,8 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
         goExtraBinop op res arg1 arg2 = do
           off <- getAP
           insertVar res off
-          output' 1 $
-            ExtraBinop
+          output' 1
+            $ ExtraBinop
               InstrExtraBinop
                 { _instrExtraBinopOpcode = op,
                   _instrExtraBinopResult = MemRef Ap 0,
@@ -490,8 +490,8 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
         goAlloc :: Reg.InstrAlloc -> Sem r ()
         goAlloc Reg.InstrAlloc {..} = do
           goAllocCall _instrAllocResult
-          unless (Reg.isConstrRecord tab _instrAllocTag) $
-            goAssignAp (Val $ Imm $ fromIntegral tagId)
+          unless (Reg.isConstrRecord tab _instrAllocTag)
+            $ goAssignAp (Val $ Imm $ fromIntegral tagId)
           mapM_ goAssignApValue _instrAllocArgs
           where
             tagId = getTagId _instrAllocTag
@@ -608,8 +608,8 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
             bltOff <- getBuiltinOffset
             goLocalBlock ap0 vars bltOff liveVars outVar branchTrue
             -- outVar is Nothing iff the branch returns
-            when (isJust outVar) $
-              output'' (mkJumpRel (Val $ Lab labEnd))
+            when (isJust outVar)
+              $ output'' (mkJumpRel (Val $ Lab labEnd))
             addrFalse <- getPC
             registerLabelAddress symFalse addrFalse
             output'' $ Label labFalse
@@ -652,8 +652,8 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
           -- may be removed by the peephole optimizer)
           mapM_ (goCaseBranch ap0 vars bltOff symMap labEnd) (reverse _instrCaseBranches)
           mapM_ (goDefaultLabel symMap) defaultTags
-          whenJust _instrCaseDefault $
-            goLocalBlock ap0 vars bltOff liveVars _instrCaseOutVar
+          whenJust _instrCaseDefault
+            $ goLocalBlock ap0 vars bltOff liveVars _instrCaseOutVar
           addrEnd <- getPC
           registerLabelAddress symEnd addrEnd
           output'' $ Label labEnd
@@ -671,8 +671,8 @@ fromReg tab = mkResult $ run $ runLabelInfoBuilderWithNextId (Reg.getNextSymbolI
               output'' $ Label lab
               goLocalBlock ap0 vars bltOff liveVars _instrCaseOutVar _caseBranchCode
               -- _instrCaseOutVar is Nothing iff the branch returns
-              when (isJust _instrCaseOutVar) $
-                output'' (mkJumpRel (Val $ Lab labEnd))
+              when (isJust _instrCaseOutVar)
+                $ output'' (mkJumpRel (Val $ Lab labEnd))
 
             goDefaultLabel :: HashMap Tag Symbol -> Reg.Tag -> Sem r ()
             goDefaultLabel symMap tag = do

--- a/src/Juvix/Compiler/Casm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Casm/Translation/FromSource.hs
@@ -61,10 +61,10 @@ label addr = P.try $ do
     Just sym -> do
       b <- lift $ hasOffset sym
       if
-          | b -> parseFailure off' "duplicate label"
-          | otherwise -> do
-              lift $ registerLabelAddress sym addr
-              return $ Label $ LabelRef {_labelRefSymbol = sym, _labelRefName = Just txt}
+        | b -> parseFailure off' "duplicate label"
+        | otherwise -> do
+            lift $ registerLabelAddress sym addr
+            return $ Label $ LabelRef {_labelRefSymbol = sym, _labelRefName = Just txt}
 
 instruction :: (Member LabelInfoBuilder r) => ParsecS r Instruction
 instruction =
@@ -111,11 +111,11 @@ parseAlloc = do
   kw kwAp
   kw kwPlusEq
   i <- parseRValue
-  return $
-    Alloc $
-      InstrAlloc
-        { _instrAllocSize = i
-        }
+  return
+    $ Alloc
+    $ InstrAlloc
+      { _instrAllocSize = i
+      }
 
 parseRValue :: forall r. (Member LabelInfoBuilder r) => ParsecS r RValue
 parseRValue = load <|> binop <|> val
@@ -126,12 +126,12 @@ parseRValue = load <|> binop <|> val
       src <- parseMemRef
       off <- parseOffset
       rbracket
-      return $
-        Load $
-          LoadValue
-            { _loadValueSrc = src,
-              _loadValueOff = off
-            }
+      return
+        $ Load
+        $ LoadValue
+          { _loadValueSrc = src,
+            _loadValueOff = off
+          }
 
     binop :: ParsecS r RValue
     binop = P.try $ do
@@ -142,25 +142,25 @@ parseRValue = load <|> binop <|> val
         subconst arg1 = do
           kw kwMinus
           v <- parseImm
-          return $
-            Binop $
-              BinopValue
-                { _binopValueOpcode = FieldAdd,
-                  _binopValueArg1 = arg1,
-                  _binopValueArg2 = Imm (-v)
-                }
+          return
+            $ Binop
+            $ BinopValue
+              { _binopValueOpcode = FieldAdd,
+                _binopValueArg1 = arg1,
+                _binopValueArg2 = Imm (-v)
+              }
 
         oper :: MemRef -> ParsecS r RValue
         oper arg1 = do
           op <- opcode
           arg2 <- parseValue
-          return $
-            Binop $
-              BinopValue
-                { _binopValueOpcode = op,
-                  _binopValueArg1 = arg1,
-                  _binopValueArg2 = arg2
-                }
+          return
+            $ Binop
+            $ BinopValue
+              { _binopValueOpcode = op,
+                _binopValueArg1 = arg1,
+                _binopValueArg2 = arg2
+              }
 
     val :: ParsecS r RValue
     val = Val <$> parseValue
@@ -216,26 +216,26 @@ parseJump = do
       kw kwNotEq
       symbol "0"
       incAp <- parseIncAp
-      return $
-        JumpIf $
-          InstrJumpIf
-            { _instrJumpIfTarget = tgt,
-              _instrJumpIfValue = v,
-              _instrJumpIfIncAp = incAp
-            }
+      return
+        $ JumpIf
+        $ InstrJumpIf
+          { _instrJumpIfTarget = tgt,
+            _instrJumpIfValue = v,
+            _instrJumpIfIncAp = incAp
+          }
 
     jmp :: ParsecS r Instruction
     jmp = do
       isRel <- parseRel
       tgt <- parseRValue
       incAp <- parseIncAp
-      return $
-        Jump $
-          InstrJump
-            { _instrJumpTarget = tgt,
-              _instrJumpRel = isRel,
-              _instrJumpIncAp = incAp
-            }
+      return
+        $ Jump
+        $ InstrJump
+          { _instrJumpTarget = tgt,
+            _instrJumpRel = isRel,
+            _instrJumpIncAp = incAp
+          }
 
 parseCall :: (Member LabelInfoBuilder r) => ParsecS r Instruction
 parseCall = do
@@ -265,13 +265,13 @@ parseAssign = do
     asn res = do
       v <- parseRValue
       incAp <- parseIncAp
-      return $
-        Assign $
-          InstrAssign
-            { _instrAssignValue = v,
-              _instrAssignResult = res,
-              _instrAssignIncAp = incAp
-            }
+      return
+        $ Assign
+        $ InstrAssign
+          { _instrAssignValue = v,
+            _instrAssignResult = res,
+            _instrAssignIncAp = incAp
+          }
 
     extraBinop :: MemRef -> ParsecS r Instruction
     extraBinop res = P.try $ do
@@ -279,15 +279,15 @@ parseAssign = do
       op <- extraOpcode
       arg2 <- parseExtraValue op
       incAp <- parseIncAp
-      return $
-        ExtraBinop $
-          InstrExtraBinop
-            { _instrExtraBinopArg1 = arg1,
-              _instrExtraBinopArg2 = arg2,
-              _instrExtraBinopOpcode = op,
-              _instrExtraBinopResult = res,
-              _instrExtraBinopIncAp = incAp
-            }
+      return
+        $ ExtraBinop
+        $ InstrExtraBinop
+          { _instrExtraBinopArg1 = arg1,
+            _instrExtraBinopArg2 = arg2,
+            _instrExtraBinopOpcode = op,
+            _instrExtraBinopResult = res,
+            _instrExtraBinopIncAp = incAp
+          }
 
     parseExtraValue :: ExtraOpcode -> ParsecS r Value
     parseExtraValue = \case

--- a/src/Juvix/Compiler/Casm/Validate.hs
+++ b/src/Juvix/Compiler/Casm/Validate.hs
@@ -25,12 +25,12 @@ validate labi instrs = mapM_ go instrs
 
     goLabelRef :: LabelRef -> Either CasmError ()
     goLabelRef l@LabelRef {..} = do
-      unless (HashMap.member _labelRefSymbol (labi ^. labelInfoTable)) $
-        Left $
-          CasmError
-            { _casmErrorMsg = "undefined label: " <> ppPrint l,
-              _casmErrorLoc = Nothing
-            }
+      unless (HashMap.member _labelRefSymbol (labi ^. labelInfoTable))
+        $ Left
+        $ CasmError
+          { _casmErrorMsg = "undefined label: " <> ppPrint l,
+            _casmErrorLoc = Nothing
+          }
 
     goValue :: Value -> Either CasmError ()
     goValue = \case

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/PrettyJudoc.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/PrettyJudoc.hs
@@ -39,8 +39,8 @@ ppDoc n ty j = do
   n' <- ppScoped n
   ty' <- fmap ((n' <+> kwColon) <+>) <$> mapM ppInternal ty
   j' <- mapM ppJudoc j
-  return $
-    case (ty', j') of
+  return
+    $ case (ty', j') of
       (Just jty', Just jj') -> return (jty' <+> line <> line <> jj')
       _ -> ty' <|> j'
 

--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
@@ -190,13 +190,13 @@ addSymbol' :: forall s r. (SingI s) => IsImplicit -> Maybe (ArgDefault s) -> Sym
 addSymbol' impl mdef sym ty = do
   curImpl <- gets @(BuilderState s) (^. stateCurrentImplicit)
   if
-      | Just impl == curImpl -> addToCurrentBlock
-      | otherwise -> startNewBlock
+    | Just impl == curImpl -> addToCurrentBlock
+    | otherwise -> startNewBlock
   where
     errDuplicateName :: Symbol -> Sem (Re s r) ()
     errDuplicateName _dupNameFirst =
-      throw $
-        ErrDuplicateName
+      throw
+        $ ErrDuplicateName
           DuplicateName
             { _dupNameSecond = symbolParsed sym,
               ..
@@ -234,8 +234,8 @@ endBuild' = get @(BuilderState s) >>= throw
 
 mkRecordNameSignature :: forall s. (SingI s) => RhsRecord s -> RecordNameSignature s
 mkRecordNameSignature rhs =
-  RecordNameSignature $
-    HashMap.fromList
+  RecordNameSignature
+    $ HashMap.fromList
       [ (symbolParsed _nameItemSymbol, NameItem {..})
         | (Indexed _nameItemIndex field) <- indexFrom 0 (toList (rhs ^.. rhsRecordStatements . each . _RecordStatementField)),
           let _nameItemSymbol :: SymbolType s = field ^. fieldName

--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Error.hs
@@ -24,8 +24,10 @@ instance ToGenericError DuplicateName where
     let _genericErrorLoc = getLoc _dupNameSecond
         _genericErrorMessage :: AnsiText
         _genericErrorMessage =
-          prettyError $
-            "The symbol" <+> ppCode opts _dupNameFirst <+> "cannot be repeated"
+          prettyError
+            $ "The symbol"
+            <+> ppCode opts _dupNameFirst
+            <+> "cannot be repeated"
         _genericErrorIntervals = map getLoc [_dupNameFirst, _dupNameSecond]
 
     return GenericError {..}

--- a/src/Juvix/Compiler/Concrete/Data/ScopedName.hs
+++ b/src/Juvix/Compiler/Concrete/Data/ScopedName.hs
@@ -43,8 +43,13 @@ isChildOf :: AbsModulePath -> AbsModulePath -> Bool
 isChildOf child parentMod
   | null (child ^. absLocalPath) = False
   | otherwise =
-      init (child ^. absLocalPath) == parentMod ^. absLocalPath
-        && child ^. absTopModulePath == parentMod ^. absTopModulePath
+      init (child ^. absLocalPath)
+        == parentMod
+        ^. absLocalPath
+        && child
+        ^. absTopModulePath
+        == parentMod
+        ^. absTopModulePath
 
 -- | Appends a local path to the absolute path
 -- e.g. TopMod.Local <.> Inner == TopMod.Local.Inner

--- a/src/Juvix/Compiler/Concrete/Gen.hs
+++ b/src/Juvix/Compiler/Concrete/Gen.hs
@@ -50,8 +50,8 @@ isExhaustive _isExhaustive = do
   _isExhaustiveKw <-
     Irrelevant
       <$> if
-          | _isExhaustive -> kw kwAt
-          | otherwise -> kw kwAtQuestion
+        | _isExhaustive -> kw kwAt
+        | otherwise -> kw kwAtQuestion
 
   return IsExhaustive {..}
 

--- a/src/Juvix/Compiler/Concrete/Language/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Language/Base.hs
@@ -2815,8 +2815,12 @@ instance HasAtomicity (PatternAtom 'Parsed) where
 instance (SingI s) => HasAtomicity (FunctionParameters s) where
   atomicity p
     | not (null (p ^. paramNames))
-        || p ^. paramImplicit == Implicit
-        || p ^. paramImplicit == ImplicitInstance =
+        || p
+        ^. paramImplicit
+        == Implicit
+        || p
+        ^. paramImplicit
+        == ImplicitInstance =
         Atom
     | otherwise = case sing :: SStage s of
         SParsed -> atomicity (p ^. paramType)

--- a/src/Juvix/Compiler/Concrete/Language/IsApeInstances.hs
+++ b/src/Juvix/Compiler/Concrete/Language/IsApeInstances.hs
@@ -89,8 +89,8 @@ instance (SingI s) => IsApe (NamedApplication s) ApeLeaf where
 
 instance (SingI s) => IsApe (NamedApplicationNew s) ApeLeaf where
   toApe a =
-    ApeLeaf $
-      Leaf
+    ApeLeaf
+      $ Leaf
         { _leafAtomicity = atomicity a,
           _leafExpr = ApeLeafAtom (sing :&: AtomNamedApplicationNew a)
         }

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -199,7 +199,9 @@ instance (SingI s) => PrettyPrint (NameItem s) where
     let defaultVal = do
           d <- _nameItemDefault
           return (noLoc C.kwAssign <+> ppExpressionType (d ^. argDefaultValue))
-    ppSymbolType _nameItemSymbol <> ppCode Kw.kwExclamation <> noLoc (pretty _nameItemIndex)
+    ppSymbolType _nameItemSymbol
+      <> ppCode Kw.kwExclamation
+      <> noLoc (pretty _nameItemIndex)
       <+> ppCode Kw.kwColon
       <+> ppExpressionType _nameItemType
       <+?> defaultVal
@@ -282,8 +284,8 @@ ppIterator isTop Iterator {..} = do
       b
         | _iteratorBodyBraces = braces (oneLineOrNextNoIndent (ppTopExpressionType _iteratorBody))
         | otherwise = line <> ppMaybeTopExpression isTop _iteratorBody
-  parensIf _iteratorParens $
-    hang (n <+?> is' <+?> rngs' <> b)
+  parensIf _iteratorParens
+    $ hang (n <+?> is' <+?> rngs' <> b)
 
 instance PrettyPrint S.AName where
   ppCode n = annotated (AnnKind (S.getNameKind n)) (noLoc (pretty (n ^. S.anameVerbatim)))
@@ -323,8 +325,8 @@ instance (SingI s) => PrettyPrint (NamedApplicationNew s) where
     let args'
           | null _namedApplicationNewArguments = mempty
           | otherwise =
-              blockIndent $
-                sequenceWith
+              blockIndent
+                $ sequenceWith
                   (semicolon >> line)
                   (ppCode <$> _namedApplicationNewArguments)
     ppIdentifierType _namedApplicationNewName
@@ -560,7 +562,7 @@ instance (SingI s, SingI k) => PrettyPrint (SideIfBranch s k) where
       <?+> ( kwIfElse'
                <+?> condition'
                <+> kwAssign'
-                 <> oneLineOrNext body'
+               <> oneLineOrNext body'
            )
 
 instance (SingI s) => PrettyPrint (SideIfs s) where
@@ -640,17 +642,18 @@ ppIfBranchElse isTop IfBranch {..} = do
   let e' = ppMaybeTopExpression isTop _ifBranchExpression
   ppCode _ifBranchPipe
     <+> ppCode _ifBranchCondition
-    <+> ppCode _ifBranchAssignKw <> oneLineOrNext e'
+    <+> ppCode _ifBranchAssignKw
+    <> oneLineOrNext e'
 
 ppIf :: forall r s. (Members '[ExactPrint, Reader Options] r, SingI s) => IsTop -> If s -> Sem r ()
 ppIf isTop If {..} = do
   ppCode _ifKw
     <+> hardline
-      <> indent
-        ( vsepHard (ppIfBranch <$> _ifBranches)
-            <> hardline
-            <> ppIfBranch _ifBranchElse
-        )
+    <> indent
+      ( vsepHard (ppIfBranch <$> _ifBranches)
+          <> hardline
+          <> ppIfBranch _ifBranchElse
+      )
   where
     ppIfBranch :: forall k. (SingI k) => IfBranch s k -> Sem r ()
     ppIfBranch b = case sing :: SIfBranchKind k of
@@ -895,16 +898,16 @@ instance PrettyPrint Expression where
 instance PrettyPrint (WithSource Pragmas) where
   ppCode pragma = do
     b <- asks (^. optPrintPragmas)
-    when b $
-      let txt = pretty (Str.pragmasStart <> pragma ^. withSourceText <> Str.pragmasEnd)
-       in annotated AnnComment (noLoc txt) <> line
+    when b
+      $ let txt = pretty (Str.pragmasStart <> pragma ^. withSourceText <> Str.pragmasEnd)
+         in annotated AnnComment (noLoc txt) <> line
 
 ppJudocStart :: (Members '[ExactPrint, Reader Options] r) => Sem r (Maybe ())
 ppJudocStart = do
   inBlock <- asks (^. optInJudocBlock)
   if
-      | inBlock -> return Nothing
-      | otherwise -> ppCode Kw.delimJudocStart $> Just ()
+    | inBlock -> return Nothing
+    | otherwise -> ppCode Kw.delimJudocStart $> Just ()
 
 instance (PrettyPrint a) => PrettyPrint (WithLoc a) where
   ppCode a = morphemeM (getLoc a) (ppCode (a ^. withLocParam))
@@ -1384,7 +1387,7 @@ instance (SingI s) => PrettyPrint (InductiveDef s) where
       ?<> pragmas'
       ?<> sig'
       <+> ppCode _inductiveAssignKw
-        <> constrs'
+      <> constrs'
     where
       ppConstructorBlock :: NonEmpty (ConstructorDef s) -> Sem r ()
       ppConstructorBlock = \case

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -794,8 +794,8 @@ entryToScopedIden name e = do
     PreSymbolAlias {} -> do
       e' <- normalizePreSymbolEntry e
       let scopedName' =
-            over S.nameFixity (maybe (e' ^. symbolEntry . S.nameFixity) Just) $
-              set S.nameKind (getNameKind e') scopedName
+            over S.nameFixity (maybe (e' ^. symbolEntry . S.nameFixity) Just)
+              $ set S.nameKind (getNameKind e') scopedName
       return
         ScopedIden
           { _scopedIdenAlias = Just scopedName',
@@ -956,10 +956,10 @@ resolveFixitySyntaxDef fdef@FixitySyntaxDef {..} = topBindings $ do
       belowPrec = fromIntegral $ maximum (minInt + 1 : abovePrecs)
       abovePrec :: Integer
       abovePrec = fromIntegral $ minimum (maxInt - 1 : belowPrecs)
-  when (belowPrec + 1 >= abovePrec) $
-    throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
-  when (isJust same && not (null below && null above)) $
-    throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
+  when (belowPrec + 1 >= abovePrec)
+    $ throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
+  when (isJust same && not (null below && null above))
+    $ throw (ErrPrecedenceInconsistency (PrecedenceInconsistencyError fdef))
   -- we need Integer to avoid overflow when computing prec
   let prec = fromMaybe (fromInteger $ (abovePrec + belowPrec) `div` 2) samePrec
       fx =
@@ -1482,8 +1482,8 @@ checkSections sec = topBindings helper
                     case _definitionsNext of
                       Nothing -> do
                         ms'' <- goInductiveModules ms'
-                        return $
-                          Just
+                        return
+                          $ Just
                             NonDefinitionsSection
                               { _nonDefinitionsSection = ms'',
                                 _nonDefinitionsNext = Nothing
@@ -1560,11 +1560,11 @@ checkSections sec = topBindings helper
                           | not (null cs) -> fail
                           | otherwise -> do
                               fs <-
-                                failMaybe $
-                                  mkRec
-                                    ^? constructorRhs
-                                    . _ConstructorRhsRecord
-                                    . to mkRecordNameSignature
+                                failMaybe
+                                  $ mkRec
+                                  ^? constructorRhs
+                                  . _ConstructorRhsRecord
+                                  . to mkRecordNameSignature
                               let info =
                                     RecordInfo
                                       { _recordInfoSignature = fs,
@@ -1894,8 +1894,8 @@ checkUsingHiding modulepath exportInfo = \case
       let s = h ^. hidingSymbol
       scopedSym <-
         if
-            | isJust (h ^. hidingModuleKw) -> scopeSymbol SNameSpaceModules s
-            | otherwise -> scopeSymbol SNameSpaceSymbols s
+          | isJust (h ^. hidingModuleKw) -> scopeSymbol SNameSpaceModules s
+          | otherwise -> scopeSymbol SNameSpaceSymbols s
       return
         HidingItem
           { _hidingSymbol = scopedSym,
@@ -1907,8 +1907,8 @@ checkUsingHiding modulepath exportInfo = \case
       let s = i ^. usingSymbol
       scopedSym <-
         if
-            | isJust (i ^. usingModuleKw) -> scopeSymbol SNameSpaceModules s
-            | otherwise -> scopeSymbol SNameSpaceSymbols s
+          | isJust (i ^. usingModuleKw) -> scopeSymbol SNameSpaceModules s
+          | otherwise -> scopeSymbol SNameSpaceSymbols s
       let scopedAs = do
             c <- i ^. usingAs
             return (set S.nameConcrete c scopedSym)
@@ -2101,10 +2101,10 @@ checkRecordPattern r = do
   fields <- fromMaybeM (return (RecordNameSignature mempty)) (gets (^. scoperConstructorFields . at (c' ^. scopedIdenFinal . S.nameId)))
   l' <-
     if
-        | null (r ^. recordPatternItems) -> return []
-        | otherwise -> do
-            when (null (fields ^. recordNames)) (throw (noFields c'))
-            runReader fields (mapM checkItem (r ^. recordPatternItems))
+      | null (r ^. recordPatternItems) -> return []
+      | otherwise -> do
+          when (null (fields ^. recordNames)) (throw (noFields c'))
+          runReader fields (mapM checkItem (r ^. recordPatternItems))
   return
     RecordPattern
       { _recordPatternConstructor = c',
@@ -2124,8 +2124,8 @@ checkRecordPattern r = do
       where
         findField :: Symbol -> Sem r' Int
         findField f =
-          fromMaybeM (throw err) $
-            asks @(RecordNameSignature 'Parsed) (^? recordNames . at f . _Just . nameItemIndex)
+          fromMaybeM (throw err)
+            $ asks @(RecordNameSignature 'Parsed) (^? recordNames . at f . _Just . nameItemIndex)
           where
             err :: ScoperError
             err = ErrUnexpectedField (UnexpectedField f)
@@ -2290,8 +2290,8 @@ checkCaseBranch ::
 checkCaseBranch CaseBranch {..} = withLocalScope $ do
   pattern' <- checkParsePatternAtoms _caseBranchPattern
   rhs' <- checkCaseBranchRhs _caseBranchRhs
-  return $
-    CaseBranch
+  return
+    $ CaseBranch
       { _caseBranchPattern = pattern',
         _caseBranchRhs = rhs',
         ..
@@ -2304,8 +2304,8 @@ checkCase ::
 checkCase Case {..} = do
   caseBranches' <- mapM checkCaseBranch _caseBranches
   caseExpression' <- checkParseExpressionAtoms _caseExpression
-  return $
-    Case
+  return
+    $ Case
       { _caseExpression = caseExpression',
         _caseBranches = caseBranches',
         _caseKw,
@@ -2322,8 +2322,8 @@ checkIfBranch IfBranch {..} = withLocalScope $ do
     SBranchIfBool -> checkParseExpressionAtoms _ifBranchCondition
     SBranchIfElse -> return _ifBranchCondition
   expression' <- checkParseExpressionAtoms _ifBranchExpression
-  return $
-    IfBranch
+  return
+    $ IfBranch
       { _ifBranchCondition = cond',
         _ifBranchExpression = expression',
         ..
@@ -2336,8 +2336,8 @@ checkIf ::
 checkIf If {..} = do
   ifBranches' <- mapM checkIfBranch _ifBranches
   ifBranchElse' <- checkIfBranch _ifBranchElse
-  return $
-    If
+  return
+    $ If
       { _ifBranchElse = ifBranchElse',
         _ifBranches = ifBranches',
         _ifKw
@@ -2490,8 +2490,8 @@ checkPatternBinding PatternBinding {..} = do
   p' <- checkParsePatternAtom _patternBindingPattern
   n' <- bindVariableSymbol _patternBindingName
   if
-      | isJust (p' ^. patternArgName) -> throw (ErrDoubleBinderPattern (DoubleBinderPattern n' p'))
-      | otherwise -> return (set patternArgName (Just n') p')
+    | isJust (p' ^. patternArgName) -> throw (ErrDoubleBinderPattern (DoubleBinderPattern n' p'))
+    | otherwise -> return (set patternArgName (Just n') p')
 
 checkPatternAtoms ::
   (Members '[Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen] r) =>
@@ -2587,11 +2587,12 @@ checkNamedApplicationNew napp = do
         HashSet.fromList
           . concatMap (HashMap.keys . (^. nameBlock))
           . filter (not . isImplicitOrInstance . (^. nameImplicit))
-          $ sig ^. nameSignatureArgs
+          $ sig
+          ^. nameSignatureArgs
       sargs :: HashSet Symbol = hashSet (map (^. namedArgumentNewSymbol) nargs)
       missingArgs = HashSet.difference enames sargs
-  unless (null missingArgs || not (napp ^. namedApplicationNewExhaustive . isExhaustive)) $
-    throw (ErrMissingArgs (MissingArgs (aname ^. scopedIdenFinal . nameConcrete) missingArgs))
+  unless (null missingArgs || not (napp ^. namedApplicationNewExhaustive . isExhaustive))
+    $ throw (ErrMissingArgs (MissingArgs (aname ^. scopedIdenFinal . nameConcrete) missingArgs))
   return
     NamedApplicationNew
       { _namedApplicationNewName = aname,
@@ -2615,8 +2616,8 @@ checkNamedArgumentFunctionDef ::
 checkNamedArgumentFunctionDef snames NamedArgumentFunctionDef {..} = do
   def <- localBindings . ignoreSyntax $ checkFunctionDef _namedArgumentFunctionDef
   let fname = def ^. signName . nameConcrete
-  unless (HashSet.member fname snames) $
-    throw (ErrUnexpectedArgument (UnexpectedArgument fname))
+  unless (HashSet.member fname snames)
+    $ throw (ErrUnexpectedArgument (UnexpectedArgument fname))
   return
     NamedArgumentFunctionDef
       { _namedArgumentFunctionDef = def
@@ -2833,7 +2834,8 @@ checkJudoc ::
 checkJudoc (Judoc groups) =
   ignoreHighlightBuilder
     . ignoreInfoTableBuilder
-    $ Judoc <$> mapM checkJudocGroup groups
+    $ Judoc
+    <$> mapM checkJudocGroup groups
 
 checkJudocGroup ::
   (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader Package] r) =>
@@ -2936,18 +2938,18 @@ checkPrecedences opers = do
   graph <- getPrecedenceGraph
   let fids = mapMaybe (^. fixityId) $ mapMaybe (^. S.nameFixity) opers
       deps = createDependencyInfo graph mempty
-  mapM_ (uncurry (checkPath deps)) $
-    [(fid1, fid2) | fid1 <- fids, fid2 <- fids, fid1 /= fid2]
+  mapM_ (uncurry (checkPath deps))
+    $ [(fid1, fid2) | fid1 <- fids, fid2 <- fids, fid1 /= fid2]
   where
     checkPath :: DependencyInfo S.NameId -> S.NameId -> S.NameId -> Sem r ()
     checkPath deps fid1 fid2 =
-      unless (isPath deps fid1 fid2 || isPath deps fid2 fid1) $
-        throw (ErrIncomparablePrecedences (IncomaprablePrecedences (findOper fid1) (findOper fid2)))
+      unless (isPath deps fid1 fid2 || isPath deps fid2 fid1)
+        $ throw (ErrIncomparablePrecedences (IncomaprablePrecedences (findOper fid1) (findOper fid2)))
 
     findOper :: S.NameId -> S.Name
     findOper fid =
-      fromJust $
-        find
+      fromJust
+        $ find
           (maybe False (\fx -> Just fid == (fx ^. fixityId)) . (^. S.nameFixity))
           opers
 
@@ -3035,8 +3037,8 @@ makeExpressionTable (ExpressionAtoms atoms _) = [recordUpdate] : [appOpExplicit]
       where
         app :: Expression -> Expression -> Expression
         app f x =
-          ExpressionApplication $
-            Application
+          ExpressionApplication
+            $ Application
               { _applicationFunction = f,
                 _applicationParameter = x
               }

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error/Types.hs
@@ -40,10 +40,10 @@ instance ToGenericError MultipleDeclarations where
       msg =
         "Multiple declarations of"
           <+> pretty _multipleDeclSecond
-            <> line
-            <> "Declared at:"
-            <> line
-            <> itemize (map pretty [i1, i2])
+          <> line
+          <> "Declared at:"
+          <> line
+          <> itemize (map pretty [i1, i2])
 
 -- | megaparsec error while resolving infixities.
 newtype InfixError = InfixError
@@ -210,9 +210,9 @@ instance ToGenericError DuplicateOperator where
           msg =
             "Multiple operator declarations for symbol"
               <+> ppCode opts' sym
-                <> ":"
-                <> line
-                <> indent' (align locs)
+              <> ":"
+              <> line
+              <> indent' (align locs)
             where
               sym = _dupOperatorFirst ^. opSymbol
               locs = vsep $ map (pretty . getLoc) [_dupOperatorFirst, _dupOperatorSecond]
@@ -241,9 +241,9 @@ instance ToGenericError DuplicateIterator where
           msg =
             "Multiple iterator declarations for symbol"
               <+> ppCode opts' sym
-                <> ":"
-                <> line
-                <> indent' (align locs)
+              <> ":"
+              <> line
+              <> indent' (align locs)
             where
               sym = _dupIteratorFirst ^. iterSymbol
               locs = vsep $ map (pretty . getLoc) [_dupIteratorFirst, _dupIteratorFirst]
@@ -303,7 +303,7 @@ instance ToGenericError NotInScope where
           msg =
             "Symbol not in scope:"
               <+> ppCode opts' _notInScopeSymbol
-                <>? ((line <>) <$> suggestion)
+              <>? ((line <>) <$> suggestion)
           suggestion :: Maybe (Doc a)
           suggestion
             | null suggestions = Nothing
@@ -313,8 +313,8 @@ instance ToGenericError NotInScope where
           maxDist = 2
           suggestions :: [Doc a]
           suggestions =
-            map (pretty . fst) $
-              sortOn
+            map (pretty . fst)
+              $ sortOn
                 snd
                 [ (c, dist) | c <- toList candidates, let dist = textDistance sym c, dist <= maxDist
                 ]
@@ -349,8 +349,8 @@ instance ToGenericError AppLeftImplicit where
             "The expression"
               <+> ppCode opts' (e ^. appLeftImplicit)
               <+> "cannot appear by itself."
-                <> line
-                <> "It needs to be the argument of a function expecting an implicit argument."
+              <> line
+              <> "It needs to be the argument of a function expecting an implicit argument."
 
 newtype DanglingDoubleBrace = DanglingDoubleBrace
   { _danglingDoubleBrace :: DoubleBracesExpression 'Scoped
@@ -377,8 +377,8 @@ instance ToGenericError DanglingDoubleBrace where
             "The expression"
               <+> ppCode opts' expr
               <+> "cannot appear by itself."
-                <> line
-                <> "It needs to be on the left of a function arrow."
+              <> line
+              <> "It needs to be on the left of a function arrow."
 
 newtype ModuleNotInScope = ModuleNotInScope
   { _moduleNotInScopeName :: Name
@@ -497,9 +497,9 @@ infixErrorAux :: Doc Ann -> Doc Ann -> Doc Ann
 infixErrorAux kind pp =
   "Error while resolving infixities in the"
     <+> kind
-      <> ":"
-      <> line
-      <> indent' pp
+    <> ":"
+    <> line
+    <> indent' pp
 
 ambiguousMessage :: Options -> Name -> [Doc Ann] -> Doc Ann
 ambiguousMessage opts' n es =
@@ -508,10 +508,10 @@ ambiguousMessage opts' n es =
     <+> "at"
     <+> pretty (getLoc n)
     <+> "is ambiguous."
-      <> line
-      <> "It could be any of:"
-      <> line
-      <> itemize es
+    <> line
+    <> "It could be any of:"
+    <> line
+    <> itemize es
 
 data DoubleBracesPattern = DoubleBracesPattern
   { _doubleBracesPatternArg :: PatternArg,
@@ -910,9 +910,9 @@ instance ToGenericError MissingArgs where
     let msg =
           "Missing arguments for"
             <+> ppCode opts _missingArgsName
-              <> ":"
-              <> line
-              <> itemize (map (ppCode opts) (toList _missingArgs))
+            <> ":"
+            <> line
+            <> itemize (map (ppCode opts) (toList _missingArgs))
     return
       GenericError
         { _genericErrorLoc = i,

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner.hs
@@ -48,8 +48,8 @@ scanBSImports fp inputBS = do
         Nothing -> Megaparsec.scanBSImports fp inputBS
     ImportScanStrategyFlatParse -> case FlatParse.scanBSImports fp inputBS of
       Nothing ->
-        throw $
-          ErrFlatParseError
+        throw
+          $ ErrFlatParseError
             FlatParseError
               { _flatParseErrorLoc = fileLoc
               }

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -102,11 +102,15 @@ pImport = do
 
 pToken :: Parser e Token
 pToken =
-  lexeme $
-    TokenString <$ pString
-      <|> TokenImport <$> pImport
-      <|> TokenReserved <$ pReserved
-      <|> TokenCode <$ pCode
+  lexeme
+    $ TokenString
+    <$ pString
+    <|> TokenImport
+    <$> pImport
+    <|> TokenReserved
+    <$ pReserved
+    <|> TokenCode
+    <$ pCode
 
 pCode :: Parser e ()
 pCode = skipSome (satisfy validCodeChar)
@@ -152,13 +156,15 @@ comment =
         go :: Int -> Parser e ()
         go n = do
           let startOrEnd =
-                start $> True
-                  <|> end $> False
+                start
+                  $> True
+                  <|> end
+                  $> False
           isStart <- snd <$> manyTill_ skipAnyChar startOrEnd
           if
-              | isStart -> go (n + 1)
-              | n > 1 -> go (n - 1)
-              | otherwise -> return ()
+            | isStart -> go (n + 1)
+            | n > 1 -> go (n - 1)
+            | otherwise -> return ()
 
     pragmaBlock :: Parser e ()
     pragmaBlock = nonNestedBlock $(string Str.pragmasStart) $(string Str.pragmasEnd)

--- a/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
@@ -13,8 +13,8 @@ createCallGraphMap :: InfoTable -> HashMap Symbol (HashSet Symbol)
 createCallGraphMap tab =
   fmap
     ( \IdentifierInfo {..} ->
-        HashSet.map (\Ident {..} -> _identSymbol) $
-          getIdents (lookupTabIdentifierNode tab _identifierSymbol)
+        HashSet.map (\Ident {..} -> _identSymbol)
+          $ getIdents (lookupTabIdentifierNode tab _identifierSymbol)
     )
     (tab ^. infoIdentifiers)
 
@@ -75,23 +75,23 @@ recursiveIdentsClosure tab =
     dfs path acc sym = do
       visited <- get
       if
-          | HashSet.member sym visited ->
-              return acc
-          | otherwise -> do
-              let path' = HashSet.insert sym path
-                  acc' =
-                    if
-                        | any (`HashSet.member` path') chlds ->
-                            HashSet.insert sym acc
-                        | otherwise ->
-                            acc
-              modify' (HashSet.insert sym)
-              acc'' <- foldM (dfs path') acc' chlds
-              if
-                  | any (`HashSet.member` acc'') chlds ->
-                      return $ HashSet.insert sym acc''
-                  | otherwise ->
-                      return acc''
+        | HashSet.member sym visited ->
+            return acc
+        | otherwise -> do
+            let path' = HashSet.insert sym path
+                acc' =
+                  if
+                    | any (`HashSet.member` path') chlds ->
+                        HashSet.insert sym acc
+                    | otherwise ->
+                        acc
+            modify' (HashSet.insert sym)
+            acc'' <- foldM (dfs path') acc' chlds
+            if
+              | any (`HashSet.member` acc'') chlds ->
+                  return $ HashSet.insert sym acc''
+              | otherwise ->
+                  return acc''
       where
         chlds = fromJust $ HashMap.lookup sym graph
 

--- a/src/Juvix/Compiler/Core/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTable.hs
@@ -107,10 +107,10 @@ typeName' tab sym = lookupTabInductiveInfo tab sym ^. inductiveName
 
 identNames' :: InfoTable -> HashSet Text
 identNames' tab =
-  HashSet.fromList $
-    map (^. identifierName) (HashMap.elems (tab ^. infoIdentifiers))
-      ++ map (^. constructorName) (HashMap.elems (tab ^. infoConstructors))
-      ++ map (^. inductiveName) (HashMap.elems (tab ^. infoInductives))
+  HashSet.fromList
+    $ map (^. identifierName) (HashMap.elems (tab ^. infoIdentifiers))
+    ++ map (^. constructorName) (HashMap.elems (tab ^. infoConstructors))
+    ++ map (^. inductiveName) (HashMap.elems (tab ^. infoInductives))
 
 freshIdentName' :: InfoTable -> Text -> Text
 freshIdentName' tab = freshName (identNames' tab)

--- a/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTableBuilder.hs
@@ -69,9 +69,9 @@ getEcPointSymbol = (^. inductiveSymbol) <$> getBuiltinInductiveInfo BuiltinEcPoi
 checkSymbolDefined :: (Member InfoTableBuilder r) => Symbol -> Sem r Bool
 checkSymbolDefined sym = do
   m <- getModule
-  return $
-    HashMap.member sym (m ^. moduleInfoTable . identContext)
-      || HashMap.member sym (m ^. moduleImportsTable . identContext)
+  return
+    $ HashMap.member sym (m ^. moduleInfoTable . identContext)
+    || HashMap.member sym (m ^. moduleImportsTable . identContext)
 
 setIdentArgs :: (Member InfoTableBuilder r) => Symbol -> [Binder] -> Sem r ()
 setIdentArgs sym = overIdentArgs sym . const
@@ -315,8 +315,8 @@ setupLiteralIntToNat mkNode = do
         info s = do
           m <- getModule
           ty <- targetType
-          return $
-            IdentifierInfo
+          return
+            $ IdentifierInfo
               { _identifierSymbol = s,
                 _identifierName = freshIdentName m "intToNat",
                 _identifierLocation = Nothing,
@@ -351,8 +351,8 @@ setupLiteralIntToInt node = do
         info s = do
           m <- getModule
           ty <- targetType
-          return $
-            IdentifierInfo
+          return
+            $ IdentifierInfo
               { _identifierSymbol = s,
                 _identifierName = freshIdentName m "literalIntToInt",
                 _identifierLocation = Nothing,

--- a/src/Juvix/Compiler/Core/Data/Module.hs
+++ b/src/Juvix/Compiler/Core/Data/Module.hs
@@ -57,9 +57,9 @@ lookupIdentifierNode' Module {..} sym =
 
 lookupSpecialisationInfo :: Module -> Symbol -> [SpecialisationInfo]
 lookupSpecialisationInfo Module {..} sym =
-  fromMaybe [] $
-    lookupTabSpecialisationInfo' _moduleInfoTable sym
-      <|> lookupTabSpecialisationInfo' _moduleImportsTable sym
+  fromMaybe []
+    $ lookupTabSpecialisationInfo' _moduleInfoTable sym
+    <|> lookupTabSpecialisationInfo' _moduleImportsTable sym
 
 lookupInductiveInfo :: Module -> Symbol -> InductiveInfo
 lookupInductiveInfo m sym = fromJust $ lookupInductiveInfo' m sym
@@ -85,18 +85,24 @@ lookupBuiltinConstructor Module {..} b =
 
 getInfoLiteralIntToNat :: Module -> Maybe Symbol
 getInfoLiteralIntToNat Module {..} =
-  _moduleInfoTable ^. infoLiteralIntToNat
-    <|> _moduleImportsTable ^. infoLiteralIntToNat
+  _moduleInfoTable
+    ^. infoLiteralIntToNat
+    <|> _moduleImportsTable
+    ^. infoLiteralIntToNat
 
 getInfoLiteralIntToInt :: Module -> Maybe Symbol
 getInfoLiteralIntToInt Module {..} =
-  _moduleInfoTable ^. infoLiteralIntToInt
-    <|> _moduleImportsTable ^. infoLiteralIntToInt
+  _moduleInfoTable
+    ^. infoLiteralIntToInt
+    <|> _moduleImportsTable
+    ^. infoLiteralIntToInt
 
 getInfoMain :: Module -> Maybe Symbol
 getInfoMain Module {..} =
-  _moduleInfoTable ^. infoMain
-    <|> _moduleImportsTable ^. infoMain
+  _moduleInfoTable
+    ^. infoMain
+    <|> _moduleImportsTable
+    ^. infoMain
 
 identName :: Module -> Symbol -> Text
 identName md sym = lookupIdentifierInfo md sym ^. identifierName

--- a/src/Juvix/Compiler/Core/Data/TransformationId/Parser/Base.hs
+++ b/src/Juvix/Compiler/Core/Data/TransformationId/Parser/Base.hs
@@ -51,8 +51,10 @@ symbol = void . lexeme . P.chunk
 
 transformationLike :: (PipelineId' t p, MonadParsec e Text m) => m (TransformationLikeId' t p)
 transformationLike =
-  TransformationId <$> parseTransformation
-    <|> PipelineId <$> parsePipeline
+  TransformationId
+    <$> parseTransformation
+    <|> PipelineId
+    <$> parsePipeline
 
 transformationLikeText :: (PipelineId' t p) => TransformationLikeId' t p -> Text
 transformationLikeText = \case

--- a/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/TypeDependencyInfo.hs
@@ -12,7 +12,8 @@ createTypeDependencyInfo tab = createDependencyInfo graph startVertices
   where
     graph :: HashMap Symbol (HashSet Symbol)
     graph =
-      HashSet.fromList . (^.. inductiveSymbols)
+      HashSet.fromList
+        . (^.. inductiveSymbols)
         <$> HashMap.filter (isNothing . (^. inductiveBuiltin)) (tab ^. infoInductives)
 
     constructorTypes :: SimpleFold Tag Type

--- a/src/Juvix/Compiler/Core/Extra/Base.hs
+++ b/src/Juvix/Compiler/Core/Extra/Base.hs
@@ -266,12 +266,12 @@ expandType :: [Binder] -> Type -> Type
 expandType argtys ty =
   let (tyargs, target) = unfoldPi ty
    in if
-          | length tyargs >= length argtys ->
-              ty
-          | isDynamic target ->
-              rePis tyargs (mkPis (drop (length tyargs) argtys) target)
-          | otherwise ->
-              impossible
+        | length tyargs >= length argtys ->
+            ty
+        | isDynamic target ->
+            rePis tyargs (mkPis (drop (length tyargs) argtys) target)
+        | otherwise ->
+            impossible
 
 {------------------------------------------------------------------------}
 {- functions on Node -}
@@ -624,12 +624,12 @@ destruct = \case
         allNodes =
           noBinders rty
             : map noBinders (toList vtys)
-            ++ map noBinders (toList vs)
-            ++ concat
-              [ br
-                  : reverse (foldl' (\acc b -> manyBinders (take (length acc) bis) (b ^. binderType) : acc) [] bis)
-                | (bis, br) <- branchChildren
-              ]
+              ++ map noBinders (toList vs)
+              ++ concat
+                [ br
+                    : reverse (foldl' (\acc b -> manyBinders (take (length acc) bis) (b ^. binderType) : acc) [] bis)
+                  | (bis, br) <- branchChildren
+                ]
           where
             branchChildren :: [([Binder], NodeChild)]
             branchChildren =
@@ -687,10 +687,10 @@ destruct = \case
                   (values', branchesChildren') = first nonEmpty' (splitAtExact numVals chs'')
                   branches' :: [MatchBranch]
                   branches' =
-                    run $
-                      runInputList is' $
-                        runInputList branchesChildren' $
-                          mapM mkBranch branches
+                    run
+                      $ runInputList is'
+                      $ runInputList branchesChildren'
+                      $ mapM mkBranch branches
                in mkMatch
                     i'
                     valueTypes'

--- a/src/Juvix/Compiler/Core/Extra/Recursors/RMap.hs
+++ b/src/Juvix/Compiler/Core/Extra/Recursors/RMap.hs
@@ -82,8 +82,8 @@ rmapG coll f = go mempty 0 (coll ^. cEmpty)
               binders' = BL.prepend rbs' binders
            in \case
                 NVar v ->
-                  return $
-                    maybe
+                  return
+                    $ maybe
                       (NVar v {_varIndex = getBinderIndex bl' lvl})
                       (shift (bl' - lvl))
                       mnode

--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -443,11 +443,19 @@ translateCase translateIfFun dflt Case {..} = case _caseBranches of
     | _caseBranchTag == BuiltinTag TagFalse ->
         translateIfFun _caseValue (fromMaybe branchFailure _caseDefault) (br ^. caseBranchBody)
   [br1, br2]
-    | br1 ^. caseBranchTag == BuiltinTag TagTrue
-        && br2 ^. caseBranchTag == BuiltinTag TagFalse ->
+    | br1
+        ^. caseBranchTag
+        == BuiltinTag TagTrue
+        && br2
+        ^. caseBranchTag
+        == BuiltinTag TagFalse ->
         translateIfFun _caseValue (br1 ^. caseBranchBody) (br2 ^. caseBranchBody)
-    | br1 ^. caseBranchTag == BuiltinTag TagFalse
-        && br2 ^. caseBranchTag == BuiltinTag TagTrue ->
+    | br1
+        ^. caseBranchTag
+        == BuiltinTag TagFalse
+        && br2
+        ^. caseBranchTag
+        == BuiltinTag TagTrue ->
         translateIfFun _caseValue (br2 ^. caseBranchBody) (br1 ^. caseBranchBody)
   _ ->
     dflt
@@ -477,11 +485,19 @@ isCaseBoolean = \case
   [CaseBranch {..}]
     | _caseBranchTag == BuiltinTag TagFalse -> True
   [br1, br2]
-    | br1 ^. caseBranchTag == BuiltinTag TagTrue
-        && br2 ^. caseBranchTag == BuiltinTag TagFalse ->
+    | br1
+        ^. caseBranchTag
+        == BuiltinTag TagTrue
+        && br2
+        ^. caseBranchTag
+        == BuiltinTag TagFalse ->
         True
-    | br1 ^. caseBranchTag == BuiltinTag TagFalse
-        && br2 ^. caseBranchTag == BuiltinTag TagTrue ->
+    | br1
+        ^. caseBranchTag
+        == BuiltinTag TagFalse
+        && br2
+        ^. caseBranchTag
+        == BuiltinTag TagTrue ->
         True
   _ ->
     False

--- a/src/Juvix/Compiler/Core/Extra/Value.hs
+++ b/src/Juvix/Compiler/Core/Extra/Value.hs
@@ -49,10 +49,10 @@ toValue tab = \case
       let (lams, body) = unfoldLambdas (NLam lam)
           n = length $ takeWhile (Info.member kExpansionInfo . (^. lambdaLhsInfo)) lams
        in if
-              | n < length lams ->
-                  ValueFun
-              | otherwise ->
-                  case body of
-                    NCtr c ->
-                      toValue tab (NCtr (over constrArgs (dropEnd n) c))
-                    _ -> ValueFun
+            | n < length lams ->
+                ValueFun
+            | otherwise ->
+                case body of
+                  NCtr c ->
+                    toValue tab (NCtr (over constrArgs (dropEnd n) c))
+                  _ -> ValueFun

--- a/src/Juvix/Compiler/Core/Info.hs
+++ b/src/Juvix/Compiler/Core/Info.hs
@@ -54,8 +54,8 @@ delete k i = Info (HashMap.delete (typeRep k) (i ^. infoMap))
 
 adjust :: forall a. (IsInfo a) => (a -> a) -> Info -> Info
 adjust f i =
-  Info $
-    HashMap.adjust
+  Info
+    $ HashMap.adjust
       (\x -> toDyn $ f $ fromDyn x impossible)
       (typeRep (Proxy :: Proxy a))
       (i ^. infoMap)

--- a/src/Juvix/Compiler/Core/Info/FreeVarsInfo.hs
+++ b/src/Juvix/Compiler/Core/Info/FreeVarsInfo.hs
@@ -31,14 +31,14 @@ computeFreeVarsInfo = umap go
         modifyInfo (Info.insert fvi) node
         where
           fvi =
-            FreeVarsInfo $
-              foldr
+            FreeVarsInfo
+              $ foldr
                 ( \NodeChild {..} acc ->
-                    Map.unionWith (+) acc $
-                      Map.mapKeysMonotonic (\idx -> idx - _childBindersNum) $
-                        Map.filterWithKey
-                          (\idx _ -> idx >= _childBindersNum)
-                          (getFreeVarsInfo _childNode ^. infoFreeVars)
+                    Map.unionWith (+) acc
+                      $ Map.mapKeysMonotonic (\idx -> idx - _childBindersNum)
+                      $ Map.filterWithKey
+                        (\idx _ -> idx >= _childBindersNum)
+                        (getFreeVarsInfo _childNode ^. infoFreeVars)
                 )
                 mempty
                 (children node)

--- a/src/Juvix/Compiler/Core/Normalizer.hs
+++ b/src/Juvix/Compiler/Core/Normalizer.hs
@@ -72,9 +72,9 @@ normalize fsize md = run . evalInfoTableBuilder md . runReader normEnv . normali
     underBinder cont = do
       sym <- freshSymbol
       bl <- asks (^. normEnvLevel)
-      local (over normEnvVars (HashMap.insert sym bl)) $
-        local (over normEnvEvalEnv (mkIdent' sym :)) $
-          local (over normEnvLevel (1 +)) cont
+      local (over normEnvVars (HashMap.insert sym bl))
+        $ local (over normEnvEvalEnv (mkIdent' sym :))
+        $ local (over normEnvLevel (1 +)) cont
     {-# INLINE underBinder #-}
 
     underBinders :: Int -> Norm a -> Norm a
@@ -91,11 +91,11 @@ normalize fsize md = run . evalInfoTableBuilder md . runReader normEnv . normali
     goIdent Ident {..} = do
       bl <- asks (^. normEnvLevel)
       vars <- asks (^. normEnvVars)
-      return $
-        mkVar' $
-          getBinderIndex bl $
-            fromJust $
-              HashMap.lookup _identSymbol vars
+      return
+        $ mkVar'
+        $ getBinderIndex bl
+        $ fromJust
+        $ HashMap.lookup _identSymbol vars
     {-# INLINE goIdent #-}
 
     goApp :: App -> Norm Node

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -150,7 +150,8 @@ ppCodeConstr' name c = do
 instance (Pretty k, PrettyCode a) => PrettyCode (Map k a) where
   ppCode m = do
     m' <-
-      sep . punctuate ","
+      sep
+        . punctuate ","
         <$> sequence
           [ do
               a' <- ppCode a
@@ -309,10 +310,10 @@ instance PrettyCode LetRec where
       [hbs] -> kwLetRec <+> hbs <+> kwAssign <+> head vs <+> kwIn <+> b'
       _ ->
         let bss =
-              indent' $
-                align $
-                  concatWith (\a b -> a <> kwSemicolon <> line <> b) $
-                    zipWithExact (\b val -> b <+> kwAssign <+> val) (toList bs) (toList vs)
+              indent'
+                $ align
+                $ concatWith (\a b -> a <> kwSemicolon <> line <> b)
+                $ zipWithExact (\b val -> b <+> kwAssign <+> val) (toList bs) (toList vs)
             nss = enclose kwSquareL kwSquareR (concatWith (<+>) names)
          in kwLetRec <> nss <> line <> bss <> kwSemicolon <> line <> kwIn <> line <> b'
     where
@@ -386,22 +387,22 @@ instance PrettyCode Pi where
   ppCode Pi {..} =
     let piType = _piBinder ^. binderType
      in if
-            | varOccurs 0 _piBody -> do
-                n <- ppName KNameLocal (_piBinder ^. binderName)
-                ty <- ppCode piType
-                b <- ppCode _piBody
-                return $ kwPi <+> n <+> kwColon <+> ty <> comma <+> b
-            | otherwise -> do
-                ty <- ppLeftExpression funFixity piType
-                b <- ppRightExpression funFixity _piBody
-                return $ ty <+> kwArrow <+> b
+          | varOccurs 0 _piBody -> do
+              n <- ppName KNameLocal (_piBinder ^. binderName)
+              ty <- ppCode piType
+              b <- ppCode _piBody
+              return $ kwPi <+> n <+> kwColon <+> ty <> comma <+> b
+          | otherwise -> do
+              ty <- ppLeftExpression funFixity piType
+              b <- ppRightExpression funFixity _piBody
+              return $ ty <+> kwArrow <+> b
 
 instance PrettyCode (Univ' i) where
   ppCode Univ {..} =
-    return $
-      if
-          | _univLevel == 0 -> kwType
-          | otherwise -> kwType <+> pretty _univLevel
+    return
+      $ if
+        | _univLevel == 0 -> kwType
+        | otherwise -> kwType <+> pretty _univLevel
 
 instance PrettyCode Stripped.TypeApp where
   ppCode Stripped.TypeApp {..} = do
@@ -611,10 +612,10 @@ goBinary isComma fixity name = \case
     arg1' <- ppLeftExpression fixity arg1
     arg2' <- ppRightExpression fixity arg2
     if
-        | isComma ->
-            return $ arg1' <> name <+> arg2'
-        | otherwise ->
-            return $ arg1' <+> name <+> arg2'
+      | isComma ->
+          return $ arg1' <> name <+> arg2'
+      | otherwise ->
+          return $ arg1' <+> name <+> arg2'
   _ ->
     impossible
 

--- a/src/Juvix/Compiler/Core/Transformation/Base.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Base.hs
@@ -55,22 +55,22 @@ mapT f = over (moduleInfoTable . identContext) (HashMap.mapWithKey f)
 
 mapT' :: (Symbol -> Node -> Sem (InfoTableBuilder ': r) Node) -> Module -> Sem r Module
 mapT' f m =
-  fmap fst $
-    runInfoTableBuilder m $
-      mapM_
-        (\(k, v) -> f k v >>= registerIdentNode k)
-        (HashMap.toList (m ^. moduleInfoTable . identContext))
+  fmap fst
+    $ runInfoTableBuilder m
+    $ mapM_
+      (\(k, v) -> f k v >>= registerIdentNode k)
+      (HashMap.toList (m ^. moduleInfoTable . identContext))
 
 walkT :: (Applicative f) => (Symbol -> Node -> f ()) -> InfoTable -> f ()
 walkT f tab = for_ (HashMap.toList (tab ^. identContext)) (uncurry f)
 
 mapAllNodes :: (Node -> Node) -> Module -> Module
 mapAllNodes f md =
-  mapAxioms convertAxiom $
-    mapInductives convertInductive $
-      mapConstructors convertConstructor $
-        mapIdents convertIdent $
-          mapT (const f) md
+  mapAxioms convertAxiom
+    $ mapInductives convertInductive
+    $ mapConstructors convertConstructor
+    $ mapIdents convertIdent
+    $ mapT (const f) md
   where
     convertIdent :: IdentifierInfo -> IdentifierInfo
     convertIdent ii =
@@ -95,8 +95,8 @@ withOptimizationLevel :: (Member (Reader CoreOptions) r) => Int -> (Module -> Se
 withOptimizationLevel n f tab = do
   l <- asks (^. optOptimizationLevel)
   if
-      | l >= n -> f tab
-      | otherwise -> return tab
+    | l >= n -> f tab
+    | otherwise -> return tab
 
 withOptimizationLevel' :: (Member (Reader CoreOptions) r) => Module -> Int -> (Module -> Sem r Module) -> Sem r Module
 withOptimizationLevel' tab n f = withOptimizationLevel n f tab

--- a/src/Juvix/Compiler/Core/Transformation/Check/Base.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Check/Base.hs
@@ -58,9 +58,9 @@ checkBuiltins allowUntypedFail = dmapRM go
           OpTrace -> throw $ unsupportedError "tracing" node (getInfoLocation _builtinAppInfo)
           OpFail | not allowUntypedFail -> do
             let ty = Info.getInfoType _builtinAppInfo
-            when (isDynamic ty) $
-              throw $
-                unsupportedError "failing without type info" node (getInfoLocation _builtinAppInfo)
+            when (isDynamic ty)
+              $ throw
+              $ unsupportedError "failing without type info" node (getInfoLocation _builtinAppInfo)
             return $ Recur node
           OpFail -> do
             return $ End node
@@ -145,8 +145,8 @@ checkTypes allowPolymorphism md = dmapM go
 
 checkNoRecursiveTypes :: forall r. (Member (Error CoreError) r) => Module -> Sem r ()
 checkNoRecursiveTypes md =
-  when (isCyclic (createTypeDependencyInfo (md ^. moduleInfoTable))) $
-    throw
+  when (isCyclic (createTypeDependencyInfo (md ^. moduleInfoTable)))
+    $ throw
       CoreError
         { _coreErrorMsg = ppOutput "recursive types not supported for this target",
           _coreErrorNode = Nothing,
@@ -155,8 +155,8 @@ checkNoRecursiveTypes md =
 
 checkMainExists :: forall r. (Member (Error CoreError) r) => Module -> Sem r ()
 checkMainExists md =
-  when (isNothing (md ^. moduleInfoTable . infoMain)) $
-    throw
+  when (isNothing (md ^. moduleInfoTable . infoMain))
+    $ throw
       CoreError
         { _coreErrorMsg = ppOutput "no `main` function",
           _coreErrorNode = Nothing,

--- a/src/Juvix/Compiler/Core/Transformation/Check/Cairo.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Check/Cairo.hs
@@ -16,8 +16,8 @@ checkCairo md = do
   where
     checkMainType :: Sem r ()
     checkMainType =
-      unless (checkType (ii ^. identifierType)) $
-        throw
+      unless (checkType (ii ^. identifierType))
+        $ throw
           CoreError
             { _coreErrorMsg = ppOutput "for this target the arguments the `main` function need to be field elements, numbers, booleans, records or lists, and the result needs to be a field element, number, boolean or a record of field elements, numbers and booleans",
               _coreErrorLoc = fromMaybe defaultLoc (ii ^. identifierLocation),

--- a/src/Juvix/Compiler/Core/Transformation/Check/VampIR.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Check/VampIR.hs
@@ -17,8 +17,8 @@ checkVampIR md =
   where
     checkMainType :: Sem r ()
     checkMainType =
-      unless (checkType (ii ^. identifierType)) $
-        throw
+      unless (checkType (ii ^. identifierType))
+        $ throw
           CoreError
             { _coreErrorMsg = ppOutput "for this target the arguments and the result of the `main` function must be numbers or booleans",
               _coreErrorLoc = fromMaybe defaultLoc (ii ^. identifierLocation),
@@ -37,8 +37,8 @@ checkVampIR md =
 
     checkPublicInputs :: Sem r ()
     checkPublicInputs =
-      unless (maybe True (all (`elem` argnames) . (^. pragmaPublic)) (ii ^. identifierPragmas . pragmasPublic)) $
-        throw
+      unless (maybe True (all (`elem` argnames) . (^. pragmaPublic)) (ii ^. identifierPragmas . pragmasPublic))
+        $ throw
           CoreError
             { _coreErrorMsg = ppOutput "invalid public input: not an argument name",
               _coreErrorLoc = fromMaybe defaultLoc (ii ^. identifierLocation),

--- a/src/Juvix/Compiler/Core/Transformation/DisambiguateNames.hs
+++ b/src/Juvix/Compiler/Core/Transformation/DisambiguateNames.hs
@@ -26,8 +26,8 @@ disambiguateNodeNames' disambiguate md = dmapL go
         NRec
           ( set
               letRecValues
-              ( NonEmpty.fromList $
-                  zipWithExact
+              ( NonEmpty.fromList
+                  $ zipWithExact
                     (set letItemBinder)
                     (disambiguateBinders bl (map (^. letItemBinder) vs))
                     vs

--- a/src/Juvix/Compiler/Core/Transformation/FoldTypeSynonyms.hs
+++ b/src/Juvix/Compiler/Core/Transformation/FoldTypeSynonyms.hs
@@ -23,5 +23,5 @@ convertNode md = rmap go
 
 foldTypeSynonyms :: Module -> Module
 foldTypeSynonyms md =
-  filterOutTypeSynonyms $
-    mapAllNodes (convertNode md) md
+  filterOutTypeSynonyms
+    $ mapAllNodes (convertNode md) md

--- a/src/Juvix/Compiler/Core/Transformation/IntToPrimInt.hs
+++ b/src/Juvix/Compiler/Core/Transformation/IntToPrimInt.hs
@@ -139,9 +139,9 @@ convertNode md = rmap go
               convertIdentApp
                 node
                 ( \g ->
-                    mkLet' mkTypeInteger' l $
-                      mkLambda' mkTypeInteger' $
-                        g info (mkVar' 1) (mkVar' 0)
+                    mkLet' mkTypeInteger' l
+                      $ mkLambda' mkTypeInteger'
+                      $ g info (mkVar' 1) (mkVar' 0)
                 )
                 sym
 
@@ -156,9 +156,9 @@ convertNode md = rmap go
               convertIdentApp
                 node
                 ( \g ->
-                    mkLambda' mkTypeInteger' $
-                      mkLambda' mkTypeInteger' $
-                        g info (mkVar' 1) (mkVar' 0)
+                    mkLambda' mkTypeInteger'
+                      $ mkLambda' mkTypeInteger'
+                      $ g info (mkVar' 1) (mkVar' 0)
                 )
                 sym
 

--- a/src/Juvix/Compiler/Core/Transformation/LambdaLetRecLifting.hs
+++ b/src/Juvix/Compiler/Core/Transformation/LambdaLetRecLifting.hs
@@ -47,8 +47,8 @@ lambdaLiftNode aboveBl top =
         goLambda l = do
           onlyLetRec <- ask @OnlyLetRec
           if
-              | onlyLetRec -> return (Recur (NLam l))
-              | otherwise -> goLambdaGo l
+            | onlyLetRec -> return (Recur (NLam l))
+            | otherwise -> goLambdaGo l
           where
             goLambdaGo :: Lambda -> Sem r Recur
             goLambdaGo lm = do

--- a/src/Juvix/Compiler/Core/Transformation/MatchToCase.hs
+++ b/src/Juvix/Compiler/Core/Transformation/MatchToCase.hs
@@ -82,22 +82,22 @@ goMatchToCase recur node = case node of
         -- The matrix has no rows -- matching fails (Section 4, case 1).
         fCoverage <- asks (^. optCheckCoverage)
         if
-            | fCoverage ->
-                throw
-                  CoreError
-                    { _coreErrorMsg =
-                        ppOutput
-                          ( "Pattern matching not exhaustive. Example pattern "
-                              <> seq
-                              <> "not matched: "
-                              <> pat'
-                          ),
-                      _coreErrorNode = Nothing,
-                      _coreErrorLoc = fromMaybe defaultLoc (getNodeLocation node)
-                    }
-            | otherwise ->
-                return $
-                  mkBuiltinApp' OpFail [mkConstant' (ConstString ("Pattern sequence not matched: " <> ppTrace pat))]
+          | fCoverage ->
+              throw
+                CoreError
+                  { _coreErrorMsg =
+                      ppOutput
+                        ( "Pattern matching not exhaustive. Example pattern "
+                            <> seq
+                            <> "not matched: "
+                            <> pat'
+                        ),
+                    _coreErrorNode = Nothing,
+                    _coreErrorLoc = fromMaybe defaultLoc (getNodeLocation node)
+                  }
+          | otherwise ->
+              return
+                $ mkBuiltinApp' OpFail [mkConstant' (ConstString ("Pattern sequence not matched: " <> ppTrace pat))]
         where
           pat = err (replicate (length vs) ValueWildcard)
           seq = if length pat == 1 then "" else "sequence "
@@ -119,29 +119,29 @@ goMatchToCase recur node = case node of
             tagsSet = getPatTags col
             tags = toList tagsSet
          in if
-                | null tags ->
-                    -- There are no constructor patterns
-                    compileDefault Nothing err bindersNum vs' col matrix'
-                | otherwise -> do
-                    -- Section 4, case 3(a)
-                    let ind = lookupConstructorInfo tab (head' tags) ^. constructorInductive
-                        ctrsNum = length (lookupInductiveInfo tab ind ^. inductiveConstructors)
-                    branches <- mapM (compileBranch err bindersNum vs' col matrix') tags
-                    defaultBranch <-
-                      if
-                          | length tags == ctrsNum ->
-                              return Nothing
-                          | otherwise ->
-                              Just <$> compileDefault (Just $ missingTag tab ind tagsSet) err bindersNum vs' col matrix'
-                    return $
-                      NCase
-                        Case
-                          { _caseInfo = mempty,
-                            _caseInductive = ind,
-                            _caseValue = val,
-                            _caseBranches = branches,
-                            _caseDefault = defaultBranch
-                          }
+              | null tags ->
+                  -- There are no constructor patterns
+                  compileDefault Nothing err bindersNum vs' col matrix'
+              | otherwise -> do
+                  -- Section 4, case 3(a)
+                  let ind = lookupConstructorInfo tab (head' tags) ^. constructorInductive
+                      ctrsNum = length (lookupInductiveInfo tab ind ^. inductiveConstructors)
+                  branches <- mapM (compileBranch err bindersNum vs' col matrix') tags
+                  defaultBranch <-
+                    if
+                      | length tags == ctrsNum ->
+                          return Nothing
+                      | otherwise ->
+                          Just <$> compileDefault (Just $ missingTag tab ind tagsSet) err bindersNum vs' col matrix'
+                  return
+                    $ NCase
+                      Case
+                        { _caseInfo = mempty,
+                          _caseInductive = ind,
+                          _caseValue = val,
+                          _caseBranches = branches,
+                          _caseDefault = defaultBranch
+                        }
 
     mkVal :: Level -> Level -> Node
     mkVal bindersNum vl = mkVar' (getBinderIndex bindersNum vl)
@@ -160,8 +160,8 @@ goMatchToCase recur node = case node of
               _patternRowIgnoredPatternsNum = max 0 (nIgnored - 1),
               _patternRowBinderChangesRev =
                 if
-                    | nIgnored > 0 -> rbcs
-                    | otherwise -> mkBCRemove binder val : rbcs
+                  | nIgnored > 0 -> rbcs
+                  | otherwise -> mkBCRemove binder val : rbcs
             }
           where
             nIgnored = row ^. patternRowIgnoredPatternsNum
@@ -186,8 +186,8 @@ goMatchToCase recur node = case node of
       goMatchToCase (recur . (bcs ++)) _patternRowBody
       where
         bcs =
-          reverse $
-            foldl'
+          reverse
+            $ foldl'
               ( \acc (pat, vl) ->
                   mkBCRemove (getPatternBinder pat) (mkVal bindersNum vl) : acc
               )
@@ -245,8 +245,8 @@ goMatchToCase recur node = case node of
       binders' <- getBranchBinders col matrix tag
       matrix' <- getBranchMatrix col matrix tag
       body <- compile err' bindersNum' (vs' ++ vs) matrix'
-      return $
-        CaseBranch
+      return
+        $ CaseBranch
           { _caseBranchInfo = setInfoName (ci ^. constructorName) mempty,
             _caseBranchTag = tag,
             _caseBranchBinders = binders',
@@ -256,7 +256,8 @@ goMatchToCase recur node = case node of
 
     getBranchBinders :: [Pattern] -> PatternMatrix -> Tag -> Sem r [Binder]
     getBranchBinders col matrix tag =
-      reverse . snd
+      reverse
+        . snd
         <$> foldl'
           ( \a pat -> do
               (rbcs, acc) <- a
@@ -287,19 +288,19 @@ goMatchToCase recur node = case node of
           helper row = \case
             PatConstr PatternConstr {..}
               | _patternConstrTag == tag ->
-                  Just $
-                    row
+                  Just
+                    $ row
                       { _patternRowPatterns =
                           _patternConstrArgs ++ row ^. patternRowPatterns,
                         _patternRowBinderChangesRev = BCAdd argsNum : row ^. patternRowBinderChangesRev
                       }
             PatWildcard {} ->
-              Just $
-                row
+              Just
+                $ row
                   { _patternRowPatterns =
                       map (PatWildcard . PatternWildcard mempty . Binder "_" Nothing) argtys
                         ++ row
-                          ^. patternRowPatterns,
+                        ^. patternRowPatterns,
                     _patternRowBinderChangesRev = BCAdd argsNum : row ^. patternRowBinderChangesRev,
                     _patternRowIgnoredPatternsNum = argsNum + row ^. patternRowIgnoredPatternsNum
                   }

--- a/src/Juvix/Compiler/Core/Transformation/NatToPrimInt.hs
+++ b/src/Juvix/Compiler/Core/Transformation/NatToPrimInt.hs
@@ -19,26 +19,26 @@ convertNode md = rmap go
       NApp (App _ (NApp (App _ (NIdt (Ident {..})) l)) r) ->
         recur [] $ convertIdentApp node (\g -> g _identInfo l r) _identSymbol
       NApp (App _ (NIdt (Ident {..})) l) ->
-        recur [] $
-          convertIdentApp
+        recur []
+          $ convertIdentApp
             node
             ( \g ->
-                mkLet' mkTypeInteger' l $
-                  mkLambda' mkTypeInteger' $
-                    g _identInfo (mkVar' 1) (mkVar' 0)
+                mkLet' mkTypeInteger' l
+                  $ mkLambda' mkTypeInteger'
+                  $ g _identInfo (mkVar' 1) (mkVar' 0)
             )
             _identSymbol
       NIdt (Ident {..})
         | Just _identSymbol == intToNat ->
             mkLambda' mkTypeInteger' (mkVar' 0)
       NIdt (Ident {..}) ->
-        recur [] $
-          convertIdentApp
+        recur []
+          $ convertIdentApp
             node
             ( \g ->
-                mkLambda' mkTypeInteger' $
-                  mkLambda' mkTypeInteger' $
-                    g _identInfo (mkVar' 1) (mkVar' 0)
+                mkLambda' mkTypeInteger'
+                  $ mkLambda' mkTypeInteger'
+                  $ g _identInfo (mkVar' 1) (mkVar' 0)
             )
             _identSymbol
       NCtr (Constr {..}) ->
@@ -57,12 +57,12 @@ convertNode md = rmap go
                   [br] -> makeIf br (maybeBranch _caseDefault)
                   [br1, br2] ->
                     if
-                        | br1 ^. caseBranchBindersNum == 1 && br2 ^. caseBranchBindersNum == 0 ->
-                            makeIf br1 (br2 ^. caseBranchBody)
-                        | br2 ^. caseBranchBindersNum == 1 && br1 ^. caseBranchBindersNum == 0 ->
-                            makeIf br2 (br1 ^. caseBranchBody)
-                        | otherwise ->
-                            impossible
+                      | br1 ^. caseBranchBindersNum == 1 && br2 ^. caseBranchBindersNum == 0 ->
+                          makeIf br1 (br2 ^. caseBranchBody)
+                      | br2 ^. caseBranchBindersNum == 1 && br1 ^. caseBranchBindersNum == 0 ->
+                          makeIf br2 (br1 ^. caseBranchBody)
+                      | otherwise ->
+                          impossible
                   [] -> recur [] $ fromJust _caseDefault
                   _ -> impossible
               _ -> recur [] node
@@ -75,8 +75,8 @@ convertNode md = rmap go
                   0 ->
                     recur [] $ mkIf _caseInfo sym (mkBuiltinApp' OpEq [_caseValue, mkConstant' (ConstInteger 0)]) _caseBranchBody br
                   1 ->
-                    mkLet mempty binder' (go recur _caseValue) $
-                      mkIf
+                    mkLet mempty binder' (go recur _caseValue)
+                      $ mkIf
                         _caseInfo
                         sym
                         (mkBuiltinApp' OpEq [mkConstant' (ConstInteger 0), mkVar (Info.singleton (NameInfo name)) 0])
@@ -106,8 +106,8 @@ convertNode md = rmap go
             Just BuiltinNatSub ->
               f
                 ( \info x y ->
-                    mkLet' mkTypeInteger' (mkBuiltinApp info OpIntSub [x, y]) $
-                      mkIf'
+                    mkLet' mkTypeInteger' (mkBuiltinApp info OpIntSub [x, y])
+                      $ mkIf'
                         boolSymbol
                         (mkBuiltinApp' OpIntLe [mkConstant' (ConstInteger 0), mkVar' 0])
                         (mkVar' 0)

--- a/src/Juvix/Compiler/Core/Transformation/Normalize.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Normalize.hs
@@ -9,10 +9,10 @@ normalize :: (Member (Reader CoreOptions) r) => Module -> Sem r Module
 normalize md = do
   opts <- ask
   let node = Normalizer.normalize (opts ^. optFieldSize) md (lookupIdentifierNode md sym)
-  return $
-    pruneInfoTable $
-      set (moduleInfoTable . identContext) (HashMap.singleton sym node) $
-        set (moduleInfoTable . infoIdentifiers) (HashMap.singleton sym ii) md
+  return
+    $ pruneInfoTable
+    $ set (moduleInfoTable . identContext) (HashMap.singleton sym node)
+    $ set (moduleInfoTable . infoIdentifiers) (HashMap.singleton sym ii) md
   where
     sym = fromJust $ getInfoMain md
     ii = lookupIdentifierInfo md sym

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/CaseCallLifting.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/CaseCallLifting.hs
@@ -12,13 +12,13 @@ convertNode md = umap go
       NCase Case {..}
         | not (null idents) ->
             if
-                | isCaseBoolean _caseBranches && not (isImmediate md _caseValue) ->
-                    mkLet'
-                      mkTypeBool'
-                      _caseValue
-                      (liftApps 0 _caseInductive (mkVar' 0) (brs' 1) (def' 1) idents)
-                | otherwise ->
-                    liftApps 0 _caseInductive _caseValue (brs' 0) (def' 0) idents
+              | isCaseBoolean _caseBranches && not (isImmediate md _caseValue) ->
+                  mkLet'
+                    mkTypeBool'
+                    _caseValue
+                    (liftApps 0 _caseInductive (mkVar' 0) (brs' 1) (def' 1) idents)
+              | otherwise ->
+                  liftApps 0 _caseInductive _caseValue (brs' 0) (def' 0) idents
         where
           bodies = map (^. caseBranchBody) _caseBranches ++ maybeToList _caseDefault
           idts = foldr (flip gatherIdents) mempty bodies
@@ -91,8 +91,10 @@ convertNode md = umap go
             let (h, args) = unfoldApps' node
              in case h of
                   NIdt Ident {..}
-                    | _identSymbol == sym
-                        && length args == argsNum ->
+                    | _identSymbol
+                        == sym
+                        && length args
+                        == argsNum ->
                         acc + 1
                   _ -> acc
           _ -> acc
@@ -108,8 +110,10 @@ convertNode md = umap go
             let (h, args) = unfoldApps' node
              in case h of
                   NIdt Ident {..}
-                    | _identSymbol == sym
-                        && length args == argsNum ->
+                    | _identSymbol
+                        == sym
+                        && length args
+                        == argsNum ->
                         Just args
                   _ -> acc
           _ -> acc
@@ -125,8 +129,10 @@ convertNode md = umap go
             let (h, args) = unfoldApps' node
              in case h of
                   NIdt Ident {..}
-                    | _identSymbol == sym
-                        && length args == argsNum ->
+                    | _identSymbol
+                        == sym
+                        && length args
+                        == argsNum ->
                         snode
                   _ -> node
           _ -> node

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/CasePermutation.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/CasePermutation.hs
@@ -27,7 +27,8 @@ isConstructorTree md c node = case run $ runFail $ go mempty node of
     checkDefault :: HashMap Tag Int -> Maybe Node -> Bool
     checkDefault ctrsMap = \case
       Just d ->
-        sum (HashMap.filterWithKey (\k _ -> not (HashSet.member k tags')) ctrsMap) <= 1
+        sum (HashMap.filterWithKey (\k _ -> not (HashSet.member k tags')) ctrsMap)
+          <= 1
           || isImmediate md d
         where
           tags' = HashSet.fromList tags

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/ConstantFolding.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/ConstantFolding.hs
@@ -24,8 +24,12 @@ convertNode opts nonRecSyms tab md = umap go
               NIdt Ident {..}
                 | HashSet.member _identSymbol nonRecSyms
                     && evalAllowed
-                    && length args == ii ^. identifierArgsNum
-                    && length tyargs == ii ^. identifierArgsNum
+                    && length args
+                    == ii
+                    ^. identifierArgsNum
+                    && length tyargs
+                    == ii
+                    ^. identifierArgsNum
                     && isZeroOrderType md tgt'
                     && all isNonRecValue args ->
                     doEval' node

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/FilterUnreachable.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/FilterUnreachable.hs
@@ -6,9 +6,9 @@ import Juvix.Compiler.Core.Transformation.Base
 
 filterUnreachable :: Module -> Module
 filterUnreachable md =
-  pruneInfoTable $
-    over (moduleInfoTable . infoInductives) goFilter $
-      over (moduleInfoTable . infoIdentifiers) goFilter md
+  pruneInfoTable
+    $ over (moduleInfoTable . infoInductives) goFilter
+    $ over (moduleInfoTable . infoIdentifiers) goFilter md
   where
     depInfo = createSymbolDependencyInfo (md ^. moduleInfoTable)
 

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
@@ -39,7 +39,8 @@ convertNode inlineDepth nonRecSyms md = dmapL go
                   _
                     | HashSet.member _identSymbol nonRecSyms
                         && isInlineableLambda inlineDepth md bl def
-                        && length args >= argsNum ->
+                        && length args
+                        >= argsNum ->
                         mkApps def args
                   _ ->
                     node

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/LambdaFolding.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/LambdaFolding.hs
@@ -31,8 +31,8 @@ convertNode = rmap go
                   (go (recur . (revAppend bcs)) body)
                   (map (go (recur . (BCAdd (length bcs) :))) args)
               (lam : lams', arg : args') ->
-                mkLet mempty bd' (go (recur . (BCAdd (length bcs) :)) arg) $
-                  goLams (BCKeep bd : bcs) lams' args' body
+                mkLet mempty bd' (go (recur . (BCAdd (length bcs) :)) arg)
+                  $ goLams (BCKeep bd : bcs) lams' args' body
                 where
                   bd = lam ^. lambdaLhsBinder
                   bd' = over binderType (go (recur . (revAppend bcs))) bd

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/LetFolding.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/LetFolding.hs
@@ -24,7 +24,8 @@ convertNode isFoldable md = rmapL go
     go recur bl = \case
       NLet Let {..}
         | isImmediate md (_letItem ^. letItemValue)
-            || Info.freeVarOccurrences 0 _letBody <= 1
+            || Info.freeVarOccurrences 0 _letBody
+            <= 1
             || isFoldable md bl (_letItem ^. letItemValue) ->
             go (recur . (mkBCRemove b val' :)) (BL.cons b bl) _letBody
         where

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/Exec.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/Exec.hs
@@ -10,9 +10,9 @@ import Juvix.Compiler.Core.Transformation.TopEtaExpand
 optimize :: (Member (Reader CoreOptions) r) => Module -> Sem r Module
 optimize tab = do
   opts <- ask
-  withOptimizationLevel' tab 1 $
-    return
-      . topEtaExpand
-      . letFolding
-      . lambdaLetRecLifting
-      . Main.optimize' opts
+  withOptimizationLevel' tab 1
+    $ return
+    . topEtaExpand
+    . letFolding
+    . lambdaLetRecLifting
+    . Main.optimize' opts

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/Main.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/Main.hs
@@ -49,8 +49,8 @@ optimize' opts@CoreOptions {..} md =
       where
         nonRecs' =
           if
-              | _optOptimizationLevel > 1 -> nonRecursiveIdents md'
-              | otherwise -> nonRecs
+            | _optOptimizationLevel > 1 -> nonRecursiveIdents md'
+            | otherwise -> nonRecs
 
     doSimplification :: Int -> Module -> Module
     doSimplification n =

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/VampIR.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Phase/VampIR.hs
@@ -9,5 +9,10 @@ import Juvix.Compiler.Core.Transformation.Optimize.SimplifyIfs
 
 optimize :: (Member (Reader CoreOptions) r) => Module -> Sem r Module
 optimize =
-  withOptimizationLevel 1 $
-    return . letFolding . simplifyIfs . caseCallLifting . letFolding . lambdaFolding
+  withOptimizationLevel 1
+    $ return
+    . letFolding
+    . simplifyIfs
+    . caseCallLifting
+    . letFolding
+    . lambdaFolding

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/SimplifyArithmetic.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/SimplifyArithmetic.hs
@@ -22,12 +22,12 @@ convertNode = dmap go
           blt' ^. builtinAppOp == OpIntAdd,
           [x, m] <- blt' ^. builtinAppArgs ->
             if
-                | m == n ->
-                    x
-                | x == n ->
-                    m
-                | otherwise ->
-                    node
+              | m == n ->
+                  x
+              | x == n ->
+                  m
+              | otherwise ->
+                  node
       NBlt BuiltinApp {..}
         | _builtinAppOp == OpIntAdd,
           [n, NBlt blt'] <- _builtinAppArgs,
@@ -72,12 +72,12 @@ convertNode = dmap go
           blt' ^. builtinAppOp == OpFieldAdd,
           [x, m] <- blt' ^. builtinAppArgs ->
             if
-                | m == n ->
-                    x
-                | x == n ->
-                    m
-                | otherwise ->
-                    node
+              | m == n ->
+                  x
+              | x == n ->
+                  m
+              | otherwise ->
+                  node
       NBlt BuiltinApp {..}
         | _builtinAppOp == OpFieldAdd,
           [n, NBlt blt'] <- _builtinAppArgs,

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/SimplifyComparisons.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/SimplifyComparisons.hs
@@ -27,12 +27,12 @@ convertNode md = dmap go
                 | OpIntLt <- blt' ^. builtinAppOp,
                   blt ^. builtinAppArgs == blt' ^. builtinAppArgs ->
                     if
-                        | isFalseConstr b1 ->
-                            b2
-                        | isTrueConstr b1 ->
-                            NBlt blt {_builtinAppOp = OpIntLe}
-                        | otherwise ->
-                            mkIf' boolSym v b1 b2
+                      | isFalseConstr b1 ->
+                          b2
+                      | isTrueConstr b1 ->
+                          NBlt blt {_builtinAppOp = OpIntLe}
+                      | otherwise ->
+                          mkIf' boolSym v b1 b2
               _ ->
                 mkIf' boolSym v b1 b2
         | OpIntLt <- _builtinAppOp,
@@ -58,34 +58,34 @@ convertNode md = dmap go
         | (OpEq, OpIntLt) <- (blt ^. builtinAppOp, blt' ^. builtinAppOp),
           blt ^. builtinAppArgs == blt' ^. builtinAppArgs ->
             if
-                | isFalseConstr b1 && isTrueConstr b1' && isFalseConstr b2' ->
-                    v'
-                | isTrueConstr b1 && isFalseConstr b1' && isFalseConstr b2' ->
-                    v
-                | isTrueConstr b1 && isTrueConstr b1' && isFalseConstr b2' ->
-                    NBlt blt {_builtinAppOp = OpIntLe}
-                | isFalseConstr b1 && isFalseConstr b1' && isTrueConstr b2' ->
-                    NBlt
-                      blt
-                        { _builtinAppOp = OpIntLt,
-                          _builtinAppArgs = reverse (blt ^. builtinAppArgs)
-                        }
-                | isTrueConstr b1 && isFalseConstr b1' && isTrueConstr b2' ->
-                    NBlt
-                      blt
-                        { _builtinAppOp = OpIntLe,
-                          _builtinAppArgs = reverse (blt ^. builtinAppArgs)
-                        }
-                | isFalseConstr b1 && isTrueConstr b1' && isTrueConstr b2' ->
-                    mkIf' boolSym v b1 b1'
-                | b1 == b2' ->
-                    mkIf' boolSym v' b1' b2'
-                | b1' == b2' ->
-                    mkIf' boolSym v b1 b1'
-                | b1 == b1' ->
-                    mkIf' boolSym (NBlt blt {_builtinAppOp = OpIntLe}) b1 b2'
-                | otherwise ->
-                    theIfs
+              | isFalseConstr b1 && isTrueConstr b1' && isFalseConstr b2' ->
+                  v'
+              | isTrueConstr b1 && isFalseConstr b1' && isFalseConstr b2' ->
+                  v
+              | isTrueConstr b1 && isTrueConstr b1' && isFalseConstr b2' ->
+                  NBlt blt {_builtinAppOp = OpIntLe}
+              | isFalseConstr b1 && isFalseConstr b1' && isTrueConstr b2' ->
+                  NBlt
+                    blt
+                      { _builtinAppOp = OpIntLt,
+                        _builtinAppArgs = reverse (blt ^. builtinAppArgs)
+                      }
+              | isTrueConstr b1 && isFalseConstr b1' && isTrueConstr b2' ->
+                  NBlt
+                    blt
+                      { _builtinAppOp = OpIntLe,
+                        _builtinAppArgs = reverse (blt ^. builtinAppArgs)
+                      }
+              | isFalseConstr b1 && isTrueConstr b1' && isTrueConstr b2' ->
+                  mkIf' boolSym v b1 b1'
+              | b1 == b2' ->
+                  mkIf' boolSym v' b1' b2'
+              | b1' == b2' ->
+                  mkIf' boolSym v b1 b1'
+              | b1 == b1' ->
+                  mkIf' boolSym (NBlt blt {_builtinAppOp = OpIntLe}) b1 b2'
+              | otherwise ->
+                  theIfs
       _ ->
         theIfs
       where

--- a/src/Juvix/Compiler/Core/Transformation/Optimize/SpecializeArgs.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/SpecializeArgs.hs
@@ -32,7 +32,8 @@ isMarkedSpecializable md = \case
   NTyp TypeConstr {..}
     | Just (PragmaSpecialise True) <-
         lookupInductiveInfo md _typeConstrSymbol
-          ^. inductivePragmas . pragmasSpecialise ->
+          ^. inductivePragmas
+          . pragmasSpecialise ->
         True
   node ->
     let (h, _) = unfoldApps' node
@@ -40,7 +41,8 @@ isMarkedSpecializable md = \case
           NIdt Ident {..}
             | Just (PragmaSpecialise True) <-
                 lookupIdentifierInfo md _identSymbol
-                  ^. identifierPragmas . pragmasSpecialise ->
+                  ^. identifierPragmas
+                  . pragmasSpecialise ->
                 True
           _ ->
             False
@@ -61,7 +63,8 @@ isArgSpecializable tab sym argNum = run $ execState True $ dmapNRM go body
               NIdt Ident {..}
                 | _identSymbol == sym ->
                     let b =
-                          argNum <= length args
+                          argNum
+                            <= length args
                             && case args !! (argNum - 1) of
                               NVar Var {..} | _varIndex == lvl + n - argNum -> True
                               _ -> False
@@ -106,136 +109,137 @@ convertNode = dmapLRM go
 
           -- arguments marked for specialisation with `specialize: true`
           psargs0 =
-            map fst3 $
-              filter (\(_, arg, ty) -> isMarkedSpecializable md arg || isMarkedSpecializable md ty) $
-                zip3 [1 .. argsNum] args' tyargs
+            map fst3
+              $ filter (\(_, arg, ty) -> isMarkedSpecializable md arg || isMarkedSpecializable md ty)
+              $ zip3 [1 .. argsNum] args' tyargs
 
           getArgIndex :: PragmaSpecialiseArg -> Maybe Int
           getArgIndex = \case
             SpecialiseArgNum i -> Just i
             SpecialiseArgNamed x -> fmap (+ 1) $ x `elemIndex` argnames
       if
-          | (isJust pspec || isJust pspecby || not (null psargs0)) && length args == argsNum -> do
-              let psargs1 = mapMaybe getArgIndex $ maybe [] (^. pragmaSpecialiseArgs) pspec
-                  psargs2 = maybe [] (map (+ 1) . mapMaybe (`elemIndex` argnames) . (^. pragmaSpecialiseBy)) pspecby
-                  psargs = nubSort (psargs0 ++ psargs1 ++ psargs2)
-              -- assumption: all type variables are at the front
-              let specargs0 =
-                    filter
-                      ( \argNum ->
-                          argNum <= argsNum
-                            && isSpecializable md (args' !! (argNum - 1))
-                            && isArgSpecializable md _identSymbol argNum
-                      )
-                      psargs
-                  tyargsNum = length (takeWhile (isTypeConstr md) tyargs)
-                  -- in addition to the arguments explicitly marked for
-                  -- specialisation, also specialise all type arguments
-                  specargs =
-                    nub $
-                      [1 .. tyargsNum]
-                        ++ specargs0
-                  -- the arguments marked for specialisation which we don't
-                  -- specialise now
-                  remainingSpecargs =
-                    shiftSpecargs specargs $ filter (not . (`elem` specargs0)) psargs
-                  pragmas =
-                    (ii ^. identifierPragmas)
-                      { _pragmasSpecialiseArgs =
-                          Just $
-                            PragmaSpecialiseArgs $
-                              map SpecialiseArgNum remainingSpecargs
-                      }
+        | (isJust pspec || isJust pspecby || not (null psargs0)) && length args == argsNum -> do
+            let psargs1 = mapMaybe getArgIndex $ maybe [] (^. pragmaSpecialiseArgs) pspec
+                psargs2 = maybe [] (map (+ 1) . mapMaybe (`elemIndex` argnames) . (^. pragmaSpecialiseBy)) pspecby
+                psargs = nubSort (psargs0 ++ psargs1 ++ psargs2)
+            -- assumption: all type variables are at the front
+            let specargs0 =
+                  filter
+                    ( \argNum ->
+                        argNum
+                          <= argsNum
+                          && isSpecializable md (args' !! (argNum - 1))
+                          && isArgSpecializable md _identSymbol argNum
+                    )
+                    psargs
+                tyargsNum = length (takeWhile (isTypeConstr md) tyargs)
+                -- in addition to the arguments explicitly marked for
+                -- specialisation, also specialise all type arguments
+                specargs =
+                  nub
+                    $ [1 .. tyargsNum]
+                    ++ specargs0
+                -- the arguments marked for specialisation which we don't
+                -- specialise now
+                remainingSpecargs =
+                  shiftSpecargs specargs $ filter (not . (`elem` specargs0)) psargs
+                pragmas =
+                  (ii ^. identifierPragmas)
+                    { _pragmasSpecialiseArgs =
+                        Just
+                          $ PragmaSpecialiseArgs
+                          $ map SpecialiseArgNum remainingSpecargs
+                    }
 
-                  createFun :: Int -> Symbol -> [Node] -> (Type, [LambdaLhs], Node)
-                  createFun shiftIdx sym' sargs =
-                    let body' =
-                          replaceArgs shiftIdx argsNum specargs sargs $
-                            replaceIdent _identSymbol sym' argsNum specargs body
-                        tyargs' = removeSpecTypeArgs specargs sargs (take argsNum tyargs)
-                        tgt' = replaceArgs shiftIdx argsNum specargs sargs (mkPis' (drop argsNum tyargs) tgt)
-                        ty' = mkPis' tyargs' tgt'
-                        lams' =
-                          zipWithExact
-                            (\lam ty -> over lambdaLhsBinder (set binderType ty) lam)
-                            (removeSpecargs specargs lams)
-                            tyargs'
-                     in (ty', lams', body')
-              if
-                  | null specargs0 ->
-                      return $ End (mkApps' (NIdt idt) args')
-                  | otherwise -> do
-                      eassert (tyargsNum < argsNum)
-                      eassert (length lams == argsNum)
-                      eassert (length args' == argsNum)
-                      eassert (argsNum <= length tyargs)
-                      -- assumption: all type variables are at the front
-                      eassert (not $ any (isTypeConstr md) (drop tyargsNum tyargs))
-                      -- the specialisation signature: the values we specialise the arguments by
-                      let specSigArgs = selectSpecargs specargs args'
-                          specSig = (specSigArgs, specargs)
-                      if
-                          | all isClosed specSigArgs ->
-                              case find ((== specSig) . (^. specSignature)) (lookupSpecialisationInfo md _identSymbol) of
-                                Just SpecialisationInfo {..} ->
-                                  return $
-                                    End $
-                                      mkApps'
-                                        (mkIdent' _specSymbol)
-                                        (removeSpecargs specargs args')
-                                Nothing -> do
-                                  sym' <- freshSymbol
-                                  let (ty', lams', body') = createFun 0 sym' args'
-                                      name = uniqueName ("spec_" <> ii ^. identifierName) sym'
-                                  registerIdent
-                                    name
-                                    IdentifierInfo
-                                      { _identifierSymbol = sym',
-                                        _identifierName = name,
-                                        _identifierLocation = ii ^. identifierLocation,
-                                        _identifierType = ty',
-                                        _identifierArgsNum = length lams',
-                                        _identifierIsExported = False,
-                                        _identifierBuiltin = Nothing,
-                                        _identifierPragmas = pragmas,
-                                        _identifierArgNames =
-                                          removeSpecargs specargs (ii ^. identifierArgNames)
-                                      }
-                                  registerIdentNode sym' (reLambdas lams' body')
-                                  let si =
-                                        SpecialisationInfo
-                                          { _specSignature = specSig,
-                                            _specSymbol = sym'
-                                          }
-                                  registerSpecialisation _identSymbol si
-                                  return $
-                                    End $
-                                      mkApps'
-                                        (mkIdent' sym')
-                                        (removeSpecargs specargs args')
-                          | otherwise -> do
-                              sym' <- freshSymbol
-                              let -- We're adding the letrec binder, so need to shift by 1
-                                  sargs = map (shift 1) args'
-                                  (ty', lams', body') = createFun 1 sym' sargs
-                                  body'' = substSym sym' (argsNum - length specargs) body'
-                                  args'' = removeSpecargs specargs sargs
-                                  fun = reLambdas lams' body''
-                                  letitem =
-                                    mkLetItem
-                                      (ii ^. identifierName)
-                                      -- the type is not in the scope of the binder
-                                      (shift (-1) ty')
-                                      fun
-                                  node' =
-                                    mkLetRec
-                                      (setInfoPragmas [pragmas] mempty)
-                                      (NonEmpty.singleton letitem)
-                                      (mkApps' (mkVar' 0) args'')
-                              node'' <- lambdaLiftNode' True bl node'
-                              return $ End node''
-          | otherwise ->
-              return $ End $ mkApps' (NIdt idt) args'
+                createFun :: Int -> Symbol -> [Node] -> (Type, [LambdaLhs], Node)
+                createFun shiftIdx sym' sargs =
+                  let body' =
+                        replaceArgs shiftIdx argsNum specargs sargs
+                          $ replaceIdent _identSymbol sym' argsNum specargs body
+                      tyargs' = removeSpecTypeArgs specargs sargs (take argsNum tyargs)
+                      tgt' = replaceArgs shiftIdx argsNum specargs sargs (mkPis' (drop argsNum tyargs) tgt)
+                      ty' = mkPis' tyargs' tgt'
+                      lams' =
+                        zipWithExact
+                          (\lam ty -> over lambdaLhsBinder (set binderType ty) lam)
+                          (removeSpecargs specargs lams)
+                          tyargs'
+                   in (ty', lams', body')
+            if
+              | null specargs0 ->
+                  return $ End (mkApps' (NIdt idt) args')
+              | otherwise -> do
+                  eassert (tyargsNum < argsNum)
+                  eassert (length lams == argsNum)
+                  eassert (length args' == argsNum)
+                  eassert (argsNum <= length tyargs)
+                  -- assumption: all type variables are at the front
+                  eassert (not $ any (isTypeConstr md) (drop tyargsNum tyargs))
+                  -- the specialisation signature: the values we specialise the arguments by
+                  let specSigArgs = selectSpecargs specargs args'
+                      specSig = (specSigArgs, specargs)
+                  if
+                    | all isClosed specSigArgs ->
+                        case find ((== specSig) . (^. specSignature)) (lookupSpecialisationInfo md _identSymbol) of
+                          Just SpecialisationInfo {..} ->
+                            return
+                              $ End
+                              $ mkApps'
+                                (mkIdent' _specSymbol)
+                                (removeSpecargs specargs args')
+                          Nothing -> do
+                            sym' <- freshSymbol
+                            let (ty', lams', body') = createFun 0 sym' args'
+                                name = uniqueName ("spec_" <> ii ^. identifierName) sym'
+                            registerIdent
+                              name
+                              IdentifierInfo
+                                { _identifierSymbol = sym',
+                                  _identifierName = name,
+                                  _identifierLocation = ii ^. identifierLocation,
+                                  _identifierType = ty',
+                                  _identifierArgsNum = length lams',
+                                  _identifierIsExported = False,
+                                  _identifierBuiltin = Nothing,
+                                  _identifierPragmas = pragmas,
+                                  _identifierArgNames =
+                                    removeSpecargs specargs (ii ^. identifierArgNames)
+                                }
+                            registerIdentNode sym' (reLambdas lams' body')
+                            let si =
+                                  SpecialisationInfo
+                                    { _specSignature = specSig,
+                                      _specSymbol = sym'
+                                    }
+                            registerSpecialisation _identSymbol si
+                            return
+                              $ End
+                              $ mkApps'
+                                (mkIdent' sym')
+                                (removeSpecargs specargs args')
+                    | otherwise -> do
+                        sym' <- freshSymbol
+                        let -- We're adding the letrec binder, so need to shift by 1
+                            sargs = map (shift 1) args'
+                            (ty', lams', body') = createFun 1 sym' sargs
+                            body'' = substSym sym' (argsNum - length specargs) body'
+                            args'' = removeSpecargs specargs sargs
+                            fun = reLambdas lams' body''
+                            letitem =
+                              mkLetItem
+                                (ii ^. identifierName)
+                                -- the type is not in the scope of the binder
+                                (shift (-1) ty')
+                                fun
+                            node' =
+                              mkLetRec
+                                (setInfoPragmas [pragmas] mempty)
+                                (NonEmpty.singleton letitem)
+                                (mkApps' (mkVar' 0) args'')
+                        node'' <- lambdaLiftNode' True bl node'
+                        return $ End node''
+        | otherwise ->
+            return $ End $ mkApps' (NIdt idt) args'
 
     -- assumption: all type arguments are substituted, so no binders in the type
     -- list refer to other elements in the list
@@ -255,15 +259,15 @@ convertNode = dmapLRM go
 
     removeSpecargs :: [Int] -> [a] -> [a]
     removeSpecargs specargs args =
-      map fst $
-        filter
+      map fst
+        $ filter
           (not . (`elem` specargs) . snd)
           (zip args [1 ..])
 
     selectSpecargs :: [Int] -> [a] -> [a]
     selectSpecargs specargs args =
-      map fst $
-        filter
+      map fst
+        $ filter
           ((`elem` specargs) . snd)
           (zip args [1 ..])
 
@@ -319,18 +323,18 @@ convertNode = dmapLRM go
           NVar v@Var {..}
             | _varIndex >= lvl ->
                 if
-                    | argIdx < argsNum ->
-                        if
-                            | argNum `elem` specargs ->
-                                -- paste in the argument we specialise by
-                                shift (lvl + argsNum') (args !! (argNum - 1))
-                            | otherwise ->
-                                -- decrease de Bruijn index by the number of lambdas removed below the binder
-                                NVar $
-                                  shiftVar (-(length (filter (argNum <) specargs))) v
-                    | otherwise ->
-                        -- (argsNum - argsNum') binders removed (the specialised arguments) and shiftIdx binders added (the letrec binders)
-                        NVar $ shiftVar (argsNum' - argsNum + shiftIdx) v
+                  | argIdx < argsNum ->
+                      if
+                        | argNum `elem` specargs ->
+                            -- paste in the argument we specialise by
+                            shift (lvl + argsNum') (args !! (argNum - 1))
+                        | otherwise ->
+                            -- decrease de Bruijn index by the number of lambdas removed below the binder
+                            NVar
+                              $ shiftVar (-(length (filter (argNum <) specargs))) v
+                  | otherwise ->
+                      -- (argsNum - argsNum') binders removed (the specialised arguments) and shiftIdx binders added (the letrec binders)
+                      NVar $ shiftVar (argsNum' - argsNum + shiftIdx) v
             where
               argIdx = _varIndex - lvl
               argNum = argsNum - argIdx

--- a/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
+++ b/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
@@ -23,17 +23,17 @@ convertNode md = convert mempty
       NVar v@(Var {..}) ->
         let ty = BL.lookup _varIndex vars ^. binderType
          in if
-                | isTypeConstr md ty -> End (mkDynamic _varInfo)
-                | otherwise -> End (NVar (shiftVar (-k) v))
+              | isTypeConstr md ty -> End (mkDynamic _varInfo)
+              | otherwise -> End (NVar (shiftVar (-k) v))
         where
           k = length (filter (isTypeConstr md . (^. binderType)) (take _varIndex (toList vars)))
       NIdt Ident {..} ->
         let fi = lookupIdentifierInfo md _identSymbol
          in if
-                | isTypeConstr md (fi ^. identifierType) ->
-                    Recur (lookupIdentifierNode md _identSymbol)
-                | otherwise ->
-                    Recur node
+              | isTypeConstr md (fi ^. identifierType) ->
+                  Recur (lookupIdentifierNode md _identSymbol)
+              | otherwise ->
+                  Recur node
       NApp App {..} ->
         let (h, args) = unfoldApps node
             ty =
@@ -46,12 +46,12 @@ convertNode md = convert mempty
                 _ -> unsupported node
             args' = filterArgs snd ty args
          in if
-                | isTypeConstr md ty ->
-                    End (mkDynamic _appInfo)
-                | null args' ->
-                    End (convert vars h)
-                | otherwise ->
-                    End (mkApps (convert vars h) (map (second (convert vars)) args'))
+              | isTypeConstr md ty ->
+                  End (mkDynamic _appInfo)
+              | null args' ->
+                  End (convert vars h)
+              | otherwise ->
+                  End (mkApps (convert vars h) (map (second (convert vars)) args'))
       NCtr (Constr {..}) ->
         let ci = lookupConstructorInfo md _constrTag
             ty = ci ^. constructorType
@@ -105,10 +105,10 @@ convertNode md = convert mempty
             let ty' = subst (getNode arg) _piBody
                 args'' = filterArgs getNode ty' args'
              in if
-                    | isTypeConstr md (_piBinder ^. binderType) ->
-                        args''
-                    | otherwise ->
-                        arg : args''
+                  | isTypeConstr md (_piBinder ^. binderType) ->
+                      args''
+                  | otherwise ->
+                      arg : args''
           _ ->
             args
 
@@ -157,9 +157,9 @@ convertAxiom md = over axiomType (convertNode md)
 
 removeTypeArgs :: Module -> Module
 removeTypeArgs md =
-  filterOutTypeSynonyms $
-    mapAxioms (convertAxiom md) $
-      mapInductives (convertInductive md) $
-        mapConstructors (convertConstructor md) $
-          mapIdents (convertIdent md) $
-            mapT (const (convertNode md)) md
+  filterOutTypeSynonyms
+    $ mapAxioms (convertAxiom md)
+    $ mapInductives (convertInductive md)
+    $ mapConstructors (convertConstructor md)
+    $ mapIdents (convertIdent md)
+    $ mapT (const (convertNode md)) md

--- a/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
+++ b/src/Juvix/Compiler/Core/Transformation/UnrollRecursion.hs
@@ -83,8 +83,8 @@ unrollRecursion md = do
                   ii' = ii {_identifierSymbol = sym', _identifierName = name'}
               registerIdent name' ii'
               let failNode =
-                    setNodeType (ii ^. identifierType) $
-                      mkBuiltinApp' OpFail [mkConstant' (ConstString "recursion limit reached")]
+                    setNodeType (ii ^. identifierType)
+                      $ mkBuiltinApp' OpFail [mkConstant' (ConstString "recursion limit reached")]
                   node
                     | limit == 0 =
                         etaExpand (typeArgs (ii ^. identifierType)) failNode

--- a/src/Juvix/Compiler/Core/Translation/FromInternal/Builtins/Int.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal/Builtins/Int.hs
@@ -13,11 +13,11 @@ literalIntToIntNode = do
       tagOfNatM = (^. constructorTag) <$> lookupBuiltinConstructor md BuiltinIntOfNat
       tagNegSucM = (^. constructorTag) <$> lookupBuiltinConstructor md BuiltinIntNegSuc
       boolSymM = (^. inductiveSymbol) <$> lookupBuiltinInductive md BuiltinBool
-  return $
-    case (tagOfNatM, tagNegSucM, boolSymM, intToNatSymM) of
+  return
+    $ case (tagOfNatM, tagNegSucM, boolSymM, intToNatSymM) of
       (Just tagOfNat, Just tagNegSuc, Just boolSym, Just intToNatSym) ->
-        mkLambda' mkTypeInteger' $
-          mkIf'
+        mkLambda' mkTypeInteger'
+          $ mkIf'
             boolSym
             (mkBuiltinApp' OpIntLt [mkVar' 0, mkConstant' (ConstInteger 0)])
             ( mkConstr

--- a/src/Juvix/Compiler/Core/Translation/FromInternal/Builtins/Nat.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal/Builtins/Nat.hs
@@ -15,8 +15,8 @@ literalIntToNatNode sym = do
       boolSymM = (^. inductiveSymbol) <$> lookupBuiltinInductive md BuiltinBool
   return $ case (tagZeroM, tagSucM, boolSymM) of
     (Just tagZero, Just tagSuc, Just boolSym) ->
-      mkLambda' mkTypeInteger' $
-        mkIf'
+      mkLambda' mkTypeInteger'
+        $ mkIf'
           boolSym
           (mkBuiltinApp' OpEq [mkVar' 0, mkConstant' (ConstInteger 0)])
           (mkConstr (setInfoName "zero" mempty) tagZero [])

--- a/src/Juvix/Compiler/Core/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource.hs
@@ -26,9 +26,9 @@ import Text.Megaparsec qualified as P
 -- generated during parsing
 runParser :: Path Abs File -> ModuleId -> InfoTable -> Text -> Either MegaparsecError (InfoTable, Maybe Node)
 runParser fileName mid tab input_ =
-  case run $
-    runInfoTableBuilder (Module mid tab mempty) $
-      P.runParserT parseToplevel (fromAbsFile fileName) input_ of
+  case run
+    $ runInfoTableBuilder (Module mid tab mempty)
+    $ P.runParserT parseToplevel (fromAbsFile fileName) input_ of
     (_, Left err) -> Left (MegaparsecError err)
     (md, Right r) -> Right (md ^. moduleInfoTable, r)
 
@@ -99,25 +99,25 @@ statementBuiltin = do
   sym <- statementDef
   ii <- lift $ getIdentifierInfo sym
   if
-      | ii ^. identifierName == Str.natPlus ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatPlus}
-      | ii ^. identifierName == Str.natSub ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatSub}
-      | ii ^. identifierName == Str.natMul ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatMul}
-      | ii ^. identifierName == Str.natDiv ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatDiv}
-      | ii ^. identifierName == Str.natMod ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatMod}
-      | ii ^. identifierName == Str.natUDiv ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatUDiv}
-      | ii ^. identifierName == Str.natLe ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatLe}
-      | ii ^. identifierName == Str.natLt ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatLt}
-      | ii ^. identifierName == Str.natEq ->
-          lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatEq}
-      | otherwise -> parseFailure off "unrecorgnized builtin definition"
+    | ii ^. identifierName == Str.natPlus ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatPlus}
+    | ii ^. identifierName == Str.natSub ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatSub}
+    | ii ^. identifierName == Str.natMul ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatMul}
+    | ii ^. identifierName == Str.natDiv ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatDiv}
+    | ii ^. identifierName == Str.natMod ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatMod}
+    | ii ^. identifierName == Str.natUDiv ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatUDiv}
+    | ii ^. identifierName == Str.natLe ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatLe}
+    | ii ^. identifierName == Str.natLt ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatLt}
+    | ii ^. identifierName == Str.natEq ->
+        lift $ registerIdent (ii ^. identifierName) ii {_identifierBuiltin = Just BuiltinNatEq}
+    | otherwise -> parseFailure off "unrecorgnized builtin definition"
 
 statementDef ::
   (Member InfoTableBuilder r) =>
@@ -136,8 +136,8 @@ statementDef = do
       mty <- optional typeAnnotation
       let fi = fromMaybe impossible $ HashMap.lookup sym (tab ^. infoIdentifiers)
           ty = fromMaybe (fi ^. identifierType) mty
-      unless (isDynamic (fi ^. identifierType) || ty == fi ^. identifierType) $
-        parseFailure off "type signature doesn't match earlier definition"
+      unless (isDynamic (fi ^. identifierType) || ty == fi ^. identifierType)
+        $ parseFailure off "type signature doesn't match earlier definition"
       parseDefinition sym ty
       return sym
     Just IdentInd {} ->
@@ -176,7 +176,8 @@ parseDefinition sym ty = do
   lift $ registerIdentNode sym node
   let (is, _) = unfoldLambdas node
   when
-    ( length is > length (typeArgs ty)
+    ( length is
+        > length (typeArgs ty)
         && not (isDynamic (typeTarget ty))
     )
     $ parseFailure off "type mismatch: too many lambdas"
@@ -190,8 +191,8 @@ statementInductive = do
   off <- P.getOffset
   (txt, i) <- identifierL
   idt <- lift $ getIdent txt
-  when (isJust idt) $
-    parseFailure off ("duplicate identifier: " ++ fromText txt)
+  when (isJust idt)
+    $ parseFailure off ("duplicate identifier: " ++ fromText txt)
   mty <- optional typeAnnotation
   sym <- lift freshSymbol
   let ii =
@@ -218,8 +219,8 @@ constrDecl symInd = do
   off <- P.getOffset
   (txt, i) <- identifierL
   idt <- lift $ getIdent txt
-  when (isJust idt) $
-    parseFailure off ("duplicate identifier: " ++ fromText txt)
+  when (isJust idt)
+    $ parseFailure off ("duplicate identifier: " ++ fromText txt)
   tag <- lift freshTag
   ty <- typeAnnotation
   let argsNum = length (typeArgs ty)
@@ -365,8 +366,8 @@ seqExpr' ::
 seqExpr' varsNum vars node = do
   ((), i) <- interval (kw kwSeq)
   node' <- cmpExpr (varsNum + 1) vars
-  ioExpr' varsNum vars $
-    mkConstr
+  ioExpr' varsNum vars
+    $ mkConstr
       Info.empty
       (BuiltinTag TagBind)
       [node, mkLambda mempty (Binder "_" (Just i) mkDynamic') node']
@@ -714,7 +715,8 @@ exprLambda varsNum vars = do
             ty <- typeAnnot varsNum vars
             return (n, Just ty)
         )
-        <|> (\n -> (n, Nothing)) <$> parseLocalName
+        <|> (\n -> (n, Nothing))
+        <$> parseLocalName
 
 exprLetrecOne ::
   (Member InfoTableBuilder r) =>
@@ -742,8 +744,8 @@ exprLetrecMany ::
 exprLetrecMany varsNum vars = do
   off <- P.getOffset
   defNames <- P.try (kw kwLetRec >> letrecNames)
-  when (null defNames) $
-    parseFailure off "expected at least one identifier name in letrec signature"
+  when (null defNames)
+    $ parseFailure off "expected at least one identifier name in letrec signature"
   let (vars', varsNum') = foldl' (\(vs, k) txt -> (HashMap.insert txt k vs, k + 1)) (vars, varsNum) defNames
   defs <- letrecDefs defNames varsNum vars varsNum' vars'
   kw kwIn
@@ -769,8 +771,8 @@ letrecDefs names varsNum0 vars0 varsNum vars = forM names letrecItem
       off <- P.getOffset
       (txt, i) <- identifierL
       mty <- optional (typeAnnot varsNum0 vars0)
-      when (n /= txt) $
-        parseFailure off "identifier name doesn't match letrec signature"
+      when (n /= txt)
+        $ parseFailure off "identifier name doesn't match letrec signature"
       kw kwAssign
       v <- bracedExpr varsNum vars
       kw delimSemicolon
@@ -905,8 +907,8 @@ caseMatchingBranch varsNum vars = do
         (parseFailure off "wrong number of constructor arguments")
       kw kwAssign
       let vars' =
-            fst $
-              foldl'
+            fst
+              $ foldl'
                 ( \(vs, k) ((name, _), _) ->
                     (HashMap.insert name k vs, k + 1)
                 )
@@ -994,8 +996,8 @@ matchBranch patsNum varsNum vars = do
   off <- P.getOffset
   pats <- branchPatterns varsNum vars
   kw kwAssign
-  unless (length pats == patsNum) $
-    parseFailure off "wrong number of patterns"
+  unless (length pats == patsNum)
+    $ parseFailure off "wrong number of patterns"
   let pis :: [Binder]
       pis = concatMap getPatternBinders pats
       (vars', varsNum') =

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -118,8 +118,8 @@ fromCore fsize tab =
 
 translateFunctionInfo :: InfoTable -> IdentifierInfo -> Stripped.FunctionInfo
 translateFunctionInfo tab IdentifierInfo {..} =
-  assert (length (typeArgsBinders _identifierType) == _identifierArgsNum) $
-    Stripped.FunctionInfo
+  assert (length (typeArgsBinders _identifierType) == _identifierArgsNum)
+    $ Stripped.FunctionInfo
       { _functionName = _identifierName,
         _functionLocation = _identifierLocation,
         _functionSymbol = _identifierSymbol,
@@ -178,16 +178,16 @@ translateFunction :: Int -> Node -> Stripped.Node
 translateFunction argsNum node =
   let (k, body) = unfoldLambdas' node
    in if
-          | k /= argsNum ->
-              error
-                ( "wrong number of arguments. argsNum = "
-                    <> show argsNum
-                    <> ", unfoldLambdas = "
-                    <> show k
-                    <> "\nNode = "
-                    <> ppTrace node
-                )
-          | otherwise -> translateNode body
+        | k /= argsNum ->
+            error
+              ( "wrong number of arguments. argsNum = "
+                  <> show argsNum
+                  <> ", unfoldLambdas = "
+                  <> show k
+                  <> "\nNode = "
+                  <> ppTrace node
+              )
+        | otherwise -> translateNode body
 
 translateNode :: Node -> Stripped.Node
 translateNode node = case node of
@@ -296,8 +296,8 @@ translateType node = case node of
   NUniv Univ {} ->
     Stripped.TyDynamic
   NTyp TypeConstr {..} ->
-    Stripped.TyApp $
-      Stripped.TypeApp
+    Stripped.TyApp
+      $ Stripped.TypeApp
         { _typeAppName = getInfoName _typeConstrInfo,
           _typeAppLocation = getInfoLocation _typeConstrInfo,
           _typeAppSymbol = _typeConstrSymbol,

--- a/src/Juvix/Compiler/Internal/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Internal/Data/InfoTable.hs
@@ -126,14 +126,14 @@ computeInternalModuleInfoTable m = InfoTable {..}
 
     _infoFunctions :: HashMap Name FunctionInfo
     _infoFunctions =
-      HashMap.fromList $
-        [ (f ^. funDefName, functionInfoFromFunctionDef f)
-          | StatementFunction f <- mutuals
-        ]
-          <> [ (f ^. funDefName, functionInfoFromFunctionDef f)
-               | s <- ss,
-                 f <- letFunctionDefs s
-             ]
+      HashMap.fromList
+        $ [ (f ^. funDefName, functionInfoFromFunctionDef f)
+            | StatementFunction f <- mutuals
+          ]
+        <> [ (f ^. funDefName, functionInfoFromFunctionDef f)
+             | s <- ss,
+               f <- letFunctionDefs s
+           ]
 
     _infoAxioms :: HashMap Name AxiomInfo
     _infoAxioms =
@@ -144,11 +144,11 @@ computeInternalModuleInfoTable m = InfoTable {..}
 
     _infoBuiltins :: HashMap BuiltinPrim Name
     _infoBuiltins =
-      HashMap.fromList $
-        mapMaybe goInd (HashMap.elems _infoInductives)
-          <> mapMaybe goConstr (HashMap.elems _infoConstructors)
-          <> mapMaybe goFun (HashMap.elems _infoFunctions)
-          <> mapMaybe goAxiom (HashMap.elems _infoAxioms)
+      HashMap.fromList
+        $ mapMaybe goInd (HashMap.elems _infoInductives)
+        <> mapMaybe goConstr (HashMap.elems _infoConstructors)
+        <> mapMaybe goFun (HashMap.elems _infoFunctions)
+        <> mapMaybe goAxiom (HashMap.elems _infoAxioms)
       where
         goInd :: InductiveInfo -> Maybe (BuiltinPrim, Name)
         goInd InductiveInfo {..} =
@@ -167,7 +167,8 @@ computeInternalModuleInfoTable m = InfoTable {..}
 
         goAxiom :: AxiomInfo -> Maybe (BuiltinPrim, Name)
         goAxiom AxiomInfo {..} =
-          _axiomInfoDef ^. axiomBuiltin
+          _axiomInfoDef
+            ^. axiomBuiltin
             >>= (\b -> Just (BuiltinsAxiom b, _axiomInfoDef ^. axiomName))
 
     ss :: [MutualBlock]
@@ -184,10 +185,10 @@ lookupConstructor f = do
       return
         . error
         $ "impossible: "
-          <> ppTrace f
-          <> " is not in the InfoTable\n"
-          <> "\nThe registered constructors are: "
-          <> ppTrace (HashMap.keys tbl)
+        <> ppTrace f
+        <> " is not in the InfoTable\n"
+        <> "\nThe registered constructors are: "
+        <> ppTrace (HashMap.keys tbl)
 
 lookupConstructorArgTypes :: (Member (Reader InfoTable) r) => Name -> Sem r ([InductiveParameter], [Expression])
 lookupConstructorArgTypes = fmap constructorArgTypes . lookupConstructor
@@ -203,10 +204,10 @@ lookupInductive f = do
       return
         . error
         $ "impossible: "
-          <> ppTrace f
-          <> " is not in the InfoTable\n"
-          <> "\nThe registered inductives are: "
-          <> ppTrace (HashMap.keys tbl)
+        <> ppTrace f
+        <> " is not in the InfoTable\n"
+        <> "\nThe registered inductives are: "
+        <> ppTrace (HashMap.keys tbl)
 
 lookupFunctionMaybe :: forall r. (Member (Reader InfoTable) r) => Name -> Sem r (Maybe FunctionInfo)
 lookupFunctionMaybe f = HashMap.lookup f <$> asks (^. infoFunctions)
@@ -222,11 +223,11 @@ lookupFunction f = do
       return
         . error
         $ "impossible: "
-          <> ppTrace f
-          <> " is not in the InfoTable\n"
-          <> ppTrace (getLoc f)
-          <> "\nThe registered functions are: "
-          <> ppTrace (HashMap.keys tbl)
+        <> ppTrace f
+        <> " is not in the InfoTable\n"
+        <> ppTrace (getLoc f)
+        <> "\nThe registered functions are: "
+        <> ppTrace (HashMap.keys tbl)
 
 lookupAxiom :: (Member (Reader InfoTable) r) => Name -> Sem r AxiomInfo
 lookupAxiom f = HashMap.lookupDefault (error ("impossible: couldn't find axiom " <> ppTrace f)) f <$> asks (^. infoAxioms)

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -136,8 +136,9 @@ genFieldProjection _funDefName _funDefBuiltin mpragmas info fieldIx = do
               { _lambdaPatterns = pure pat,
                 _lambdaBody = body
               }
-      return . ExpressionLambda $
-        Lambda
+      return
+        . ExpressionLambda
+        $ Lambda
           { _lambdaType = Nothing,
             _lambdaClauses = pure cl
           }

--- a/src/Juvix/Compiler/Internal/Extra/Base.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Base.hs
@@ -441,8 +441,8 @@ patternCosmos f p = case p of
   PatternConstructorApp ConstructorApp {..} ->
     f p *> do
       args' <- traverse (traverseOf patternArgPattern (patternCosmos f)) _constrAppParameters
-      pure $
-        PatternConstructorApp
+      pure
+        $ PatternConstructorApp
           ConstructorApp
             { _constrAppParameters = args',
               _constrAppConstructor,
@@ -470,8 +470,8 @@ patternSubCosmos f p = case p of
   PatternWildcardConstructor {} -> pure p
   PatternConstructorApp ConstructorApp {..} -> do
     args' <- traverse (patternArgCosmos f) _constrAppParameters
-    pure $
-      PatternConstructorApp
+    pure
+      $ PatternConstructorApp
         ConstructorApp
           { _constrAppParameters = args',
             _constrAppConstructor,

--- a/src/Juvix/Compiler/Internal/Extra/CoercionInfo.hs
+++ b/src/Juvix/Compiler/Internal/Extra/CoercionInfo.hs
@@ -31,8 +31,8 @@ coercionFromTypedExpression TypedExpression {..}
   | otherwise = do
       tgt <- traitFromExpression metaVars (t ^. paramType)
       InstanceApp {..} <- traitFromExpression metaVars e
-      return $
-        CoercionInfo
+      return
+        $ CoercionInfo
           { _coercionInfoInductive = _instanceAppHead,
             _coercionInfoParams = _instanceAppArgs,
             _coercionInfoTarget = tgt,

--- a/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
@@ -84,8 +84,9 @@ addEdgeMayRev n2 = whenJustM ask $ \n1 -> addEdge n2 n1
 
 addNode :: (Member (State DependencyGraph) r) => Name -> Sem r ()
 addNode n =
-  modify @DependencyGraph . over (at n) $
-    \case
+  modify @DependencyGraph
+    . over (at n)
+    $ \case
       Just x -> Just x
       Nothing -> Just (mempty :: HashSet Name)
 

--- a/src/Juvix/Compiler/Internal/Extra/InstanceInfo.hs
+++ b/src/Juvix/Compiler/Internal/Extra/InstanceInfo.hs
@@ -39,21 +39,21 @@ paramToExpression = \case
 paramFromExpression :: HashSet VarName -> Expression -> Maybe InstanceParam
 paramFromExpression metaVars e = case e of
   ExpressionIden (IdenInductive n) ->
-    Just $
-      InstanceParamApp $
-        InstanceApp
-          { _instanceAppHead = n,
-            _instanceAppArgs = [],
-            _instanceAppExpression = e
-          }
+    Just
+      $ InstanceParamApp
+      $ InstanceApp
+        { _instanceAppHead = n,
+          _instanceAppArgs = [],
+          _instanceAppExpression = e
+        }
   ExpressionIden (IdenAxiom n) ->
-    Just $
-      InstanceParamApp $
-        InstanceApp
-          { _instanceAppHead = n,
-            _instanceAppArgs = [],
-            _instanceAppExpression = e
-          }
+    Just
+      $ InstanceParamApp
+      $ InstanceApp
+        { _instanceAppHead = n,
+          _instanceAppArgs = [],
+          _instanceAppExpression = e
+        }
   ExpressionIden (IdenVar v)
     | HashSet.member v metaVars -> Just $ InstanceParamMeta v
     | otherwise -> Just $ InstanceParamVar v
@@ -63,29 +63,29 @@ paramFromExpression metaVars e = case e of
     args' <- mapM (paramFromExpression metaVars) args
     case h of
       ExpressionIden (IdenInductive n) ->
-        return $
-          InstanceParamApp $
-            InstanceApp
-              { _instanceAppHead = n,
-                _instanceAppArgs = toList args',
-                _instanceAppExpression = e
-              }
+        return
+          $ InstanceParamApp
+          $ InstanceApp
+            { _instanceAppHead = n,
+              _instanceAppArgs = toList args',
+              _instanceAppExpression = e
+            }
       ExpressionIden (IdenAxiom n) ->
-        return $
-          InstanceParamApp $
-            InstanceApp
-              { _instanceAppHead = n,
-                _instanceAppArgs = toList args',
-                _instanceAppExpression = e
-              }
+        return
+          $ InstanceParamApp
+          $ InstanceApp
+            { _instanceAppHead = n,
+              _instanceAppArgs = toList args',
+              _instanceAppExpression = e
+            }
       _ ->
         Nothing
   ExpressionFunction Function {..}
     | _functionLeft ^. paramImplicit == Explicit -> do
         l <- paramFromExpression metaVars (_functionLeft ^. paramType)
         r <- paramFromExpression metaVars _functionRight
-        return $
-          InstanceParamFun
+        return
+          $ InstanceParamFun
             InstanceFun
               { _instanceFunLeft = l,
                 _instanceFunRight = r,
@@ -102,8 +102,8 @@ traitFromExpression metaVars e = case paramFromExpression metaVars e of
 instanceFromTypedExpression :: TypedExpression -> Maybe InstanceInfo
 instanceFromTypedExpression TypedExpression {..} = do
   InstanceApp {..} <- traitFromExpression metaVars e
-  return $
-    InstanceInfo
+  return
+    $ InstanceInfo
       { _instanceInfoInductive = _instanceAppHead,
         _instanceInfoParams = _instanceAppArgs,
         _instanceInfoResult = _typedExpression,

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -87,12 +87,12 @@ instance PrettyCode SideIfBranch where
   ppCode SideIfBranch {..} = do
     condition' <- ppCode _sideIfBranchCondition
     body' <- ppCode _sideIfBranchBody
-    return $
-      kwPipe
-        <+> kwIf
-        <+> condition'
-        <+> kwAssign
-        <+> oneLineOrNext body'
+    return
+      $ kwPipe
+      <+> kwIf
+      <+> condition'
+      <+> kwAssign
+      <+> oneLineOrNext body'
 
 instance PrettyCode SideIfs where
   ppCode SideIfs {..} =
@@ -102,8 +102,9 @@ instance PrettyCode SideIfs where
         ifbranches <- mapM ppCode (toList _sideIfBranches)
         elseBr <- mapM ppCode _sideIfElse
         let allBranches = snocMaybe ifbranches elseBr
-        return $
-          line <> indent' (vsep allBranches)
+        return
+          $ line
+          <> indent' (vsep allBranches)
 
 instance PrettyCode CaseBranchRhs where
   ppCode = \case
@@ -171,16 +172,16 @@ instance PrettyCode NameDependencyInfo where
     edges' <- vsep <$> mapM ppCode _depInfoEdgeList
     reachable' <- ppCode (toList _depInfoReachable)
     topsort' <- ppCode _depInfoTopSort
-    return $
-      header "Edges:"
-        <> edges'
-        <> line
-        <> header "Reachable:"
-        <> reachable'
-        <> line
-        <> header "Topologically sorted:"
-        <> topsort'
-        <> line
+    return
+      $ header "Edges:"
+      <> edges'
+      <> line
+      <> header "Reachable:"
+      <> reachable'
+      <> line
+      <> header "Topologically sorted:"
+      <> topsort'
+      <> line
 
 instance PrettyCode LambdaClause where
   ppCode LambdaClause {..} = do
@@ -287,12 +288,12 @@ instance PrettyCode FunctionDef where
     funDefName' <- ppCode (f ^. funDefName)
     funDefType' <- ppCode (f ^. funDefType)
     body' <- ppCode (f ^. funDefBody)
-    return $
-      builtin'
-        <?+> funDefName'
-          <+> kwColon
-          <+> funDefType'
-            <> oneLineOrNext (kwAssign <+> body')
+    return
+      $ builtin'
+      <?+> funDefName'
+      <+> kwColon
+      <+> funDefType'
+      <> oneLineOrNext (kwAssign <+> body')
 
 instance PrettyCode PreLetStatement where
   ppCode = \case
@@ -343,14 +344,14 @@ instance PrettyCode Module where
   ppCode m = do
     name' <- ppCode (m ^. moduleName)
     body' <- ppCode (m ^. moduleBody)
-    return $
-      kwModule
-        <+> name'
-          <> kwSemicolon
-          <> line
-          <> line
-          <> body'
-          <> line
+    return
+      $ kwModule
+      <+> name'
+      <> kwSemicolon
+      <> line
+      <> line
+      <> body'
+      <> line
 
 instance PrettyCode Interval where
   ppCode = return . annotate AnnCode . pretty
@@ -392,15 +393,15 @@ instance PrettyCode InfoTable where
     inds <- ppCode (HashMap.keys (tbl ^. infoInductives))
     constrs <- ppCode (HashMap.keys (tbl ^. infoConstructors))
     funs <- ppCode (HashMap.keys (tbl ^. infoFunctions))
-    return $
-      header "InfoTable"
-        <> "\n========="
-        <> header "\nInductives: "
-        <> inds
-        <> header "\nConstructors: "
-        <> constrs
-        <> header "\nFunctions: "
-        <> funs
+    return
+      $ header "InfoTable"
+      <> "\n========="
+      <> header "\nInductives: "
+      <> inds
+      <> header "\nConstructors: "
+      <> constrs
+      <> header "\nFunctions: "
+      <> funs
 
 ppPostExpression ::
   (PrettyCode a, HasAtomicity a, Member (Reader Options) r) =>

--- a/src/Juvix/Compiler/Internal/Translation/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Translation/Extra.hs
@@ -27,9 +27,9 @@ filterCompileTimeArgsOrPatterns idenname lst = do
   tab <- asks (^. typesTable)
   let funParams = fst (unfoldFunType (ty tab))
       typedArgs =
-        map fst $
-          filter (not . isUniverse . snd) $
-            zip lst (map (^. paramType) funParams)
+        map fst
+          $ filter (not . isUniverse . snd)
+          $ zip lst (map (^. paramType) funParams)
   return $ typedArgs ++ drop (length funParams) lst
   where
     ty = HashMap.lookupDefault impossible (idenname ^. nameId)

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete/NamedArguments.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete/NamedArguments.hs
@@ -103,8 +103,8 @@ helper loc = do
       emitImplicit False (mkNamesIndex sig) sig mempty
       moreNames <- not . null <$> gets (^. stateRemainingNames)
       if
-          | moreNames -> modify' (over stateRemainingArgs (ArgumentBlock (Irrelevant Nothing) Explicit (nonEmpty' pendingArgs) :))
-          | otherwise -> throw . ErrUnexpectedArguments $ UnexpectedArguments pendingArgs'
+        | moreNames -> modify' (over stateRemainingArgs (ArgumentBlock (Irrelevant Nothing) Explicit (nonEmpty' pendingArgs) :))
+        | otherwise -> throw . ErrUnexpectedArguments $ UnexpectedArguments pendingArgs'
     helper loc
   where
     nextNameGroup :: IsImplicit -> Sem r [NameItem 'Scoped]
@@ -163,11 +163,11 @@ helper loc = do
         emitExplicit :: Bool -> NamesByIndex -> [NameItem 'Scoped] -> IntMap Arg -> Sem r ()
         emitExplicit lastBlock _ omittedArgs args = do
           if
-              | lastBlock ->
-                  unless
-                    (IntMap.keys args == [0 .. IntMap.size args - 1])
-                    (missingErr (nonEmpty' (map (^. nameItemSymbol) (filterMissing omittedArgs))))
-              | otherwise -> whenJust (nonEmpty (map (^. nameItemSymbol) omittedArgs)) missingErr
+            | lastBlock ->
+                unless
+                  (IntMap.keys args == [0 .. IntMap.size args - 1])
+                  (missingErr (nonEmpty' (map (^. nameItemSymbol) (filterMissing omittedArgs))))
+            | otherwise -> whenJust (nonEmpty (map (^. nameItemSymbol) omittedArgs)) missingErr
           forM_ args output
           where
             filterMissing :: [NameItem 'Scoped] -> [NameItem 'Scoped]
@@ -266,14 +266,14 @@ helper loc = do
                 -- the arg may belong to the next explicit group
                 output arg
               Implicit ->
-                throw $
-                  ErrUnexpectedArguments $
-                    UnexpectedArguments
-                      { _unexpectedArguments = pure arg
-                      }
+                throw
+                  $ ErrUnexpectedArguments
+                  $ UnexpectedArguments
+                    { _unexpectedArguments = pure arg
+                    }
               ImplicitInstance ->
-                throw $
-                  ErrUnexpectedArguments $
-                    UnexpectedArguments
-                      { _unexpectedArguments = pure arg
-                      }
+                throw
+                  $ ErrUnexpectedArguments
+                  $ UnexpectedArguments
+                    { _unexpectedArguments = pure arg
+                    }

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete/NamedArguments/Error.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete/NamedArguments/Error.hs
@@ -30,11 +30,11 @@ instance ToGenericError DuplicateArgument where
         _genericErrorMessage :: AnsiText
         argumentStr = plural "argument" "arguments" (length _duplicateArguments)
         _genericErrorMessage =
-          prettyError $
-            "Duplicate"
-              <+> argumentStr
-              <+> "in named application:"
-              <+> hsep (ppCode opts <$> _duplicateArguments)
+          prettyError
+            $ "Duplicate"
+            <+> argumentStr
+            <+> "in named application:"
+            <+> hsep (ppCode opts <$> _duplicateArguments)
         _genericErrorIntervals = getLoc <$> toList _duplicateArguments
     return GenericError {..}
 
@@ -49,10 +49,10 @@ instance ToGenericError UnexpectedArguments where
     let _genericErrorLoc = getLocSpan _unexpectedArguments
         _genericErrorMessage :: AnsiText
         _genericErrorMessage =
-          prettyError $
-            "Unexpected named arguments:"
-              <> line
-              <> itemize (ppCode opts <$> _unexpectedArguments)
+          prettyError
+            $ "Unexpected named arguments:"
+            <> line
+            <> itemize (ppCode opts <$> _unexpectedArguments)
         _genericErrorIntervals = getLoc <$> toList _unexpectedArguments
     return GenericError {..}
 
@@ -69,9 +69,9 @@ instance ToGenericError MissingArguments where
         _genericErrorLoc = i
         _genericErrorMessage :: AnsiText
         _genericErrorMessage =
-          prettyError $
-            "Missing arguments in named application:"
-              <> line
-              <> itemize (ppCode opts <$> _missingArguments)
+          prettyError
+            $ "Missing arguments in named application:"
+            <> line
+            <> itemize (ppCode opts <$> _missingArguments)
         _genericErrorIntervals = pure i
     return GenericError {..}

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -38,7 +38,7 @@ typeCheckExpressionType exp = do
     . mapError (JuvixError @TypeCheckerError)
     . runInferenceDef
     $ inferExpression Nothing exp
-      >>= traverseOf typedType strongNormalize_
+    >>= traverseOf typedType strongNormalize_
 
 typeCheckExpression ::
   (Members '[Error JuvixError, State Artifacts, Termination] r) =>

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/ArityChecking/Error/Types.hs
@@ -31,10 +31,10 @@ instance ToGenericError WrongConstructorAppLength where
               <+> ppCode opts' (e ^. wrongConstructorAppLength . constrAppConstructor)
               <+> "should have"
               <+> arguments (e ^. wrongConstructorAppLengthExpected)
-                <> ", but has been given"
+              <> ", but has been given"
               <+> pretty actual
-                <> line
-                <> "Perhaps you forgot parentheses around a pattern?"
+              <> line
+              <> "Perhaps you forgot parentheses around a pattern?"
 
           actual :: Int
           actual = length (e ^. wrongConstructorAppLength . constrAppParameters)
@@ -134,9 +134,9 @@ instance ToGenericError ExpectedExplicitArgument where
               <+> ppCode opts' f
               <+> "but found"
               <+> ppArg opts' arg
-                <> "."
-                <> softline
-                <> "In the application"
+              <> "."
+              <> softline
+              <> "In the application"
               <+> ppApp opts' app
 
 newtype PatternFunction = PatternFunction
@@ -160,7 +160,8 @@ instance ToGenericError PatternFunction where
           i = getLoc (e ^. patternFunction)
           msg =
             "Invalid pattern"
-              <+> ppCode opts' (e ^. patternFunction) <> "."
+              <+> ppCode opts' (e ^. patternFunction)
+              <> "."
               <+> "Function types cannot be pattern matched"
 
 data TooManyArguments = TooManyArguments
@@ -193,12 +194,13 @@ instance ToGenericError TooManyArguments where
           app = foldApplication fun args
           msg =
             "Too many arguments in the application"
-              <+> ppCode opts' app <> "."
+              <+> ppCode opts' app
+              <> "."
               <+> "The last"
               <+> numArguments
-                <> ", namely"
+              <> ", namely"
               <+> ppUnexpectedArgs
-                <> ","
+              <> ","
               <+> wasNotExpected
           numArguments :: Doc ann
           numArguments = plural "argument" (pretty numUnexpected <+> "arguments") numUnexpected

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Checker.hs
@@ -39,8 +39,9 @@ checkPositivity ::
   InductiveInfo ->
   Sem r ()
 checkPositivity indInfo = do
-  unlessM (asks (^. E.entryPointNoPositivity)) $
-    forM_ (indInfo ^. inductiveInfoConstructors) $ \ctorName -> do
+  unlessM (asks (^. E.entryPointNoPositivity))
+    $ forM_ (indInfo ^. inductiveInfoConstructors)
+    $ \ctorName -> do
       ctor <- asks (fromJust . HashMap.lookup ctorName . (^. infoConstructors))
       unless (indInfo ^. inductiveInfoPositive) $ do
         numInductives <- HashMap.size <$> asks (^. infoInductives)
@@ -169,11 +170,11 @@ checkStrictlyPositiveOccurrences p = do
           let (hdExpr, args) = unfoldApplication tyApp
           case hdExpr of
             ax@(ExpressionIden IdenAxiom {}) -> do
-              when (isJust $ find (varOrInductiveInExpression name) args) $
-                throwTypeAsArgumentOfBoundVarError ax
+              when (isJust $ find (varOrInductiveInExpression name) args)
+                $ throwTypeAsArgumentOfBoundVarError ax
             var@(ExpressionIden IdenVar {}) -> do
-              when (isJust $ find (varOrInductiveInExpression name) args) $
-                throwTypeAsArgumentOfBoundVarError var
+              when (isJust $ find (varOrInductiveInExpression name) args)
+                $ throwTypeAsArgumentOfBoundVarError var
             ExpressionIden (IdenInductive ty') -> do
               when (inside && name == ty') (throwNegativePositonError expr)
               indInfo' <- lookupInductive ty'
@@ -195,8 +196,9 @@ checkStrictlyPositiveOccurrences p = do
               when
                 (HashSet.member pName' negParms)
                 (throwNegativePositonError tyArg)
-              when (recLimit > 0) $
-                forM_ (indInfo' ^. inductiveInfoConstructors) $ \ctorName' -> do
+              when (recLimit > 0)
+                $ forM_ (indInfo' ^. inductiveInfoConstructors)
+                $ \ctorName' -> do
                   ctorType' <- lookupConstructorType ctorName'
                   let errorRef = fromMaybe tyArg ref
                       args = constructorArgs ctorType'

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Positivity/Error/Types.hs
@@ -35,9 +35,10 @@ instance ToGenericError TypeInNegativePosition where
             "The type"
               <+> ppCode opts' ty
               <+> "is not strictly positive."
-                <> line
-                <> "It appears at a negative position in one of the type arguments of the constructor"
-              <+> ppCode opts' ctor <> "."
+              <> line
+              <> "It appears at a negative position in one of the type arguments of the constructor"
+              <+> ppCode opts' ctor
+              <> "."
 
 data TypeAsArgumentOfBoundVar = TypeAsArgumentOfBoundVar
   { _typeAsArgumentOfBoundVarType :: Name,
@@ -68,8 +69,9 @@ instance ToGenericError TypeAsArgumentOfBoundVar where
             "The type"
               <+> ppCode opts' ty
               <+> "is not strictly positive."
-                <> line
-                <> "It appears as an argument of the bound variable"
+              <> line
+              <> "It appears as an argument of the bound variable"
               <+> ppCode opts' var
               <+> "in one of the type arguments of the constructor"
-              <+> ppCode opts' ctor <> "."
+              <+> ppCode opts' ctor
+              <> "."

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Checker.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Checker.hs
@@ -40,8 +40,11 @@ runTermination ini m = do
   where
     checkNonTerminating :: TerminationState -> Sem r ()
     checkNonTerminating i =
-      whenJust (i ^. terminationFailedSet . to (nonEmpty . toList)) $
-        throw . JuvixError . ErrNoLexOrder . NoLexOrder
+      whenJust (i ^. terminationFailedSet . to (nonEmpty . toList))
+        $ throw
+        . JuvixError
+        . ErrNoLexOrder
+        . NoLexOrder
 
 evalTermination :: (Members '[Error JuvixError] r) => TerminationState -> Sem (Termination ': r) a -> Sem r a
 evalTermination s = fmap snd . runTermination s
@@ -93,11 +96,11 @@ checkTerminationShallow' topModule = do
           where
             err = error ("Impossible: function not found: " <> funName ^. nameText)
         order = findOrder rb
-    addTerminating funName $
-      if
-          | Just {} <- order -> TerminatingChecked
-          | markedTerminating -> TerminatingFailedMarked
-          | Nothing <- order -> TerminatingFailed
+    addTerminating funName
+      $ if
+        | Just {} <- order -> TerminatingChecked
+        | markedTerminating -> TerminatingFailedMarked
+        | Nothing <- order -> TerminatingFailed
 
 scanModule ::
   (Members '[State CallMap] r) =>

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/Graph.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Data/Graph.hs
@@ -41,15 +41,17 @@ instance PrettyCode Edge where
     fromFun <- ppCode _edgeFrom
     toFun <- ppCode _edgeTo
     matrices <-
-      indent 2 . ppMatrices . zip [0 :: Int ..]
+      indent 2
+        . ppMatrices
+        . zip [0 :: Int ..]
         <$> mapM ppCode (toList _edgeMatrices)
-    return $
-      pretty ("Edge" :: Text)
-        <+> fromFun
-        <+> kwWaveArrow
-        <+> toFun
-          <> line
-          <> matrices
+    return
+      $ pretty ("Edge" :: Text)
+      <+> fromFun
+      <+> kwWaveArrow
+      <+> toFun
+      <> line
+      <> matrices
     where
       ppMatrices :: [(Int, Doc a)] -> Doc a
       ppMatrices = vsep2 . map ppMatrix
@@ -70,11 +72,11 @@ instance PrettyCode RecursiveBehaviour where
   ppCode (RecursiveBehaviour f m0) = do
     f' <- ppCode f
     let m' = PP.vsep (map (PP.list . map pretty) m)
-    return $
-      pretty ("Recursive behaviour of" :: Text)
-        <+> f'
-          <> colon
-          <> line
-          <> indent 2 (align m')
+    return
+      $ pretty ("Recursive behaviour of" :: Text)
+      <+> f'
+      <> colon
+      <> line
+      <> indent 2 (align m')
     where
       m = toList (HashSet.fromList m0)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/Termination/Error/Types.hs
@@ -32,8 +32,8 @@ instance ToGenericError NoLexOrder where
           <+> function
           <+> fails
           <+> "the termination checker:"
-            <> line
-            <> itemize (fmap (code . pretty) names)
+          <> line
+          <> itemize (fmap (code . pretty) names)
         where
           function :: Doc Ann
           function

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
@@ -133,10 +133,10 @@ checkCoercionCycles ::
 checkCoercionCycles = do
   ctab <- getCombinedCoercionTable
   let s = toList $ cyclicCoercions ctab
-  whenJust (nonEmpty s) $
-    throw
-      . ErrCoercionCycles
-      . CoercionCycles
+  whenJust (nonEmpty s)
+    $ throw
+    . ErrCoercionCycles
+    . CoercionCycles
 
 checkTopModule ::
   (Members '[HighlightBuilder, Reader EntryPoint, Reader InfoTable, Error TypeCheckerError, NameIdGen, ResultBuilder, Termination] r) =>
@@ -334,10 +334,10 @@ checkFunctionDef FunctionDef {..} = do
           _funDefBuiltin,
           _funDefPragmas
         }
-  when _funDefInstance $
-    checkInstanceType funDef
-  when _funDefCoercion $
-    checkCoercionType funDef
+  when _funDefInstance
+    $ checkInstanceType funDef
+  when _funDefCoercion
+    $ checkCoercionType funDef
   registerFunctionDef funDef
   rememberFunctionDef funDef
   return funDef
@@ -383,20 +383,20 @@ checkInstanceType ::
 checkInstanceType FunctionDef {..} = do
   ty <- strongNormalize _funDefType
   let mi =
-        instanceFromTypedExpression $
-          TypedExpression
+        instanceFromTypedExpression
+          $ TypedExpression
             { _typedType = ty ^. normalizedExpression,
               _typedExpression = ExpressionIden (IdenFunction _funDefName)
             }
   case mi of
     Just ii@InstanceInfo {..} -> do
       tab <- ask
-      unless (isTrait tab _instanceInfoInductive) $
-        throw (ErrTargetNotATrait (TargetNotATrait _funDefType))
+      unless (isTrait tab _instanceInfoInductive)
+        $ throw (ErrTargetNotATrait (TargetNotATrait _funDefType))
       itab <- getCombinedInstanceTable
       is <- subsumingInstances itab ii
-      unless (null is) $
-        throw (ErrSubsumedInstance (SubsumedInstance ii is (getLoc _funDefName)))
+      unless (null is)
+        $ throw (ErrSubsumedInstance (SubsumedInstance ii is (getLoc _funDefName)))
       let metaVars = HashSet.fromList $ mapMaybe (^. paramName) _instanceInfoArgs
       mapM_ (checkArg tab metaVars ii) _instanceInfoArgs
       addInstanceInfo ii
@@ -442,10 +442,10 @@ checkCoercionType FunctionDef {..} = do
   case mi of
     Just ci@CoercionInfo {..} -> do
       tab <- ask
-      unless (isTrait tab _coercionInfoInductive) $
-        throw (ErrTargetNotATrait (TargetNotATrait _funDefType))
-      unless (isTrait tab (_coercionInfoTarget ^. instanceAppHead)) $
-        throw (ErrInvalidCoercionType (InvalidCoercionType _funDefType))
+      unless (isTrait tab _coercionInfoInductive)
+        $ throw (ErrTargetNotATrait (TargetNotATrait _funDefType))
+      unless (isTrait tab (_coercionInfoTarget ^. instanceAppHead))
+        $ throw (ErrInvalidCoercionType (InvalidCoercionType _funDefType))
       mapM_ checkArg _coercionInfoArgs
       addCoercionInfo ci
       checkCoercionCycles
@@ -687,13 +687,13 @@ checkClause clauseLoc clauseType clausePats body = do
             aI :: Int = preImplicits (map (^. paramImplicit) bodyParams)
             targetI :: Int = preImplicits (map (^. arityParameterImplicit) guessedBodyParams)
         if
-            | 0 < pref -> do
-                let n = length pref'
-                    bodyParams' = drop n bodyParams
-                    ty' = foldFunType bodyParams' bodyRest
-                wildcards <- mapM (genPatternWildcard clauseLoc) pref'
-                return (wildcards, ty')
-            | otherwise -> return ([], bodyTy)
+          | 0 < pref -> do
+              let n = length pref'
+                  bodyParams' = drop n bodyParams
+                  ty' = foldFunType bodyParams' bodyRest
+              wildcards <- mapM (genPatternWildcard clauseLoc) pref'
+              return (wildcards, ty')
+          | otherwise -> return ([], bodyTy)
       p : ps -> do
         bodyTy' <- weakNormalize bodyTy
         case bodyTy' of
@@ -730,16 +730,18 @@ checkClause clauseLoc clauseType clausePats body = do
         where
           throwWrongIsImplicit :: (Members '[Error TypeCheckerError] r') => PatternArg -> IsImplicit -> Sem r' a
           throwWrongIsImplicit patArg expected =
-            throw . ErrArityCheckerError $
-              ErrWrongPatternIsImplicit
+            throw
+              . ErrArityCheckerError
+              $ ErrWrongPatternIsImplicit
                 WrongPatternIsImplicit
                   { _wrongPatternIsImplicitActual = patArg,
                     _wrongPatternIsImplicitExpected = expected
                   }
           throwTooManyPatterns :: (Members '[Error TypeCheckerError] r') => Sem r' a
           throwTooManyPatterns =
-            throw . ErrArityCheckerError $
-              ErrLhsTooManyPatterns
+            throw
+              . ErrArityCheckerError
+              $ ErrLhsTooManyPatterns
                 LhsTooManyPatterns
                   { _lhsTooManyPatternsRemaining = p :| ps
                   }
@@ -827,8 +829,8 @@ checkPattern = go
               constrName = a ^. constrAppConstructor
               err :: MatchError -> Sem r ()
               err m =
-                throw $
-                  ErrWrongType
+                throw
+                  $ ErrWrongType
                     WrongType
                       { _wrongTypeThing = WrongTypeThingPattern pat,
                         _wrongTypeExpected = m ^. matchErrorRight,
@@ -895,8 +897,8 @@ checkPattern = go
               numParams = length params
           when
             (numArgs < numParams)
-            ( throw $
-                ErrTooFewArgumentsIndType
+            ( throw
+                $ ErrTooFewArgumentsIndType
                   WrongNumberArgumentsIndType
                     { _wrongNumberArgumentsIndTypeActualType = ty,
                       _wrongNumberArgumentsIndTypeActualNumArgs = numArgs,
@@ -905,8 +907,8 @@ checkPattern = go
             )
           when
             (numArgs > numParams)
-            ( throw $
-                ErrTooManyArgumentsIndType
+            ( throw
+                $ ErrTooManyArgumentsIndType
                   WrongNumberArgumentsIndType
                     { _wrongNumberArgumentsIndTypeActualType = ty,
                       _wrongNumberArgumentsIndTypeActualNumArgs = numArgs,
@@ -1080,15 +1082,15 @@ inferLeftAppExpression mhint e = case e of
       LitNumeric v -> outHole v >> typedLitNumeric v
       LitInteger {} -> do
         ty <- getIntTy
-        return $
-          TypedExpression
+        return
+          $ TypedExpression
             { _typedType = ty,
               _typedExpression = ExpressionLiteral lit
             }
       LitNatural {} -> do
         ty <- getNatTy
-        return $
-          TypedExpression
+        return
+          $ TypedExpression
             { _typedType = ty,
               _typedExpression = ExpressionLiteral lit
             }
@@ -1110,8 +1112,8 @@ inferLeftAppExpression mhint e = case e of
               from <- getBuiltinName i blt
               ihole <- freshHoleImpl i ImplicitInstance
               let ty' = fromMaybe ty mhint
-              inferExpression' (Just ty') $
-                foldApplication
+              inferExpression' (Just ty')
+                $ foldApplication
                   (ExpressionIden (IdenFunction from))
                   [ ApplicationArg Implicit ty',
                     ApplicationArg ImplicitInstance ihole,
@@ -1283,15 +1285,15 @@ holesHelper mhint expr = do
     checkBuiltinApp n implArgsNum argsNum args = do
       args' <- goImplArgs implArgsNum args
       if
-          | length args' >= argsNum -> return ()
-          | otherwise ->
-              throw
-                . ErrArityCheckerError
-                $ ErrBuiltinNotFullyApplied
-                  BuiltinNotFullyApplied
-                    { _builtinNotFullyAppliedName = n,
-                      _builtinNotFullyAplliedExpectedArgsNum = argsNum
-                    }
+        | length args' >= argsNum -> return ()
+        | otherwise ->
+            throw
+              . ErrArityCheckerError
+              $ ErrBuiltinNotFullyApplied
+                BuiltinNotFullyApplied
+                  { _builtinNotFullyAppliedName = n,
+                    _builtinNotFullyAplliedExpectedArgsNum = argsNum
+                  }
       where
         goImplArgs :: Int -> [ApplicationArg] -> Sem r [ApplicationArg]
         goImplArgs 0 as = return as
@@ -1485,8 +1487,8 @@ holesHelper mhint expr = do
                       builderTy <- gets (^. appBuilderType)
                       args <- gets (^. appBuilderArgs)
                       let a :: Expression = foldApplication l (map (^. appBuilderArg) args)
-                      throw $
-                        ErrExpectedFunctionType
+                      throw
+                        $ ErrExpectedFunctionType
                           ExpectedFunctionType
                             { _expectedFunctionTypeExpression = a,
                               _expectedFunctionTypeLeft = l,
@@ -1645,10 +1647,10 @@ simplelambda = error "simple lambda expressions are not supported by the arity c
 arityLambda :: forall r. (Members '[Reader InfoTable, Inference, Reader LocalVars] r) => Lambda -> Sem r Arity
 arityLambda l = do
   aris <- mapM guessClauseArity (l ^. lambdaClauses)
-  return $
-    if
-        | allSame aris -> head aris
-        | otherwise -> ArityNotKnown
+  return
+    $ if
+      | allSame aris -> head aris
+      | otherwise -> ArityNotKnown
   where
     guessClauseArity :: LambdaClause -> Sem r Arity
     guessClauseArity cl = do
@@ -1752,8 +1754,8 @@ getBuiltinName i b = fromMaybeM notDefined (asks (^. infoBuiltins . at b'))
   where
     b' = toBuiltinPrim b
     notDefined =
-      throw $
-        ErrBuiltinNotDefined
+      throw
+        $ ErrBuiltinNotDefined
           NotDefined
             { _notDefinedBuiltin = b',
               _notDefinedLoc = i

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Inference.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Inference.hs
@@ -98,8 +98,8 @@ closeState = \case
           let st = getState h
            in case st of
                 Fresh ->
-                  throw $
-                    ErrUnsolvedMeta
+                  throw
+                    $ ErrUnsolvedMeta
                       UnsolvedMeta
                         { _unsolvedMeta = h,
                           _unsolvedIsLoop = False
@@ -473,8 +473,8 @@ runInferenceState inis = reinterpret (runState inis) $ \case
                           m <- ask @(HashMap VarName VarName)
                           (m', patMatch) <- runState m (mapM (uncurry matchPatterns) z)
                           if
-                              | and patMatch -> local (const m') (go b1 b2)
-                              | otherwise -> err
+                            | and patMatch -> local (const m') (go b1 b2)
+                            | otherwise -> err
 
 matchPatterns ::
   forall r.

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Error/Types.hs
@@ -36,12 +36,12 @@ instance ToGenericError WrongConstructorType where
             "The constructor"
               <+> ppCode opts' ctorName
               <+> "belongs to the inductive type:"
-                <> line
-                <> indent' (ppCode opts' (e ^. wrongCtorTypeActual))
-                <> line
-                <> "but is expected to belong to the inductive type:"
-                <> line
-                <> indent' (ppCode opts' (e ^. wrongCtorTypeExpected))
+              <> line
+              <> indent' (ppCode opts' (e ^. wrongCtorTypeActual))
+              <> line
+              <> "but is expected to belong to the inductive type:"
+              <> line
+              <> indent' (ppCode opts' (e ^. wrongCtorTypeExpected))
 
 data WrongReturnType = WrongReturnType
   { _wrongReturnTypeConstructorName :: Name,
@@ -71,12 +71,12 @@ instance ToGenericError WrongReturnType where
             "The constructor"
               <+> ppCode opts' ctorName
               <+> "has the wrong return type:"
-                <> line
-                <> indent' (ppCode opts' ty)
-                <> line
-                <> "but is expected to have type:"
-                <> line
-                <> indent' (ppCode opts' (e ^. wrongReturnTypeExpected))
+              <> line
+              <> indent' (ppCode opts' ty)
+              <> line
+              <> "but is expected to have type:"
+              <> line
+              <> indent' (ppCode opts' (e ^. wrongReturnTypeExpected))
 
 data UnsolvedMeta = UnsolvedMeta
   { _unsolvedMeta :: Hole,
@@ -139,15 +139,15 @@ instance ToGenericError WrongConstructorAppArgs where
               <+> ctorName
               <+> "is being matched against"
               <+> numPats
-                <> ":"
-                <> line
-                <> indent' (ppCode opts' (e ^. wrongCtorAppApp))
-                <> line
-                <> "but is expected to be matched against"
+              <> ":"
+              <> line
+              <> indent' (ppCode opts' (e ^. wrongCtorAppApp))
+              <> line
+              <> "but is expected to be matched against"
               <+> numTypes
               <+> "with the following types:"
-                <> line
-                <> indent' (hsep (ctorName : (ppCode opts' <$> (e ^. wrongCtorAppTypes))))
+              <> line
+              <> indent' (hsep (ctorName : (ppCode opts' <$> (e ^. wrongCtorAppTypes))))
           numPats :: Doc ann
           numPats = pat (length (e ^. wrongCtorAppApp . constrAppParameters))
           numTypes :: Doc ann
@@ -205,12 +205,12 @@ instance ToGenericError WrongType where
               <+> thingName
               <+> thing
               <+> "has type:"
-                <> line
-                <> indent' (ppCode opts' (err ^. wrongTypeActual . normalizedExpression))
-                <> line
-                <> "but is expected to have type:"
-                <> line
-                <> indent' (ppCode opts' (err ^. wrongTypeExpected . normalizedExpression))
+              <> line
+              <> indent' (ppCode opts' (err ^. wrongTypeActual . normalizedExpression))
+              <> line
+              <> "but is expected to have type:"
+              <> line
+              <> indent' (ppCode opts' (err ^. wrongTypeExpected . normalizedExpression))
 
           thingName :: Doc a
           thingName = case err ^. wrongTypeThing of
@@ -248,17 +248,17 @@ instance ToGenericError ExpectedFunctionType where
           msg =
             "Type error near"
               <+> pretty (getLoc subjectExpr)
-                <> "."
-                <> line
-                <> "In the expression:"
-                <> line
-                <> indent' (ppCode opts' (e ^. expectedFunctionTypeExpression))
-                <> line
-                <> "the expression"
+              <> "."
+              <> line
+              <> "In the expression:"
+              <> line
+              <> indent' (ppCode opts' (e ^. expectedFunctionTypeExpression))
+              <> line
+              <> "the expression"
               <+> ppCode opts' (e ^. expectedFunctionTypeLeft)
               <+> "is expected to have a function type but has type:"
-                <> line
-                <> indent' (ppCode opts' (e ^. expectedFunctionTypeType))
+              <> line
+              <> indent' (ppCode opts' (e ^. expectedFunctionTypeType))
           subjectExpr :: Expression
           subjectExpr = e ^. expectedFunctionTypeExpression
 
@@ -291,15 +291,15 @@ instance ToGenericError WrongNumberArgumentsIndType where
               <+> ppCode opts' ty
               <+> "expects"
               <+> ( if
-                        | expectedNumArgs == 0 -> "no arguments"
-                        | expectedNumArgs == 1 -> "one argument"
-                        | otherwise -> pretty expectedNumArgs <+> "arguments"
+                      | expectedNumArgs == 0 -> "no arguments"
+                      | expectedNumArgs == 1 -> "one argument"
+                      | otherwise -> pretty expectedNumArgs <+> "arguments"
                   )
-                <> ", but"
+              <> ", but"
               <+> ( if
-                        | actualNumArgs == 0 -> "no argument is"
-                        | actualNumArgs == 1 -> "only one argument is"
-                        | otherwise -> pretty actualNumArgs <+> "arguments are"
+                      | actualNumArgs == 0 -> "no argument is"
+                      | actualNumArgs == 1 -> "only one argument is"
+                      | otherwise -> pretty actualNumArgs <+> "arguments are"
                   )
               <+> "given"
 
@@ -339,9 +339,9 @@ instance ToGenericError UnsupportedTypeFunction where
     let msg =
           "Unsupported type function"
             <+> ppCode opts (_unsupportedTypeFunction ^. funDefName)
-              <> "."
-              <> line
-              <> "Only terminating functions with a single clause and no pattern matching are supported."
+            <> "."
+            <> line
+            <> "Only terminating functions with a single clause and no pattern matching are supported."
     return
       GenericError
         { _genericErrorLoc = i,
@@ -382,8 +382,8 @@ instance ToGenericError InvalidCoercionType where
     let msg =
           "Invalid coercion type:"
             <+> ppCode opts _invalidCoercionTypeExpression
-              <> line
-              <> "A coercion must have exactly one instance argument."
+            <> line
+            <> "A coercion must have exactly one instance argument."
     return
       GenericError
         { _genericErrorLoc = i,
@@ -408,10 +408,10 @@ instance ToGenericError WrongCoercionArgument where
           GenericError
             { _genericErrorLoc = i,
               _genericErrorMessage =
-                ppOutput $
-                  "Expected an implicit type argument."
-                    <> line
-                    <> "A coercion can have only implicit type arguments followed by exactly one instance argument.",
+                ppOutput
+                  $ "Expected an implicit type argument."
+                  <> line
+                  <> "A coercion can have only implicit type arguments followed by exactly one instance argument.",
               _genericErrorIntervals = [i]
             }
         where
@@ -533,10 +533,10 @@ instance ToGenericError AmbiguousInstances where
           msg =
             "Multiple trait instances found for"
               <+> ppCode opts' (e ^. ambiguousInstancesType . normalizedExpression)
-                <> line
-                <> "Matching instances found at:"
-                <> line
-                <> indent' locs
+              <> line
+              <> "Matching instances found at:"
+              <> line
+              <> indent' locs
 
 data SubsumedInstance = SubsumedInstance
   { _subsumedInstance :: InstanceInfo,
@@ -564,8 +564,8 @@ instance ToGenericError SubsumedInstance where
             "The instance"
               <+> ppCode opts' (e ^. subsumedInstance . instanceInfoResult)
               <+> "is subsumed by instances at:"
-                <> line
-                <> indent' locs
+              <> line
+              <> indent' locs
 
 newtype ExplicitInstanceArgument = ExplicitInstanceArgument
   { _explicitInstanceArgumentParameter :: FunctionParameter
@@ -608,8 +608,8 @@ instance ToGenericError TraitNotTerminating where
           msg =
             "Non-decreasing trait argument:"
               <+> ppCode opts' (e ^. traitNotTerminating)
-                <> line
-                <> "Each parameter of a trait in an instance argument must be structurally smaller than some parameter of the trait in the instance target"
+              <> line
+              <> "Each parameter of a trait in an instance argument must be structurally smaller than some parameter of the trait in the instance target"
 
 newtype DefaultArgLoop = DefaultArgLoop
   { _defaultArgLoop :: NonEmpty ArgId
@@ -661,7 +661,7 @@ instance ToGenericError BadScope where
               <> "Most likely, the inference algorithm inserted the variable"
               <+> ppCode opts' var
               <+> "in a place where it is not in scope."
-                <> line
-                <> "As a workaround, explicitly provide a type in the place where you think the variable got inserted."
-                <> line
-                <> "More information at https://github.com/anoma/juvix/issues/2247"
+              <> line
+              <> "As a workaround, explicitly provide a type in the place where you think the variable got inserted."
+              <> line
+              <> "More information at https://github.com/anoma/juvix/issues/2247"

--- a/src/Juvix/Compiler/Nockma/Encoding/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Base.hs
@@ -65,16 +65,16 @@ consumeLength :: forall r. (Members '[BitReader, Error BitReadError] r) => Sem r
 consumeLength = do
   lenOfLen <- countBitsUntilOne
   if
-      | lenOfLen == 0 -> return 0
-      | otherwise -> do
-          -- The most significant bit of the length is omitted
-          let lenBits = lenOfLen - 1
-          foldlM go (bit lenBits) [0 .. lenBits - 1]
+    | lenOfLen == 0 -> return 0
+    | otherwise -> do
+        -- The most significant bit of the length is omitted
+        let lenBits = lenOfLen - 1
+        foldlM go (bit lenBits) [0 .. lenBits - 1]
   where
     go :: Int -> Int -> Sem r Int
     go acc n = do
       Bit b <- nextBit
-      return $
-        if
-            | b -> setBit acc n
-            | otherwise -> acc
+      return
+        $ if
+          | b -> setBit acc n
+          | otherwise -> acc

--- a/src/Juvix/Compiler/Nockma/Encoding/Cue.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Cue.hs
@@ -103,12 +103,12 @@ consumeTag ::
 consumeTag = do
   Bit b0 <- nextBit'
   if
-      | b0 -> do
-          Bit b1 <- nextBit'
-          if
-              | b1 -> return JamTagBackref
-              | otherwise -> return JamTagCell
-      | otherwise -> return JamTagAtom
+    | b0 -> do
+        Bit b1 <- nextBit'
+        if
+          | b1 -> return JamTagBackref
+          | otherwise -> return JamTagCell
+    | otherwise -> return JamTagAtom
   where
     nextBit' :: Sem r Bit
     nextBit' = handleBitError DecodingErrorInvalidTag nextBit
@@ -211,22 +211,22 @@ cueFromBitsSem = registerElementStart $ do
     consumeNatAtom = do
       len <- consumeLength'
       if
-          | len == 0 -> return (Atom 0 emptyAtomInfo)
-          | otherwise -> do
-              a <- consumeInteger DecodingErrorInvalidAtom len
-              return (Atom (fromInteger a) emptyAtomInfo)
+        | len == 0 -> return (Atom 0 emptyAtomInfo)
+        | otherwise -> do
+            a <- consumeInteger DecodingErrorInvalidAtom len
+            return (Atom (fromInteger a) emptyAtomInfo)
 
     consumeAtom :: Sem r (Atom a)
     consumeAtom = do
       len <- consumeLength'
       if
-          | len == 0 -> do
-              z <- fromNatural' @a 0
-              return (Atom z emptyAtomInfo)
-          | otherwise -> do
-              a <- consumeInteger DecodingErrorInvalidAtom len
-              n <- fromNatural' (fromInteger a)
-              return (Atom n emptyAtomInfo)
+        | len == 0 -> do
+            z <- fromNatural' @a 0
+            return (Atom z emptyAtomInfo)
+        | otherwise -> do
+            a <- consumeInteger DecodingErrorInvalidAtom len
+            n <- fromNatural' (fromInteger a)
+            return (Atom n emptyAtomInfo)
 
 -- | Decode an nock Atom to a nock term
 cue ::

--- a/src/Juvix/Compiler/Nockma/Encoding/Effect/BitReader.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Effect/BitReader.hs
@@ -26,8 +26,8 @@ countBitsUntil p = go 0
     go n = do
       b <- nextBit
       if
-          | p b -> return n
-          | otherwise -> go (n + 1)
+        | p b -> return n
+        | otherwise -> go (n + 1)
 
 countBitsUntilOne :: (Members '[BitReader, Error BitReadError] r) => Sem r Int
 countBitsUntilOne = countBitsUntil (== Bit True)

--- a/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
@@ -78,8 +78,8 @@ jamSem t = do
         let idxBitLength = finiteBitSize idx - countLeadingZeros idx
             atomBitLength = bitLength (a ^. atom)
         if
-            | atomBitLength <= idxBitLength -> writeAtom a
-            | otherwise -> writeBackref idx
+          | atomBitLength <= idxBitLength -> writeAtom a
+          | otherwise -> writeBackref idx
       TermCell {} -> writeBackref idx
     Nothing -> do
       cacheTerm t

--- a/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator/Error.hs
@@ -76,8 +76,8 @@ data VerificationFailed a = VerificationFailed
 throwInvalidNockOp :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Atom a -> Sem r x
 throwInvalidNockOp a = do
   ctx <- ask
-  throw $
-    ErrInvalidNockOp
+  throw
+    $ ErrInvalidNockOp
       InvalidNockOp
         { _invalidNockOpCtx = ctx,
           _invalidNockOp = a
@@ -86,8 +86,8 @@ throwInvalidNockOp a = do
 throwInvalidPath :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Term a -> Path -> Sem r x
 throwInvalidPath tm p = do
   ctx <- ask
-  throw $
-    ErrInvalidPath
+  throw
+    $ ErrInvalidPath
       InvalidPath
         { _invalidPathCtx = ctx,
           _invalidPathTerm = tm,
@@ -97,8 +97,8 @@ throwInvalidPath tm p = do
 throwExpectedCell :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Atom a -> Sem r x
 throwExpectedCell a = do
   ctx <- ask
-  throw $
-    ErrExpectedCell
+  throw
+    $ ErrExpectedCell
       ExpectedCell
         { _expectedCellCtx = ctx,
           _expectedCellAtom = a
@@ -107,8 +107,8 @@ throwExpectedCell a = do
 throwExpectedAtom :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Cell a -> Sem r x
 throwExpectedAtom a = do
   ctx <- ask
-  throw $
-    ErrExpectedAtom
+  throw
+    $ ErrExpectedAtom
       ExpectedAtom
         { _expectedAtomCtx = ctx,
           _expectedAtomCell = a
@@ -117,8 +117,8 @@ throwExpectedAtom a = do
 throwKeyNotInStorage :: (Members '[Reader (Storage a), Error (NockEvalError a)] r) => Term a -> Sem r x
 throwKeyNotInStorage k = do
   s <- ask
-  throw $
-    ErrKeyNotInStorage
+  throw
+    $ ErrKeyNotInStorage
       KeyNotInStorage
         { _keyNotInStorageKey = k,
           _keyNotInStorageStorage = s
@@ -127,8 +127,8 @@ throwKeyNotInStorage k = do
 throwDecodingFailed :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Term a -> DecodingError -> Sem r x
 throwDecodingFailed a e = do
   ctx <- ask
-  throw $
-    ErrDecodingFailed
+  throw
+    $ ErrDecodingFailed
       DecodingFailed
         { _decodingFailedCtx = ctx,
           _decodingFailedTerm = a,
@@ -138,8 +138,8 @@ throwDecodingFailed a e = do
 throwVerificationFailed :: (Members '[Error (NockEvalError a), Reader EvalCtx] r) => Atom a -> Atom a -> Sem r x
 throwVerificationFailed m k = do
   ctx <- ask
-  throw $
-    ErrVerificationFailed
+  throw
+    $ ErrVerificationFailed
       VerificationFailed
         { _verificationFailedCtx = ctx,
           _verificationFailedMessage = m,

--- a/src/Juvix/Compiler/Nockma/Language/Path.hs
+++ b/src/Juvix/Compiler/Nockma/Language/Path.hs
@@ -27,12 +27,12 @@ decodePath ep = execOutputList (go (ep ^. encodedPath))
       1 -> return ()
       x ->
         if
-            | even x -> do
-                go (x `div` 2)
-                output L
-            | otherwise -> do
-                go ((x - 1) `div` 2)
-                output R
+          | even x -> do
+              go (x `div` 2)
+              output L
+          | otherwise -> do
+              go ((x - 1) `div` 2)
+              output R
 
 decodePath' :: EncodedPath -> Path
 decodePath' = run . runFailDefault (error "encoded path cannot be 0") . decodePath

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -30,8 +30,10 @@ instance forall a. (PrettyCode a, NockNatural a) => PrettyCode (Atom a) where
       failWhenM (asks (^. optIgnoreTags))
       failMaybe (atm ^. atomTag) >>= ppCode
     let def = fmap (t <?+>) (annotate (AnnKind KNameFunction) <$> ppCode (atm ^. atom))
-    fmap (t <?+>) . runFailDefaultM def . failFromError @(ErrNockNatural a) $
-      do
+    fmap (t <?+>)
+      . runFailDefaultM def
+      . failFromError @(ErrNockNatural a)
+      $ do
         whenM (asks (^. optIgnoreHints)) fail
         h' <- failMaybe (atm ^. atomHint)
         case h' of

--- a/src/Juvix/Compiler/Nockma/Stdlib.hs
+++ b/src/Juvix/Compiler/Nockma/Stdlib.hs
@@ -6,6 +6,6 @@ import Juvix.Prelude.Base
 
 stdlib :: Term Natural
 stdlib =
-  fromRight impossible $
-    parseText $
-      decodeUtf8 $(FE.makeRelativeToProject "runtime/nockma/stdlib.nockma" >>= FE.embedFile)
+  fromRight impossible
+    $ parseText
+    $ decodeUtf8 $(FE.makeRelativeToProject "runtime/nockma/stdlib.nockma" >>= FE.embedFile)

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -103,13 +103,17 @@ atomPath mtag = do
 
 direction :: Parser Direction
 direction =
-  symbol "L" $> L
-    <|> symbol "R" $> R
+  symbol "L"
+    $> L
+    <|> symbol "R"
+    $> R
 
 pPath :: Parser Path
 pPath =
-  symbol "S" $> []
-    <|> NonEmpty.toList <$> some direction
+  symbol "S"
+    $> []
+    <|> NonEmpty.toList
+    <$> some direction
 
 atomNat :: Maybe Tag -> Parser (Atom Natural)
 atomNat mtag = do
@@ -216,8 +220,10 @@ cell = do
 
 term :: Parser (Term Natural)
 term =
-  TermAtom <$> patom
-    <|> TermCell <$> cell
+  TermAtom
+    <$> patom
+    <|> TermCell
+    <$> cell
 
 assig :: Parser (Assignment Natural)
 assig = do
@@ -236,7 +242,8 @@ program = Program <$> many statement <* eof
     statement :: Parser (Statement Natural)
     statement =
       P.try (StatementAssignment <$> assig)
-        <|> StatementStandalone <$> term
+        <|> StatementStandalone
+        <$> term
 
 name :: Parser Text
 name = lexeme $ do
@@ -257,15 +264,21 @@ withStack = do
 
 replExpression :: Parser (ReplExpression Natural)
 replExpression =
-  ReplExpressionWithStack <$> P.try withStack
-    <|> ReplExpressionTerm <$> replTerm
+  ReplExpressionWithStack
+    <$> P.try withStack
+    <|> ReplExpressionTerm
+    <$> replTerm
 
 replStatement :: Parser (ReplStatement Natural)
 replStatement =
-  ReplStatementAssignment <$> P.try assig
-    <|> ReplStatementExpression <$> replExpression
+  ReplStatementAssignment
+    <$> P.try assig
+    <|> ReplStatementExpression
+    <$> replExpression
 
 replTerm :: Parser (ReplTerm Natural)
 replTerm =
-  ReplName <$> name
-    <|> ReplTerm <$> term
+  ReplName
+    <$> name
+    <|> ReplTerm
+    <$> term

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -202,7 +202,8 @@ runCompilerFunction ctx fun =
   run
     . runReader (FunctionCtx (fun ^. compilerFunctionArity))
     . runReader ctx
-    $ fun ^. compilerFunction
+    $ fun
+    ^. compilerFunction
 
 pathToArg :: (Members '[Reader FunctionCtx] r) => Natural -> Sem r Path
 pathToArg n = do
@@ -328,8 +329,8 @@ anomaCallableClosureWrapper =
   let closureArgsNum :: Term Natural = getClosureFieldInSubject ClosureArgsNum
       closureTotalArgsNum :: Term Natural = getClosureFieldInSubject ClosureTotalArgsNum
       appendAndReplaceArgsTuple =
-        replaceArgsWithTerm "anomaCallableClosureWrapper" $
-          appendToTuple
+        replaceArgsWithTerm "anomaCallableClosureWrapper"
+          $ appendToTuple
             (getClosureFieldInSubject ClosureArgs)
             closureArgsNum
             (getClosureFieldInSubject ArgsTuple)
@@ -579,10 +580,10 @@ compile = \case
     goTrace :: Term Natural -> Sem r (Term Natural)
     goTrace arg = do
       enabled <- asks (^. compilerOptions . compilerOptionsEnableTrace)
-      return $
-        if
-            | enabled -> OpTrace # arg # arg
-            | otherwise -> arg
+      return
+        $ if
+          | enabled -> OpTrace # arg # arg
+          | otherwise -> arg
 
     goBinop :: Tree.NodeBinop -> Sem r (Term Natural)
     goBinop Tree.NodeBinop {..} = do
@@ -688,8 +689,8 @@ withTemp toBePushed body =
       remakeList
         [ let p = opAddress "pushTemp" (stackPath s)
            in if
-                  | TempStack == s -> toBePushed # p
-                  | otherwise -> p
+                | TempStack == s -> toBePushed # p
+                | otherwise -> p
           | s <- allElements
         ]
 
@@ -1107,8 +1108,8 @@ caseCmd arg defaultBranch = \case
     goBoolTag v b bs =
       let otherBranch = fromMaybe crash (firstJust f bs <|> defaultBranch)
        in if
-              | v -> branch arg b otherBranch
-              | otherwise -> branch arg otherBranch b
+            | v -> branch arg b otherBranch
+            | otherwise -> branch arg otherBranch b
       where
         f :: (Tree.Tag, Term Natural) -> Maybe (Term Natural)
         f (tag', br) = case tag' of

--- a/src/Juvix/Compiler/Pipeline/Driver.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver.hs
@@ -98,20 +98,27 @@ processModuleCacheMiss entryIx = do
   m :: Maybe Store.ModuleInfo <- loadFromFile absPath
   case m of
     Just info
-      | info ^. Store.moduleInfoSHA256 == sha256
-          && info ^. Store.moduleInfoOptions == opts
-          && info ^. Store.moduleInfoFieldSize == entry ^. entryPointFieldSize -> do
+      | info
+          ^. Store.moduleInfoSHA256
+          == sha256
+          && info
+          ^. Store.moduleInfoOptions
+          == opts
+          && info
+          ^. Store.moduleInfoFieldSize
+          == entry
+          ^. entryPointFieldSize -> do
           CompileResult {..} <- runReader entry (processImports (info ^. Store.moduleInfoImports))
           if
-              | _compileResultChanged ->
-                  recompile sha256 absPath
-              | otherwise ->
-                  return
-                    PipelineResult
-                      { _pipelineResult = info,
-                        _pipelineResultImports = _compileResultModuleTable,
-                        _pipelineResultChanged = False
-                      }
+            | _compileResultChanged ->
+                recompile sha256 absPath
+            | otherwise ->
+                return
+                  PipelineResult
+                    { _pipelineResult = info,
+                      _pipelineResultImports = _compileResultModuleTable,
+                      _pipelineResultChanged = False
+                    }
     _ ->
       recompile sha256 absPath
   where
@@ -183,10 +190,10 @@ processImport p = withPathFile p getCachedImport
       b <- supportsParallel
       eix <- mkEntryIndex node
       if
-          | b -> do
-              res <- cacheGetResult eix
-              return (res ^. cacheResult)
-          | otherwise -> processModule eix
+        | b -> do
+            res <- cacheGetResult eix
+            return (res ^. cacheResult)
+        | otherwise -> processModule eix
 
 processFileUpToParsing ::
   forall r.

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver.hs
@@ -75,11 +75,11 @@ mkPackageInfo mpackageEntry _packageRoot pkg = do
   globalPackageBaseAbsDir <- globalPackageBaseRoot
   let _packageJuvixRelativeFiles = keepJuvixFiles (hashSet files)
       _packageAvailableRoots =
-        hashSet $
-          globalPackageDescriptionAbsDir
-            : globalPackageBaseAbsDir
-            : _packageRoot
-            : depsPaths
+        hashSet
+          $ globalPackageDescriptionAbsDir
+          : globalPackageBaseAbsDir
+          : _packageRoot
+          : depsPaths
   return PackageInfo {..}
   where
     pkgFile :: Path Abs File
@@ -329,15 +329,15 @@ resolvePath' scan = do
   case packagesWithExt of
     [(r, relPath)] -> return (r, relPath)
     [] ->
-      throw $
-        ErrMissingModule
+      throw
+        $ ErrMissingModule
           MissingModule
             { _missingInfo = curPkg,
               _missingModule = scan
             }
     (r, _) : rs ->
-      throw $
-        ErrDependencyConflict
+      throw
+        $ ErrDependencyConflict
           DependencyConflict
             { _conflictPackages = r :| map fst rs,
               _conflictPath = scan

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Error.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Error.hs
@@ -58,8 +58,8 @@ instance PrettyCodeAnn DependencyErrorGit where
         <> "The directory"
         <+> code (pretty (d ^. dependencyErrorGitCloneDir))
         <+> "is not a valid git clone."
-          <> line
-          <> "Try running"
+        <> line
+        <> "Try running"
         <+> code "juvix clean --global"
     NoSuchRef ref ->
       prefix
@@ -77,10 +77,10 @@ instance PrettyCodeAnn MissingLockfileDependency where
       <+> code dependencyId
       <+> "is declared in the package's juvix.yaml but is not declared in the lockfile:"
       <+> lockfilePath
-        <> line
-        <> "Try running the following command:"
-        <> line
-        <> code "juvix dependencies update"
+      <> line
+      <> "Try running the following command:"
+      <> line
+      <> code "juvix dependencies update"
     where
       lockfilePath :: Doc CodeAnn
       lockfilePath = pretty (e ^. missingLockfileDependencyPath)
@@ -97,8 +97,8 @@ data PathResolverError
 
 instance ToGenericError PathResolverError where
   genericError e =
-    return $
-      GenericError
+    return
+      $ GenericError
         { _genericErrorLoc = i,
           _genericErrorMessage = mkAnsiText $ ppCodeAnn e,
           _genericErrorIntervals = [i]
@@ -152,14 +152,14 @@ instance PrettyCodeAnn MissingModule where
     "The module"
       <+> importScanPrettyName _missingModule
       <+> "does not exist."
-        <> line
-        <> suggestion
+      <> line
+      <> suggestion
     where
       suggestion :: Doc Ann
       suggestion =
         "It should be in"
           <+> pcode (_missingInfo ^. packageRoot <//> addFileExt FileExtJuvix (importScanToRelPath _missingModule))
-            <> dependenciesSuggestion
+          <> dependenciesSuggestion
 
       dependenciesSuggestion :: Doc Ann
       dependenciesSuggestion
@@ -182,5 +182,5 @@ instance PrettyCodeAnn PackageInvalidImport where
     "The module"
       <+> pcode _packageInvalidImport
       <+> "cannot be imported by the Package file."
-        <> line
-        <> "Package files may only import modules from the Juvix standard library, Juvix.Builtin modules, or from the PackageDescription module."
+      <> line
+      <> "Package files may only import modules from the Juvix standard library, Juvix.Builtin modules, or from the PackageDescription module."

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree.hs
@@ -133,14 +133,14 @@ checkImportTreeCycles tree = do
       find cond edges
       where
         unexpected =
-          error $
-            "Impossible: Could not find edge between\n"
-              <> prettyText fromN
-              <> "\nand\n"
-              <> prettyText toN
-              <> "\n"
-              <> "Available Edges:\n"
-              <> prettyText (toList (tree ^. importTreeEdges . at fromN . _Just))
+          error
+            $ "Impossible: Could not find edge between\n"
+            <> prettyText fromN
+            <> "\nand\n"
+            <> prettyText toN
+            <> "\n"
+            <> "Available Edges:\n"
+            <> prettyText (toList (tree ^. importTreeEdges . at fromN . _Just))
 
     getCycle :: SCC ImportNode -> Maybe (NonEmpty ImportNode)
     getCycle = \case

--- a/src/Juvix/Compiler/Pipeline/Lockfile.hs
+++ b/src/Juvix/Compiler/Pipeline/Lockfile.hs
@@ -143,9 +143,9 @@ instance FromJSON VersionedLockfile where
           parseVersion' = do
             n <- asIntegral
             if
-                | lockfileVersionNumber LockfileV1Tag == n -> return LockfileV1Tag
-                | lockfileVersionNumber LockfileV2Tag == n -> return LockfileV2Tag
-                | otherwise -> throwCustomError LockfileUnsupportedVersion
+              | lockfileVersionNumber LockfileV1Tag == n -> return LockfileV1Tag
+              | lockfileVersionNumber LockfileV2Tag == n -> return LockfileV2Tag
+              | otherwise -> throwCustomError LockfileUnsupportedVersion
 
       displayErr :: LockfileParseErr -> Text
       displayErr = \case
@@ -162,10 +162,10 @@ mayReadLockfile ::
 mayReadLockfile root = do
   lockfileExists <- fileExists' lockfilePath
   if
-      | lockfileExists -> do
-          bs <- readFileBS' lockfilePath
-          either (throwErr . pack . prettyPrintParseException) ((return . Just) . mkLockfileInfo lockfilePath) (decodeEither' @VersionedLockfile bs)
-      | otherwise -> return Nothing
+    | lockfileExists -> do
+        bs <- readFileBS' lockfilePath
+        either (throwErr . pack . prettyPrintParseException) ((return . Just) . mkLockfileInfo lockfilePath) (decodeEither' @VersionedLockfile bs)
+    | otherwise -> return Nothing
   where
     mkLockfileInfo :: Path Abs File -> VersionedLockfile -> LockfileInfo
     mkLockfileInfo _lockfileInfoPath vl =
@@ -196,11 +196,11 @@ lockfileEncodeConfig = setConfCompare keyCompare defConfig
     keyCompare :: Text -> Text -> Ordering
     keyCompare x y =
       if
-          | y == Str.dependencies -> LT
-          | x == Str.dependencies -> GT
-          | x == Str.version -> LT
-          | y == Str.version -> GT
-          | otherwise -> compare x y
+        | y == Str.dependencies -> LT
+        | x == Str.dependencies -> GT
+        | x == Str.version -> LT
+        | y == Str.version -> GT
+        | otherwise -> compare x y
 
 writeLockfile :: (Members '[Files] r) => Path Abs File -> Text -> Lockfile -> Sem r ()
 writeLockfile lockfilePath checksum' lf = do

--- a/src/Juvix/Compiler/Pipeline/Package.hs
+++ b/src/Juvix/Compiler/Pipeline/Package.hs
@@ -95,8 +95,8 @@ readYamlPackage root buildDir = mapError (JuvixError @PackageLoaderError) $ do
   bs <- readFileBS' yamlPath
   mLockfile <- mayReadLockfile root
   if
-      | ByteString.null bs -> return (emptyPackage buildDir yamlPath)
-      | otherwise -> either (throwErr . pack . prettyPrintParseException) (processPackage yamlPath buildDir mLockfile) (decodeEither' bs)
+    | ByteString.null bs -> return (emptyPackage buildDir yamlPath)
+    | otherwise -> either (throwErr . pack . prettyPrintParseException) (processPackage yamlPath buildDir mLockfile) (decodeEither' bs)
   where
     yamlPath = mkPackageFilePath root
 

--- a/src/Juvix/Compiler/Pipeline/Package/Loader.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader.hs
@@ -115,8 +115,8 @@ toConcrete t p = run . runReader l $ do
                 _openModulePublic = NoPublic,
                 _openModuleKw
               }
-      return $
-        StatementImport
+      return
+        $ StatementImport
           Import
             { _importOpen = Just openShort,
               _importPublic = NoPublic,
@@ -138,6 +138,6 @@ packageDescriptionDir' :: Path Abs Dir
 packageDescriptionDir' =
   $( FE.makeRelativeToProject (toFilePath packageDescriptionDir)
        >>= runIO
-         . parseAbsDir
+       . parseAbsDir
        >>= lift
    )

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
@@ -142,7 +142,8 @@ loadPackage' packagePath = do
       . runPackagePathResolver rootPath
       . runTopModuleNameChecker
       . evalModuleInfoCache
-      $ (^. pipelineResult) <$> processFileToStoredCore packageEntryPoint
+      $ (^. pipelineResult)
+      <$> processFileToStoredCore packageEntryPoint
     )
   where
     rootPath :: Path Abs Dir

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/PathResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/PathResolver.hs
@@ -46,8 +46,9 @@ runPackagePathResolver rootPath sem = do
     RegisterDependencies {} -> return ()
     ResolvePath scan -> case mkRootInfo ds fs (addFileExt FileExtJuvix (importScanToRelPath scan)) of
       Nothing ->
-        throw . JuvixError $
-          ErrPackageInvalidImport
+        throw
+          . JuvixError
+          $ ErrPackageInvalidImport
             PackageInvalidImport
               { _packageInvalidImport = scan
               }
@@ -59,8 +60,8 @@ runPackagePathResolver rootPath sem = do
       let _pathInfoTopModule = m
           _pathInfoRootInfo =
             --  A Package file is a member of a package by definition.
-            fromMaybe (error "runPackagePathResolver: expected root info") $
-              mkRootInfo' (topModulePathToRelativePath' m)
+            fromMaybe (error "runPackagePathResolver: expected root info")
+              $ mkRootInfo' (topModulePathToRelativePath' m)
       return PathInfoTopModule {..}
     WithResolverRoot _root' m ->
       -- the _root' is not used because ResolvePath does not depend on it
@@ -77,7 +78,8 @@ runPackagePathResolver rootPath sem = do
       pkgType <- mkPkgPackageType
       return
         . hashMap
-        $ mkAssoc <$> [pkgBase, pkgType, gstdlib, pkgDotJuvix]
+        $ mkAssoc
+        <$> [pkgBase, pkgType, gstdlib, pkgDotJuvix]
       where
         mkAssoc :: PackageInfo -> (Path Abs Dir, PackageInfo)
         mkAssoc pkg = (pkg ^. packageRoot, pkg)

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/Versions.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/Versions.hs
@@ -138,8 +138,8 @@ v1v2FromPackage p = run . runReader l $ do
           case deps of
             [d] ->
               if
-                  | d == defaultStdlibDep DefaultBuildDir -> return Nothing
-                  | otherwise -> dependenciesArg
+                | d == defaultStdlibDep DefaultBuildDir -> return Nothing
+                | otherwise -> dependenciesArg
             _ -> dependenciesArg
           where
             mkDependenciesArg' :: [Dependency] -> Sem r (NamedArgumentAssign 'Parsed)

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -44,7 +44,9 @@ upToInternalExpression p = do
     . runStateArtifacts artifactScoperState
     . runReader pkg
     $ runNameIdGenArtifacts (Scoper.scopeCheckExpression (Store.getScopedModuleTable mtab) scopeTable p)
-      >>= runNameIdGenArtifacts . runReader scopeTable . Internal.fromConcreteExpression
+    >>= runNameIdGenArtifacts
+    . runReader scopeTable
+    . Internal.fromConcreteExpression
 
 expressionUpToAtomsParsed ::
   (Members '[State Artifacts, Error JuvixError] r) =>
@@ -71,7 +73,7 @@ expressionUpToAtomsScoped fp txt = do
     . runNameIdGenArtifacts
     . runReader pkg
     $ Parser.expressionFromTextSource fp txt
-      >>= Scoper.scopeCheckExpressionAtoms (Store.getScopedModuleTable mtab) scopeTable
+    >>= Scoper.scopeCheckExpressionAtoms (Store.getScopedModuleTable mtab) scopeTable
 
 scopeCheckExpression ::
   (Members '[Reader EntryPoint, Error JuvixError, State Artifacts] r) =>
@@ -234,8 +236,8 @@ runTransformations shouldDisambiguate ts n = runCoreInfoTableBuilderArtifacts $ 
       md' <- mapReader Core.fromEntryPoint $ Core.applyTransformations ts' md
       let md'' =
             if
-                | shouldDisambiguate' -> disambiguateNames md'
-                | otherwise -> md'
+              | shouldDisambiguate' -> disambiguateNames md'
+              | otherwise -> md'
       Core.setModule md''
 
     getNode :: Core.Symbol -> Sem (Core.InfoTableBuilder ': r) Core.Node

--- a/src/Juvix/Compiler/Pipeline/Root.hs
+++ b/src/Juvix/Compiler/Pipeline/Root.hs
@@ -52,11 +52,11 @@ findRootAndChangeDir minputFileDir mbuildDir _rootInvokeDir = do
           packageBaseRootDir <- runFilesIO globalPackageBaseRoot
           (_rootRootDir, _rootPackageType) <-
             if
-                | isPathPrefix packageBaseRootDir cwd ->
-                    return (packageBaseRootDir, GlobalPackageBase)
-                | otherwise -> do
-                    r <- runFilesIO globalRoot
-                    return (r, GlobalStdlib)
+              | isPathPrefix packageBaseRootDir cwd ->
+                  return (packageBaseRootDir, GlobalPackageBase)
+              | otherwise -> do
+                  r <- runFilesIO globalRoot
+                  return (r, GlobalStdlib)
           let _rootBuildDir = getBuildDir mbuildDir
           return Root {..}
         Just pkgPath -> do

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -101,8 +101,8 @@ runPathResolverInput ::
 runPathResolverInput m = do
   entry <- ask
   if
-      | mainIsPackageFile entry -> runPackagePathResolver' (entry ^. entryPointResolverRoot) m
-      | otherwise -> runPathResolverPipe m
+    | mainIsPackageFile entry -> runPackagePathResolver' (entry ^. entryPointResolverRoot) m
+    | otherwise -> runPathResolverPipe m
 
 runIOEitherPipeline' ::
   forall a r.
@@ -160,8 +160,8 @@ evalModuleInfoCacheHelper m = do
   b <- supportsParallel
   threads <- ask >>= numThreads
   if
-      | b && threads > 1 -> DriverPar.evalModuleInfoCache m
-      | otherwise -> evalModuleInfoCache m
+    | b && threads > 1 -> DriverPar.evalModuleInfoCache m
+    | otherwise -> evalModuleInfoCache m
 
 mainIsPackageFile :: EntryPoint -> Bool
 mainIsPackageFile entry = case entry ^. entryPointModulePath of
@@ -280,26 +280,26 @@ runReplPipelineIOEither' lockMode entry = do
 
           resultScoperTable :: InfoTable
           resultScoperTable = Scoped.getCombinedInfoTable (scopedResult ^. Scoped.resultScopedModule)
-       in Right $
-            appendArtifactsModuleTable _pipelineResultImports $
-              Artifacts
-                { _artifactMainModuleScope = Just $ scopedResult ^. Scoped.resultScope,
-                  _artifactParsing = parserResult ^. P.resultParserState,
-                  _artifactInternalTypedTable = typedTable,
-                  _artifactTerminationState = typedResult ^. Typed.resultTermination,
-                  _artifactCoreModule = coreModule,
-                  _artifactScopeTable = resultScoperTable,
-                  _artifactScopeExports = scopedResult ^. Scoped.resultExports,
-                  _artifactTypes = typesTable,
-                  _artifactFunctions = functionsTable,
-                  _artifactInstances = instanceTable,
-                  _artifactCoercions = coercionTable,
-                  _artifactScoperState = scopedResult ^. Scoped.resultScoperState,
-                  _artifactResolver = art ^. artifactResolver,
-                  _artifactBuiltins = art ^. artifactBuiltins,
-                  _artifactNameIdState = art ^. artifactNameIdState,
-                  _artifactModuleTable = mempty
-                }
+       in Right
+            $ appendArtifactsModuleTable _pipelineResultImports
+            $ Artifacts
+              { _artifactMainModuleScope = Just $ scopedResult ^. Scoped.resultScope,
+                _artifactParsing = parserResult ^. P.resultParserState,
+                _artifactInternalTypedTable = typedTable,
+                _artifactTerminationState = typedResult ^. Typed.resultTermination,
+                _artifactCoreModule = coreModule,
+                _artifactScopeTable = resultScoperTable,
+                _artifactScopeExports = scopedResult ^. Scoped.resultExports,
+                _artifactTypes = typesTable,
+                _artifactFunctions = functionsTable,
+                _artifactInstances = instanceTable,
+                _artifactCoercions = coercionTable,
+                _artifactScoperState = scopedResult ^. Scoped.resultScoperState,
+                _artifactResolver = art ^. artifactResolver,
+                _artifactBuiltins = art ^. artifactBuiltins,
+                _artifactNameIdState = art ^. artifactNameIdState,
+                _artifactModuleTable = mempty
+              }
   where
     initialArtifacts :: Artifacts
     initialArtifacts =

--- a/src/Juvix/Compiler/Reg/Extra/Base.hs
+++ b/src/Juvix/Compiler/Reg/Extra/Base.hs
@@ -122,8 +122,8 @@ overValueRefs'' f = \case
     goCall InstrCall {..} = do
       ct <- goCallType _instrCallType
       args <- mapM goValue _instrCallArgs
-      return $
-        InstrCall
+      return
+        $ InstrCall
           { _instrCallType = ct,
             _instrCallArgs = args,
             ..
@@ -133,8 +133,8 @@ overValueRefs'' f = \case
     goCallClosures InstrCallClosures {..} = do
       args <- mapM goValue _instrCallClosuresArgs
       val <- f _instrCallClosuresValue
-      return $
-        InstrCallClosures
+      return
+        $ InstrCallClosures
           { _instrCallClosuresArgs = args,
             _instrCallClosuresValue = fromVarRef val,
             ..

--- a/src/Juvix/Compiler/Reg/Extra/Blocks.hs
+++ b/src/Juvix/Compiler/Reg/Extra/Blocks.hs
@@ -18,9 +18,9 @@ overSubBlocks f block = block'
       Branch x ->
         Branch $ over instrBranchTrue f $ over instrBranchFalse f x
       Case x ->
-        Case $
-          over instrCaseDefault (fmap f) $
-            over instrCaseBranches (map (over caseBranchCode f)) x
+        Case
+          $ over instrCaseDefault (fmap f)
+          $ over instrCaseBranches (map (over caseBranchCode f)) x
 
 getSubBlocks :: Block -> [Block]
 getSubBlocks block = maybe [] goFinal (block ^. blockFinal)

--- a/src/Juvix/Compiler/Reg/Extra/Info.hs
+++ b/src/Juvix/Compiler/Reg/Extra/Info.hs
@@ -36,13 +36,13 @@ computeMaxStackHeight lims = maximum . map go
         length _instrTailCallClosuresArgs
           + 1
           + lims
-            ^. limitsDispatchStackSize
+          ^. limitsDispatchStackSize
       CallClosures InstrCallClosures {..} ->
         length _instrCallClosuresLiveVars
           + length _instrCallClosuresArgs
           + 1
           + lims
-            ^. limitsDispatchStackSize
+          ^. limitsDispatchStackSize
       Return {} -> 0
       If InstrIf {..} ->
         max
@@ -165,8 +165,8 @@ computeStringMap strs = snd . run . execState (HashMap.size strs, strs) . mapM g
         modify'
           ( \(sid :: Int, sstrs) ->
               if
-                  | HashMap.member str sstrs -> (sid, sstrs)
-                  | otherwise -> (sid + 1, HashMap.insert str sid sstrs)
+                | HashMap.member str sstrs -> (sid, sstrs)
+                | otherwise -> (sid + 1, HashMap.insert str sid sstrs)
           )
       _ -> return ()
 
@@ -261,7 +261,8 @@ computeExtraInfo lims tab =
         maximum (map (^. functionArgsNum) (HashMap.elems (tab ^. infoFunctions))),
       _extraInfoMaxCallClosuresArgsNum =
         maximum1
-          ( lims ^. limitsSpecialisedApply
+          ( lims
+              ^. limitsSpecialisedApply
               :| map (computeMaxCallClosuresArgsNum . (^. functionCode)) (HashMap.elems (tab ^. infoFunctions))
           ),
       _extraInfoConstrsNum =

--- a/src/Juvix/Compiler/Reg/Interpreter.hs
+++ b/src/Juvix/Compiler/Reg/Interpreter.hs
@@ -330,8 +330,8 @@ runIO hin hout infoTable = \case
         x'' <- runFunction hout infoTable (args ++ [x']) fi
         runIO hin hout infoTable x''
       _ ->
-        throw $
-          RegError
+        throw
+          $ RegError
             { _regErrorMsg = "expected a closure",
               _regErrorLoc = Nothing
             }

--- a/src/Juvix/Compiler/Reg/Interpreter/Error.hs
+++ b/src/Juvix/Compiler/Reg/Interpreter/Error.hs
@@ -25,8 +25,8 @@ throwRunError msg loc = Exception.throw (RunError msg loc)
 
 catchRunError :: (MonadIO m) => a -> m (Either RegError a)
 catchRunError a =
-  liftIO $
-    Exception.catch
+  liftIO
+    $ Exception.catch
       (Exception.evaluate a >>= \a' -> return $ Right a')
       (\(ex :: RunError) -> return $ Left (toRegError ex))
 

--- a/src/Juvix/Compiler/Reg/Language/Instrs.hs
+++ b/src/Juvix/Compiler/Reg/Language/Instrs.hs
@@ -45,8 +45,14 @@ instance Hashable VarRef where
 
 instance Eq VarRef where
   vr1 == vr2 =
-    vr1 ^. varRefGroup == vr2 ^. varRefGroup
-      && vr1 ^. varRefIndex == vr2 ^. varRefIndex
+    vr1
+      ^. varRefGroup
+      == vr2
+      ^. varRefGroup
+      && vr1
+      ^. varRefIndex
+      == vr2
+      ^. varRefIndex
 
 deriving stock instance (Eq ConstrField)
 

--- a/src/Juvix/Compiler/Reg/Pipeline.hs
+++ b/src/Juvix/Compiler/Reg/Pipeline.hs
@@ -34,4 +34,6 @@ toCasm = mapReader fromEntryPoint . toCasm'
     toCasm' :: (Member (Reader Options) r) => InfoTable -> Sem r Blocks.InfoTable
     toCasm' =
       applyTransformations toCasmTransformations
-        >=> return . Blocks.computeLiveness . Blocks.fromReg
+        >=> return
+        . Blocks.computeLiveness
+        . Blocks.fromReg

--- a/src/Juvix/Compiler/Reg/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Reg/Pretty/Base.hs
@@ -109,36 +109,36 @@ instance PrettyCode InstrAlloc where
     res <- ppCode _instrAllocResult
     tag <- Tree.ppConstrName _instrAllocTag
     args <- mapM ppCode _instrAllocArgs
-    return $
-      res
-        <+> primitive Str.equal
-        <+> primitive Str.alloc
-        <+> tag
-        <+> arglist args
+    return
+      $ res
+      <+> primitive Str.equal
+      <+> primitive Str.alloc
+      <+> tag
+      <+> arglist args
 
 instance PrettyCode InstrAllocClosure where
   ppCode InstrAllocClosure {..} = do
     res <- ppCode _instrAllocClosureResult
     fn <- Tree.ppFunName _instrAllocClosureSymbol
     args <- mapM ppCode _instrAllocClosureArgs
-    return $
-      res
-        <+> primitive Str.equal
-        <+> primitive Str.calloc
-        <+> fn
-        <+> arglist args
+    return
+      $ res
+      <+> primitive Str.equal
+      <+> primitive Str.calloc
+      <+> fn
+      <+> arglist args
 
 instance PrettyCode InstrExtendClosure where
   ppCode InstrExtendClosure {..} = do
     res <- ppCode _instrExtendClosureResult
     fn <- ppCode _instrExtendClosureValue
     args <- mapM ppCode _instrExtendClosureArgs
-    return $
-      res
-        <+> primitive Str.equal
-        <+> primitive Str.cextend
-        <+> fn
-        <+> arglist args
+    return
+      $ res
+      <+> primitive Str.equal
+      <+> primitive Str.cextend
+      <+> fn
+      <+> arglist args
 
 instance PrettyCode CallType where
   ppCode = \case
@@ -151,22 +151,22 @@ instance PrettyCode InstrCall where
     fn <- ppCode _instrCallType
     args <- mapM ppCode _instrCallArgs
     vars <- ppLiveVars _instrCallLiveVars
-    return $
-      res
-        <+> primitive Str.equal
-        <+> primitive Str.call
-        <+> fn
-        <+> arglist args
-          <> vars
+    return
+      $ res
+      <+> primitive Str.equal
+      <+> primitive Str.call
+      <+> fn
+      <+> arglist args
+      <> vars
 
 instance PrettyCode InstrTailCall where
   ppCode InstrTailCall {..} = do
     fn <- ppCode _instrTailCallType
     args <- mapM ppCode _instrTailCallArgs
-    return $
-      primitive Str.tcall
-        <+> fn
-        <+> arglist args
+    return
+      $ primitive Str.tcall
+      <+> fn
+      <+> arglist args
 
 instance PrettyCode InstrCallClosures where
   ppCode InstrCallClosures {..} = do
@@ -174,22 +174,22 @@ instance PrettyCode InstrCallClosures where
     fn <- ppCode _instrCallClosuresValue
     args <- mapM ppCode _instrCallClosuresArgs
     vars <- ppLiveVars _instrCallClosuresLiveVars
-    return $
-      res
-        <+> primitive Str.equal
-        <+> primitive Str.ccall
-        <+> fn
-        <+> arglist args
-          <> vars
+    return
+      $ res
+      <+> primitive Str.equal
+      <+> primitive Str.ccall
+      <+> fn
+      <+> arglist args
+      <> vars
 
 instance PrettyCode InstrTailCallClosures where
   ppCode InstrTailCallClosures {..} = do
     fn <- ppCode _instrTailCallClosuresValue
     args <- mapM ppCode _instrTailCallClosuresArgs
-    return $
-      primitive Str.instrTccall
-        <+> fn
-        <+> arglist args
+    return
+      $ primitive Str.instrTccall
+      <+> fn
+      <+> arglist args
 
 instance PrettyCode InstrReturn where
   ppCode InstrReturn {..} = do
@@ -204,21 +204,23 @@ instance PrettyCode InstrIf where
     br1 <- ppCodeCode _instrIfTrue
     br2 <- ppCodeCode _instrIfFalse
     var <- ppOutVar _instrIfOutVar
-    return $
-      primitive Str.if_
-        <+> op
-        <+> arg1
-        <+> arg2
-          <> var
-        <+> braces'
-          ( constr Str.true_ <> colon
-              <+> braces' br1
-                <> semi
-                <> line
-                <> constr Str.false_
-                <> colon
-              <+> braces' br2 <> semi
-          )
+    return
+      $ primitive Str.if_
+      <+> op
+      <+> arg1
+      <+> arg2
+      <> var
+      <+> braces'
+        ( constr Str.true_
+            <> colon
+            <+> braces' br1
+            <> semi
+            <> line
+            <> constr Str.false_
+            <> colon
+            <+> braces' br2
+            <> semi
+        )
 
 instance PrettyCode InstrBranch where
   ppCode InstrBranch {..} = do
@@ -226,19 +228,21 @@ instance PrettyCode InstrBranch where
     br1 <- ppCodeCode _instrBranchTrue
     br2 <- ppCodeCode _instrBranchFalse
     var <- ppOutVar _instrBranchOutVar
-    return $
-      primitive Str.br
-        <+> val
-          <> var
-        <+> braces'
-          ( constr Str.true_ <> colon
-              <+> braces' br1
-                <> semi
-                <> line
-                <> constr Str.false_
-                <> colon
-              <+> braces' br2 <> semi
-          )
+    return
+      $ primitive Str.br
+      <+> val
+      <> var
+      <+> braces'
+        ( constr Str.true_
+            <> colon
+            <+> braces' br1
+            <> semi
+            <> line
+            <> constr Str.false_
+            <> colon
+            <+> braces' br2
+            <> semi
+        )
 
 instance PrettyCode CaseBranch where
   ppCode CaseBranch {..} = do

--- a/src/Juvix/Compiler/Reg/Transformation/Optimize/Phase/Cairo.hs
+++ b/src/Juvix/Compiler/Reg/Transformation/Optimize/Phase/Cairo.hs
@@ -7,8 +7,8 @@ import Juvix.Compiler.Reg.Transformation.Optimize.Phase.Main qualified as Main
 
 optimize :: (Member (Reader Options) r) => InfoTable -> Sem r InfoTable
 optimize =
-  withOptimizationLevel 1 $
-    Main.optimize
-      >=> return
-        . removeDeadAssignments
-        . convertBranchOnZeroToIf
+  withOptimizationLevel 1
+    $ Main.optimize
+    >=> return
+    . removeDeadAssignments
+    . convertBranchOnZeroToIf

--- a/src/Juvix/Compiler/Reg/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromSource.hs
@@ -114,8 +114,8 @@ parseBinaryOp kwd op vref = do
   kw kwd
   arg1 <- value
   arg2 <- value
-  return $
-    InstrBinop
+  return
+    $ InstrBinop
       { _instrBinopOpcode = op,
         _instrBinopResult = vref,
         _instrBinopArg1 = arg1,
@@ -140,8 +140,8 @@ parseUnaryOp ::
 parseUnaryOp kwd op vref = do
   kw kwd
   arg <- value
-  return $
-    InstrUnop
+  return
+    $ InstrUnop
       { _instrUnopOpcode = op,
         _instrUnopResult = vref,
         _instrUnopArg = arg
@@ -165,8 +165,8 @@ parseCairoOp ::
 parseCairoOp kwd op vref = do
   kw kwd
   args <- replicateM (cairoOpArgsNum op) value
-  return $
-    InstrCairo
+  return
+    $ InstrCairo
       { _instrCairoOpcode = op,
         _instrCairoResult = vref,
         _instrCairoArgs = args

--- a/src/Juvix/Compiler/Store/Extra.hs
+++ b/src/Juvix/Compiler/Store/Extra.hs
@@ -25,8 +25,8 @@ getScopedModuleTable mtab =
 
 getInternalModuleTable :: ModuleTable -> InternalModuleTable
 getInternalModuleTable mtab =
-  InternalModuleTable $
-    HashMap.fromList (map (\mi -> (mi ^. moduleInfoInternalModule . internalModuleName, mi ^. moduleInfoInternalModule)) (HashMap.elems (mtab ^. moduleTable)))
+  InternalModuleTable
+    $ HashMap.fromList (map (\mi -> (mi ^. moduleInfoInternalModule . internalModuleName, mi ^. moduleInfoInternalModule)) (HashMap.elems (mtab ^. moduleTable)))
 
 mkModuleTable :: [ModuleInfo] -> ModuleTable
 mkModuleTable = ModuleTable . hashMap . map (\mi -> (getModulePath mi, mi))

--- a/src/Juvix/Compiler/Store/Internal/Data/CoercionInfo.hs
+++ b/src/Juvix/Compiler/Store/Internal/Data/CoercionInfo.hs
@@ -37,8 +37,8 @@ makeLenses ''CoercionTable
 
 instance Semigroup CoercionTable where
   t1 <> t2 =
-    CoercionTable $
-      HashMap.unionWith combine (t1 ^. coercionTableMap) (t2 ^. coercionTableMap)
+    CoercionTable
+      $ HashMap.unionWith combine (t1 ^. coercionTableMap) (t2 ^. coercionTableMap)
     where
       combine :: [CoercionInfo] -> [CoercionInfo] -> [CoercionInfo]
       combine ii1 ii2 = nubHashable (ii1 ++ ii2)

--- a/src/Juvix/Compiler/Store/Internal/Data/InstanceInfo.hs
+++ b/src/Juvix/Compiler/Store/Internal/Data/InstanceInfo.hs
@@ -73,8 +73,8 @@ makeLenses ''InstanceTable
 
 instance Semigroup InstanceTable where
   t1 <> t2 =
-    InstanceTable $
-      HashMap.unionWith combine (t1 ^. instanceTableMap) (t2 ^. instanceTableMap)
+    InstanceTable
+      $ HashMap.unionWith combine (t1 ^. instanceTableMap) (t2 ^. instanceTableMap)
     where
       combine :: [InstanceInfo] -> [InstanceInfo] -> [InstanceInfo]
       combine ii1 ii2 = nubHashable (ii1 ++ ii2)

--- a/src/Juvix/Compiler/Store/Scoped/Language.hs
+++ b/src/Juvix/Compiler/Store/Scoped/Language.hs
@@ -52,11 +52,11 @@ exportAllNames =
     . each
     . preSymbolName
     <> exportModuleSymbols
-      . each
-      . moduleEntry
+    . each
+    . moduleEntry
     <> exportFixitySymbols
-      . each
-      . fixityEntry
+    . each
+    . fixityEntry
 
 createExportsTable :: ExportInfo -> HashSet NameId
 createExportsTable = HashSet.fromList . (^.. exportAllNames . S.nameId)

--- a/src/Juvix/Compiler/Tree/Data/InfoTableBuilder/Base.hs
+++ b/src/Juvix/Compiler/Tree/Data/InfoTableBuilder/Base.hs
@@ -56,10 +56,10 @@ builderStateFromInfoTable tab =
       _stateNextUserTag = getNextUserTag tab,
       _stateInfoTable = tab,
       _stateIdents =
-        HashMap.fromList $
-          map (\fi -> (fi ^. functionName, IdentFun (fi ^. functionSymbol))) (HashMap.elems (tab ^. infoFunctions))
-            ++ map (\ii -> (ii ^. inductiveName, IdentInd (ii ^. inductiveSymbol))) (HashMap.elems (tab ^. infoInductives))
-            ++ map (\ci -> (ci ^. constructorName, IdentConstr (ci ^. constructorTag))) (HashMap.elems (tab ^. infoConstrs))
+        HashMap.fromList
+          $ map (\fi -> (fi ^. functionName, IdentFun (fi ^. functionSymbol))) (HashMap.elems (tab ^. infoFunctions))
+          ++ map (\ii -> (ii ^. inductiveName, IdentInd (ii ^. inductiveSymbol))) (HashMap.elems (tab ^. infoInductives))
+          ++ map (\ci -> (ci ^. constructorName, IdentConstr (ci ^. constructorTag))) (HashMap.elems (tab ^. infoConstrs))
     }
 
 runInfoTableBuilderWithInfoTable :: InfoTable' t e -> Sem (InfoTableBuilder' t e ': r) b -> Sem r (InfoTable' t e, b)

--- a/src/Juvix/Compiler/Tree/Evaluator.hs
+++ b/src/Juvix/Compiler/Tree/Evaluator.hs
@@ -143,10 +143,10 @@ hEval hout tab = eval' [] mempty
               fi = lookupFunInfo tab sym
               vs' = vs0 ++ vs
            in if
-                  | length vs' == fi ^. functionArgsNum ->
-                      eval' vs' mempty (fi ^. functionCode)
-                  | otherwise ->
-                      evalError "wrong number of arguments"
+                | length vs' == fi ^. functionArgsNum ->
+                    eval' vs' mempty (fi ^. functionCode)
+                | otherwise ->
+                    evalError "wrong number of arguments"
 
         doCallClosure :: Node -> [Node] -> Value
         doCallClosure cl cargs = case eval' args temps cl of

--- a/src/Juvix/Compiler/Tree/Evaluator/Builtins.hs
+++ b/src/Juvix/Compiler/Tree/Evaluator/Builtins.hs
@@ -126,10 +126,10 @@ valueToConstant = \case
 
 evalBinop' :: BinaryOp -> Constant -> Constant -> Either ErrorMsg Constant
 evalBinop' op arg1 arg2 =
-  mapRight valueToConstant $
-    evalBinop op (constantToValue arg1) (constantToValue arg2)
+  mapRight valueToConstant
+    $ evalBinop op (constantToValue arg1) (constantToValue arg2)
 
 evalUnop' :: InfoTable' t e -> UnaryOp -> Constant -> Either ErrorMsg Constant
 evalUnop' tab op v =
-  mapRight valueToConstant $
-    evalUnop tab op (constantToValue v)
+  mapRight valueToConstant
+    $ evalUnop tab op (constantToValue v)

--- a/src/Juvix/Compiler/Tree/EvaluatorEff.hs
+++ b/src/Juvix/Compiler/Tree/EvaluatorEff.hs
@@ -156,15 +156,15 @@ eval tab = runReader emptyEvalCtx . eval'
           let fi = lookupFunInfo tab sym
               vs' = clArgs ++ vs
            in if
-                  | length vs' == fi ^. functionArgsNum -> do
-                      let ctx' =
-                            EvalCtx
-                              { _evalCtxArgs = vs',
-                                _evalCtxTemp = mempty
-                              }
-                      withCtx ctx' (eval' (fi ^. functionCode))
-                  | otherwise ->
-                      evalError "wrong number of arguments"
+                | length vs' == fi ^. functionArgsNum -> do
+                    let ctx' =
+                          EvalCtx
+                            { _evalCtxArgs = vs',
+                              _evalCtxTemp = mempty
+                            }
+                    withCtx ctx' (eval' (fi ^. functionCode))
+                | otherwise ->
+                    evalError "wrong number of arguments"
 
         doCallClosure :: Node -> [Node] -> Sem r' Value
         doCallClosure cl cargs = do

--- a/src/Juvix/Compiler/Tree/Extra/Apply.hs
+++ b/src/Juvix/Compiler/Tree/Extra/Apply.hs
@@ -25,9 +25,9 @@ addApplyBuiltins tab = (blts, bs' ^. stateInfoTable)
 
     bs' :: BuilderState
     bs' =
-      fromRight impossible $
-        parseText' bs $
-          decodeUtf8 $(FE.makeRelativeToProject "runtime/tree/apply.jvt" >>= FE.embedFile)
+      fromRight impossible
+        $ parseText' bs
+        $ decodeUtf8 $(FE.makeRelativeToProject "runtime/tree/apply.jvt" >>= FE.embedFile)
 
     blts :: ApplyBuiltins
     blts =

--- a/src/Juvix/Compiler/Tree/Extra/Info.hs
+++ b/src/Juvix/Compiler/Tree/Extra/Info.hs
@@ -7,21 +7,21 @@ import Juvix.Compiler.Tree.Language.Base
 
 userConstrs :: InfoTable' a e -> [ConstructorInfo]
 userConstrs tab =
-  filter (\ci -> not (isBuiltinTag (ci ^. constructorTag))) $
-    HashMap.elems (tab ^. infoConstrs)
+  filter (\ci -> not (isBuiltinTag (ci ^. constructorTag)))
+    $ HashMap.elems (tab ^. infoConstrs)
 
 computeUIDs :: Limits -> InfoTable' a e -> HashMap Tag Int
 computeUIDs lims tab =
-  HashMap.fromList $
-    zipWith
+  HashMap.fromList
+    $ zipWith
       (\ci uid -> (ci ^. constructorTag, uid))
       (userConstrs tab)
       [lims ^. limitsBuiltinUIDsNum ..]
 
 computeFUIDs :: InfoTable' a e -> HashMap Symbol Int
 computeFUIDs tab =
-  HashMap.fromList $
-    zipWith
+  HashMap.fromList
+    $ zipWith
       (\fi fuid -> (fi ^. functionSymbol, fuid))
       (HashMap.elems (tab ^. infoFunctions))
       [0 ..]

--- a/src/Juvix/Compiler/Tree/Extra/Type.hs
+++ b/src/Juvix/Compiler/Tree/Extra/Type.hs
@@ -57,8 +57,14 @@ isSubtype ty1 ty2 = case (ty1, ty2) of
   (TyConstr TypeConstr {..}, TyInductive TypeInductive {..}) ->
     _typeConstrInductive == _typeInductiveSymbol
   (TyConstr c1, TyConstr c2) ->
-    c1 ^. typeConstrInductive == c2 ^. typeConstrInductive
-      && c1 ^. typeConstrTag == c2 ^. typeConstrTag
+    c1
+      ^. typeConstrInductive
+      == c2
+      ^. typeConstrInductive
+      && c1
+      ^. typeConstrTag
+      == c2
+      ^. typeConstrTag
       && all (uncurry isSubtype) (zip (c1 ^. typeConstrFields) (c2 ^. typeConstrFields))
   (TyFun t1, TyFun t2) ->
     let l1 = toList (t1 ^. typeFunArgs)
@@ -119,8 +125,14 @@ unifyTypes ty1 ty2 = case (ty1, ty2) of
         return ty1
   (TyConstr {}, TyInductive {}) -> unifyTypes @t @e ty2 ty1
   (TyConstr c1, TyConstr c2)
-    | c1 ^. typeConstrInductive == c2 ^. typeConstrInductive
-        && c1 ^. typeConstrTag == c2 ^. typeConstrTag -> do
+    | c1
+        ^. typeConstrInductive
+        == c2
+        ^. typeConstrInductive
+        && c1
+        ^. typeConstrTag
+        == c2
+        ^. typeConstrTag -> do
         flds <- zipWithM (unifyTypes @t @e) (c1 ^. typeConstrFields) (c2 ^. typeConstrFields)
         return $ TyConstr (set typeConstrFields flds c1)
   (TyConstr c1, TyConstr c2)
@@ -175,15 +187,16 @@ unifyTypes ty1 ty2 = case (ty1, ty2) of
 
 unifyTypes' :: forall t e r. (Member (Error TreeError) r) => Maybe Location -> InfoTable' t e -> Type -> Type -> Sem r Type
 unifyTypes' loc tab ty1 ty2 =
-  runReader loc $
-    runReader tab $
-      -- The `if` is to ensure correct behaviour with dynamic type targets. E.g.
-      -- `(A, B) -> *` should unify with `A -> B -> C -> D`.
-      if
-          | tgt1 == TyDynamic || tgt2 == TyDynamic ->
-              unifyTypes @t @e (curryType ty1) (curryType ty2)
-          | otherwise ->
-              unifyTypes @t @e ty1 ty2
+  runReader loc
+    $ runReader tab
+    $
+    -- The `if` is to ensure correct behaviour with dynamic type targets. E.g.
+    -- `(A, B) -> *` should unify with `A -> B -> C -> D`.
+    if
+      | tgt1 == TyDynamic || tgt2 == TyDynamic ->
+          unifyTypes @t @e (curryType ty1) (curryType ty2)
+      | otherwise ->
+          unifyTypes @t @e ty1 ty2
   where
     tgt1 = typeTarget (uncurryType ty1)
     tgt2 = typeTarget (uncurryType ty2)

--- a/src/Juvix/Compiler/Tree/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Tree/Pretty/Base.hs
@@ -54,9 +54,9 @@ ppFunName :: (Member (Reader Options) r) => Symbol -> Sem r (Doc Ann)
 ppFunName sym = do
   symNames <- asks (^. optSymbolNames)
   maybe
-    ( return $
-        annotate (AnnKind KNameFunction) $
-          pretty ("unnamed_function_" ++ show sym :: String)
+    ( return
+        $ annotate (AnnKind KNameFunction)
+        $ pretty ("unnamed_function_" ++ show sym :: String)
     )
     (return . annotate (AnnKind KNameFunction) . pretty . quoteFunName . quoteName)
     (HashMap.lookup sym symNames)
@@ -124,11 +124,11 @@ instance PrettyCode TypeFun where
   ppCode TypeFun {..} = do
     l <-
       if
-          | null (NonEmpty.tail _typeFunArgs) ->
-              ppLeftExpression funFixity (head _typeFunArgs)
-          | otherwise -> do
-              args <- mapM ppCode _typeFunArgs
-              return $ parens $ hsep $ punctuate comma (toList args)
+        | null (NonEmpty.tail _typeFunArgs) ->
+            ppLeftExpression funFixity (head _typeFunArgs)
+        | otherwise -> do
+            args <- mapM ppCode _typeFunArgs
+            return $ parens $ hsep $ punctuate comma (toList args)
     r <- ppRightExpression funFixity _typeFunTarget
     return $ l <+> kwArrow <+> r
 
@@ -330,10 +330,10 @@ instance PrettyCode NodeBranch where
     br2 <- ppCode _nodeBranchFalse
     let true_ = annotate (AnnKind KNameConstructor) Str.true_
         false_ = annotate (AnnKind KNameConstructor) Str.false_
-    return $
-      primitive Str.instrBr
-        <> parens arg
-        <+> braces' (true_ <> colon <+> br1 <> line <> false_ <> colon <+> br2)
+    return
+      $ primitive Str.instrBr
+      <> parens arg
+      <+> braces' (true_ <> colon <+> br1 <> line <> false_ <> colon <+> br2)
 
 instance PrettyCode CaseBranch where
   ppCode :: (Member (Reader Options) r) => CaseBranch -> Sem r (Doc Ann)
@@ -397,25 +397,25 @@ ppFunInfo ppCode' FunctionInfo {..} = do
       args = zipWithExact (\mn ty -> maybe mempty (\n -> n <+> colon <> space) mn <> ty) argnames argtys
   targetty <- ppCode (if _functionArgsNum == 0 then _functionType else typeTarget _functionType)
   c <- ppCode' _functionCode
-  return $
-    keyword Str.function
-      <+> annotate (AnnKind KNameFunction) (pretty (quoteFunName $ quoteName _functionName))
-        <> parens (hsep (punctuate comma args))
-      <+> colon
-      <+> targetty
-      <+> braces' c
+  return
+    $ keyword Str.function
+    <+> annotate (AnnKind KNameFunction) (pretty (quoteFunName $ quoteName _functionName))
+    <> parens (hsep (punctuate comma args))
+    <+> colon
+    <+> targetty
+    <+> braces' c
 
 ppFunSig :: (Member (Reader Options) r) => FunctionInfo' t e -> Sem r (Doc Ann)
 ppFunSig FunctionInfo {..} = do
   argtys <- mapM ppCode (typeArgs _functionType)
   targetty <- ppCode (typeTarget _functionType)
-  return $
-    keyword Str.function
-      <+> annotate (AnnKind KNameFunction) (pretty (quoteFunName $ quoteName _functionName))
-        <> parens (hsep (punctuate comma argtys))
-      <+> colon
-      <+> targetty
-        <> semi
+  return
+    $ keyword Str.function
+    <+> annotate (AnnKind KNameFunction) (pretty (quoteFunName $ quoteName _functionName))
+    <> parens (hsep (punctuate comma argtys))
+    <+> colon
+    <+> targetty
+    <> semi
 
 instance PrettyCode ConstructorInfo where
   ppCode ConstructorInfo {..} = do

--- a/src/Juvix/Compiler/Tree/Transformation/Generic/Base.hs
+++ b/src/Juvix/Compiler/Tree/Transformation/Generic/Base.hs
@@ -29,11 +29,11 @@ mapT f = over infoFunctions (HashMap.mapWithKey (over functionCode . f))
 
 mapT' :: forall a e r. (Symbol -> a -> Sem (InfoTableBuilder' a e ': r) a) -> InfoTable' a e -> Sem r (InfoTable' a e)
 mapT' f tab =
-  fmap fst $
-    runInfoTableBuilderWithInfoTable tab $
-      mapM_
-        (\(sym, fi) -> overM functionCode (f sym) fi >>= registerFunction' @a @e)
-        (HashMap.toList (tab ^. infoFunctions))
+  fmap fst
+    $ runInfoTableBuilderWithInfoTable tab
+    $ mapM_
+      (\(sym, fi) -> overM functionCode (f sym) fi >>= registerFunction' @a @e)
+      (HashMap.toList (tab ^. infoFunctions))
 
 walkT :: (Applicative f) => (Symbol -> a -> f ()) -> InfoTable' a e -> f ()
 walkT f tab = for_ (HashMap.toList (tab ^. infoFunctions)) (\(k, v) -> f k (v ^. functionCode))
@@ -42,8 +42,8 @@ withOptimizationLevel :: (Member (Reader Options) r) => Int -> (InfoTable' a e -
 withOptimizationLevel n f tab = do
   l <- asks (^. optOptimizationLevel)
   if
-      | l >= n -> f tab
-      | otherwise -> return tab
+    | l >= n -> f tab
+    | otherwise -> return tab
 
 withOptimizationLevel' :: (Member (Reader Options) r) => InfoTable' a e -> Int -> (InfoTable' a e -> Sem r (InfoTable' a e)) -> Sem r (InfoTable' a e)
 withOptimizationLevel' tab n f = withOptimizationLevel n f tab

--- a/src/Juvix/Compiler/Tree/Transformation/TempHeight.hs
+++ b/src/Juvix/Compiler/Tree/Transformation/TempHeight.hs
@@ -14,8 +14,8 @@ computeFunctionTempHeight = umapN go
          in MemRef $ NodeMemRef i $ DRef (TempRef r')
       MemRef (NodeMemRef i (ConstrRef field@Field {_fieldRef = TempRef r})) ->
         let r' = set refTempTempHeight (Just k) r
-         in MemRef $
-              NodeMemRef
+         in MemRef
+              $ NodeMemRef
                 i
                 ( ConstrRef
                     field

--- a/src/Juvix/Compiler/Tree/Transformation/Validate.hs
+++ b/src/Juvix/Compiler/Tree/Transformation/Validate.hs
@@ -117,8 +117,8 @@ inferType tab funInfo = goInfer mempty
       | _offsetRefOffset < length tys = return $ tys !! _offsetRefOffset
       | typeTarget (funInfo ^. functionType) == TyDynamic = return TyDynamic
       | otherwise =
-          throw $
-            TreeError
+          throw
+            $ TreeError
               { _treeErrorLoc = loc,
                 _treeErrorMsg = "Wrong target type"
               }
@@ -142,8 +142,8 @@ inferType tab funInfo = goInfer mempty
           forM_ (zipExact _nodeAllocConstrArgs tys) (uncurry (checkType bl))
           return $ typeTarget (ci ^. constructorType)
       | otherwise =
-          throw $
-            TreeError
+          throw
+            $ TreeError
               { _treeErrorLoc = _nodeAllocConstrInfo ^. nodeInfoLocation,
                 _treeErrorMsg = ""
               }
@@ -157,8 +157,8 @@ inferType tab funInfo = goInfer mempty
           forM_ (zipExact _nodeAllocClosureArgs (take n tys)) (uncurry (checkType bl))
           return $ mkTypeFun (drop n tys) (typeTarget (fi ^. functionType))
       | otherwise =
-          throw $
-            TreeError
+          throw
+            $ TreeError
               { _treeErrorLoc = _nodeAllocClosureInfo ^. nodeInfoLocation,
                 _treeErrorMsg = "Wrong number of arguments"
               }
@@ -174,30 +174,30 @@ inferType tab funInfo = goInfer mempty
           m = length tys
           n = length _nodeExtendClosureArgs
       if
-          | n < m -> do
-              forM_ (zipExact (toList _nodeExtendClosureArgs) (take n tys)) (uncurry (checkType bl))
-              return $ mkTypeFun (drop n tys) (typeTarget ty)
-          | typeTarget ty == TyDynamic -> do
-              let tys' = tys ++ replicate (n - m) TyDynamic
-              forM_ (zipExact (toList _nodeExtendClosureArgs) tys') (uncurry (checkType bl))
-              return $ typeTarget ty
-          | otherwise ->
-              throw $
-                TreeError
-                  { _treeErrorLoc = _nodeExtendClosureInfo ^. nodeInfoLocation,
-                    _treeErrorMsg = "Too many arguments"
-                  }
+        | n < m -> do
+            forM_ (zipExact (toList _nodeExtendClosureArgs) (take n tys)) (uncurry (checkType bl))
+            return $ mkTypeFun (drop n tys) (typeTarget ty)
+        | typeTarget ty == TyDynamic -> do
+            let tys' = tys ++ replicate (n - m) TyDynamic
+            forM_ (zipExact (toList _nodeExtendClosureArgs) tys') (uncurry (checkType bl))
+            return $ typeTarget ty
+        | otherwise ->
+            throw
+              $ TreeError
+                { _treeErrorLoc = _nodeExtendClosureInfo ^. nodeInfoLocation,
+                  _treeErrorMsg = "Too many arguments"
+                }
 
     goCall :: BinderList Type -> NodeCall -> Sem r Type
     goCall bl NodeCall {..} = case _nodeCallType of
       CallFun sym
         | n == fi ^. functionArgsNum -> do
-            unless (n == 0) $
-              forM_ (zipExact _nodeCallArgs tys) (uncurry (checkType bl))
+            unless (n == 0)
+              $ forM_ (zipExact _nodeCallArgs tys) (uncurry (checkType bl))
             return $ mkTypeFun (drop n tys) (typeTarget (fi ^. functionType))
         | otherwise ->
-            throw $
-              TreeError
+            throw
+              $ TreeError
                 { _treeErrorLoc = _nodeCallInfo ^. nodeInfoLocation,
                   _treeErrorMsg = "Wrong number of arguments"
                 }
@@ -209,18 +209,18 @@ inferType tab funInfo = goInfer mempty
         ty <- goInfer bl cl
         let tys = typeArgs ty
             n = length _nodeCallArgs
-        when (length tys > n) $
-          throw $
-            TreeError
-              { _treeErrorLoc = _nodeCallInfo ^. nodeInfoLocation,
-                _treeErrorMsg = "Too few arguments"
-              }
-        when (length tys < n && typeTarget ty /= TyDynamic) $
-          throw $
-            TreeError
-              { _treeErrorLoc = _nodeCallInfo ^. nodeInfoLocation,
-                _treeErrorMsg = "Too many arguments"
-              }
+        when (length tys > n)
+          $ throw
+          $ TreeError
+            { _treeErrorLoc = _nodeCallInfo ^. nodeInfoLocation,
+              _treeErrorMsg = "Too few arguments"
+            }
+        when (length tys < n && typeTarget ty /= TyDynamic)
+          $ throw
+          $ TreeError
+            { _treeErrorLoc = _nodeCallInfo ^. nodeInfoLocation,
+              _treeErrorMsg = "Too many arguments"
+            }
         let tys' = tys ++ replicate (n - length tys) TyDynamic
         forM_ (zipExact _nodeCallArgs tys') (uncurry (checkType bl))
         return $ typeTarget ty
@@ -255,12 +255,12 @@ inferType tab funInfo = goInfer mempty
     goCase :: BinderList Type -> NodeCase -> Sem r Type
     goCase bl NodeCase {..} = do
       ity <- goInfer bl _nodeCaseArg
-      unless (ity == mkTypeInductive _nodeCaseInductive || ity == TyDynamic) $
-        throw $
-          TreeError
-            { _treeErrorLoc = _nodeCaseInfo ^. nodeInfoLocation,
-              _treeErrorMsg = "Inductive type mismatch"
-            }
+      unless (ity == mkTypeInductive _nodeCaseInductive || ity == TyDynamic)
+        $ throw
+        $ TreeError
+          { _treeErrorLoc = _nodeCaseInfo ^. nodeInfoLocation,
+            _treeErrorMsg = "Inductive type mismatch"
+          }
       ty <- maybe (return TyDynamic) (goInfer bl) _nodeCaseDefault
       go ity ty _nodeCaseBranches
       where

--- a/src/Juvix/Compiler/Tree/Translation/FromAsm/Translator.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromAsm/Translator.hs
@@ -23,8 +23,8 @@ runTranslator cs = runTranslator' (TranslatorState cs Nothing)
 runTranslator' :: forall r a. (Member (Error TreeError) r) => TranslatorState -> Sem (Translator ': r) a -> Sem r a
 runTranslator' st m = do
   (st', a) <- reinterpret (runState st) interp m
-  unless (null (st' ^. stateCode)) $
-    throw
+  unless (null (st' ^. stateCode))
+    $ throw
       TreeError
         { _treeErrorLoc = getCommandLocation $ head' (st' ^. stateCode),
           _treeErrorMsg = "extra instructions"
@@ -35,8 +35,8 @@ runTranslator' st m = do
     interp = \case
       NextCommand -> do
         s <- get
-        when (null (s ^. stateCode)) $
-          throw
+        when (null (s ^. stateCode))
+          $ throw
             TreeError
               { _treeErrorLoc = s ^. statePrevLoc,
                 _treeErrorMsg = "expected instruction"

--- a/src/Juvix/Compiler/Tree/Translation/FromCore.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromCore.hs
@@ -26,12 +26,13 @@ genCode :: Core.InfoTable -> Core.FunctionInfo -> FunctionInfo
 genCode infoTable fi =
   let argnames = map (Just . (^. Core.argumentName)) (fi ^. Core.functionArgsInfo)
       bl =
-        BL.fromList . reverse $
-          ( zipWithExact
-              (\x y -> DRef $ ArgRef $ OffsetRef x y)
-              [0 .. fi ^. Core.functionArgsNum - 1]
-              argnames
-          )
+        BL.fromList
+          . reverse
+          $ ( zipWithExact
+                (\x y -> DRef $ ArgRef $ OffsetRef x y)
+                [0 .. fi ^. Core.functionArgsNum - 1]
+                argnames
+            )
       code = go 0 bl (fi ^. Core.functionBody)
    in FunctionInfo
         { _functionName = fi ^. Core.functionName,
@@ -63,15 +64,15 @@ genCode infoTable fi =
     goIdent :: Core.Ident -> Node
     goIdent Core.Ident {..}
       | getArgsNum _identSymbol == 0 =
-          Call $
-            NodeCall
+          Call
+            $ NodeCall
               { _nodeCallInfo = mempty,
                 _nodeCallType = CallFun _identSymbol,
                 _nodeCallArgs = []
               }
       | otherwise =
-          AllocClosure $
-            NodeAllocClosure
+          AllocClosure
+            $ NodeAllocClosure
               { _nodeAllocClosureInfo = mempty,
                 _nodeAllocClosureFunSymbol = _identSymbol,
                 _nodeAllocClosureArgs = []
@@ -94,43 +95,43 @@ genCode infoTable fi =
        in case _appsFun of
             Core.FunIdent Core.Ident {..} ->
               if
-                  | argsNum > suppliedArgsNum ->
-                      AllocClosure $
-                        NodeAllocClosure
-                          { _nodeAllocClosureInfo = mempty,
-                            _nodeAllocClosureFunSymbol = _identSymbol,
-                            _nodeAllocClosureArgs = suppliedArgs
-                          }
-                  | argsNum == suppliedArgsNum ->
-                      Call $
-                        NodeCall
-                          { _nodeCallInfo = mempty,
-                            _nodeCallType = CallFun _identSymbol,
-                            _nodeCallArgs = suppliedArgs
-                          }
-                  | otherwise ->
-                      -- If more arguments are supplied (suppliedArgsNum) than
-                      -- the function eats up (argsNum), then the function
-                      -- returns a closure. We should first call the function
-                      -- (with Call) and then use CallClosures on the result
-                      -- with the remaining arguments.
-                      CallClosures $
-                        NodeCallClosures
-                          { _nodeCallClosuresInfo = mempty,
-                            _nodeCallClosuresFun =
-                              Call $
-                                NodeCall
-                                  { _nodeCallInfo = mempty,
-                                    _nodeCallType = CallFun _identSymbol,
-                                    _nodeCallArgs = take argsNum suppliedArgs
-                                  },
-                            _nodeCallClosuresArgs = nonEmpty' $ drop argsNum suppliedArgs
-                          }
+                | argsNum > suppliedArgsNum ->
+                    AllocClosure
+                      $ NodeAllocClosure
+                        { _nodeAllocClosureInfo = mempty,
+                          _nodeAllocClosureFunSymbol = _identSymbol,
+                          _nodeAllocClosureArgs = suppliedArgs
+                        }
+                | argsNum == suppliedArgsNum ->
+                    Call
+                      $ NodeCall
+                        { _nodeCallInfo = mempty,
+                          _nodeCallType = CallFun _identSymbol,
+                          _nodeCallArgs = suppliedArgs
+                        }
+                | otherwise ->
+                    -- If more arguments are supplied (suppliedArgsNum) than
+                    -- the function eats up (argsNum), then the function
+                    -- returns a closure. We should first call the function
+                    -- (with Call) and then use CallClosures on the result
+                    -- with the remaining arguments.
+                    CallClosures
+                      $ NodeCallClosures
+                        { _nodeCallClosuresInfo = mempty,
+                          _nodeCallClosuresFun =
+                            Call
+                              $ NodeCall
+                                { _nodeCallInfo = mempty,
+                                  _nodeCallType = CallFun _identSymbol,
+                                  _nodeCallArgs = take argsNum suppliedArgs
+                                },
+                          _nodeCallClosuresArgs = nonEmpty' $ drop argsNum suppliedArgs
+                        }
               where
                 argsNum = getArgsNum _identSymbol
             Core.FunVar Core.Var {..} ->
-              CallClosures $
-                NodeCallClosures
+              CallClosures
+                $ NodeCallClosures
                   { _nodeCallClosuresInfo = mempty,
                     _nodeCallClosuresFun = mkMemRef $ BL.lookup _varIndex refs,
                     _nodeCallClosuresArgs = suppliedArgs'
@@ -139,15 +140,15 @@ genCode infoTable fi =
     goBuiltinApp :: Int -> BinderList MemRef -> Core.BuiltinApp -> Node
     goBuiltinApp tempSize refs Core.BuiltinApp {..}
       | Core.builtinIsCairo _builtinAppOp =
-          Cairo $
-            NodeCairo
+          Cairo
+            $ NodeCairo
               { _nodeCairoInfo = mempty,
                 _nodeCairoOpcode = genCairoOp _builtinAppOp,
                 _nodeCairoArgs = args
               }
       | Core.builtinIsAnoma _builtinAppOp =
-          Anoma $
-            NodeAnoma
+          Anoma
+            $ NodeAnoma
               { _nodeAnomaInfo = mempty,
                 _nodeAnomaOpcode = genAnomaOp _builtinAppOp,
                 _nodeAnomaArgs = args
@@ -155,15 +156,15 @@ genCode infoTable fi =
       | otherwise =
           case args of
             [arg] ->
-              Unop $
-                NodeUnop
+              Unop
+                $ NodeUnop
                   { _nodeUnopInfo = mempty,
                     _nodeUnopOpcode = genUnOp _builtinAppOp,
                     _nodeUnopArg = arg
                   }
             [arg1, arg2] ->
-              Binop $
-                NodeBinop
+              Binop
+                $ NodeBinop
                   { _nodeBinopInfo = mempty,
                     _nodeBinopOpcode = genBinOp _builtinAppOp,
                     _nodeBinopArg1 = arg1,
@@ -180,8 +181,8 @@ genCode infoTable fi =
       Core.Constr _ (Core.BuiltinTag Core.TagFalse) _ ->
         mkConst (ConstBool False)
       Core.Constr {..} ->
-        AllocConstr $
-          NodeAllocConstr
+        AllocConstr
+          $ NodeAllocConstr
             { _nodeAllocConstrInfo = mempty,
               _nodeAllocConstrTag = _constrTag,
               _nodeAllocConstrArgs = args
@@ -191,8 +192,8 @@ genCode infoTable fi =
 
     goLet :: Int -> BinderList MemRef -> Core.Let -> Node
     goLet tempSize refs (Core.Let {..}) =
-      Save $
-        NodeSave
+      Save
+        $ NodeSave
           { _nodeSaveInfo = mempty,
             _nodeSaveArg = arg,
             _nodeSaveBody = body,
@@ -207,8 +208,8 @@ genCode infoTable fi =
 
     goCase :: Int -> BinderList MemRef -> Core.Case -> Node
     goCase tempSize refs Core.Case {..} =
-      Case $
-        NodeCase
+      Case
+        $ NodeCase
           { _nodeCaseInfo = mempty,
             _nodeCaseArg = go tempSize refs _caseValue,
             _nodeCaseInductive = _caseInductive,
@@ -221,10 +222,10 @@ genCode infoTable fi =
           map
             ( \Core.CaseBranch {..} ->
                 if
-                    | _caseBranchBindersNum == 0 ->
-                        compileCaseBranchNoBinders _caseBranchTag _caseBranchBody
-                    | otherwise ->
-                        compileCaseBranch _caseBranchBindersNum _caseBranchTag _caseBranchBody
+                  | _caseBranchBindersNum == 0 ->
+                      compileCaseBranchNoBinders _caseBranchTag _caseBranchBody
+                  | otherwise ->
+                      compileCaseBranch _caseBranchBindersNum _caseBranchTag _caseBranchBody
             )
             branches
 
@@ -255,8 +256,8 @@ genCode infoTable fi =
           where
             mkFieldRef :: Offset -> MemRef
             mkFieldRef off =
-              ConstrRef $
-                Field
+              ConstrRef
+                $ Field
                   { _fieldName = Nothing,
                     _fieldTag = tag,
                     _fieldRef = mkTempRef (OffsetRef tempSize Nothing),
@@ -268,8 +269,8 @@ genCode infoTable fi =
 
     goIf :: Int -> BinderList MemRef -> Core.If -> Node
     goIf tempSize refs Core.If {..} =
-      Branch $
-        NodeBranch
+      Branch
+        $ NodeBranch
           { _nodeBranchInfo = mempty,
             _nodeBranchArg = go tempSize refs _ifValue,
             _nodeBranchTrue = go tempSize refs _ifTrue,

--- a/src/Juvix/Compiler/Tree/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource/Base.hs
@@ -96,8 +96,8 @@ declareBuiltins = do
           createBuiltinConstr sym TagWrite "write" (mkTypeFun [TyDynamic] tyio) i,
           createBuiltinConstr sym TagReadLn "readLn" tyio i
         ]
-  lift $
-    registerInductive' @t @e
+  lift
+    $ registerInductive' @t @e
       ( InductiveInfo
           { _inductiveName = "IO",
             _inductiveSymbol = sym,
@@ -137,8 +137,8 @@ statementFunction = do
     Nothing -> lift $ freshSymbol' @t @e
     Just (IdentFwd sym) -> return sym
     _ -> parseFailure off ("duplicate identifier: " ++ fromText txt)
-  when (txt == "main") $
-    lift (registerMain' @t @e sym)
+  when (txt == "main")
+    $ lift (registerMain' @t @e sym)
   args <- functionArguments @t @e @d
   let argtys = map snd args
       argnames = map fst args
@@ -163,19 +163,22 @@ statementFunction = do
   let fi = fi0 {_functionCode = fromMaybe ec mcode}
   case idt of
     Just (IdentFwd _) -> do
-      when (isNothing mcode) $
-        parseFailure off ("duplicate forward declaration of " ++ fromText txt)
+      when (isNothing mcode)
+        $ parseFailure off ("duplicate forward declaration of " ++ fromText txt)
       fi' <- lift $ getFunctionInfo' @t @e sym
       unless
-        ( fi' ^. functionArgsNum == fi ^. functionArgsNum
+        ( fi'
+            ^. functionArgsNum
+            == fi
+            ^. functionArgsNum
             && isSubtype (fi' ^. functionType) (fi ^. functionType)
         )
         $ parseFailure off "function definition does not match earlier declaration"
       lift $ registerFunction' fi
     _ -> do
       lift $ registerFunction' fi
-      when (isNothing mcode) $
-        lift (registerForward' @t @e txt sym)
+      when (isNothing mcode)
+        $ lift (registerForward' @t @e txt sym)
 
 statementInductive ::
   forall t e d r.
@@ -186,8 +189,8 @@ statementInductive = do
   off <- P.getOffset
   (txt, i) <- identifierL @t @e @d
   idt <- lift $ getIdent' @t @e txt
-  when (isJust idt) $
-    parseFailure off ("duplicate identifier: " ++ fromText txt)
+  when (isJust idt)
+    $ parseFailure off ("duplicate identifier: " ++ fromText txt)
   sym <- lift $ freshSymbol' @t @e
   let ii =
         InductiveInfo
@@ -221,8 +224,8 @@ constrDecl symInd = do
   off <- P.getOffset
   (txt, i) <- identifierL @t @e @d
   idt <- lift $ getIdent' @t @e txt
-  when (isJust idt) $
-    parseFailure off ("duplicate identifier: " ++ fromText txt)
+  when (isJust idt)
+    $ parseFailure off ("duplicate identifier: " ++ fromText txt)
   tag <- lift $ freshTag' @t @e
   ty <- typeAnnotation @t @e @d
   let ty' = uncurryType ty
@@ -271,8 +274,8 @@ parseType = do
   off <- P.getOffset
   typeFun' @t @e @d tys
     <|> do
-      unless (null (NonEmpty.tail tys)) $
-        parseFailure off "expected \"->\""
+      unless (null (NonEmpty.tail tys))
+        $ parseFailure off "expected \"->\""
       return (head tys)
 
 typeFun' ::

--- a/src/Juvix/Data/DependencyInfo.hs
+++ b/src/Juvix/Data/DependencyInfo.hs
@@ -42,9 +42,9 @@ createDependencyInfo edges startNames =
     edgeList = map (\(x, y) -> (x, x, HashSet.toList y)) (HashMap.toList edges)
     reachableNames :: HashSet n
     reachableNames =
-      HashSet.fromList $
-        map (\v -> case nodeFromVertex v of (_, x, _) -> x) $
-          concatMap (Graph.reachable graph) startVertices
+      HashSet.fromList
+        $ map (\v -> case nodeFromVertex v of (_, x, _) -> x)
+        $ concatMap (Graph.reachable graph) startVertices
     startVertices :: [Vertex]
     startVertices = mapMaybe vertexFromName (HashSet.toList startNames)
     topSortedNames :: [n]

--- a/src/Juvix/Data/Effect/Files.hs
+++ b/src/Juvix/Data/Effect/Files.hs
@@ -47,8 +47,8 @@ walkDirRel ::
 walkDirRel handler topdir = do
   let walkAvoidLoop :: Path Rel Dir -> Sem (State (HashSet Uid) ': r) ()
       walkAvoidLoop curdir =
-        unlessM (checkLoop (topdir <//> curdir)) $
-          walktree curdir
+        unlessM (checkLoop (topdir <//> curdir))
+          $ walktree curdir
       walktree :: Path Rel Dir -> Sem (State (HashSet Uid) ': r) ()
       walktree curdir = do
         let fullDir :: Path Abs Dir = topdir <//> curdir
@@ -76,8 +76,8 @@ walkDirRel handler topdir = do
         visited <- get
         ufid <- pathUid dir
         if
-            | HashSet.member ufid visited -> return True
-            | otherwise -> modify' (HashSet.insert ufid) $> False
+          | HashSet.member ufid visited -> return True
+          | otherwise -> modify' (HashSet.insert ufid) $> False
   evalState mempty (walkAvoidLoop $(mkRelDir "."))
 
 -- | Find all files relative to a root directory

--- a/src/Juvix/Data/Effect/Files/Pure.hs
+++ b/src/Juvix/Data/Effect/Files/Pure.hs
@@ -115,13 +115,13 @@ juvixConfigDirPure = $(mkAbsDir "/.config/juvix/") <//> versionDir
 missingErr :: (Members '[State FS] r) => FilePath -> Sem r a
 missingErr f = do
   root <- get @FS
-  error $
-    pack $
-      "file "
-        <> f
-        <> " does not exist."
-        <> "\nThe contents of the mocked file system are:\n"
-        <> Prelude.show root
+  error
+    $ pack
+    $ "file "
+    <> f
+    <> " does not exist."
+    <> "\nThe contents of the mocked file system are:\n"
+    <> Prelude.show root
 
 checkRoot :: (Members '[State FS] r) => Path Abs Dir -> Sem r ()
 checkRoot r = do

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -41,8 +41,8 @@ genericErrorHeader g =
   pretty (g ^. genericErrorLoc)
     <> colon
     <+> "error"
-      <> colon
-      <> line
+    <> colon
+    <> line
 
 class ToGenericError a where
   genericError :: (Member (Reader GenericOptions) r) => a -> Sem r GenericError
@@ -62,8 +62,8 @@ render ansi endChar err = do
       header = genericErrorHeader g
       helper f x = (f . layoutPretty defaultLayoutOptions) (header <> x <> lastChar)
   if
-      | ansi -> return $ helper Ansi.renderStrict (toAnsiDoc gMsg)
-      | otherwise -> return $ helper renderStrict (toTextDoc gMsg)
+    | ansi -> return $ helper Ansi.renderStrict (toAnsiDoc gMsg)
+    | otherwise -> return $ helper renderStrict (toTextDoc gMsg)
   where
     lastChar :: Doc a
     lastChar

--- a/src/Juvix/Data/FixityInfo.hs
+++ b/src/Juvix/Data/FixityInfo.hs
@@ -37,8 +37,8 @@ instance FromJSON FixityInfo where
         _fixityPrecSame <- keyMay "same" asText
         _fixityPrecBelow <- fromMaybe [] <$> keyMay "below" (eachInArray asText)
         _fixityPrecAbove <- fromMaybe [] <$> keyMay "above" (eachInArray asText)
-        when (isJust _fixityPrecSame && not (null _fixityPrecBelow && null _fixityPrecAbove)) $
-          throwCustomError "'same' cannot be provided together with 'above' or 'below'"
+        when (isJust _fixityPrecSame && not (null _fixityPrecBelow && null _fixityPrecAbove))
+          $ throwCustomError "'same' cannot be provided together with 'above' or 'below'"
         return FixityInfo {..}
 
       parseArity :: Parse YamlError Arity

--- a/src/Juvix/Data/Pragmas.hs
+++ b/src/Juvix/Data/Pragmas.hs
@@ -244,8 +244,8 @@ instance FromJSON Pragmas where
       checkArgName :: Text -> Parse YamlError ()
       checkArgName name = do
         let name' = unpack name
-        unless (isFirstLetter name' && all isValidIdentChar name') $
-          throwCustomError ("invalid argument name: " <> name)
+        unless (isFirstLetter name' && all isValidIdentChar name')
+          $ throwCustomError ("invalid argument name: " <> name)
 
 -- | The Semigroup `<>` is used to propagate pragmas from an enclosing context.
 -- For example, if `p1` are the pragmas declared for a module `M`, and `p2` the
@@ -294,8 +294,8 @@ adjustPragmaSpecialiseArg n = \case
 
 adjustPragmas :: Int -> Pragmas -> Pragmas
 adjustPragmas fvnum pragmas =
-  over pragmasInline (fmap (adjustPragmaInline fvnum)) $
-    over
+  over pragmasInline (fmap (adjustPragmaInline fvnum))
+    $ over
       pragmasSpecialiseArgs
       (fmap (over pragmaSpecialiseArgs (map (adjustPragmaSpecialiseArg fvnum))))
       pragmas

--- a/src/Juvix/Data/Uid.hs
+++ b/src/Juvix/Data/Uid.hs
@@ -4,7 +4,8 @@ import Data.Type.Equality
 import Juvix.Prelude.Base
 import Type.Reflection qualified as R
 
-data Uid = forall a.
+data Uid
+  = forall a.
   (Typeable a, Hashable a, Eq a) =>
   Uid
   { _fileUid :: a

--- a/src/Juvix/Data/Yaml.hs
+++ b/src/Juvix/Data/Yaml.hs
@@ -20,8 +20,8 @@ checkYamlKeys :: [Text] -> Parse YamlError ()
 checkYamlKeys keys = do
   forEachInObject
     ( \k ->
-        unless (k `elem` keys) $
-          throwCustomError ("unknown key: " <> k)
+        unless (k `elem` keys)
+          $ throwCustomError ("unknown key: " <> k)
     )
   return ()
 

--- a/src/Juvix/Extra/Assets.hs
+++ b/src/Juvix/Extra/Assets.hs
@@ -14,8 +14,8 @@ data AssetKind
   | Images
 
 assetsDirByKind :: AssetKind -> [(Path Rel File, ByteString)]
-assetsDirByKind k = map (first relFile) $
-  case k of
+assetsDirByKind k = map (first relFile)
+  $ case k of
     Css -> $(cssDirQ)
     Js -> $(jsDirQ)
     Images -> $(imagesDirQ)

--- a/src/Juvix/Extra/Serialize.hs
+++ b/src/Juvix/Extra/Serialize.hs
@@ -46,8 +46,8 @@ loadFromFile :: forall a r. (Members '[Files, TaggedLock] r, Serialize a) => Pat
 loadFromFile file = withTaggedLockDir (parent file) $ do
   ex <- fileExists' file
   if
-      | ex -> deserialize <$> readFileBS' file
-      | otherwise -> return Nothing
+    | ex -> deserialize <$> readFileBS' file
+    | otherwise -> return Nothing
   where
     deserialize :: ByteString -> Maybe a
     deserialize bs = case runGet (Serial.get @a) bs of

--- a/src/Juvix/Extra/Stdlib.hs
+++ b/src/Juvix/Extra/Stdlib.hs
@@ -24,10 +24,10 @@ packageStdlib rootDir buildDir = firstJustM isStdLib
         adir <- canonicalDir rootDir (dep ^. pathDependencyPath)
         normBuildDir <- normalizeDir buildDir
         let mstdlib :: Maybe (Path Rel Dir) = stripProperPrefix normBuildDir adir
-        return $
-          if
-              | mstdlib == Just relStdlibDir -> Just stdLibBuildDir
-              | otherwise -> Nothing
+        return
+          $ if
+            | mstdlib == Just relStdlibDir -> Just stdLibBuildDir
+            | otherwise -> Nothing
         where
           stdLibBuildDir :: Path Abs Dir
           stdLibBuildDir = juvixStdlibDir buildDir

--- a/src/Juvix/Extra/Version.hs
+++ b/src/Juvix/Extra/Version.hs
@@ -58,15 +58,15 @@ infoVersionRepo = do
         <> "Branch"
         <> colon
         <+> PP.pretty branch
-          <> line
-          <> "Commit"
-          <> colon
+        <> line
+        <> "Commit"
+        <> colon
         <+> PP.pretty commit
-          <> line
-          <> "Date"
-          <> colon
+        <> line
+        <> "Date"
+        <> colon
         <+> PP.pretty commitDate
-          <> line
+        <> line
     )
 
 runDisplayVersion :: (MonadIO m) => m ()

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -122,19 +122,19 @@ formatModuleInfo node moduleInfo =
     $ do
       pkg :: Package <- ask
       parseRes :: ParserResult <-
-        runTopModuleNameChecker $
-          fromSource Nothing (Just (node ^. importNodeAbsFile))
+        runTopModuleNameChecker
+          $ fromSource Nothing (Just (node ^. importNodeAbsFile))
       let modules = moduleInfo ^. pipelineResultImports
           scopedModules :: ScopedModuleTable = getScopedModuleTable modules
           tmp :: TopModulePathKey = relPathtoTopModulePathKey (node ^. importNodeFile)
           moduleid :: ModuleId = run (runReader pkg (getModuleId tmp))
       scopeRes :: ScoperResult <-
-        evalTopNameIdGen moduleid $
-          scopeCheck pkg scopedModules parseRes
+        evalTopNameIdGen moduleid
+          $ scopeCheck pkg scopedModules parseRes
       originalSource :: Text <- readFile' (node ^. importNodeAbsFile)
       formattedTxt <-
-        runReader originalSource $
-          formatScoperResult False scopeRes
+        runReader originalSource
+          $ formatScoperResult False scopeRes
       let formatRes =
             SourceCode
               { _sourceCodeFormatted = formattedTxt,
@@ -172,8 +172,8 @@ formatResultSourceCode ::
   Sem r FormatResult
 formatResultSourceCode filepath src = do
   if
-      | src ^. sourceCodeOriginal /= src ^. sourceCodeFormatted -> mkResult FormatResultNotFormatted
-      | otherwise -> mkResult FormatResultOK
+    | src ^. sourceCodeOriginal /= src ^. sourceCodeFormatted -> mkResult FormatResultNotFormatted
+    | otherwise -> mkResult FormatResultOK
   where
     mkResult :: FormatResult -> Sem r FormatResult
     mkResult res = do

--- a/src/Juvix/Parser/Error.hs
+++ b/src/Juvix/Parser/Error.hs
@@ -135,12 +135,12 @@ instance ToGenericError WrongTopModuleName where
             "The top module"
               <+> ppCode opts' _wrongTopModuleNameActualName
               <+> "is defined in the file:"
-                <> line
-                <> pretty _wrongTopModuleNameActualPath
-                <> line
-                <> "But it should be in the file:"
-                <> line
-                <> pretty _wrongTopModuleNameExpectedPath
+              <> line
+              <> pretty _wrongTopModuleNameActualPath
+              <> line
+              <> "But it should be in the file:"
+              <> line
+              <> pretty _wrongTopModuleNameExpectedPath
 
 data WrongTopModuleNameOrphan = WrongTopModuleNameOrphan
   { _wrongTopModuleNameOrpahnExpectedName :: Text,
@@ -166,8 +166,8 @@ instance ToGenericError WrongTopModuleNameOrphan where
               <> line
               <> "Expected module name:"
               <+> annotate (AnnKind KNameTopModule) (pcode _wrongTopModuleNameOrpahnExpectedName)
-                <> line
-                <> "Actual module name:"
+              <> line
+              <> "Actual module name:"
               <+> ppCode opts' _wrongTopModuleNameOrpahnActualName
 
 data StdinOrFileError = StdinOrFileError

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -42,8 +42,10 @@ spaceMsg = "white space (only spaces and newlines allowed)"
 -- | `special` is set when judoc comments or pragmas are supported
 space' :: forall e m. (MonadParsec e Text m) => Bool -> m (Maybe SpaceSpan)
 space' special =
-  hidden $
-    fmap SpaceSpan . nonEmpty <$> spaceSections
+  hidden
+    $ fmap SpaceSpan
+    . nonEmpty
+    <$> spaceSections
   where
     spaceSections :: m [SpaceSection]
     spaceSections = catMaybes <$> go []
@@ -63,13 +65,13 @@ space' special =
         pred . length <$> whileJustM (P.try (optional (newline >> hspace_)))
       return
         if
-            | k > 0 ->
-                Just
-                  EmptyLines
-                    { _emptyLinesLoc = i,
-                      _emptyLinesNum = k
-                    }
-            | otherwise -> mzero
+          | k > 0 ->
+              Just
+                EmptyLines
+                  { _emptyLinesLoc = i,
+                    _emptyLinesNum = k
+                  }
+          | otherwise -> mzero
 
     comment :: m Comment
     comment = lineComment <|> blockComment

--- a/src/Juvix/Prelude/Effects/Input.hs
+++ b/src/Juvix/Prelude/Effects/Input.hs
@@ -21,8 +21,8 @@ newtype instance StaticRep (Input i) = Input
 
 input :: (Member (Input i) r) => Sem r (Maybe i)
 input =
-  stateStaticRep $
-    \case
+  stateStaticRep
+    $ \case
       Input [] -> (Nothing, Input [])
       Input (i : is) -> (Just i, Input is)
 

--- a/src/Juvix/Prelude/Prepath.hs
+++ b/src/Juvix/Prelude/Prepath.hs
@@ -58,9 +58,12 @@ expandPrepath (Prepath p) =
       where
         prepathPart :: m PrepathPart
         prepathPart =
-          PrepathVar <$> evar
-            <|> PrepathHome <$ home
-            <|> PrepathString <$> str
+          PrepathVar
+            <$> evar
+            <|> PrepathHome
+            <$ home
+            <|> PrepathString
+            <$> str
           where
             reserved :: [Char]
             reserved = "$()~"
@@ -124,8 +127,8 @@ fromPreFileOrDir cwd fp = do
   absPath <- prepathToFilePath cwd fp
   isDirectory <- liftIO (System.doesDirectoryExist absPath)
   if
-      | isDirectory -> Right <$> parseAbsDir absPath
-      | otherwise -> Left <$> parseAbsFile absPath
+    | isDirectory -> Right <$> parseAbsDir absPath
+    | otherwise -> Left <$> parseAbsFile absPath
 
 preFileFromAbs :: Path Abs File -> Prepath File
 preFileFromAbs = mkPrepath . toFilePath

--- a/src/Juvix/Prelude/Pretty.hs
+++ b/src/Juvix/Prelude/Pretty.hs
@@ -39,7 +39,8 @@ class HasTextBackend a where
 
   toTextDoc :: a -> Doc b
 
-data AnsiTextAtom = forall t.
+data AnsiTextAtom
+  = forall t.
   (HasAnsiBackend t, HasTextBackend t) =>
   AnsiTextAtom
   { _ansiTextAtom :: t

--- a/src/Juvix/Prelude/Trace.hs
+++ b/src/Juvix/Prelude/Trace.hs
@@ -35,11 +35,11 @@ traceShow b = traceLabel "" (pack . show $ b) b
 
 traceToFile :: Path Abs File -> Text -> a -> a
 traceToFile fpath t a =
-  traceLabel (pack ("[" <> toFilePath fpath <> "]")) t $
-    unsafePerformIO $
-      do
-        writeFileEnsureLn fpath t
-        return a
+  traceLabel (pack ("[" <> toFilePath fpath <> "]")) t
+    $ unsafePerformIO
+    $ do
+      writeFileEnsureLn fpath t
+      return a
 {-# WARNING traceToFile "Using traceToFile" #-}
 
 traceToFileM :: (Applicative m) => Path Abs File -> Text -> a -> m ()

--- a/src/Parallel/ParallelTemplate.hs
+++ b/src/Parallel/ParallelTemplate.hs
@@ -178,8 +178,8 @@ compile args@CompileArgs {..} = do
     . crashOnError
     $ do
       withAsync handleLogs $ \logHandler -> do
-        replicateConcurrently_ _compileArgsNumWorkers $
-          lookForWork @nodeId @node @compileProof
+        replicateConcurrently_ _compileArgsNumWorkers
+          $ lookForWork @nodeId @node @compileProof
         wait logHandler
   (^. compilationState) <$> readTVarIO varCompilationState
 
@@ -233,13 +233,15 @@ getTask = do
               kwBracketL
                 <> annotate AnnLiteralInteger (pretty num)
                 <+> kwOf
-                <+> annotate AnnLiteralInteger (pretty total) <> kwBracketR <> " "
+                <+> annotate AnnLiteralInteger (pretty total)
+                <> kwBracketR
+                <> " "
             kwCompiling = annotate AnnKeyword "Compiling"
             isLast = num == total
         logMsg tid logs (progress <> kwCompiling <> " " <> name)
         when isLast (logClose logs)
-        return $
-          Just
+        return
+          $ Just
             Task
               { _taskNum = num,
                 _taskTotal = total,

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -36,7 +36,8 @@ mkAnomaCallTest' enableDebug _testProgramStorage _testName relRoot mainFile args
     compileMain rootCopyDir = do
       let testRootDir = rootCopyDir <//> relRoot
       entryPoint <-
-        set entryPointTarget (Just TargetAnoma) . set entryPointDebug enableDebug
+        set entryPointTarget (Just TargetAnoma)
+          . set entryPointDebug enableDebug
           <$> testDefaultEntryPointIO testRootDir (testRootDir <//> mainFile)
       (^. pipelineResult) . snd <$> testRunIO entryPoint upToAnoma
 

--- a/test/Asm/Transformation/Reachability.hs
+++ b/test/Asm/Transformation/Reachability.hs
@@ -16,8 +16,8 @@ data ReachabilityTest = ReachabilityTest
 
 allTests :: TestTree
 allTests =
-  testGroup "Reachability" $
-    map liftTest rtests
+  testGroup "Reachability"
+    $ map liftTest rtests
 
 rtests :: [ReachabilityTest]
 rtests =

--- a/test/Base.hs
+++ b/test/Base.hs
@@ -108,8 +108,8 @@ testRunIO e =
 
 testDefaultEntryPointIO :: (MonadIO m) => Path Abs Dir -> Path Abs File -> m EntryPoint
 testDefaultEntryPointIO cwd mainFile =
-  testTaggedLockedToIO $
-    defaultEntryPointIO cwd mainFile
+  testTaggedLockedToIO
+    $ defaultEntryPointIO cwd mainFile
 
 testDefaultEntryPointNoFileIO :: Path Abs Dir -> IO EntryPoint
 testDefaultEntryPointNoFileIO cwd = testTaggedLockedToIO (defaultEntryPointNoFileIO cwd)

--- a/test/Casm/Compilation/Positive.hs
+++ b/test/Casm/Compilation/Positive.hs
@@ -37,8 +37,8 @@ mkAllTests title optimLevel = do
       vmGroup = testGroup "With VM" (mkTest . toTestDescr optimLevel <$> vmTests)
   vmTestTree <- withPrecondition cairoVmPrecondition (return vmGroup)
   let nonVmTestTree = testGroup "Without VM" (mkTest . toTestDescr optimLevel <$> nonVmTests)
-  return $
-    testGroup
+  return
+    $ testGroup
       title
       [vmTestTree, nonVmTestTree]
 

--- a/test/Casm/Reg/Cairo.hs
+++ b/test/Casm/Reg/Cairo.hs
@@ -38,7 +38,7 @@ allTests =
         "Test036: Streams without memoization"
       ]
       P.tests
-      ++ cairoTests
+    ++ cairoTests
 
 cairoTests :: [P.PosTest]
 cairoTests =

--- a/test/Casm/Run/Base.hs
+++ b/test/Casm/Run/Base.hs
@@ -84,10 +84,10 @@ casmRunAssertion' entryPoint bInterp bRunVM labi instrs blts outputSize inputFil
     Left err -> do
       assertFailure (prettyString err)
     Right () -> do
-      when bInterp $
-        casmInterpret labi instrs inputFile expectedFile step
-      when bRunVM $
-        casmRunVM entryPoint labi instrs blts outputSize inputFile expectedFile step
+      when bInterp
+        $ casmInterpret labi instrs inputFile expectedFile step
+      when bRunVM
+        $ casmRunVM entryPoint labi instrs blts outputSize inputFile expectedFile step
 
 casmRunAssertion :: Bool -> Bool -> Path Abs Dir -> Path Abs File -> Maybe (Path Abs File) -> Path Abs File -> (String -> IO ()) -> Assertion
 casmRunAssertion bInterp bRunVM root mainFile inputFile expectedFile step = do

--- a/test/Casm/Run/Positive.hs
+++ b/test/Casm/Run/Positive.hs
@@ -36,8 +36,8 @@ allTests = do
       vmGroup = testGroup "With VM" (mkTest . testDescr <$> vmTests)
   vmTestTree <- withPrecondition cairoVmPrecondition (return vmGroup)
   let nonVmTestTree = testGroup "Without VM" (mkTest . testDescr <$> nonVmTests)
-  return $
-    testGroup
+  return
+    $ testGroup
       "CASM run positive tests"
       [vmTestTree, nonVmTestTree]
 

--- a/test/Compilation/Base.hs
+++ b/test/Compilation/Base.hs
@@ -60,7 +60,7 @@ compileErrorAssertion root' mainFile step = do
               . runError @JuvixError
               . runReader entryPoint
               $ Core.toStored (core ^. pipelineResult . Core.coreResultModule)
-                >>= Core.toStripped Core.CheckExec
+              >>= Core.toStripped Core.CheckExec
       case res' of
         Left {} -> return ()
         Right {} -> noError

--- a/test/Core/Compile/Base.hs
+++ b/test/Core/Compile/Base.hs
@@ -56,8 +56,8 @@ coreCompileAssertion' entryPoint optLevel tab mainFile expectedFile stdinText st
       let tab0 = computeCombinedInfoTable m
       assertBool "Check info table" (checkInfoTable tab0)
       let tab' = Asm.fromTree . Tree.fromCore $ Stripped.fromCore (maximum allowedFieldSizes) tab0
-      length (fromText (Asm.ppPrint tab' tab') :: String) `seq`
-        Asm.asmCompileAssertion' entryPoint' optLevel tab' mainFile expectedFile stdinText step
+      length (fromText (Asm.ppPrint tab' tab') :: String)
+        `seq` Asm.asmCompileAssertion' entryPoint' optLevel tab' mainFile expectedFile stdinText step
   where
     entryPoint' = entryPoint {_entryPointOptimizationLevel = optLevel}
 

--- a/test/Core/Eval/Base.hs
+++ b/test/Core/Eval/Base.hs
@@ -51,8 +51,8 @@ coreEvalAssertion' ::
   (String -> IO ()) ->
   Assertion
 coreEvalAssertion' mode tab mainFile expectedFile step =
-  length (fromText (ppPrint tab) :: String) `seq`
-    case HashMap.lookup sym (tab ^. identContext) of
+  length (fromText (ppPrint tab) :: String)
+    `seq` case HashMap.lookup sym (tab ^. identContext) of
       Just node -> do
         d <- readEvalData (ii ^. identifierArgNames)
         case d of
@@ -102,12 +102,12 @@ coreEvalAssertion' mode tab mainFile expectedFile step =
     readEvalData argnames = case mode of
       EvalModePlain -> do
         expected <- readFile expectedFile
-        return $
-          Right $
-            EvalData
-              { _evalDataInput = [],
-                _evalDataOutput = expected
-              }
+        return
+          $ Right
+          $ EvalData
+            { _evalDataInput = [],
+              _evalDataOutput = expected
+            }
       EvalModeJSON -> do
         fmap
           ( over evalDataInput sortArgs
@@ -127,10 +127,10 @@ coreEvalAssertion' mode tab mainFile expectedFile step =
 
               argnames' =
                 if
-                    | length args == 1 ->
-                        [fromMaybe "in" (head (nonEmpty' argnames))]
-                    | otherwise ->
-                        zipWith (\n -> fromMaybe ("in" <> show n)) [1 .. length args] (argnames ++ repeat Nothing)
+                  | length args == 1 ->
+                      [fromMaybe "in" (head (nonEmpty' argnames))]
+                  | otherwise ->
+                      zipWith (\n -> fromMaybe ("in" <> show n)) [1 .. length args] (argnames ++ repeat Nothing)
 
 coreEvalAssertion ::
   Path Abs File ->

--- a/test/Core/VampIR/Base.hs
+++ b/test/Core/VampIR/Base.hs
@@ -32,8 +32,10 @@ coreVampIRAssertion' ::
   Assertion
 coreVampIRAssertion' tab transforms mainFile expectedFile step = do
   step "Transform and normalize"
-  case run . runReader defaultCoreOptions . runError @JuvixError $
-    applyTransformations transforms (moduleFromInfoTable tab) of
+  case run
+    . runReader defaultCoreOptions
+    . runError @JuvixError
+    $ applyTransformations transforms (moduleFromInfoTable tab) of
     Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
     Right m -> do
       let tab' = computeCombinedInfoTable m

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -48,8 +48,8 @@ slowTests =
 
 fastTests :: IO TestTree
 fastTests =
-  return $
-    testGroup
+  return
+    $ testGroup
       "Juvix fast tests"
       [ Parsing.allTests,
         Resolver.allTests,

--- a/test/Nockma/Compile/Tree/Positive.hs
+++ b/test/Nockma/Compile/Tree/Positive.hs
@@ -68,10 +68,10 @@ testsToIgnore = testsUnsupported ++ testsNegativeInteger
 convertTest :: Tree.PosTest -> Maybe (Tree.PosTest)
 convertTest p = do
   guard (testNum `notElem` map to3DigitString testsToIgnore)
-  return $
-    if
-        | testNum `elem` map to3DigitString testsConstr -> over Tree.expectedFile go p
-        | otherwise -> p
+  return
+    $ if
+      | testNum `elem` map to3DigitString testsConstr -> over Tree.expectedFile go p
+      | otherwise -> p
   where
     go :: Base.Path Rel File -> Base.Path Rel File
     go = replaceExtensions' [".nockma", ".out"]

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -243,8 +243,8 @@ juvixCallingConventionTests =
                l' :: NonEmpty (Term Natural) = nockNatLiteral <$> l
             in compilerTest "foldTermsOrNil (non-empty)" (foldTermsOrNil (toList l')) (eqNock (foldTerms (toNock @Natural <$> l))),
            let l :: NonEmpty (Term Natural) = toNock <$> nonEmpty' [1 :: Natural .. 3]
-            in compilerTest "list to tuple" (listToTuple (OpQuote # makeList (toList l)) (nockIntegralLiteral (length l))) $
-                 eqNock (foldTerms l),
+            in compilerTest "list to tuple" (listToTuple (OpQuote # makeList (toList l)) (nockIntegralLiteral (length l)))
+                 $ eqNock (foldTerms l),
            let l :: Term Natural = OpQuote # foldTerms (toNock @Natural <$> (1 :| [2, 3]))
             in compilerTest "replaceSubterm'" (replaceSubterm' l (OpQuote # toNock [R]) (OpQuote # (toNock @Natural 999))) (eqNock (toNock @Natural 1 # toNock @Natural 999)),
            let lst :: [Term Natural] = toNock @Natural <$> [1, 2, 3]

--- a/test/Package/Positive.hs
+++ b/test/Package/Positive.hs
@@ -57,24 +57,24 @@ yamlTests =
       $(mkRelDir "YamlEmpty")
       $ \p _ ->
         if
-            | p ^. packageName == defaultPackageName -> Nothing
-            | otherwise -> Just "Package did not have default name",
+          | p ^. packageName == defaultPackageName -> Nothing
+          | otherwise -> Just "Package did not have default name",
     PosTest
       "no dependencies uses default stdlib"
       $(mkRelDir "YamlNoDependencies")
       $ \p b -> case p ^? packageDependencies . _head of
         Just d ->
           if
-              | d == defaultStdlibDep b -> Nothing
-              | otherwise -> Just "Package dependency is not the default standard library"
+            | d == defaultStdlibDep b -> Nothing
+            | otherwise -> Just "Package dependency is not the default standard library"
         _ -> Just "The package has no dependencies",
     PosTest
       "empty dependencies does not use default stdlib"
       $(mkRelDir "YamlEmptyDependencies")
       $ \p _ ->
         if
-            | null (p ^. packageDependencies) -> Nothing
-            | otherwise -> Just "Expected dependencies to be empty"
+          | null (p ^. packageDependencies) -> Nothing
+          | otherwise -> Just "Expected dependencies to be empty"
   ]
 
 packageLoadingTests :: [PosTest]
@@ -84,43 +84,43 @@ packageLoadingTests =
       $(mkRelDir "PackageJuvix")
       $ \p _ ->
         if
-            | p ^. packageName == "package-juvix" -> Nothing
-            | otherwise -> Just "Expected package name to be package-juvix",
+          | p ^. packageName == "package-juvix" -> Nothing
+          | otherwise -> Just "Expected package name to be package-juvix",
     PosTest
       "Package.juvix is read in priority over yaml"
       $(mkRelDir "PackageJuvixAndYaml")
       $ \p _ ->
         if
-            | p ^. packageName == "package-juvix" -> Nothing
-            | otherwise -> Just "Expected package name to be package-juvix",
+          | p ^. packageName == "package-juvix" -> Nothing
+          | otherwise -> Just "Expected package name to be package-juvix",
     PosTest
       "Package.juvix uses lock file"
       $(mkRelDir "PackageJuvixUsesLockfile")
       $ \p _ ->
         if
-            | isJust (p ^. packageLockfile) -> Nothing
-            | otherwise -> Just "No lock file was read",
+          | isJust (p ^. packageLockfile) -> Nothing
+          | otherwise -> Just "No lock file was read",
     PosTest
       "Package.juvix unspecified dependencies uses default stdlib"
       $(mkRelDir "PackageJuvixNoDependencies")
       $ \p b -> case p ^? packageDependencies . _head of
         Just d ->
           if
-              | d == defaultStdlibDep b -> Nothing
-              | otherwise -> Just ("Package dependency is not the default standard library: " <> show (d, defaultStdlibDep b))
+            | d == defaultStdlibDep b -> Nothing
+            | otherwise -> Just ("Package dependency is not the default standard library: " <> show (d, defaultStdlibDep b))
         _ -> Just "The package has no dependencies",
     PosTest
       "empty dependencies does not use default stdlib"
       $(mkRelDir "PackageJuvixEmptyDependencies")
       $ \p _ ->
         if
-            | null (p ^. packageDependencies) -> Nothing
-            | otherwise -> Just "Expected dependencies to be empty",
+          | null (p ^. packageDependencies) -> Nothing
+          | otherwise -> Just "Expected dependencies to be empty",
     PosTest
       "Package.juvix can be defined with PackageDescription.Basic"
       $(mkRelDir "PackageJuvixBasic")
       $ \p _ ->
         if
-            | p ^. packageName == defaultPackageName -> Nothing
-            | otherwise -> Just "Package did not have default name"
+          | p ^. packageName == defaultPackageName -> Nothing
+          | otherwise -> Just "Package did not have default name"
   ]

--- a/test/Reg/Run/Base.hs
+++ b/test/Reg/Run/Base.hs
@@ -54,8 +54,8 @@ regRunAssertionParam interpretFun mainFile expectedFile trans testTrans step = d
   case r of
     Left err -> assertFailure (prettyString err)
     Right tab0 -> do
-      unless (null trans) $
-        step "Transform"
+      unless (null trans)
+        $ step "Transform"
       case run $ runError @JuvixError $ runReader Reg.defaultOptions $ applyTransformations trans tab0 of
         Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
         Right tab -> do

--- a/test/Rust/Compilation.hs
+++ b/test/Rust/Compilation.hs
@@ -6,5 +6,6 @@ import Rust.Compilation.Positive qualified as P
 
 allTests :: IO TestTree
 allTests =
-  withPrecondition precondition . return $
-    testGroup "Juvix to native Rust compilation tests" [P.allTests, P.allTestsNoOptimize]
+  withPrecondition precondition
+    . return
+    $ testGroup "Juvix to native Rust compilation tests" [P.allTests, P.allTestsNoOptimize]

--- a/test/Rust/Compilation/Base.hs
+++ b/test/Rust/Compilation/Base.hs
@@ -76,7 +76,7 @@ nativeArgs optLevel outputFile inputFile =
     juvixLibraryDir :: FilePath
     juvixLibraryDir =
       if
-          | optLevel > 0 ->
-              $(makeRelativeToProject "runtime/rust/juvix/target/release" >>= strToExp)
-          | otherwise ->
-              $(makeRelativeToProject "runtime/rust/juvix/target/debug" >>= strToExp)
+        | optLevel > 0 ->
+            $(makeRelativeToProject "runtime/rust/juvix/target/release" >>= strToExp)
+        | otherwise ->
+            $(makeRelativeToProject "runtime/rust/juvix/target/debug" >>= strToExp)

--- a/test/Rust/RiscZero.hs
+++ b/test/Rust/RiscZero.hs
@@ -6,5 +6,6 @@ import Rust.RiscZero.Positive qualified as P
 
 allTests :: IO TestTree
 allTests =
-  withPrecondition precondition . return $
-    sequentialTestGroup "Juvix to RISC0 Rust compilation tests" AllFinish [P.allTests, P.allTestsNoOptimize]
+  withPrecondition precondition
+    . return
+    $ sequentialTestGroup "Juvix to RISC0 Rust compilation tests" AllFinish [P.allTests, P.allTestsNoOptimize]

--- a/test/Tree/Eval/Base.hs
+++ b/test/Tree/Eval/Base.hs
@@ -39,8 +39,8 @@ treeEvalAssertionParam evalParam mainFile expectedFile trans testTrans step = do
       case run $ runError @JuvixError $ applyTransformations [Validate] tab0 of
         Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
         Right tab1 -> do
-          unless (null trans) $
-            step "Transform"
+          unless (null trans)
+            $ step "Transform"
           case run $ runError @JuvixError $ applyTransformations trans tab1 of
             Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
             Right tab -> do

--- a/test/Tree/Transformation/Apply.hs
+++ b/test/Tree/Transformation/Apply.hs
@@ -10,8 +10,8 @@ allTests :: TestTree
 allTests =
   testGroup
     "Apply"
-    ( map liftTest $
-        Eval.filterTests
+    ( map liftTest
+        $ Eval.filterTests
           [ "Test007: Higher-order functions",
             "Test022: Self-application",
             "Test025: Dynamic closure extension",

--- a/test/Tree/Transformation/CheckNoAnoma.hs
+++ b/test/Tree/Transformation/CheckNoAnoma.hs
@@ -33,8 +33,8 @@ treeEvalTransformationErrorAssertion mainFile trans checkError step = do
       case run $ runError @JuvixError $ applyTransformations [Validate] tab0 of
         Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
         Right tab1 -> do
-          unless (null trans) $
-            step "Transform"
+          unless (null trans)
+            $ step "Transform"
           case run $ runError @JuvixError $ applyTransformations trans tab1 of
             Left e -> checkError e
             Right {} -> assertFailure "Expected error"

--- a/test/Tree/Transformation/Reachability.hs
+++ b/test/Tree/Transformation/Reachability.hs
@@ -13,8 +13,8 @@ data ReachabilityTest = ReachabilityTest
 
 allTests :: TestTree
 allTests =
-  testGroup "Reachability" $
-    map liftTest rtests
+  testGroup "Reachability"
+    $ map liftTest rtests
 
 rtests :: [ReachabilityTest]
 rtests =

--- a/test/Typecheck/Negative.hs
+++ b/test/Typecheck/Negative.hs
@@ -268,48 +268,48 @@ tests =
 
 negPositivityTests :: [NegTest]
 negPositivityTests =
-  [ negTest "E1" $(mkRelDir "Internal/Positivity") $(mkRelFile "E1.juvix") $
-      \case
+  [ negTest "E1" $(mkRelDir "Internal/Positivity") $(mkRelFile "E1.juvix")
+      $ \case
         ErrNonStrictlyPositive ErrTypeInNegativePosition {} -> Nothing
         _ -> wrongError,
-    negTest "E2" $(mkRelDir "Internal/Positivity") $(mkRelFile "E2.juvix") $
-      \case
+    negTest "E2" $(mkRelDir "Internal/Positivity") $(mkRelFile "E2.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E3" $(mkRelDir "Internal/Positivity") $(mkRelFile "E3.juvix") $
-      \case
+    negTest "E3" $(mkRelDir "Internal/Positivity") $(mkRelFile "E3.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E4" $(mkRelDir "Internal/Positivity") $(mkRelFile "E4.juvix") $
-      \case
+    negTest "E4" $(mkRelDir "Internal/Positivity") $(mkRelFile "E4.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E5" $(mkRelDir "Internal/Positivity") $(mkRelFile "E5.juvix") $
-      \case
+    negTest "E5" $(mkRelDir "Internal/Positivity") $(mkRelFile "E5.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E6" $(mkRelDir "Internal/Positivity") $(mkRelFile "E6.juvix") $
-      \case
+    negTest "E6" $(mkRelDir "Internal/Positivity") $(mkRelFile "E6.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E7" $(mkRelDir "Internal/Positivity") $(mkRelFile "E7.juvix") $
-      \case
+    negTest "E7" $(mkRelDir "Internal/Positivity") $(mkRelFile "E7.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E8" $(mkRelDir "Internal/Positivity") $(mkRelFile "E8.juvix") $
-      \case
+    negTest "E8" $(mkRelDir "Internal/Positivity") $(mkRelFile "E8.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E9" $(mkRelDir "Internal/Positivity") $(mkRelFile "E9.juvix") $
-      \case
+    negTest "E9" $(mkRelDir "Internal/Positivity") $(mkRelFile "E9.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E10 uses type synonym" $(mkRelDir "Internal/Positivity") $(mkRelFile "E10.juvix") $
-      \case
+    negTest "E10 uses type synonym" $(mkRelDir "Internal/Positivity") $(mkRelFile "E10.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError,
-    negTest "E11 uses type synonym" $(mkRelDir "Internal/Positivity") $(mkRelFile "E11.juvix") $
-      \case
+    negTest "E11 uses type synonym" $(mkRelDir "Internal/Positivity") $(mkRelFile "E11.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeInNegativePosition {}) -> Nothing
         _ -> wrongError
   ]

--- a/test/Typecheck/NegativeNew.hs
+++ b/test/Typecheck/NegativeNew.hs
@@ -147,16 +147,16 @@ arityTests =
       $ \case
         ErrDefaultArgLoop {} -> Nothing
         _ -> wrongError,
-    negTest "Evil: issue 2540" $(mkRelDir "Internal/Positivity") $(mkRelFile "Evil.juvix") $
-      \case
+    negTest "Evil: issue 2540" $(mkRelDir "Internal/Positivity") $(mkRelFile "Evil.juvix")
+      $ \case
         ErrNonStrictlyPositive ErrTypeAsArgumentOfBoundVar {} -> Nothing
         _ -> wrongError,
-    negTest "Evil: issue 2540 using Axiom" $(mkRelDir "Internal/Positivity") $(mkRelFile "EvilWithAxiom.juvix") $
-      \case
+    negTest "Evil: issue 2540 using Axiom" $(mkRelDir "Internal/Positivity") $(mkRelFile "EvilWithAxiom.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeAsArgumentOfBoundVar {}) -> Nothing
         _ -> wrongError,
-    negTest "FreeT: issue 2540" $(mkRelDir "Internal/Positivity") $(mkRelFile "FreeT.juvix") $
-      \case
+    negTest "FreeT: issue 2540" $(mkRelDir "Internal/Positivity") $(mkRelFile "FreeT.juvix")
+      $ \case
         ErrNonStrictlyPositive (ErrTypeAsArgumentOfBoundVar {}) -> Nothing
         _ -> wrongError
   ]


### PR DESCRIPTION
This pr updates the version of ormolu to 0.7.4.0. Moreover, we drop the `mrkkrp/ormolu-action` github action. Instead, we invoke the ormolu version that is in the stackage snapshot selected in the `stack.yaml` file.

One can locally install the new version thus:
```
cd juvix
stack install ormolu
```
The output of `ormolu --version` should be 
```
ormolu 0.7.4.0
using ghc-lib-parser 9.8.2.20240223
```

# Questionable changes
![image](https://github.com/anoma/juvix/assets/5511599/8f12f9d7-976e-4158-a565-68978cb79b9e)

![image](https://github.com/user-attachments/assets/f9172e36-372e-4518-92e7-e92ff24d77e1)

