### PR TITLE
Add lcomposition fixity to support (>>) in the stdlib

### DIFF
--- a/include/package-base/Juvix/Builtin/V1/Fixity.juvix
+++ b/include/package-base/Juvix/Builtin/V1/Fixity.juvix
@@ -21,3 +21,4 @@ syntax fixity additive := binary {assoc := left; above := [comparison; range; co
 syntax fixity multiplicative := binary {assoc := left; above := [additive]};
 
 syntax fixity composition := binary {assoc := right; above := [multiplicative]};
+syntax fixity lcomposition := binary {assoc := left; above := [multiplicative]};


### PR DESCRIPTION
The stdlib composition function `∘` has fixity `composition` which means it is right associative.

We will rename `∘` to `<<` in the stdlib and add a new function:

```
>> {a b c} : (a -> b) -> (b -> c) -> a -> c
```

for consistency with `<<` this should be left associative.

This is not a breaking change to package-base so we don't need to increment the version number.