### PR TITLE
Add precondition to run tests

### DIFF
--- a/test/Base.hs
+++ b/test/Base.hs
@@ -10,6 +10,7 @@ module Base
   )
 where
 
+import Control.Exception qualified as E
 import Control.Monad.Extra as Monad
 import Data.Algorithm.Diff
 import Data.Algorithm.DiffOutput
@@ -59,6 +60,11 @@ mkTest :: TestDescr -> TestTree
 mkTest TestDescr {..} = case _testAssertion of
   Single assertion -> testCase _testName (withCurrentDir _testRoot assertion)
   Steps steps -> testCaseSteps _testName (withCurrentDir _testRoot . steps)
+
+withPrecondition :: Assertion -> IO TestTree -> IO TestTree
+withPrecondition assertion ifSuccess = do
+  E.catch (assertion >> ifSuccess) $ \case
+    E.SomeException e -> return (testCase "Precondition failed" (assertFailure (show e)))
 
 assertEqDiffText :: String -> Text -> Text -> Assertion
 assertEqDiffText = assertEqDiff unpack

--- a/test/Casm.hs
+++ b/test/Casm.hs
@@ -5,5 +5,11 @@ import Casm.Compilation qualified as Compile
 import Casm.Reg qualified as Reg
 import Casm.Run qualified as Run
 
-allTests :: TestTree
-allTests = testGroup "CASM tests" [Run.allTests, Reg.allTests, Compile.allTests]
+allTests :: IO TestTree
+allTests =
+  testGroup "CASM tests"
+    <$> sequence
+      [ Run.allTests,
+        Reg.allTests,
+        Compile.allTests
+      ]

--- a/test/Casm/Compilation.hs
+++ b/test/Casm/Compilation.hs
@@ -1,8 +1,14 @@
 module Casm.Compilation where
 
 import Base
-import Casm.Compilation.Negative qualified as N
-import Casm.Compilation.Positive qualified as P
+import Casm.Compilation.Negative qualified as Negative
+import Casm.Compilation.Positive qualified as Positive
 
-allTests :: TestTree
-allTests = testGroup "Juvix to CASM compilation" [P.allTests, P.allTestsNoOptimize, N.allTests]
+allTests :: IO TestTree
+allTests =
+  testGroup "Juvix to CASM compilation"
+    <$> sequence
+      [ Positive.allTests,
+        Positive.allTestsNoOptimize,
+        return Negative.allTests
+      ]

--- a/test/Casm/Compilation/Base.hs
+++ b/test/Casm/Compilation/Base.hs
@@ -1,4 +1,8 @@
-module Casm.Compilation.Base where
+module Casm.Compilation.Base
+  ( module Casm.Compilation.Base,
+    cairoVmPrecondition,
+  )
+where
 
 import Base
 import Casm.Run.Base

--- a/test/Casm/Reg.hs
+++ b/test/Casm/Reg.hs
@@ -1,8 +1,14 @@
 module Casm.Reg where
 
 import Base
-import Casm.Reg.Cairo qualified as C
-import Casm.Reg.Positive qualified as P
+import Casm.Reg.Cairo qualified as Cairo
+import Casm.Reg.Positive qualified as Positive
 
-allTests :: TestTree
-allTests = testGroup "JuvixReg to CASM translation" [P.allTests, C.allTests]
+allTests :: IO TestTree
+allTests =
+  testGroup
+    "JuvixReg to CASM translation"
+    <$> sequence
+      [ return Positive.allTests,
+        Cairo.allTests
+      ]

--- a/test/Casm/Reg/Base.hs
+++ b/test/Casm/Reg/Base.hs
@@ -13,7 +13,7 @@ import Reg.Run.Base qualified as Reg
 compileAssertion' :: EntryPoint -> Maybe (Path Abs File) -> Path Abs Dir -> Path Abs File -> Symbol -> Reg.InfoTable -> (String -> IO ()) -> Assertion
 compileAssertion' entryPoint inputFile _ outputFile _ tab step = do
   step "Translate to CASM"
