### PR TITLE
Support Anoma representation of Maybe

### DIFF
--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -583,5 +583,16 @@ allTests =
             $(mkRelDir ".")
             $(mkRelFile "test079.juvix")
             [OpQuote # inputStr]
-            $ checkOutput [[nock| "Juvix! ✨ héllo world ✨" |]]
+            $ checkOutput [[nock| "Juvix! ✨ héllo world ✨" |]],
+      mkAnomaCallTest
+        "Test080: Maybe"
+        $(mkRelDir ".")
+        $(mkRelFile "test080.juvix")
+        []
+        $ checkOutput
+          [ [nock| [nil 1] |],
+            [nock| 2 |],
+            [nock| 3 |],
+            [nock| nil |]
+          ]
     ]

--- a/tests/Anoma/Compilation/positive/test080.juvix
+++ b/tests/Anoma/Compilation/positive/test080.juvix
@@ -5,16 +5,16 @@ import Stdlib.Debug.Trace open;
 
 main : Maybe Nat :=
   trace (just 1)
-    >>> trace
+    >-> trace
       {Nat}
       case just 2 of {
         | just x := x
         | nothing := 0
       }
-    >>> trace
+    >-> trace
       {Nat}
       case nothing {Nat} of {
         | just x := 0
         | nothing := 3
       }
-    >>> nothing;
+    >-> nothing;

--- a/tests/Anoma/Compilation/positive/test080.juvix
+++ b/tests/Anoma/Compilation/positive/test080.juvix
@@ -1,0 +1,20 @@
+module test080;
+
+import Stdlib.Prelude open;
+import Stdlib.Debug.Trace open;
+
+main : Maybe Nat :=
+  trace (just 1)
+    >>> trace
+      {Nat}
+      case just 2 of {
+        | just x := x
+        | nothing := 0
+      }
+    >>> trace
+      {Nat}
+      case nothing {Nat} of {
+        | just x := 0
+        | nothing := 3
+      }
+    >>> nothing;


### PR DESCRIPTION
This PR add support for Anoma/Nockma representation of the Maybe type (and other Maybe-like inductive types).

Anoma has chosen to represent the Maybe type in Nockma in the following way:

`nothing`: `nil`
`just x`: `[nil x]`

The strategy used in this PR is the same as the one we use for 'List-like' inductive type representations.

* Closes https://github.com/anoma/juvix/issues/2854