### PR TITLE
Improve performance of formatting a project

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -298,9 +298,11 @@ runPipelineEntry entry p = runPipelineOptions $ do
   r <- runIOEither entry (inject p) >>= fromRightJuvixError
   return (snd r ^. pipelineResult)
 
-runPipelineSetup :: (Members '[App, EmbedIO, Reader PipelineOptions, TaggedLock] r) => Sem (PipelineEff' r) a -> Sem r a
--- runPipelineSetup p = ignoreProgressLog $ do -- TODO restore
-runPipelineSetup p = appRunProgressLog $ do
+runPipelineSetup ::
+  (Members '[App, EmbedIO, Reader PipelineOptions, TaggedLock] r) =>
+  Sem (PipelineEff' r) a ->
+  Sem r a
+runPipelineSetup p = ignoreProgressLog $ do
   args <- askArgs
   entry <- getEntryPointStdin' args
   r <- runIOEitherPipeline entry (inject p) >>= fromRightJuvixError

--- a/app/App.hs
+++ b/app/App.hs
@@ -32,7 +32,9 @@ data App :: Effect where
   AskGlobalOptions :: App m GlobalOptions
   FromAppPathFile :: AppPath File -> App m (Path Abs File)
   GetMainAppFile :: Maybe (AppPath File) -> App m (AppPath File)
+  GetMainAppFileMaybe :: Maybe (AppPath File) -> App m (Maybe (AppPath File))
   GetMainFile :: Maybe (AppPath File) -> App m (Path Abs File)
+  GetMainFileMaybe :: Maybe (AppPath File) -> App m (Maybe (Path Abs File))
   FromAppPathDir :: AppPath Dir -> App m (Path Abs Dir)
   RenderStdOut :: (HasAnsiBackend a, HasTextBackend a) => a -> App m ()
   Say :: Text -> App m ()
@@ -68,7 +70,9 @@ reAppIO args@RunAppIOArgs {..} =
     FromAppPathFile p -> prepathToAbsFile invDir (p ^. pathPath)
     FromAppFile m -> fromAppFile' m
     GetMainAppFile m -> getMainAppFile' m
+    GetMainAppFileMaybe m -> getMainAppFileMaybe' m
     GetMainFile m -> getMainFile' m
+    GetMainFileMaybe m -> getMainFileMaybe' m
     FromAppPathDir p -> liftIO (prepathToAbsDir invDir (p ^. pathPath))
     RenderStdOut t
       | _runAppIOArgsGlobalOptions ^. globalOnlyErrors -> return ()
@@ -105,19 +109,25 @@ reAppIO args@RunAppIOArgs {..} =
     getMainFile' :: (Members '[SCache Package, EmbedIO] r') => Maybe (AppPath File) -> Sem r' (Path Abs File)
     getMainFile' = getMainAppFile' >=> fromAppFile'
 
-    getMainAppFile' :: (Members '[SCache Package, EmbedIO] r') => Maybe (AppPath File) -> Sem r' (AppPath File)
-    getMainAppFile' = \case
-      Just p -> return p
+    getMainFileMaybe' :: (Members '[SCache Package, EmbedIO] r') => Maybe (AppPath File) -> Sem r' (Maybe (Path Abs File))
+    getMainFileMaybe' = getMainAppFileMaybe' >=> mapM fromAppFile'
+
+    getMainAppFileMaybe' :: (Members '[SCache Package, EmbedIO] r') => Maybe (AppPath File) -> Sem r' (Maybe (AppPath File))
+    getMainAppFileMaybe' = \case
+      Just p -> return (Just p)
       Nothing -> do
         pkg <- getPkg
-        case pkg ^. packageMain of
+        return $ case pkg ^. packageMain of
           Just p ->
             return
               AppPath
                 { _pathPath = p,
                   _pathIsInput = True
                 }
-          Nothing -> missingMainErr
+          Nothing -> Nothing
+
+    getMainAppFile' :: (Members '[SCache Package, EmbedIO] r') => Maybe (AppPath File) -> Sem r' (AppPath File)
+    getMainAppFile' = fromMaybeM missingMainErr . getMainAppFileMaybe'
 
     missingMainErr :: (Members '[EmbedIO] r') => Sem r' x
     missingMainErr =
@@ -148,8 +158,8 @@ getEntryPoint' RunAppIOArgs {..} inputFile = do
     if
         | opts ^. globalStdin -> Just <$> liftIO getContents
         | otherwise -> return Nothing
-  mainFile <- getMainAppFile inputFile
-  set entryPointStdin estdin <$> entryPointFromGlobalOptionsPre root (mainFile ^. pathPath) opts
+  mainFile <- getMainAppFileMaybe inputFile
+  set entryPointStdin estdin <$> entryPointFromGlobalOptionsPre root ((^. pathPath) <$> mainFile) opts
 
 runPipelineEither ::
   (Members '[EmbedIO, TaggedLock, ProgressLog, App] r, EntryPointOptions opts) =>
@@ -182,6 +192,12 @@ someBaseToAbs' :: (Members '[App] r) => SomeBase a -> Sem r (Path Abs a)
 someBaseToAbs' f = do
   r <- askInvokeDir
   return (someBaseToAbs r f)
+
+fromAppPathFileOrDir ::
+  (Members '[EmbedIO, App] r) =>
+  AppPath FileOrDir ->
+  Sem r (Either (Path Abs File) (Path Abs Dir))
+fromAppPathFileOrDir = filePathToAbs . (^. pathPath)
 
 filePathToAbs :: (Members '[EmbedIO, App] r) => Prepath FileOrDir -> Sem r (Either (Path Abs File) (Path Abs Dir))
 filePathToAbs fp = do

--- a/app/Commands/Dev/Core/Strip.hs
+++ b/app/Commands/Dev/Core/Strip.hs
@@ -11,7 +11,7 @@ runCommand opts = do
   root <- askRoot
   gopts <- askGlobalOptions
   inputFile :: Path Abs File <- fromAppPathFile sinputFile
-  ep <- entryPointFromGlobalOptions root inputFile gopts
+  ep <- entryPointFromGlobalOptions root (Just inputFile) gopts
   s' <- readFile inputFile
   (tab, _) <- getRight (Core.runParser inputFile defaultModuleId mempty s')
   let r =
@@ -19,7 +19,9 @@ runCommand opts = do
           . runReader ep
           . runError @JuvixError
           $ Core.toStripped Core.IdentityTrans (Core.moduleFromInfoTable tab)
-  tab' <- getRight $ mapRight (Stripped.fromCore (project gopts ^. Core.optFieldSize) . Core.computeCombinedInfoTable) r
+  tab' <-
+    getRight $
+      mapRight (Stripped.fromCore (project gopts ^. Core.optFieldSize) . Core.computeCombinedInfoTable) r
   unless (project opts ^. coreStripNoPrint) $ do
     renderStdOut (Core.ppOut opts tab')
   where

--- a/app/Commands/Dev/Geb/Repl.hs
+++ b/app/Commands/Dev/Geb/Repl.hs
@@ -41,7 +41,7 @@ runCommand replOpts = do
         gopts <- State.gets (^. replStateGlobalOptions)
         absInputFile :: Path Abs File <- replMakeAbsolute inputFile
         set entryPointTarget (Just Backend.TargetGeb)
-          <$> runM (runTaggedLockPermissive (entryPointFromGlobalOptions root absInputFile gopts))
+          <$> runM (runTaggedLockPermissive (entryPointFromGlobalOptions root (Just absInputFile) gopts))
   liftIO
     . State.evalStateT
       (replAction replOpts getReplEntryPoint)

--- a/app/Commands/Dev/Scope.hs
+++ b/app/Commands/Dev/Scope.hs
@@ -10,7 +10,7 @@ import Juvix.Prelude.Pretty
 runCommand :: (Members '[EmbedIO, TaggedLock, App] r) => ScopeOptions -> Sem r ()
 runCommand opts = do
   globalOpts <- askGlobalOptions
-  res :: Scoper.ScoperResult <- runPipelineNoOptions (opts ^. scopeInputFile) upToScoping
+  res :: Scoper.ScoperResult <- runPipelineNoOptions (opts ^. scopeInputFile) upToScopingEntry
   let m :: Module 'Scoped 'ModuleTop = res ^. Scoper.resultModule
   if
       | opts ^. scopeWithComments ->

--- a/app/Commands/Eval.hs
+++ b/app/Commands/Eval.hs
@@ -10,7 +10,7 @@ runCommand :: (Members '[EmbedIO, TaggedLock, App] r) => EvalOptions -> Sem r ()
 runCommand opts@EvalOptions {..} = do
   gopts <- askGlobalOptions
   root <- askRoot
-  entryPoint <- maybe (entryPointFromGlobalOptionsNoFile root gopts) (fromAppPathFile >=> \f -> entryPointFromGlobalOptions root f gopts) _evalInputFile
+  entryPoint <- maybe (entryPointFromGlobalOptionsNoFile root gopts) (fromAppPathFile >=> \f -> entryPointFromGlobalOptions root (Just f) gopts) _evalInputFile
   Core.CoreResult {..} <- ignoreProgressLog (runPipelineProgress () _evalInputFile upToCore)
   let r =
         run

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -67,15 +67,6 @@ formatProjectNew = runPipelineOptions . runPipelineSetup $ do
     return (node, src)
   formatProject res'
 
--- | Formats the project on the root
-formatProjectNewWtf ::
-  forall r.
-  (Members '[App, EmbedIO, TaggedLock, Files, Output FormattedFileInfo] r) =>
-  Sem r FormatResult
-formatProjectNewWtf = runPipelineOptions . runPipelineSetup $ do
-  res :: HashMap ImportNode SourceCode <- ignoreProgressLog formatInParallel
-  formatProject res
-
 runCommand :: forall r. (Members '[EmbedIO, App, TaggedLock, Files] r) => FormatOptions -> Sem r ()
 runCommand opts = do
   target <- targetFromOptions opts

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -47,18 +47,13 @@ targetFromOptions opts = do
                   ]
 
 -- | Formats the project on the root
--- formatProjectNew ::
---   forall r.
---   (Members '[App, EmbedIO, TaggedLock, Reader PipelineOptions, Files, Output FormattedFileInfo] r) =>
---   Sem r FormatResult
--- formatProjectNew = runPipelineSetup $ do
---   root <- askRoot
---   tree <- ask @ImportTree
---   let inProject :: ImportNode -> Bool
---       inProject ImportNode {..} = _importNodePackageRoot == root ^. rootRootDir
---       projectNodes :: [ImportNode] = filter inProject (toList (tree ^. importTreeNodes))
-
---   undefined
+formatProjectNew ::
+  forall r.
+  (Members '[App, EmbedIO, TaggedLock, Reader PipelineOptions, Files, Output FormattedFileInfo] r) =>
+  Sem r FormatResult
+formatProjectNew = runPipelineSetup $ do
+  root <- askRoot
+  undefined
 
 runCommand :: forall r. (Members '[EmbedIO, App, TaggedLock, Files] r) => FormatOptions -> Sem r ()
 runCommand opts = do

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -55,7 +55,8 @@ formatProjectNew ::
   Sem r FormatResult
 formatProjectNew = runPipelineOptions . runPipelineSetup $ do
   pkg <- askPackage
-  nodes <- toList <$> asks (^. importTreeNodes)
+  root <- (^. rootRootDir) <$> askRoot
+  nodes <- toList <$> asks (importTreeProjectNodes root)
   res :: [(ImportNode, PipelineResult ModuleInfo)] <- forM nodes $ \node -> do
     res <- mkEntryIndex node >>= processModule
     return (node, res)

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -72,7 +72,7 @@ runCommand opts = do
   runOutputSem (renderFormattedOutput target opts) . runScopeFileApp $ do
     res <- case target of
       TargetFile p -> format p
-      TargetProject {} -> formatProjectNew
+      TargetProject -> formatProjectNew
       TargetStdin -> do
         entry <- getEntryPointStdin
         runReader entry formatStdin

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -3,6 +3,7 @@ module Commands.Format where
 import Commands.Base
 import Commands.Format.Options
 import Data.Text qualified as Text
+import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
 import Juvix.Formatter
 
 data FormatNoEditRenderMode
@@ -44,6 +45,20 @@ targetFromOptions opts = do
                   [ "juvix format error: either 'JUVIX_FILE_OR_PROJECT' or '--stdin' option must be specified",
                     "Use the --help option to display more usage information."
                   ]
+
+-- | Formats the project on the root
+formatProjectNew ::
+  forall r.
+  (Members '[App, EmbedIO, TaggedLock, Reader PipelineOptions, Files, Output FormattedFileInfo] r) =>
+  Sem r FormatResult
+formatProjectNew = runPipelineSetup $ do
+  root <- askRoot
+  tree <- ask @ImportTree
+  let inProject :: ImportNode -> Bool
+      inProject ImportNode {..} = _importNodePackageRoot == root ^. rootRootDir
+      projectNodes :: [ImportNode] = filter inProject (toList (tree ^. importTreeNodes))
+
+  undefined
 
 runCommand :: forall r. (Members '[EmbedIO, App, TaggedLock, Files] r) => FormatOptions -> Sem r ()
 runCommand opts = do

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -28,7 +28,7 @@ targetFromOptions :: (Members '[EmbedIO, App] r) => FormatOptions -> Sem r Forma
 targetFromOptions opts = do
   globalOpts <- askGlobalOptions
   let isStdin = globalOpts ^. globalStdin
-  f <- mapM filePathToAbs (opts ^. formatInput)
+  f <- mapM fromAppPathFileOrDir (opts ^. formatInput)
   pkgDir <- askPkgDir
   case f of
     Just (Left p) -> return (TargetFile p)

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -61,7 +61,7 @@ formatProjectNew = runPipelineOptions . runPipelineSetup $ do
   res :: [(ImportNode, PipelineResult ModuleInfo)] <- forM nodes $ \node -> do
     res <- mkEntryIndex node >>= processModule
     return (node, res)
-  res' :: HashMap ImportNode SourceCode <- fmap hashMap . runReader pkg . forM res $ \(node, nfo) -> do
+  res' :: [(ImportNode, SourceCode)] <- runReader pkg . forM res $ \(node, nfo) -> do
     src <- formatModuleInfo node nfo
     return (node, src)
   formatProject res'

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -48,7 +48,7 @@ targetFromOptions opts = do
 runCommand :: forall r. (Members '[EmbedIO, App, TaggedLock, Files] r) => FormatOptions -> Sem r ()
 runCommand opts = do
   target <- targetFromOptions opts
-  runOutputSem (renderFormattedOutput target opts) $ runScopeFileApp $ do
+  runOutputSem (renderFormattedOutput target opts) . runScopeFileApp $ do
     res <- case target of
       TargetFile p -> format p
       TargetProject p -> formatProject p

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -3,7 +3,7 @@ module Commands.Format where
 import Commands.Base
 import Commands.Format.Options
 import Data.Text qualified as Text
-import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
+-- import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
 import Juvix.Formatter
 
 data FormatNoEditRenderMode
@@ -47,18 +47,18 @@ targetFromOptions opts = do
                   ]
 
 -- | Formats the project on the root
-formatProjectNew ::
-  forall r.
-  (Members '[App, EmbedIO, TaggedLock, Reader PipelineOptions, Files, Output FormattedFileInfo] r) =>
-  Sem r FormatResult
-formatProjectNew = runPipelineSetup $ do
-  root <- askRoot
-  tree <- ask @ImportTree
-  let inProject :: ImportNode -> Bool
-      inProject ImportNode {..} = _importNodePackageRoot == root ^. rootRootDir
-      projectNodes :: [ImportNode] = filter inProject (toList (tree ^. importTreeNodes))
+-- formatProjectNew ::
+--   forall r.
+--   (Members '[App, EmbedIO, TaggedLock, Reader PipelineOptions, Files, Output FormattedFileInfo] r) =>
+--   Sem r FormatResult
+-- formatProjectNew = runPipelineSetup $ do
+--   root <- askRoot
+--   tree <- ask @ImportTree
+--   let inProject :: ImportNode -> Bool
+--       inProject ImportNode {..} = _importNodePackageRoot == root ^. rootRootDir
+--       projectNodes :: [ImportNode] = filter inProject (toList (tree ^. importTreeNodes))
 
-  undefined
+--   undefined
 
 runCommand :: forall r. (Members '[EmbedIO, App, TaggedLock, Files] r) => FormatOptions -> Sem r ()
 runCommand opts = do
@@ -118,5 +118,5 @@ runScopeFileApp = interpret $ \case
             { _pathPath = mkPrepath (toFilePath p),
               _pathIsInput = False
             }
-    ignoreProgressLog (runPipelineProgress () (Just appFile) upToScoping)
-  ScopeStdin e -> ignoreProgressLog (runPipelineEntry e upToScoping)
+    ignoreProgressLog (runPipelineProgress () (Just appFile) upToScopingEntry)
+  ScopeStdin e -> ignoreProgressLog (runPipelineEntry e upToScopingEntry)

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -2,8 +2,6 @@ module Commands.Format where
 
 import Commands.Base
 import Commands.Format.Options
--- import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
-
 import Data.Text qualified as Text
 import Juvix.Compiler.Pipeline.Driver (processModule)
 import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -49,11 +49,11 @@ targetFromOptions opts = do
                   ]
 
 -- | Formats the project on the root
-formatProjectNew ::
+formatProject ::
   forall r.
   (Members '[App, EmbedIO, TaggedLock, Files, Output FormattedFileInfo] r) =>
   Sem r FormatResult
-formatProjectNew = runPipelineOptions . runPipelineSetup $ do
+formatProject = runPipelineOptions . runPipelineSetup $ do
   pkg <- askPackage
   root <- (^. rootRootDir) <$> askRoot
   nodes <- toList <$> asks (importTreeProjectNodes root)
@@ -63,7 +63,7 @@ formatProjectNew = runPipelineOptions . runPipelineSetup $ do
   res' :: [(ImportNode, SourceCode)] <- runReader pkg . forM res $ \(node, nfo) -> do
     src <- formatModuleInfo node nfo
     return (node, src)
-  formatProject res'
+  formatProjectSourceCode res'
 
 runCommand :: forall r. (Members '[EmbedIO, App, TaggedLock, Files] r) => FormatOptions -> Sem r ()
 runCommand opts = do
@@ -71,7 +71,7 @@ runCommand opts = do
   runOutputSem (renderFormattedOutput target opts) . runScopeFileApp $ do
     res <- case target of
       TargetFile p -> format p
-      TargetProject -> formatProjectNew
+      TargetProject -> formatProject
       TargetStdin -> do
         entry <- getEntryPointStdin
         runReader entry formatStdin

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -6,7 +6,6 @@ import Commands.Format.Options
 
 import Data.Text qualified as Text
 import Juvix.Compiler.Pipeline.Driver (processModule)
-import Juvix.Compiler.Pipeline.DriverParallel
 import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
 import Juvix.Compiler.Pipeline.ModuleInfoCache
 import Juvix.Compiler.Store.Language (ModuleInfo)

--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -4,12 +4,10 @@ import Commands.Base
 import Commands.Format.Options
 -- import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
 
-import Data.HashMap.Strict qualified as HashMap
 import Data.Text qualified as Text
 import Juvix.Compiler.Pipeline.Driver (processModule)
 import Juvix.Compiler.Pipeline.DriverParallel
 import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
-import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.ImportNode
 import Juvix.Compiler.Pipeline.ModuleInfoCache
 import Juvix.Compiler.Store.Language (ModuleInfo)
 import Juvix.Formatter

--- a/app/Commands/Format/Options.hs
+++ b/app/Commands/Format/Options.hs
@@ -3,7 +3,7 @@ module Commands.Format.Options where
 import CommonOptions
 
 data FormatOptions = FormatOptions
-  { _formatInput :: Maybe (Prepath FileOrDir),
+  { _formatInput :: Maybe (AppPath FileOrDir),
     _formatCheck :: Bool,
     _formatInPlace :: Bool
   }
@@ -11,18 +11,21 @@ data FormatOptions = FormatOptions
 
 makeLenses ''FormatOptions
 
-parseInputJuvixFileOrDir :: Parser (Prepath FileOrDir)
-parseInputJuvixFileOrDir =
-  strArgument
-    ( metavar "JUVIX_FILE_OR_PROJECT"
-        <> help ("Path to a " <> show FileExtJuvix <> " file or to a directory containing a Juvix project.")
-        <> completer (extCompleter FileExtJuvix)
-        <> action "directory"
-    )
+parseInputFileOrDir :: Parser (AppPath FileOrDir)
+parseInputFileOrDir = do
+  _pathPath <-
+    argument
+      somePreFileOrDirOpt
+      ( metavar "JUVIX_FILE_OR_PROJECT"
+          <> help ("Path to a " <> show FileExtJuvix <> " file or to a directory containing a Juvix project.")
+          <> completer (extCompleter FileExtJuvix)
+          <> action "directory"
+      )
+  pure AppPath {_pathIsInput = True, ..}
 
 parseFormat :: Parser FormatOptions
 parseFormat = do
-  _formatInput <- optional parseInputJuvixFileOrDir
+  _formatInput <- optional parseInputFileOrDir
   _formatCheck <-
     switch
       ( long "check"

--- a/app/Commands/Html.hs
+++ b/app/Commands/Html.hs
@@ -16,7 +16,7 @@ import System.Process qualified as Process
 
 runGenOnlySourceHtml :: (Members '[EmbedIO, TaggedLock, App] r) => HtmlOptions -> Sem r ()
 runGenOnlySourceHtml HtmlOptions {..} = do
-  res <- runPipelineNoOptions _htmlInputFile upToScoping
+  res <- runPipelineNoOptions _htmlInputFile upToScopingEntry
   let m = res ^. Scoper.resultModule
   outputDir <- fromAppPathDir _htmlOutputDir
   liftIO $

--- a/app/Commands/Markdown.hs
+++ b/app/Commands/Markdown.hs
@@ -17,7 +17,7 @@ runCommand ::
   Sem r ()
 runCommand opts = do
   let inputFile = opts ^. markdownInputFile
-  scopedM <- runPipelineNoOptions inputFile upToScoping
+  scopedM <- runPipelineNoOptions inputFile upToScopingEntry
   let m = scopedM ^. Scoper.resultModule
   outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
   let res =

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -143,10 +143,10 @@ getReplEntryPoint f inputFile = do
   liftIO (set entryPointSymbolPruningMode KeepAll <$> f root inputFile gopts)
 
 getReplEntryPointFromPrepath :: Prepath File -> Repl EntryPoint
-getReplEntryPointFromPrepath = getReplEntryPoint (\r x -> runM . runTaggedLockPermissive . entryPointFromGlobalOptionsPre r x)
+getReplEntryPointFromPrepath = getReplEntryPoint (\r x -> runM . runTaggedLockPermissive . entryPointFromGlobalOptionsPre r (Just x))
 
 getReplEntryPointFromPath :: Path Abs File -> Repl EntryPoint
-getReplEntryPointFromPath = getReplEntryPoint (\r a -> runM . runTaggedLockPermissive . entryPointFromGlobalOptions r a)
+getReplEntryPointFromPath = getReplEntryPoint (\r a -> runM . runTaggedLockPermissive . entryPointFromGlobalOptions r (Just a))
 
 displayVersion :: String -> Repl ()
 displayVersion _ = liftIO (putStrLn versionTag)

--- a/app/CommonOptions.hs
+++ b/app/CommonOptions.hs
@@ -37,8 +37,8 @@ makeLenses ''AppPath
 instance Show (AppPath f) where
   show = Prelude.show . (^. pathPath)
 
-parseInputFiles :: NonEmpty FileExt -> Parser (AppPath File)
-parseInputFiles exts' = do
+parseInputFilesMod :: NonEmpty FileExt -> Mod ArgumentFields (Prepath File) -> Parser (AppPath File)
+parseInputFilesMod exts' mods = do
   let exts = NonEmpty.toList exts'
       mvars = intercalate "|" (map toMetavar exts)
       dotExts = intercalate ", " (map Prelude.show exts)
@@ -51,8 +51,12 @@ parseInputFiles exts' = do
           <> help helpMsg
           <> completers
           <> action "file"
+          <> mods
       )
   pure AppPath {_pathIsInput = True, ..}
+
+parseInputFiles :: NonEmpty FileExt -> Parser (AppPath File)
+parseInputFiles exts' = parseInputFilesMod exts' mempty
 
 parseInputFile :: FileExt -> Parser (AppPath File)
 parseInputFile = parseInputFiles . NonEmpty.singleton
@@ -125,6 +129,9 @@ parseGenericOutputDir m = do
 
 somePreDirOpt :: ReadM (Prepath Dir)
 somePreDirOpt = mkPrepath <$> str
+
+somePreFileOrDirOpt :: ReadM (Prepath FileOrDir)
+somePreFileOrDirOpt = mkPrepath <$> str
 
 somePreFileOpt :: ReadM (Prepath File)
 somePreFileOpt = mkPrepath <$> str

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -166,17 +166,17 @@ parseBuildDir m = do
 entryPointFromGlobalOptionsPre ::
   (Members '[TaggedLock, EmbedIO] r) =>
   Root ->
-  Prepath File ->
+  Maybe (Prepath File) ->
   GlobalOptions ->
   Sem r EntryPoint
 entryPointFromGlobalOptionsPre root premainFile opts = do
-  mainFile <- liftIO (prepathToAbsFile (root ^. rootInvokeDir) premainFile)
+  mainFile <- mapM (prepathToAbsFile (root ^. rootInvokeDir)) premainFile
   entryPointFromGlobalOptions root mainFile opts
 
 entryPointFromGlobalOptions ::
   (Members '[TaggedLock, EmbedIO] r) =>
   Root ->
-  Path Abs File ->
+  Maybe (Path Abs File) ->
   GlobalOptions ->
   Sem r EntryPoint
 entryPointFromGlobalOptions root mainFile opts = do

--- a/app/TopCommand/Options.hs
+++ b/app/TopCommand/Options.hs
@@ -38,14 +38,10 @@ data TopCommand
   deriving stock (Data)
 
 topCommandInputPath :: TopCommand -> IO (Maybe (SomePath Abs))
-topCommandInputPath = \case
-  JuvixFormat fopts -> case fopts ^. formatInput of
-    Just f -> getInputPathFromPrepathFileOrDir f
-    Nothing -> return Nothing
-  t -> do
-    d <- firstJustM getInputFileOrDir (universeBi t)
-    f <- firstJustM getInputFile (universeBi t)
-    return (f <|> d)
+topCommandInputPath t = do
+  d <- firstJustM getInputFileOrDir (universeBi t)
+  f <- firstJustM getInputFile (universeBi t)
+  return (f <|> d)
   where
     getInputFile :: AppPath File -> IO (Maybe (SomePath Abs))
     getInputFile p

--- a/src/Juvix/Compiler/Backend/Isabelle/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Isabelle/Translation/FromTyped.hs
@@ -114,7 +114,7 @@ goModule onlyTypes infoTable Internal.Module {..} =
         defaultId =
           NameId
             { _nameIdUid = 0,
-              _nameIdModuleId = ModuleId "" "" ""
+              _nameIdModuleId = defaultModuleId
             }
 
     goConstructorDef :: Internal.ConstructorDef -> Constructor

--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -76,6 +76,16 @@ deriving newtype instance Hashable SymbolPath
 makeLenses ''QualifiedName
 makeLenses ''SymbolPath
 
+data TopModulePathKey = TopModulePathKey
+  { _modulePathKeyDir :: [Text],
+    _modulePathKeyName :: Text
+  }
+  deriving stock (Show, Eq, Ord, Generic)
+
+instance Serialize TopModulePathKey
+
+instance NFData TopModulePathKey
+
 -- | A.B.C corresponds to TopModulePath [A,B] C
 data TopModulePath = TopModulePath
   { _modulePathDir :: [Symbol],
@@ -88,6 +98,14 @@ instance Serialize TopModulePath
 instance NFData TopModulePath
 
 makeLenses ''TopModulePath
+makeLenses ''TopModulePathKey
+
+topModulePathKey :: TopModulePath -> TopModulePathKey
+topModulePathKey TopModulePath {..} =
+  TopModulePathKey
+    { _modulePathKeyDir = (^. symbolText) <$> _modulePathDir,
+      _modulePathKeyName = _modulePathName ^. symbolText
+    }
 
 instance Pretty TopModulePath where
   pretty (TopModulePath path name) =

--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -76,18 +76,6 @@ deriving newtype instance Hashable SymbolPath
 makeLenses ''QualifiedName
 makeLenses ''SymbolPath
 
-data TopModulePathKey = TopModulePathKey
-  { _modulePathKeyDir :: [Text],
-    _modulePathKeyName :: Text
-  }
-  deriving stock (Show, Eq, Ord, Generic)
-
-instance Serialize TopModulePathKey
-
-instance NFData TopModulePathKey
-
-instance Hashable TopModulePathKey
-
 -- | A.B.C corresponds to TopModulePath [A,B] C
 data TopModulePath = TopModulePath
   { _modulePathDir :: [Symbol],
@@ -102,7 +90,6 @@ instance NFData TopModulePath
 instance Hashable TopModulePath
 
 makeLenses ''TopModulePath
-makeLenses ''TopModulePathKey
 
 topModulePathKey :: TopModulePath -> TopModulePathKey
 topModulePathKey TopModulePath {..} =
@@ -112,8 +99,7 @@ topModulePathKey TopModulePath {..} =
     }
 
 instance Pretty TopModulePath where
-  pretty (TopModulePath path name) =
-    mconcat (punctuate Pretty.dot (map pretty (snoc path name)))
+  pretty = pretty . topModulePathKey
 
 instance HasLoc TopModulePath where
   getLoc TopModulePath {..} =

--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -86,6 +86,8 @@ instance Serialize TopModulePathKey
 
 instance NFData TopModulePathKey
 
+instance Hashable TopModulePathKey
+
 -- | A.B.C corresponds to TopModulePath [A,B] C
 data TopModulePath = TopModulePath
   { _modulePathDir :: [Symbol],
@@ -96,6 +98,8 @@ data TopModulePath = TopModulePath
 instance Serialize TopModulePath
 
 instance NFData TopModulePath
+
+instance Hashable TopModulePath
 
 makeLenses ''TopModulePath
 makeLenses ''TopModulePathKey
@@ -132,8 +136,6 @@ moduleNameToTopModulePath :: Name -> TopModulePath
 moduleNameToTopModulePath = \case
   NameUnqualified s -> TopModulePath [] s
   NameQualified (QualifiedName (SymbolPath p) s) -> TopModulePath (toList p) s
-
-instance Hashable TopModulePath
 
 splitName :: Name -> ([Symbol], Symbol)
 splitName = \case

--- a/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Scope/Base.hs
@@ -37,7 +37,7 @@ data Scope = Scope
     -- several imports under the same name. E.g.
     -- import A as X;
     -- import B as X;
-    _scopeTopModules :: HashMap TopModulePath (HashMap S.NameId ScopedModule),
+    _scopeTopModules :: HashMap TopModulePathKey (HashMap S.NameId ScopedModule),
     -- | Symbols that have been defined in the current scope level. Every symbol
     -- should map to itself. This is needed because we may query it with a
     -- symbol with a different location but we may want the location of the
@@ -48,11 +48,11 @@ data Scope = Scope
   }
 
 newtype ModulesCache = ModulesCache
-  { _cachedModules :: HashMap TopModulePath ScopedModule
+  { _cachedModules :: HashMap TopModulePathKey ScopedModule
   }
 
 newtype ScopeParameters = ScopeParameters
-  { _scopeImportedModules :: HashMap TopModulePath ScopedModule
+  { _scopeImportedModules :: HashMap TopModulePathKey ScopedModule
   }
 
 data ScoperState = ScoperState

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -57,10 +57,11 @@ type family FieldArgIxType s = res | res -> s where
   FieldArgIxType 'Parsed = ()
   FieldArgIxType 'Scoped = Int
 
-type ModuleIdType :: Stage -> GHC.Type
-type family ModuleIdType s = res | res -> s where
-  ModuleIdType 'Parsed = ()
-  ModuleIdType 'Scoped = ModuleId
+type ModuleIdType :: Stage -> ModuleIsTop -> GHC.Type
+type family ModuleIdType s t = res where
+  ModuleIdType 'Parsed _ = ()
+  ModuleIdType 'Scoped 'ModuleLocal = ()
+  ModuleIdType 'Scoped 'ModuleTop = ModuleId
 
 type SymbolType :: Stage -> GHC.Type
 type family SymbolType s = res | res -> s where
@@ -1197,7 +1198,7 @@ data Module (s :: Stage) (t :: ModuleIsTop) = Module
     _moduleBody :: [Statement s],
     _moduleKwEnd :: ModuleEndType t,
     _moduleOrigin :: ModuleInductiveType t,
-    _moduleId :: ModuleIdType s,
+    _moduleId :: ModuleIdType s t,
     _moduleMarkdownInfo :: Maybe MarkdownInfo
   }
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed.hs
@@ -16,7 +16,16 @@ import Juvix.Compiler.Store.Language
 import Juvix.Prelude
 
 fromParsed ::
-  (Members '[HighlightBuilder, Reader EntryPoint, Reader ModuleTable, Reader Parsed.ParserResult, Error JuvixError, NameIdGen] r) =>
+  ( Members
+      '[ HighlightBuilder,
+         Reader EntryPoint,
+         Reader ModuleTable,
+         Reader Parsed.ParserResult,
+         Error JuvixError,
+         NameIdGen
+       ]
+      r
+  ) =>
   Sem r ScoperResult
 fromParsed = do
   e <- ask

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed.hs
@@ -18,7 +18,7 @@ import Juvix.Prelude
 fromParsed ::
   ( Members
       '[ HighlightBuilder,
-         Reader EntryPoint,
+         Reader Package,
          Reader ModuleTable,
          Reader Parsed.ParserResult,
          Error JuvixError,

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -39,9 +39,9 @@ scopeCheck ::
   Parser.ParserResult ->
   Sem r ScoperResult
 scopeCheck entry importMap pr =
-  mapError (JuvixError @ScoperError) $
-    runReader entry $
-      scopeCheck' importMap pr m
+  mapError (JuvixError @ScoperError)
+    . runReader entry
+    $ scopeCheck' importMap pr m
   where
     m :: Module 'Parsed 'ModuleTop
     m = pr ^. Parser.resultModule

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1309,8 +1309,7 @@ checkTopModule comments m@Module {..} = checkedModule
               }
           smd =
             ScopedModule
-              { _scopedModuleId = _moduleId,
-                _scopedModulePath = path',
+              { _scopedModulePath = path',
                 _scopedModuleName = S.topModulePathName path',
                 _scopedModuleFilePath = P.getModuleFilePath m,
                 _scopedModuleExportInfo = e,
@@ -1754,8 +1753,7 @@ checkLocalModule md@Module {..} = do
           }
       smod =
         ScopedModule
-          { _scopedModuleId = error "FIXME should local modules have id?",
-            _scopedModulePath = set nameConcrete (moduleNameToTopModulePath (NameUnqualified _modulePath)) moduleName,
+          { _scopedModulePath = set nameConcrete (moduleNameToTopModulePath (NameUnqualified _modulePath)) moduleName,
             _scopedModuleName = moduleName,
             _scopedModuleFilePath = P.getModuleFilePath md,
             _scopedModuleExportInfo = moduleExportInfo,

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1760,7 +1760,7 @@ checkLocalModule md@Module {..} = do
             _scopedModuleFilePath = P.getModuleFilePath md,
             _scopedModuleExportInfo = moduleExportInfo,
             _scopedModuleLocalModules = localModules,
-            _scopedModuleSource = error "local modules do not store the source",
+            _scopedModuleSource = "no source", -- local modules do not store the source
             _scopedModuleInfoTable = tab
           }
   modify (over scoperModules (HashMap.insert mid smod))

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -908,6 +908,7 @@ getModuleId path = do
     ModuleId
       { _moduleIdPath =
           case sing :: SModuleIsTop t of
+            -- FIXME module id may not be unique because local modules might have the same path as top modules
             SModuleLocal -> prettyText path
             SModuleTop -> prettyText path,
         _moduleIdPackage = p ^. packageName,
@@ -1736,7 +1737,6 @@ checkLocalModule md@Module {..} = do
       doc' <- mapM checkJudoc _moduleDoc
       return (e, b, doc')
   _modulePath' <- reserveLocalModuleSymbol _modulePath
-  _moduleId' <- getModuleId _modulePath
   localModules <- getLocalModules moduleExportInfo
   let mid = _modulePath' ^. S.nameId
       moduleName = S.unqualifiedSymbol _modulePath'
@@ -1747,14 +1747,14 @@ checkLocalModule md@Module {..} = do
             _moduleDoc = moduleDoc',
             _modulePragmas = _modulePragmas,
             _moduleMarkdownInfo = Nothing,
-            _moduleId = _moduleId',
+            _moduleId = (),
             _moduleKw,
             _moduleOrigin,
             _moduleKwEnd
           }
       smod =
         ScopedModule
-          { _scopedModuleId = _moduleId',
+          { _scopedModuleId = error "FIXME should local modules have id?",
             _scopedModulePath = set nameConcrete (moduleNameToTopModulePath (NameUnqualified _modulePath)) moduleName,
             _scopedModuleName = moduleName,
             _scopedModuleFilePath = P.getModuleFilePath md,

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -905,7 +905,7 @@ getModuleId path = do
   p <- ask
   return
     ModuleId
-      { _moduleIdPath = prettyText path,
+      { _moduleIdPath = path,
         _moduleIdPackage = p ^. packageName,
         _moduleIdPackageVersion = show (p ^. packageVersion)
       }

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
@@ -3,7 +3,6 @@ module Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Cont
 import Juvix.Compiler.Concrete.Data.Scope
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromSource.Data.Context qualified as Parsed
-import Juvix.Compiler.Concrete.Translation.FromSource.Data.ParserState qualified as Parsed
 import Juvix.Compiler.Store.Scoped.Language
 import Juvix.Prelude
 
@@ -22,4 +21,4 @@ mainModule :: Lens' ScoperResult (Module 'Scoped 'ModuleTop)
 mainModule = resultModule
 
 getScoperResultComments :: ScoperResult -> Comments
-getScoperResultComments sr = mkComments $ sr ^. resultParserResult . Parsed.resultParserState . Parsed.parserStateComments
+getScoperResultComments = Parsed.getParserResultComments . (^. resultParserResult)

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -46,6 +46,16 @@ type JudocStash = State (Maybe (Judoc 'Parsed))
 
 type PragmasStash = State (Maybe ParsedPragmas)
 
+fromSourceMany ::
+  (Members '[HighlightBuilder, TopModuleNameChecker, Files, Error JuvixError] r) =>
+  [Path Abs File] ->
+  EntryPoint ->
+  Sem r (HashMap (Path Abs File) ParserResult)
+fromSourceMany files commonEntry = fmap hashMap $ forM files $ \file -> do
+  let entry = set entryPointModulePath (Just file) commonEntry
+  res <- fromSource entry
+  return (file, res)
+
 fromSource ::
   (Members '[HighlightBuilder, TopModuleNameChecker, Files, Error JuvixError] r) =>
   EntryPoint ->

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -51,10 +51,7 @@ fromSource ::
   Maybe (Path Abs File) ->
   Sem r ParserResult
 fromSource mstdin minputfile = mapError (JuvixError @ParserError) $ do
-  (_resultParserState, _resultModule) <-
-    runParserResultBuilder mempty
-      . evalTopNameIdGen defaultModuleId
-      $ getParsedModuleTop
+  (_resultParserState, _resultModule) <- runParserResultBuilder mempty getParsedModuleTop
   return ParserResult {..}
   where
     getParsedModuleTop ::

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -45,15 +45,6 @@ type JudocStash = State (Maybe (Judoc 'Parsed))
 
 type PragmasStash = State (Maybe ParsedPragmas)
 
--- | Stdin is never used
-fromSourceMany ::
-  (Members '[HighlightBuilder, TopModuleNameChecker, Files, Error JuvixError] r) =>
-  [Path Abs File] ->
-  Sem r (HashMap (Path Abs File) ParserResult)
-fromSourceMany files = fmap hashMap $ forM files $ \file -> do
-  res <- fromSource Nothing (Just file)
-  return (file, res)
-
 fromSource ::
   (Members '[HighlightBuilder, TopModuleNameChecker, Files, Error JuvixError] r) =>
   Maybe Text ->

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Data/Context.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Data/Context.hs
@@ -10,3 +10,6 @@ data ParserResult = ParserResult
   }
 
 makeLenses ''ParserResult
+
+getParserResultComments :: ParserResult -> Comments
+getParserResultComments sr = mkComments $ sr ^. resultParserState . parserStateComments

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -80,6 +80,7 @@ type PipelineLocalEff =
      Error JuvixError,
      HighlightBuilder,
      Internet,
+     Reader NumThreads,
      Concurrent
    ]
 

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -101,7 +101,9 @@ makeLenses ''PipelineOptions
 upToParsing ::
   (Members '[HighlightBuilder, TopModuleNameChecker, Reader EntryPoint, Error JuvixError, Files] r) =>
   Sem r Parser.ParserResult
-upToParsing = ask >>= Parser.fromSource
+upToParsing = do
+  e <- ask
+  Parser.fromSource (e ^. entryPointStdin) (e ^. entryPointModulePath)
 
 --------------------------------------------------------------------------------
 -- Workflows from parsed source
@@ -112,15 +114,24 @@ upToParsedSource ::
   Sem r Parser.ParserResult
 upToParsedSource = ask
 
-upToScoping ::
+upToScopingEntry ::
   (Members '[HighlightBuilder, Reader Parser.ParserResult, Reader EntryPoint, Reader Store.ModuleTable, Error JuvixError, NameIdGen] r) =>
+  Sem r Scoper.ScoperResult
+upToScopingEntry = do
+  pkg <- asks (^. entryPointPackage)
+  runReader pkg (upToScoping)
+
+upToScoping ::
+  (Members '[HighlightBuilder, Reader Parser.ParserResult, Reader Package, Reader Store.ModuleTable, Error JuvixError, NameIdGen] r) =>
   Sem r Scoper.ScoperResult
 upToScoping = Scoper.fromParsed
 
 upToInternal ::
   (Members '[HighlightBuilder, Reader Parser.ParserResult, Reader EntryPoint, Reader Store.ModuleTable, Error JuvixError, NameIdGen, Termination] r) =>
   Sem r Internal.InternalResult
-upToInternal = upToScoping >>= Internal.fromConcrete
+upToInternal = do
+  pkg <- asks (^. entryPointPackage)
+  runReader pkg upToScoping >>= Internal.fromConcrete
 
 upToInternalTyped ::
   (Members '[HighlightBuilder, Reader Parser.ParserResult, Error JuvixError, Reader EntryPoint, Reader Store.ModuleTable, NameIdGen] r) =>

--- a/src/Juvix/Compiler/Pipeline/Driver.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver.hs
@@ -143,7 +143,8 @@ processRecursiveUpToTyped = do
   PipelineResult res mtab _ <- processFileUpToParsing entry
   let imports = HashMap.keys (mtab ^. Store.moduleTable)
   ms <- forM imports (`withPathFile` goImport)
-  mid <- getModuleId (res ^. Parser.resultModule . modulePath)
+  let pkg = entry ^. entryPointPackage
+  mid <- runReader pkg (getModuleId (res ^. Parser.resultModule . modulePath))
   a <-
     evalTopNameIdGen mid
       . runReader mtab
@@ -203,7 +204,8 @@ processFileUpTo ::
 processFileUpTo a = do
   entry <- ask
   res <- processFileUpToParsing entry
-  mid <- getModuleId (res ^. pipelineResult . Parser.resultModule . modulePath)
+  let pkg = entry ^. entryPointPackage
+  mid <- runReader pkg (getModuleId (res ^. pipelineResult . Parser.resultModule . modulePath))
   a' <-
     evalTopNameIdGen mid
       . runReader (res ^. pipelineResultImports)
@@ -257,7 +259,8 @@ processFileToStoredCore ::
   Sem r (PipelineResult Core.CoreResult)
 processFileToStoredCore entry = ignoreHighlightBuilder . runReader entry $ do
   res <- processFileUpToParsing entry
-  mid <- getModuleId (res ^. pipelineResult . Parser.resultModule . modulePath)
+  let pkg = entry ^. entryPointPackage
+  mid <- runReader pkg (getModuleId (res ^. pipelineResult . Parser.resultModule . modulePath))
   r <-
     evalTopNameIdGen mid
       . runReader (res ^. pipelineResultImports)

--- a/src/Juvix/Compiler/Pipeline/DriverParallel.hs
+++ b/src/Juvix/Compiler/Pipeline/DriverParallel.hs
@@ -179,7 +179,7 @@ formatNode ::
   Path Abs Dir ->
   EntryIndex ->
   Sem r SourceCode
-formatNode pkgRoot e = do
+formatNode _pkgRoot e = do
   moduleInfo :: PipelineResult Store.ModuleInfo <- cacheGet e
   formatModuleInfo (e ^. entryIxImportNode) moduleInfo
 

--- a/src/Juvix/Compiler/Pipeline/DriverParallel.hs
+++ b/src/Juvix/Compiler/Pipeline/DriverParallel.hs
@@ -10,10 +10,7 @@ where
 
 import Data.HashMap.Strict qualified as HashMap
 import Effectful.Concurrent
-import Juvix.Compiler.Concrete.Data.Highlight (ignoreHighlightBuilder)
 import Juvix.Compiler.Concrete.Language
-import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping
-import Juvix.Compiler.Concrete.Translation.FromSource (ParserResult, fromSource)
 import Juvix.Compiler.Concrete.Translation.FromSource.TopModuleNameChecker
 import Juvix.Compiler.Concrete.Translation.ImportScanner (ImportScanStrategy)
 import Juvix.Compiler.Pipeline
@@ -22,9 +19,7 @@ import Juvix.Compiler.Pipeline.Driver qualified as Driver
 import Juvix.Compiler.Pipeline.JvoCache
 import Juvix.Compiler.Pipeline.Loader.PathResolver
 import Juvix.Compiler.Pipeline.ModuleInfoCache
-import Juvix.Compiler.Store.Extra
 import Juvix.Compiler.Store.Language qualified as Store
-import Juvix.Compiler.Store.Scoped.Language
 import Juvix.Formatter
 import Juvix.Prelude
 import Parallel.ParallelTemplate

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -53,10 +53,10 @@ getEntryPointTarget e = fromMaybe defaultTarget (e ^. entryPointTarget)
     -- TODO is having a default target a good idea?
     defaultTarget = TargetCore
 
-defaultEntryPoint :: Package -> Root -> Path Abs File -> EntryPoint
+defaultEntryPoint :: Package -> Root -> Maybe (Path Abs File) -> EntryPoint
 defaultEntryPoint pkg root mainFile =
   (defaultEntryPointNoFile pkg root)
-    { _entryPointModulePath = pure mainFile
+    { _entryPointModulePath = mainFile
     }
 
 defaultEntryPointNoFile :: Package -> Root -> EntryPoint

--- a/src/Juvix/Compiler/Pipeline/EntryPoint/IO.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint/IO.hs
@@ -9,7 +9,7 @@ defaultEntryPointIO :: (Members '[EmbedIO, TaggedLock, EmbedIO] r) => Path Abs D
 defaultEntryPointIO cwd mainFile = do
   root <- findRootAndChangeDir (Just (parent mainFile)) Nothing cwd
   pkg <- readPackageRootIO root
-  return (defaultEntryPoint pkg root mainFile)
+  return (defaultEntryPoint pkg root (Just mainFile))
 
 defaultEntryPointNoFileIO :: (Members '[EmbedIO, TaggedLock, EmbedIO] r) => Path Abs Dir -> Sem r EntryPoint
 defaultEntryPointNoFileIO cwd = do

--- a/src/Juvix/Compiler/Pipeline/JvoCache.hs
+++ b/src/Juvix/Compiler/Pipeline/JvoCache.hs
@@ -1,5 +1,6 @@
 module Juvix.Compiler.Pipeline.JvoCache where
 
+import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.ImportNode
 import Juvix.Compiler.Store.Language qualified as Store
 import Juvix.Extra.Serialize qualified as Serialize
 import Juvix.Prelude
@@ -10,8 +11,8 @@ evalJvoCache :: (Members '[TaggedLock, Files] r) => Sem (JvoCache ': r) a -> Sem
 evalJvoCache = evalCacheEmpty Serialize.loadFromFile
 
 -- | Used to fill the cache in parallel
-preLoadFromFile :: (Members '[JvoCache] r) => Path Abs File -> Sem r ()
-preLoadFromFile = void . fmap force . cacheGetResult @(Path Abs File) @(Maybe Store.ModuleInfo)
+preLoadFromFile :: (Members '[JvoCache] r) => ImportNode -> Sem r ()
+preLoadFromFile = void . fmap force . cacheGetResult @(Path Abs File) @(Maybe Store.ModuleInfo) . (^. importNodeAbsFile)
 
 loadFromFile :: (Members '[JvoCache] r) => Path Abs File -> Sem r (Maybe Store.ModuleInfo)
 loadFromFile = cacheGet

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Base.hs
@@ -37,7 +37,6 @@ data PathResolver :: Effect where
   ResolvePath :: ImportScan -> PathResolver m (PackageInfo, FileExt)
   -- | The root is assumed to be a package root.
   WithResolverRoot :: Path Abs Dir -> m a -> PathResolver m a
-  -- TODO remove: ugly af
   SupportsParallel :: PathResolver m Bool
   ResolverRoot :: PathResolver m (Path Abs Dir)
 

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
@@ -5,7 +5,7 @@ module Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
     importTreeReverse,
     importTreeEdges,
     importTreeNodes,
-    importTreeProjectFiles,
+    importTreeProjectNodes,
     ImportTreeBuilder,
     runImportTreeBuilder,
     ignoreImportTreeBuilder,
@@ -98,13 +98,13 @@ importTreeReverse = fimportTreeReverse
 importTreeNodes :: SimpleGetter ImportTree (HashSet ImportNode)
 importTreeNodes = importTree . to HashMap.keysSet
 
-importTreeProjectFiles :: ImportTree -> Path Abs Dir -> [Path Abs File]
-importTreeProjectFiles tree pkgRoot = mapMaybe projectFile (toList (tree ^. importTreeNodes))
+importTreeProjectNodes :: Path Abs Dir -> ImportTree -> [ImportNode]
+importTreeProjectNodes pkgRoot tree = mapMaybe projectFile (toList (tree ^. importTreeNodes))
   where
-    projectFile :: ImportNode -> Maybe (Path Abs File)
-    projectFile i
-      | i ^. importNodePackageRoot == pkgRoot = Just (i ^. importNodeAbsFile)
-      | otherwise = Nothing
+    projectFile :: ImportNode -> Maybe ImportNode
+    projectFile i = do
+      guard (i ^. importNodePackageRoot == pkgRoot)
+      return i
 
 importTreeEdges :: SimpleGetter ImportTree (HashMap ImportNode (HashSet ImportScan))
 importTreeEdges = fimportTreeEdges

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
@@ -5,6 +5,7 @@ module Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
     importTreeReverse,
     importTreeEdges,
     importTreeNodes,
+    importTreeProjectFiles,
     ImportTreeBuilder,
     runImportTreeBuilder,
     ignoreImportTreeBuilder,
@@ -96,6 +97,14 @@ importTreeReverse = fimportTreeReverse
 
 importTreeNodes :: SimpleGetter ImportTree (HashSet ImportNode)
 importTreeNodes = importTree . to HashMap.keysSet
+
+importTreeProjectFiles :: ImportTree -> Path Abs Dir -> [Path Abs File]
+importTreeProjectFiles tree pkgRoot = mapMaybe projectFile (toList (tree ^. importTreeNodes))
+  where
+    projectFile :: ImportNode -> Maybe (Path Abs File)
+    projectFile i
+      | i ^. importNodePackageRoot == pkgRoot = Just (i ^. importNodeAbsFile)
+      | otherwise = Nothing
 
 importTreeEdges :: SimpleGetter ImportTree (HashMap ImportNode (HashSet ImportScan))
 importTreeEdges = fimportTreeEdges

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
@@ -4,6 +4,7 @@ module Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
     importTree,
     importTreeReverse,
     importTreeEdges,
+    importTreeNodes,
     ImportTreeBuilder,
     runImportTreeBuilder,
     ignoreImportTreeBuilder,
@@ -92,6 +93,9 @@ importTree = fimportTree
 
 importTreeReverse :: SimpleGetter ImportTree (HashMap ImportNode (HashSet ImportNode))
 importTreeReverse = fimportTreeReverse
+
+importTreeNodes :: SimpleGetter ImportTree (HashSet ImportNode)
+importTreeNodes = importTree . to HashMap.keysSet
 
 importTreeEdges :: SimpleGetter ImportTree (HashMap ImportNode (HashSet ImportScan))
 importTreeEdges = fimportTreeEdges

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Paths.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/Paths.hs
@@ -11,15 +11,22 @@ topModulePathToRelativePath' m =
       ext = fileExtension' absPath
    in topModulePathToRelativePath ext "" (</>) m
 
+topModulePathKeyToRelativePathNoExt :: TopModulePathKey -> Path Rel File
+topModulePathKeyToRelativePathNoExt TopModulePathKey {..} =
+  relFile (joinFilePaths (map unpack (_modulePathKeyDir ++ [_modulePathKeyName])))
+
 topModulePathToRelativePathNoExt :: TopModulePath -> Path Rel File
-topModulePathToRelativePathNoExt TopModulePath {..} = relFile (joinFilePaths (map (unpack . (^. withLocParam)) (_modulePathDir ++ [_modulePathName])))
+topModulePathToRelativePathNoExt = topModulePathKeyToRelativePathNoExt . topModulePathKey
+
+topModulePathKeyToImportScan :: Interval -> TopModulePathKey -> ImportScan
+topModulePathKeyToImportScan loc TopModulePathKey {..} =
+  ImportScan
+    { _importNames = unpack <$> NonEmpty.prependList _modulePathKeyDir (pure _modulePathKeyName),
+      _importLoc = loc
+    }
 
 topModulePathToImportScan :: TopModulePath -> ImportScan
-topModulePathToImportScan t@TopModulePath {..} =
-  ImportScan
-    { _importNames = unpack . (^. withLocParam) <$> (NonEmpty.prependList _modulePathDir (pure _modulePathName)),
-      _importLoc = getLoc t
-    }
+topModulePathToImportScan t = topModulePathKeyToImportScan (getLoc t) (topModulePathKey t)
 
 topModulePathToRelativePath :: String -> String -> (FilePath -> FilePath -> FilePath) -> TopModulePath -> Path Rel File
 topModulePathToRelativePath ext suffix joinpath mp = relFile relFilePath

--- a/src/Juvix/Compiler/Pipeline/ModuleInfoCache.hs
+++ b/src/Juvix/Compiler/Pipeline/ModuleInfoCache.hs
@@ -22,9 +22,6 @@ instance Hashable EntryIndex where
 
 type ModuleInfoCache = Cache EntryIndex (PipelineResult Store.ModuleInfo)
 
-entryIndexTopModulePathKey :: EntryIndex -> TopModulePathKey
-entryIndexTopModulePathKey = relPathtoTopModulePathKey . (^. entryIxImportNode . importNodeFile)
-
 entryIndexPath :: EntryIndex -> Path Abs File
 entryIndexPath = fromMaybe err . (^. entryIxEntry . entryPointModulePath)
   where

--- a/src/Juvix/Compiler/Pipeline/ModuleInfoCache.hs
+++ b/src/Juvix/Compiler/Pipeline/ModuleInfoCache.hs
@@ -8,7 +8,8 @@ import Juvix.Prelude
 
 data EntryIndex = EntryIndex
   { _entryIxEntry :: EntryPoint,
-    _entryIxResolverRoot :: Path Abs Dir
+    _entryIxResolverRoot :: Path Abs Dir,
+    _entryIxTopModulePathKey :: TopModulePathKey
   }
 
 makeLenses ''EntryIndex
@@ -27,8 +28,8 @@ entryIndexPath = fromMaybe err . (^. entryIxEntry . entryPointModulePath)
     err :: a
     err = error "unexpected: EntryIndex should always have a path"
 
-mkEntryIndex :: (Members '[Reader EntryPoint] r) => Path Abs Dir -> Path Abs File -> Sem r EntryIndex
-mkEntryIndex _entryIxResolverRoot path = do
+mkEntryIndex :: (Members '[Reader EntryPoint] r) => TopModulePathKey -> Path Abs Dir -> Path Abs File -> Sem r EntryIndex
+mkEntryIndex moduleKey resolverRoot path = do
   entry <- ask
   let stdin'
         | Just path == entry ^. entryPointModulePath = entry ^. entryPointStdin
@@ -41,5 +42,6 @@ mkEntryIndex _entryIxResolverRoot path = do
   return
     EntryIndex
       { _entryIxEntry = entry',
-        _entryIxResolverRoot
+        _entryIxResolverRoot = resolverRoot,
+        _entryIxTopModulePathKey = moduleKey
       }

--- a/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader/EvalEff/IO.hs
@@ -149,7 +149,7 @@ loadPackage' packagePath = do
     rootPath = parent packagePath
 
     packageEntryPoint :: EntryPoint
-    packageEntryPoint = defaultEntryPoint rootPkg root packagePath
+    packageEntryPoint = defaultEntryPoint rootPkg root (Just packagePath)
       where
         root :: Root
         root =

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -167,6 +167,7 @@ compileReplInputIO fp txt = do
   hasInternet <- not <$> asks (^. entryPointOffline)
   runError
     . runConcurrent
+    . runReader defaultNumThreads
     . evalInternet hasInternet
     . runTaggedLockPermissive
     . runLogIO
@@ -184,7 +185,7 @@ compileReplInputIO fp txt = do
     . runReader defaultImportScanStrategy
     . withImportTree (Just fp)
     . ignoreProgressLog
-    . evalModuleInfoCacheHelper defaultNumThreads
+    . evalModuleInfoCacheHelper
     $ do
       p <- parseReplInput fp txt
       case p of

--- a/src/Juvix/Compiler/Store/Extra.hs
+++ b/src/Juvix/Compiler/Store/Extra.hs
@@ -16,9 +16,6 @@ import Juvix.Prelude
 getModulePath :: ModuleInfo -> TopModulePath
 getModulePath mi = mi ^. moduleInfoScopedModule . scopedModulePath . S.nameConcrete
 
-getModuleId :: ModuleInfo -> ModuleId
-getModuleId mi = mi ^. moduleInfoScopedModule . scopedModuleId
-
 getScopedModuleTable :: ModuleTable -> ScopedModuleTable
 getScopedModuleTable mtab =
   ScopedModuleTable $ fmap (^. moduleInfoScopedModule) (mtab ^. moduleTable)

--- a/src/Juvix/Compiler/Store/Language.hs
+++ b/src/Juvix/Compiler/Store/Language.hs
@@ -1,6 +1,6 @@
 module Juvix.Compiler.Store.Language where
 
-import Juvix.Compiler.Concrete.Language (TopModulePath)
+import Juvix.Compiler.Concrete.Data.Name
 import Juvix.Compiler.Store.Core.Data.InfoTable qualified as Core
 import Juvix.Compiler.Store.Internal.Language
 import Juvix.Compiler.Store.Options

--- a/src/Juvix/Compiler/Store/Scoped/Language.hs
+++ b/src/Juvix/Compiler/Store/Scoped/Language.hs
@@ -30,8 +30,7 @@ data ScopedModule = ScopedModule
     _scopedModuleFilePath :: Path Abs File,
     _scopedModuleExportInfo :: ExportInfo,
     _scopedModuleLocalModules :: HashMap S.NameId ScopedModule,
-    _scopedModuleInfoTable :: InfoTable,
-    _scopedModuleSource :: Text
+    _scopedModuleInfoTable :: InfoTable
   }
   deriving stock (Generic)
 

--- a/src/Juvix/Compiler/Store/Scoped/Language.hs
+++ b/src/Juvix/Compiler/Store/Scoped/Language.hs
@@ -25,8 +25,7 @@ instance Serialize ExportInfo
 instance NFData ExportInfo
 
 data ScopedModule = ScopedModule
-  { _scopedModuleId :: ModuleId,
-    _scopedModulePath :: S.TopModulePath,
+  { _scopedModulePath :: S.TopModulePath,
     _scopedModuleName :: S.Name,
     _scopedModuleFilePath :: Path Abs File,
     _scopedModuleExportInfo :: ExportInfo,

--- a/src/Juvix/Compiler/Store/Scoped/Language.hs
+++ b/src/Juvix/Compiler/Store/Scoped/Language.hs
@@ -31,7 +31,8 @@ data ScopedModule = ScopedModule
     _scopedModuleFilePath :: Path Abs File,
     _scopedModuleExportInfo :: ExportInfo,
     _scopedModuleLocalModules :: HashMap S.NameId ScopedModule,
-    _scopedModuleInfoTable :: InfoTable
+    _scopedModuleInfoTable :: InfoTable,
+    _scopedModuleSource :: Text
   }
   deriving stock (Generic)
 

--- a/src/Juvix/Compiler/Store/Scoped/Language.hs
+++ b/src/Juvix/Compiler/Store/Scoped/Language.hs
@@ -40,7 +40,7 @@ instance Serialize ScopedModule
 instance NFData ScopedModule
 
 newtype ScopedModuleTable = ScopedModuleTable
-  { _scopedModuleTable :: HashMap C.TopModulePath ScopedModule
+  { _scopedModuleTable :: HashMap TopModulePathKey ScopedModule
   }
 
 makeLenses ''ExportInfo

--- a/src/Juvix/Data.hs
+++ b/src/Juvix/Data.hs
@@ -19,6 +19,7 @@ module Juvix.Data
     module Juvix.Data.WithLoc,
     module Juvix.Data.WithSource,
     module Juvix.Data.DependencyInfo,
+    module Juvix.Data.TopModulePathKey,
     module Juvix.Data.Keyword,
   )
 where
@@ -39,6 +40,7 @@ import Juvix.Data.NameId qualified
 import Juvix.Data.NumThreads
 import Juvix.Data.Pragmas
 import Juvix.Data.Processed
+import Juvix.Data.TopModulePathKey
 import Juvix.Data.Uid
 import Juvix.Data.Universe
 import Juvix.Data.Wildcard

--- a/src/Juvix/Data/Effect.hs
+++ b/src/Juvix/Data/Effect.hs
@@ -6,6 +6,7 @@ module Juvix.Data.Effect
     module Juvix.Data.Effect.Visit,
     module Juvix.Data.Effect.Log,
     module Juvix.Data.Effect.Internet,
+    module Juvix.Data.Effect.Forcing,
     module Juvix.Data.Effect.TaggedLock,
   )
 where
@@ -13,6 +14,7 @@ where
 import Juvix.Data.Effect.Cache
 import Juvix.Data.Effect.Fail
 import Juvix.Data.Effect.Files
+import Juvix.Data.Effect.Forcing
 import Juvix.Data.Effect.Internet
 import Juvix.Data.Effect.Log
 import Juvix.Data.Effect.NameIdGen

--- a/src/Juvix/Data/Effect/Cache.hs
+++ b/src/Juvix/Data/Effect/Cache.hs
@@ -8,7 +8,6 @@ module Juvix.Data.Effect.Cache
     evalCacheEmptySetup,
     runCacheEmpty,
     cacheGet,
-    cacheGetCache,
     cacheGetResult,
     cacheLookup,
     evalSingletonCache,
@@ -37,7 +36,6 @@ makeLenses ''CacheResult
 data Cache (k :: GHCType) (v :: GHCType) :: Effect where
   CacheGetResult :: k -> Cache k v m (CacheResult v)
   CacheLookup :: k -> Cache k v m (Maybe v)
-  CacheGetCache :: Cache k v m (HashMap k v)
 
 makeSem ''Cache
 
@@ -151,7 +149,6 @@ cacheSimpleHandler ::
   EffectHandlerFO (Cache k v) (SharedState (HashMap k v) ': r)
 cacheSimpleHandler f =
   \case
-    CacheGetCache -> getShared
     CacheLookup k -> cacheLookup' k
     CacheGetResult k -> do
       mv <- cacheLookup' k
@@ -182,7 +179,6 @@ cacheSetupHandler ::
   EffectHandlerFO (Cache k v) (SharedState (HashMap k v) ': r)
 cacheSetupHandler setup f = do
   \case
-    CacheGetCache -> getShared
     CacheLookup k -> cacheLookup' k
     CacheGetResult k -> do
       mv <- cacheLookup' k

--- a/src/Juvix/Data/Effect/Cache.hs
+++ b/src/Juvix/Data/Effect/Cache.hs
@@ -8,6 +8,7 @@ module Juvix.Data.Effect.Cache
     evalCacheEmptySetup,
     runCacheEmpty,
     cacheGet,
+    cacheGetCache,
     cacheGetResult,
     cacheLookup,
     evalSingletonCache,
@@ -36,6 +37,7 @@ makeLenses ''CacheResult
 data Cache (k :: GHCType) (v :: GHCType) :: Effect where
   CacheGetResult :: k -> Cache k v m (CacheResult v)
   CacheLookup :: k -> Cache k v m (Maybe v)
+  CacheGetCache :: Cache k v m (HashMap k v)
 
 makeSem ''Cache
 
@@ -149,6 +151,7 @@ cacheSimpleHandler ::
   EffectHandlerFO (Cache k v) (SharedState (HashMap k v) ': r)
 cacheSimpleHandler f =
   \case
+    CacheGetCache -> getShared
     CacheLookup k -> cacheLookup' k
     CacheGetResult k -> do
       mv <- cacheLookup' k
@@ -179,6 +182,7 @@ cacheSetupHandler ::
   EffectHandlerFO (Cache k v) (SharedState (HashMap k v) ': r)
 cacheSetupHandler setup f = do
   \case
+    CacheGetCache -> getShared
     CacheLookup k -> cacheLookup' k
     CacheGetResult k -> do
       mv <- cacheLookup' k

--- a/src/Juvix/Data/Effect/Forcing.hs
+++ b/src/Juvix/Data/Effect/Forcing.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -Wno-unused-type-patterns #-}
+
+module Juvix.Data.Effect.Forcing where
+
+import Juvix.Prelude.Base
+
+data Forcing (a :: GHCType) :: Effect where
+  Forces :: NFData b => Lens' a b -> Forcing a m ()
+  ForcesField :: Lens' a b -> Sem '[Forcing b] () -> Forcing a m ()
+
+makeSem ''Forcing
+
+forcing :: a -> Sem '[Forcing a] () -> a
+forcing a = run . evalForcing a
+
+evalForcing :: a -> Sem (Forcing a ': r) () -> Sem r a
+evalForcing a =
+  reinterpret (execState a) $ \case
+    Forces l -> modify (over l force)
+    ForcesField l r -> modify (over l (`forcing` r))

--- a/src/Juvix/Data/Effect/Forcing.hs
+++ b/src/Juvix/Data/Effect/Forcing.hs
@@ -1,11 +1,15 @@
 {-# OPTIONS_GHC -Wno-unused-type-patterns #-}
 
+-- | This effect provides convenient syntax for individually forcing evaluation
+-- on fields of a record type (or anything pointed by a lens)
 module Juvix.Data.Effect.Forcing where
 
 import Juvix.Prelude.Base
 
 data Forcing (a :: GHCType) :: Effect where
+  -- | Forces full evaluation on the field pointed by the lens
   ForcesField :: (NFData b) => Lens' a b -> Forcing a m ()
+  -- | Forcing effect scoped to the field pointed by the lens
   Forces :: Lens' a b -> Sem '[Forcing b] () -> Forcing a m ()
 
 makeSem ''Forcing

--- a/src/Juvix/Data/Effect/Forcing.hs
+++ b/src/Juvix/Data/Effect/Forcing.hs
@@ -5,8 +5,8 @@ module Juvix.Data.Effect.Forcing where
 import Juvix.Prelude.Base
 
 data Forcing (a :: GHCType) :: Effect where
-  Forces :: NFData b => Lens' a b -> Forcing a m ()
-  ForcesField :: Lens' a b -> Sem '[Forcing b] () -> Forcing a m ()
+  ForcesField :: (NFData b) => Lens' a b -> Forcing a m ()
+  Forces :: Lens' a b -> Sem '[Forcing b] () -> Forcing a m ()
 
 makeSem ''Forcing
 
@@ -16,5 +16,5 @@ forcing a = run . evalForcing a
 evalForcing :: a -> Sem (Forcing a ': r) () -> Sem r a
 evalForcing a =
   reinterpret (execState a) $ \case
-    Forces l -> modify (over l force)
-    ForcesField l r -> modify (over l (`forcing` r))
+    ForcesField l -> modify (over l force)
+    Forces l r -> modify (over l (`forcing` r))

--- a/src/Juvix/Data/ModuleId.hs
+++ b/src/Juvix/Data/ModuleId.hs
@@ -1,11 +1,12 @@
 module Juvix.Data.ModuleId where
 
+import Juvix.Data.TopModulePathKey
 import Juvix.Extra.Serialize
 import Juvix.Prelude.Base
 import Prettyprinter
 
 data ModuleId = ModuleId
-  { _moduleIdPath :: Text,
+  { _moduleIdPath :: TopModulePathKey,
     _moduleIdPackage :: Text,
     _moduleIdPackageVersion :: Text
   }
@@ -25,7 +26,7 @@ instance NFData ModuleId
 defaultModuleId :: ModuleId
 defaultModuleId =
   ModuleId
-    { _moduleIdPath = "$DefaultModule$",
+    { _moduleIdPath = nonEmptyToTopModulePathKey (pure "$DefaultModule$"),
       _moduleIdPackage = "$",
       _moduleIdPackageVersion = "1.0"
     }

--- a/src/Juvix/Data/TopModulePathKey.hs
+++ b/src/Juvix/Data/TopModulePathKey.hs
@@ -1,7 +1,9 @@
 module Juvix.Data.TopModulePathKey where
 
+import Data.List.NonEmpty qualified as NonEmpty
 import Juvix.Extra.Serialize
 import Juvix.Prelude.Base
+import Juvix.Prelude.Path
 import Juvix.Prelude.Pretty as Pretty
 
 data TopModulePathKey = TopModulePathKey
@@ -21,3 +23,19 @@ makeLenses ''TopModulePathKey
 instance Pretty TopModulePathKey where
   pretty (TopModulePathKey path name) =
     mconcat (punctuate Pretty.dot (map pretty (snoc path name)))
+
+nonEmptyToTopModulePathKey :: NonEmpty Text -> TopModulePathKey
+nonEmptyToTopModulePathKey l =
+  TopModulePathKey
+    { _modulePathKeyDir = NonEmpty.init l,
+      _modulePathKeyName = NonEmpty.last l
+    }
+
+relPathtoTopModulePathKey :: Path Rel File -> TopModulePathKey
+relPathtoTopModulePathKey =
+  nonEmptyToTopModulePathKey
+    . fmap pack
+    . nonEmpty'
+    . splitDirectories
+    . toFilePath
+    . removeExtensions

--- a/src/Juvix/Data/TopModulePathKey.hs
+++ b/src/Juvix/Data/TopModulePathKey.hs
@@ -1,0 +1,23 @@
+module Juvix.Data.TopModulePathKey where
+
+import Juvix.Extra.Serialize
+import Juvix.Prelude.Base
+import Juvix.Prelude.Pretty as Pretty
+
+data TopModulePathKey = TopModulePathKey
+  { _modulePathKeyDir :: [Text],
+    _modulePathKeyName :: Text
+  }
+  deriving stock (Show, Eq, Ord, Generic)
+
+instance Serialize TopModulePathKey
+
+instance NFData TopModulePathKey
+
+instance Hashable TopModulePathKey
+
+makeLenses ''TopModulePathKey
+
+instance Pretty TopModulePathKey where
+  pretty (TopModulePathKey path name) =
+    mconcat (punctuate Pretty.dot (map pretty (snoc path name)))

--- a/src/Juvix/Data/TopModulePathKey.hs
+++ b/src/Juvix/Data/TopModulePathKey.hs
@@ -10,7 +10,7 @@ data TopModulePathKey = TopModulePathKey
   { _modulePathKeyDir :: [Text],
     _modulePathKeyName :: Text
   }
-  deriving stock (Show, Eq, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic, Data)
 
 instance Serialize TopModulePathKey
 

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -73,6 +73,12 @@ format p = do
 --
 -- NB: This function does not traverse into Juvix sub-projects, i.e into
 -- subdirectories that contain a juvix.yaml file.
+-- formatProjectNew ::
+--   forall r.
+--   (Members '[Files, Output FormattedFileInfo] r) =>
+--   Path Abs Dir ->
+--   Sem r FormatResult
+-- formatProjectNew p = undefined
 formatProject ::
   forall r.
   (Members '[ScopeEff, Files, Output FormattedFileInfo] r) =>

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -73,12 +73,6 @@ format p = do
 --
 -- NB: This function does not traverse into Juvix sub-projects, i.e into
 -- subdirectories that contain a juvix.yaml file.
--- formatProjectNew ::
---   forall r.
---   (Members '[Files, Output FormattedFileInfo] r) =>
---   Path Abs Dir ->
---   Sem r FormatResult
--- formatProjectNew p = undefined
 formatProject ::
   forall r.
   (Members '[ScopeEff, Files, Output FormattedFileInfo] r) =>

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -2,7 +2,6 @@
 
 module Juvix.Formatter where
 
-import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Concrete.Data.Highlight.Input (ignoreHighlightBuilder)
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Print (ppOutDefault)
@@ -99,12 +98,11 @@ format p = do
 formatProject ::
   forall r.
   (Members '[Output FormattedFileInfo] r) =>
-  HashMap ImportNode SourceCode ->
+  [(ImportNode, SourceCode)] ->
   Sem r FormatResult
 formatProject =
   mconcatMapM (uncurry formatResultSourceCode)
     . map (first (^. importNodeAbsFile))
-    . HashMap.toList
 
 formatModuleInfo ::
   ( Members

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -201,7 +201,7 @@ formatScoperResult ::
   Sem r Text
 formatScoperResult forceFormat res = do
   let comments = Scoper.getScoperResultComments res
-      formattedTxt = toPlainText (ppOutDefault comments (res ^. Scoper.resultModule))
+      formattedTxt = toPlainTextTrim (ppOutDefault comments (res ^. Scoper.resultModule))
   runFailDefault formattedTxt $ do
     pragmas <- failMaybe (res ^. Scoper.mainModule . modulePragmas)
     PragmaFormat {..} <- failMaybe (pragmas ^. withLocParam . withSourceValue . pragmasFormat)

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -140,10 +140,9 @@ formatModuleInfo node moduleInfo =
               { _sourceCodeFormatted = formattedTxt,
                 _sourceCodeOriginal = originalSource
               }
-      return . forcing formatRes $
-        when (True) $ do
-          forcesField sourceCodeFormatted
-          forcesField sourceCodeOriginal
+      return . forcing formatRes $ do
+        forcesField sourceCodeFormatted
+        forcesField sourceCodeOriginal
 
 formatPath ::
   (Members '[Reader OriginalSource, ScopeEff] r) =>

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -95,12 +95,12 @@ format p = do
 --
 -- NB: This function does not traverse into Juvix sub-projects, i.e into
 -- subdirectories that contain a juvix.yaml file.
-formatProject ::
+formatProjectSourceCode ::
   forall r.
   (Members '[Output FormattedFileInfo] r) =>
   [(ImportNode, SourceCode)] ->
   Sem r FormatResult
-formatProject =
+formatProjectSourceCode =
   mconcatMapM (uncurry formatResultSourceCode)
     . map (first (^. importNodeAbsFile))
 

--- a/src/Juvix/Prelude/Base/Foundation.hs
+++ b/src/Juvix/Prelude/Base/Foundation.hs
@@ -171,7 +171,7 @@ import Safe.Exact
 import Safe.Foldable
 import System.Exit hiding (exitFailure, exitSuccess)
 import System.Exit qualified as IO
-import System.FilePath (FilePath, dropTrailingPathSeparator, normalise, (<.>), (</>))
+import System.FilePath (FilePath, dropTrailingPathSeparator, normalise, splitDirectories, (<.>), (</>))
 import System.FilePath qualified as FilePath
 import System.IO hiding
   ( appendFile,

--- a/src/Parallel/ParallelTemplate.hs
+++ b/src/Parallel/ParallelTemplate.hs
@@ -152,14 +152,14 @@ compile args@CompileArgs {..} = do
       allNodesIds :: [nodeId] = HashMap.keys (nodesIx ^. nodesIndex)
       deps = _compileArgsDependencies
       numMods :: Natural = fromIntegral (length allNodesIds)
-      starterModules :: [nodeId] =
+      startingModules :: [nodeId] =
         [m | m <- allNodesIds, null (nodeDependencies deps m)]
   logs <- Logs <$> newTQueueIO
   qq <- newTBQueueIO (max 1 numMods)
   let compileQ = CompileQueue qq
   whenJust _compileArgsPreProcess $ \preProcess ->
     mapConcurrently_ preProcess allNodesIds
-  atomically (forM_ starterModules (writeTBQueue qq))
+  atomically (forM_ startingModules (writeTBQueue qq))
   let iniCompilationState :: CompilationState nodeId compileProof =
         CompilationState
           { _compilationStartedNum = 0,

--- a/test/BackendMarkdown/Negative.hs
+++ b/test/BackendMarkdown/Negative.hs
@@ -25,7 +25,7 @@ testDescr NegTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             entryPoint <- testDefaultEntryPointIO tRoot file'
-            result <- testTaggedLockedToIO (runIOEither entryPoint upToScoping)
+            result <- testTaggedLockedToIO (runIOEither entryPoint upToScopingEntry)
             case result of
               Left err -> whenJust (_checkErr err) assertFailure
               Right (_, pipelineRes) -> checkResult pipelineRes

--- a/test/BackendMarkdown/Positive.hs
+++ b/test/BackendMarkdown/Positive.hs
@@ -35,7 +35,7 @@ testDescr PosTest {..} =
       _testAssertion = Steps $ \step -> do
         entryPoint <- testDefaultEntryPointIO _dir _file
         step "Parsing & Scoping"
-        PipelineResult {..} <- snd <$> testRunIO entryPoint upToScoping
+        PipelineResult {..} <- snd <$> testRunIO entryPoint upToScopingEntry
         let m = _pipelineResult ^. Scoper.resultModule
         let opts =
               ProcessJuvixBlocksArgs

--- a/test/Format.hs
+++ b/test/Format.hs
@@ -36,7 +36,7 @@ testDescr PosTest {..} =
         original :: Text <- readFile f
 
         step "Parsing & scoping"
-        PipelineResult {..} <- snd <$> testRunIO entryPoint upToScoping
+        PipelineResult {..} <- snd <$> testRunIO entryPoint upToScopingEntry
 
         let formatted = formatScoperResult' _force original _pipelineResult
         case _expectedFile of

--- a/test/Formatter/Positive.hs
+++ b/test/Formatter/Positive.hs
@@ -9,9 +9,9 @@ runScopeEffIO :: (Member EmbedIO r) => Path Abs Dir -> Sem (ScopeEff ': r) a -> 
 runScopeEffIO root = interpret $ \case
   ScopeFile p -> do
     entry <- testDefaultEntryPointIO root p
-    ((^. pipelineResult) . snd <$> testRunIO entry upToScoping)
+    ((^. pipelineResult) . snd <$> testRunIO entry upToScopingEntry)
   ScopeStdin entry -> do
-    ((^. pipelineResult) . snd <$> testRunIO entry upToScoping)
+    ((^. pipelineResult) . snd <$> testRunIO entry upToScopingEntry)
 
 makeFormatTest' :: Scope.PosTest -> TestDescr
 makeFormatTest' Scope.PosTest {..} =

--- a/test/Repl/Positive.hs
+++ b/test/Repl/Positive.hs
@@ -22,7 +22,7 @@ loadPrelude :: Path Abs Dir -> IO (Artifacts, EntryPoint)
 loadPrelude rootDir = runTaggedLockIO' $ do
   runReader rootDir writeStdlib
   pkg <- readPackageRootIO root
-  let ep = defaultEntryPoint pkg root (rootDir <//> preludePath)
+  let ep = defaultEntryPoint pkg root (Just (rootDir <//> preludePath))
   artif <- runReplPipelineIO ep
   return (artif, ep)
   where

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -53,7 +53,7 @@ testDescr PosTest {..} = helper renderCodeNew
                     evalHelper input_ m = snd <$> testRunIO entryPoint {_entryPointStdin = Just input_} m
 
                 step "Parsing & Scoping"
-                PipelineResult s _ _ <- snd <$> testRunIO entryPoint upToScoping
+                PipelineResult s _ _ <- snd <$> testRunIO entryPoint upToScopingEntry
 
                 let p = s ^. Scoper.resultParserResult
                     fScoped :: Text
@@ -62,7 +62,7 @@ testDescr PosTest {..} = helper renderCodeNew
                     fParsed = renderer $ p ^. Parser.resultModule
 
                 step "Parsing & scoping pretty scoped"
-                PipelineResult s' _ _ <- evalHelper fScoped upToScoping
+                PipelineResult s' _ _ <- evalHelper fScoped upToScopingEntry
                 let p' = s' ^. Scoper.resultParserResult
 
                 step "Parsing pretty parsed"


### PR DESCRIPTION
Currently formatting a project is equivalent to running `juvix format` on each individual file. Hence, the performance is quadratic wrt the number of modules in the project. This pr fixes that and we now we only process each module once.

# Benchmark (1236% faster :rocket:)
Checking the standard library
```
hyperfine --warmup 1 'juvix format --check' 'juvix-main format --check'
Benchmark 1: juvix format --check
  Time (mean ± σ):     450.6 ms ±  33.7 ms    [User: 707.2 ms, System: 178.7 ms]
  Range (min … max):   396.0 ms … 497.0 ms    10 runs

Benchmark 2: juvix-main format --check
  Time (mean ± σ):      6.019 s ±  0.267 s    [User: 9.333 s, System: 1.512 s]
  Range (min … max):    5.598 s …  6.524 s    10 runs

Summary
  juvix format --check ran
   13.36 ± 1.16 times faster than juvix-main format --check
```

# Other changes:
1. The `EntryPoint` field `entryPointModulePath` is now optional.
2. I've introduced a new type `TopModulePathKey` which is analogous to `TopModulePath` but wihout location information. It is used in hashmap keys where the location in the key is never used. This is useful as we can now get a `TopModulePathKey` from a `Path Rel File`.
3. I've refactored the `_formatInput` field in `FormatOptions` so that it doesn't need to be a special case anymore.
4. I've introduced a new effect `Forcing` that allows to individually force fields of a record type with a convenient syntax.
5. I've refactored some of the constraints in scoping so that they only require `Reader Package` instead of  `Reader EntryPoint`.
6. I've introduced a new type family so that local modules are no longer required to have `ModuleId` from their type. Before, they were assigned one, but it was never used.


# Future work:
1. For project-wise formatting, the compilation is done in parallel, but the formatting is still done sequentially. That should be improved.