-  case run $ runError @JuvixError $ runReader entryPoint $ regToCasm tab of
+  case run . runError @JuvixError . runReader entryPoint $ regToCasm tab of
     Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
     Right Result {..} -> do
       step "Interpret"
@@ -30,7 +30,7 @@ compileAssertion' entryPoint inputFile _ outputFile _ tab step = do
 cairoAssertion' :: EntryPoint -> Maybe (Path Abs File) -> Path Abs Dir -> Path Abs File -> Symbol -> Reg.InfoTable -> (String -> IO ()) -> Assertion
 cairoAssertion' entryPoint inputFile dirPath outputFile _ tab step = do
   step "Translate to Cairo"
-  case run $ runError @JuvixError $ runReader entryPoint $ regToCairo tab of
+  case run . runError @JuvixError . runReader entryPoint $ regToCairo tab of
     Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
     Right res -> do
       step "Serialize to Cairo bytecode"

--- a/test/Casm/Reg/Cairo.hs
+++ b/test/Casm/Reg/Cairo.hs
@@ -3,6 +3,7 @@ module Casm.Reg.Cairo where
 import Base
 import Casm.Reg.Base
 import Casm.Reg.Positive qualified as P
+import Casm.Run.Base (cairoVmPrecondition)
 
 testDescr :: P.PosTest -> TestDescr
 testDescr P.PosTest {..} =
@@ -16,27 +17,28 @@ testDescr P.PosTest {..} =
           _testAssertion = Steps $ regToCairoAssertion tRoot file' input' expected'
         }
 
-allTests :: TestTree
+allTests :: IO TestTree
 allTests =
-  testGroup
-    "JuvixReg to Cairo translation positive tests"
-    ( map (mkTest . testDescr) $
-        P.filterOutTests
-          [ "Test001: Arithmetic opcodes",
-            "Test013: Fibonacci numbers in linear time",
-            "Test014: Trees",
-            "Test016: Arithmetic",
-            "Test017: Closures as arguments",
-            "Test023: McCarthy's 91 function",
-            "Test024: Higher-order recursive functions",
-            "Test027: Fast exponentiation",
-            "Test030: Mutual recursion",
-            "Test031: Temporary stack with branching",
-            "Test036: Streams without memoization"
-          ]
-          P.tests
-          ++ cairoTests
-    )
+  withPrecondition cairoVmPrecondition
+    . return
+    . testGroup
+      "JuvixReg to Cairo translation positive tests"
+    $ map (mkTest . testDescr)
+    $ P.filterOutTests
+      [ "Test001: Arithmetic opcodes",
+        "Test013: Fibonacci numbers in linear time",
+        "Test014: Trees",
+        "Test016: Arithmetic",
+        "Test017: Closures as arguments",
+        "Test023: McCarthy's 91 function",
+        "Test024: Higher-order recursive functions",
+        "Test027: Fast exponentiation",
+        "Test030: Mutual recursion",
+        "Test031: Temporary stack with branching",
+        "Test036: Streams without memoization"
+      ]
+      P.tests
+      ++ cairoTests
 
 cairoTests :: [P.PosTest]
 cairoTests =

--- a/test/Casm/Run.hs
+++ b/test/Casm/Run.hs
@@ -1,8 +1,8 @@
 module Casm.Run where
 
 import Base
-import Casm.Run.Negative qualified as RunN
-import Casm.Run.Positive qualified as RunP
+import Casm.Run.Negative qualified as Negative
+import Casm.Run.Positive qualified as Positive
 
-allTests :: TestTree
-allTests = testGroup "CASM run" [RunP.allTests, RunN.allTests]
+allTests :: IO TestTree
+allTests = testGroup "CASM run" <$> sequence [Positive.allTests, return Negative.allTests]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,41 +25,45 @@ import Tree qualified
 import Typecheck qualified
 import VampIR qualified
 
-slowTests :: TestTree
+slowTests :: IO TestTree
 slowTests =
   sequentialTestGroup
     "Juvix slow tests"
     AllFinish
