### PR TITLE
Fix CI for RISC0 version 1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
         shell: bash
         run: |
           cargo install cargo-binstall@1.6.9 --force
-          cargo binstall cargo-risczero@1.0.1 --no-confirm --rate-limit 1/10 --force
+          cargo binstall cargo-risczero@1.0.2 --no-confirm --force
           cargo risczero install
 
       - name: Checkout CairoVM


### PR DESCRIPTION
This PR updates the version of `cargo-risczero` in the CI. Ultimately, we should figure out how to properly pin a fixed version, but apparently that's not easy - it seems some dependencies need to be pinned and it's not clear which ones, how, and to which versions. The problem is that to execute the Rust code generated for RISC0 we need to compile it, and the generated code depends on some RISC0-related libraries. Having the correct version of the RISC0 Rust toolchain installed locally doesn't fully solve the problem (doesn't seem to automatically select the right versions of dependencies).
