### PR TITLE
Inline immediate values

### DIFF
--- a/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
+++ b/src/Juvix/Compiler/Core/Transformation/Optimize/Inlining.hs
@@ -55,7 +55,13 @@ convertNode inlineDepth recSyms md = dmapL go
           Just InlineFullyApplied | argsNum == 0 -> def
           Just (InlinePartiallyApplied 0) -> def
           Just InlineAlways -> def
-          _ -> node
+          Just InlineNever -> node
+          _
+            | not (HashSet.member _identSymbol recSyms)
+                && isImmediate md def ->
+                def
+            | otherwise ->
+                node
         where
           ii = lookupIdentifierInfo md _identSymbol
           pi = ii ^. identifierPragmas . pragmasInline


### PR DESCRIPTION
* Closes #2745 
* Adds inlining of immediate values, i.e., values that don't require computation or memory allocation.
* Non-immediate zero-argument functions / values should not be inlined, because when not inlined they can be computed only once.