-    [ Runtime.allTests,
-      Reg.allTests,
-      Asm.allTests,
-      Tree.allTests,
-      Core.allTests,
-      Internal.allTests,
-      Compilation.allTests,
-      Examples.allTests,
-      Rust.allTests,
-      Casm.allTests,
-      VampIR.allTests,
-      Anoma.allTests,
-      Repl.allTests
-    ]
+    <$> sequence
+      [ return Runtime.allTests,
+        return Reg.allTests,
+        return Asm.allTests,
+        return Tree.allTests,
+        return Core.allTests,
+        return Internal.allTests,
+        return Compilation.allTests,
+        return Examples.allTests,
+        Rust.allTests,
+        Casm.allTests,
+        VampIR.allTests,
+        return Anoma.allTests,
+        return Repl.allTests
+      ]
 
-fastTests :: TestTree
+fastTests :: IO TestTree
 fastTests =
-  testGroup
-    "Juvix fast tests"
-    [ Parsing.allTests,
-      Resolver.allTests,
-      Scope.allTests,
-      Termination.allTests,
-      Typecheck.allTests,
-      Format.allTests,
-      Formatter.allTests,
-      Package.allTests,
-      BackendMarkdown.allTests,
-      Nockma.allTests
-    ]
+  return $
+    testGroup
+      "Juvix fast tests"
+      [ Parsing.allTests,
+        Resolver.allTests,
+        Scope.allTests,
+        Termination.allTests,
+        Typecheck.allTests,
+        Format.allTests,
+        Formatter.allTests,
+        Package.allTests,
+        BackendMarkdown.allTests,
+        Nockma.allTests
+      ]
 
 main :: IO ()
-main = defaultMain (testGroup "Juvix tests" [fastTests, slowTests])
+main = do
+  tests <- sequence [fastTests, slowTests]
+  defaultMain (testGroup "Juvix tests" tests)

--- a/test/Rust.hs
+++ b/test/Rust.hs
@@ -4,5 +4,7 @@ import Base
 import Rust.Compilation qualified as Compilation
 import Rust.RiscZero qualified as RiscZero
 
-allTests :: TestTree
-allTests = sequentialTestGroup "Juvix to Rust tests" AllFinish [Compilation.allTests, RiscZero.allTests]
+allTests :: IO TestTree
+allTests =
+  sequentialTestGroup "Juvix to Rust tests" AllFinish
+    <$> sequence [Compilation.allTests, RiscZero.allTests]

--- a/test/Rust/Compilation.hs
+++ b/test/Rust/Compilation.hs
@@ -1,7 +1,10 @@
 module Rust.Compilation where
 
 import Base
+import Rust.Compilation.Base
 import Rust.Compilation.Positive qualified as P
 
-allTests :: TestTree
-allTests = testGroup "Juvix to native Rust compilation tests" [P.allTests, P.allTestsNoOptimize]
+allTests :: IO TestTree
+allTests =
+  withPrecondition precondition . return $
+    testGroup "Juvix to native Rust compilation tests" [P.allTests, P.allTestsNoOptimize]

--- a/test/Rust/Compilation/Base.hs
+++ b/test/Rust/Compilation/Base.hs
@@ -7,6 +7,10 @@ import Juvix.Compiler.Backend.Rust.Pretty
 import Juvix.Compiler.Core qualified as Core
 import System.Process qualified as P
 
+precondition :: Assertion
+precondition = do
+  assertCmdExists $(mkRelFile "rustc")
+
 compileAssertion ::
   Path Abs Dir ->
   Int ->
@@ -26,9 +30,6 @@ compileAssertion root' optLevel mainFile expectedFile step = do
         ( \dirPath -> do
             let inputFile = dirPath <//> $(mkRelFile "Program.rs")
             writeFileEnsureLn inputFile _resultRustCode
-
-            step "Check rustc is on path"
-            assertCmdExists $(mkRelFile "rustc")
 
             expected <- readFile expectedFile
 

--- a/test/Rust/RiscZero.hs
+++ b/test/Rust/RiscZero.hs
@@ -1,7 +1,10 @@
 module Rust.RiscZero where
 
 import Base
+import Rust.RiscZero.Base
 import Rust.RiscZero.Positive qualified as P
 
-allTests :: TestTree
-allTests = sequentialTestGroup "Juvix to RISC0 Rust compilation tests" AllFinish [P.allTests, P.allTestsNoOptimize]
+allTests :: IO TestTree
+allTests =
+  withPrecondition precondition . return $
+    sequentialTestGroup "Juvix to RISC0 Rust compilation tests" AllFinish [P.allTests, P.allTestsNoOptimize]

--- a/test/Rust/RiscZero/Base.hs
+++ b/test/Rust/RiscZero/Base.hs
@@ -10,6 +10,11 @@ import System.Directory
 import System.Environment
 import System.Process qualified as P
 
+precondition :: Assertion
+precondition = do
+  assertCmdExists $(mkRelFile "cargo")
+  assertCmdExists $(mkRelFile "r0vm")
+
 compileAssertion ::
   IO (Path Abs Dir) ->
   Path Abs Dir ->
@@ -40,12 +45,6 @@ compileAssertion tmpDir' root' optLevel mainFile expectedFile step = do
               <//> $(mkRelDir "src")
               <//> $(mkRelFile "main.rs")
       writeFileEnsureLn outFile _resultRustCode
-
-      step "Check cargo is on path"
-      assertCmdExists $(mkRelFile "cargo")
-
-      step "Check r0vm is on path"
-      assertCmdExists $(mkRelFile "r0vm")
 
       expected <- readFile expectedFile
 

--- a/test/VampIR.hs
+++ b/test/VampIR.hs
@@ -1,9 +1,18 @@
 module VampIR where
 
 import Base
-import VampIR.Compilation.Negative qualified as N
-import VampIR.Compilation.Positive qualified as PC
-import VampIR.Core.Positive qualified as PT
+import VampIR.Compilation.Negative qualified as Negative
+import VampIR.Compilation.Positive qualified as CompilationPositive
+import VampIR.Core.Base
+import VampIR.Core.Positive qualified as CorePositive
 
-allTests :: TestTree
-allTests = testGroup "VampIR tests" [PT.allTests, PC.allTests, N.allTests]
+allTests :: IO TestTree
+allTests =
+  withPrecondition precondition
+    . return
+    $ testGroup
+      "VampIR tests"
+      [ CorePositive.allTests,
+        CompilationPositive.allTests,
+        Negative.allTests
+      ]

--- a/test/VampIR/Core/Base.hs
+++ b/test/VampIR/Core/Base.hs
@@ -18,6 +18,10 @@ vampirAssertion backend root mainFile dataFile step = do
       entryPoint <- testDefaultEntryPointIO root mainFile
       vampirAssertion' entryPoint backend tab dataFile step
 
+precondition :: Assertion
+precondition = do
+  assertCmdExists $(mkRelFile "vamp-ir")
+
 vampirAssertion' :: EntryPoint -> VampirBackend -> InfoTable -> Path Abs File -> (String -> IO ()) -> Assertion
 vampirAssertion' entryPoint backend tab dataFile step = do
   withTempDir'
@@ -28,9 +32,6 @@ vampirAssertion' entryPoint backend tab dataFile step = do
           Left err -> assertFailure (prettyString (fromJuvixError @GenericError err))
           Right VampIR.Result {..} -> do
             writeFileEnsureLn vampirFile _resultCode
-
-            step "Check vamp-ir on path"
-            assertCmdExists $(mkRelFile "vamp-ir")
 
             vampirSetupArgs backend dirPath step
 


### PR DESCRIPTION
Some tests require external dependencies, such as `rustc`, `wasmer`, `run_cairo_vm.sh`, etc. If one does not have some of these available on their computer, then the test suite will have a lot of failed tests with the same fail message `X is not on $PATH`. This can be a bit ditracting and it slows running the test suite. 
I've introduced some preconditions that are checked before the actual test suite so that if some of these commands are not on path then the tests that need them are not run. Instead, you get a single failed test (for each of the subtrees that failed the precondition).