### PR TITLE
Puns for named application

### DIFF
--- a/include/package/PackageDescription/V1.juvix
+++ b/include/package/PackageDescription/V1.juvix
@@ -55,16 +55,16 @@ defaultPackage
 
 --- Construct a ;SemVer; with useful default arguments.
 mkVersion
-  (major' minor' patch' : Nat)
-  {release' : Maybe String := nothing}
-  {meta' : Maybe String := nothing}
+  (major minor patch : Nat)
+  {release : Maybe String := nothing}
+  {meta : Maybe String := nothing}
   : SemVer :=
   mkSemVer@?{
-    major := major';
-    minor := minor';
-    patch := patch';
-    release := release';
-    meta := meta'
+    major;
+    minor;
+    patch;
+    release;
+    meta;
   };
 
 --- The default version used in `defaultPackage`.

--- a/include/package/PackageDescription/V2.juvix
+++ b/include/package/PackageDescription/V2.juvix
@@ -55,16 +55,16 @@ defaultPackage
 
 --- Construct a ;SemVer; with useful default arguments.
 mkVersion
-  (major' minor' patch' : Nat)
-  {release' : Maybe String := nothing}
-  {meta' : Maybe String := nothing}
+  (major minor patch : Nat)
+  {release : Maybe String := nothing}
+  {meta : Maybe String := nothing}
   : SemVer :=
   mkSemVer@?{
-    major := major';
-    minor := minor';
-    patch := patch';
-    release := release';
-    meta := meta'
+    major;
+    minor;
+    patch;
+    release;
+    meta;
   };
 
 --- The default version used in `defaultPackage`.

--- a/src/Juvix/Compiler/Concrete/Data/Name.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Name.hs
@@ -123,6 +123,11 @@ moduleNameToTopModulePath = \case
   NameUnqualified s -> TopModulePath [] s
   NameQualified (QualifiedName (SymbolPath p) s) -> TopModulePath (toList p) s
 
+fromUnqualified' :: Name -> Symbol
+fromUnqualified' = \case
+  NameUnqualified s -> s
+  NameQualified {} -> impossible
+
 splitName :: Name -> ([Symbol], Symbol)
 splitName = \case
   NameQualified (QualifiedName (SymbolPath p) s) -> (toList p, s)

--- a/src/Juvix/Compiler/Concrete/Language/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Language/Base.hs
@@ -2310,7 +2310,7 @@ deriving stock instance Ord (NamedArgumentFunctionDef 'Parsed)
 deriving stock instance Ord (NamedArgumentFunctionDef 'Scoped)
 
 data NamedArgumentPun (s :: Stage) = NamedArgumentPun
-  { _namedArgumentPunSymbol :: SymbolType s,
+  { _namedArgumentPunSymbol :: Symbol,
     _namedArgumentReferencedSymbol :: PunSymbolType s
   }
   deriving stock (Generic)
@@ -2971,7 +2971,7 @@ instance HasLoc (List s) where
 instance (SingI s) => HasLoc (NamedApplication s) where
   getLoc NamedApplication {..} = getLocIdentifierType _namedAppName <> getLoc (last _namedAppArgs)
 
-instance (SingI s) => HasLoc (NamedArgumentPun s) where
+instance HasLoc (NamedArgumentPun s) where
   getLoc NamedArgumentPun {..} = getLocSymbolType _namedArgumentPunSymbol
 
 instance (SingI s) => HasLoc (NamedApplicationNew s) where

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -334,8 +334,8 @@ instance (SingI s) => PrettyPrint (NamedApplicationNew s) where
 instance (SingI s) => PrettyPrint (NamedArgumentFunctionDef s) where
   ppCode (NamedArgumentFunctionDef f) = ppCode f
 
-instance (SingI s) => PrettyPrint (NamedArgumentPun s) where
-  ppCode = ppSymbolType . (^. namedArgumentPunSymbol)
+instance PrettyPrint (NamedArgumentPun s) where
+  ppCode = ppCode . (^. namedArgumentPunSymbol)
 
 instance (SingI s) => PrettyPrint (NamedArgumentNew s) where
   ppCode = \case

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -334,9 +334,13 @@ instance (SingI s) => PrettyPrint (NamedApplicationNew s) where
 instance (SingI s) => PrettyPrint (NamedArgumentFunctionDef s) where
   ppCode (NamedArgumentFunctionDef f) = ppCode f
 
+instance (SingI s) => PrettyPrint (NamedArgumentPun s) where
+  ppCode = ppSymbolType . (^. namedArgumentPunSymbol)
+
 instance (SingI s) => PrettyPrint (NamedArgumentNew s) where
   ppCode = \case
     NamedArgumentNewFunction f -> ppCode f
+    NamedArgumentItemPun f -> ppCode f
 
 instance (SingI s) => PrettyPrint (RecordStatement s) where
   ppCode = \case

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1563,8 +1563,8 @@ checkSections sec = topBindings helper
                                 failMaybe $
                                   mkRec
                                     ^? constructorRhs
-                                      . _ConstructorRhsRecord
-                                      . to mkRecordNameSignature
+                                    . _ConstructorRhsRecord
+                                    . to mkRecordNameSignature
                               let info =
                                     RecordInfo
                                       { _recordInfoSignature = fs,

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1563,8 +1563,8 @@ checkSections sec = topBindings helper
                                 failMaybe $
                                   mkRec
                                     ^? constructorRhs
-                                    . _ConstructorRhsRecord
-                                    . to mkRecordNameSignature
+                                      . _ConstructorRhsRecord
+                                      . to mkRecordNameSignature
                               let info =
                                     RecordInfo
                                       { _recordInfoSignature = fs,
@@ -2573,16 +2573,23 @@ checkExpressionAtom e = case e of
 reserveNamedArgumentName :: (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder, Reader InfoTable] r) => NamedArgumentNew 'Parsed -> Sem r ()
 reserveNamedArgumentName a = case a of
   NamedArgumentNewFunction f -> void (reserveFunctionSymbol (f ^. namedArgumentFunctionDef))
+  NamedArgumentItemPun {} -> return ()
 
-checkNamedApplicationNew :: forall r. (Members '[HighlightBuilder, Error ScoperError, State Scope, State ScoperState, Reader ScopeParameters, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader Package] r) => NamedApplicationNew 'Parsed -> Sem r (NamedApplicationNew 'Scoped)
+checkNamedApplicationNew ::
+  forall r.
+  (Members '[HighlightBuilder, Error ScoperError, State Scope, State ScoperState, Reader ScopeParameters, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader Package] r) =>
+  NamedApplicationNew 'Parsed ->
+  Sem r (NamedApplicationNew 'Scoped)
 checkNamedApplicationNew napp = do
   let nargs = napp ^. namedApplicationNewArguments
   aname <- checkScopedIden (napp ^. namedApplicationNewName)
   sig <- if null nargs then return $ NameSignature [] else getNameSignature aname
-  let snames = HashSet.fromList (concatMap (HashMap.keys . (^. nameBlock)) (sig ^. nameSignatureArgs))
+  let namesInSignature = hashSet (concatMap (HashMap.keys . (^. nameBlock)) (sig ^. nameSignatureArgs))
+  forM_ nargs (checkNameInSignature namesInSignature . (^. namedArgumentNewSymbol))
+  puns <- scopePuns
   args' <- withLocalScope . localBindings . ignoreSyntax $ do
     mapM_ reserveNamedArgumentName nargs
-    mapM (checkNamedArgumentNew snames) nargs
+    mapM (checkNamedArgumentNew puns) nargs
   let enames =
         HashSet.fromList
           . concatMap (HashMap.keys . (^. nameBlock))
@@ -2598,25 +2605,50 @@ checkNamedApplicationNew napp = do
         _namedApplicationNewArguments = args',
         _namedApplicationNewExhaustive = napp ^. namedApplicationNewExhaustive
       }
+  where
+    checkNameInSignature :: HashSet Symbol -> Symbol -> Sem r ()
+    checkNameInSignature namesInSig fname =
+      unless (HashSet.member fname namesInSig) $
+        throw (ErrUnexpectedArgument (UnexpectedArgument fname))
+
+    scopePuns :: Sem r (HashMap Symbol ScopedIden)
+    scopePuns =
+      hashMap
+        <$> mapWithM
+          scopePun
+          (napp ^.. namedApplicationNewArguments . each . _NamedArgumentItemPun . namedArgumentPunSymbol)
+      where
+        scopePun :: Symbol -> Sem r ScopedIden
+        scopePun = checkScopedIden . NameUnqualified
 
 checkNamedArgumentNew ::
   (Members '[HighlightBuilder, Error ScoperError, State Scope, State ScoperState, Reader ScopeParameters, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader Package] r) =>
-  HashSet Symbol ->
+  HashMap Symbol ScopedIden ->
   NamedArgumentNew 'Parsed ->
   Sem r (NamedArgumentNew 'Scoped)
-checkNamedArgumentNew snames = \case
-  NamedArgumentNewFunction f -> NamedArgumentNewFunction <$> checkNamedArgumentFunctionDef snames f
+checkNamedArgumentNew puns = \case
+  NamedArgumentNewFunction f -> NamedArgumentNewFunction <$> checkNamedArgumentFunctionDef f
+  NamedArgumentItemPun f -> NamedArgumentItemPun <$> checkNamedArgumentItemPun puns f
+
+checkNamedArgumentItemPun ::
+  (Members '[Error ScoperError, NameIdGen, State Scope, InfoTableBuilder, Reader InfoTable, State ScoperState] r) =>
+  HashMap Symbol ScopedIden ->
+  NamedArgumentPun 'Parsed ->
+  Sem r (NamedArgumentPun 'Scoped)
+checkNamedArgumentItemPun puns NamedArgumentPun {..} = localBindings . ignoreSyntax $ do
+  sym' <- getReservedDefinitionSymbol _namedArgumentPunSymbol
+  return
+    NamedArgumentPun
+      { _namedArgumentPunSymbol = sym',
+        _namedArgumentReferencedSymbol = fromJust (puns ^. at _namedArgumentPunSymbol)
+      }
 
 checkNamedArgumentFunctionDef ::
   (Members '[HighlightBuilder, Error ScoperError, State Scope, State ScoperState, Reader ScopeParameters, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader Package] r) =>
-  HashSet Symbol ->
   NamedArgumentFunctionDef 'Parsed ->
   Sem r (NamedArgumentFunctionDef 'Scoped)
-checkNamedArgumentFunctionDef snames NamedArgumentFunctionDef {..} = do
+checkNamedArgumentFunctionDef NamedArgumentFunctionDef {..} = do
   def <- localBindings . ignoreSyntax $ checkFunctionDef _namedArgumentFunctionDef
-  let fname = def ^. signName . nameConcrete
-  unless (HashSet.member fname snames) $
-    throw (ErrUnexpectedArgument (UnexpectedArgument fname))
   return
     NamedArgumentFunctionDef
       { _namedArgumentFunctionDef = def

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -2628,20 +2628,17 @@ checkNamedArgumentNew ::
   Sem r (NamedArgumentNew 'Scoped)
 checkNamedArgumentNew puns = \case
   NamedArgumentNewFunction f -> NamedArgumentNewFunction <$> checkNamedArgumentFunctionDef f
-  NamedArgumentItemPun f -> NamedArgumentItemPun <$> checkNamedArgumentItemPun puns f
+  NamedArgumentItemPun f -> return (NamedArgumentItemPun (checkNamedArgumentItemPun puns f))
 
 checkNamedArgumentItemPun ::
-  (Members '[Error ScoperError, NameIdGen, State Scope, InfoTableBuilder, Reader InfoTable, State ScoperState] r) =>
   HashMap Symbol ScopedIden ->
   NamedArgumentPun 'Parsed ->
-  Sem r (NamedArgumentPun 'Scoped)
-checkNamedArgumentItemPun puns NamedArgumentPun {..} = localBindings . ignoreSyntax $ do
-  sym' <- getReservedDefinitionSymbol _namedArgumentPunSymbol
-  return
-    NamedArgumentPun
-      { _namedArgumentPunSymbol = sym',
-        _namedArgumentReferencedSymbol = fromJust (puns ^. at _namedArgumentPunSymbol)
-      }
+  (NamedArgumentPun 'Scoped)
+checkNamedArgumentItemPun puns NamedArgumentPun {..} =
+  NamedArgumentPun
+    { _namedArgumentPunSymbol = _namedArgumentPunSymbol,
+      _namedArgumentReferencedSymbol = fromJust (puns ^. at _namedArgumentPunSymbol)
+    }
 
 checkNamedArgumentFunctionDef ::
   (Members '[HighlightBuilder, Error ScoperError, State Scope, State ScoperState, Reader ScopeParameters, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader Package] r) =>

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -983,11 +983,25 @@ pnamedArgumentFunctionDef = do
       { _namedArgumentFunctionDef = fun
       }
 
+pnamedArgumentItemPun ::
+  forall r.
+  (Members '[ParserResultBuilder, PragmasStash, JudocStash] r) =>
+  ParsecS r (NamedArgumentPun 'Parsed)
+pnamedArgumentItemPun = do
+  sym <- symbol
+  return
+    NamedArgumentPun
+      { _namedArgumentPunSymbol = sym,
+        _namedArgumentReferencedSymbol = ()
+      }
+
 namedArgumentNew ::
   forall r.
   (Members '[ParserResultBuilder, PragmasStash, JudocStash] r) =>
   ParsecS r (NamedArgumentNew 'Parsed)
-namedArgumentNew = NamedArgumentNewFunction <$> pnamedArgumentFunctionDef
+namedArgumentNew =
+  P.try (NamedArgumentItemPun <$> pnamedArgumentItemPun)
+    <|> NamedArgumentNewFunction <$> pnamedArgumentFunctionDef
 
 pisExhaustive ::
   forall r.

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -1000,8 +1000,9 @@ namedArgumentNew ::
   (Members '[ParserResultBuilder, PragmasStash, JudocStash] r) =>
   ParsecS r (NamedArgumentNew 'Parsed)
 namedArgumentNew =
-  P.try (NamedArgumentItemPun <$> pnamedArgumentItemPun)
-    <|> NamedArgumentNewFunction <$> pnamedArgumentFunctionDef
+  -- TODO this Try should be removed somehow
+  P.try (NamedArgumentNewFunction <$> pnamedArgumentFunctionDef)
+    <|> NamedArgumentItemPun <$> pnamedArgumentItemPun
 
 pisExhaustive ::
   forall r.

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -726,7 +726,11 @@ createArgumentBlocks appargs =
     . evalState args0
     . mapM_ goBlock
   where
-    args0 :: HashSet S.Symbol = hashSet ((^. namedArgumentNewSymbol) <$> appargs)
+    namedArgumentRefSymbol :: NamedArgumentNew 'Scoped -> S.Symbol
+    namedArgumentRefSymbol = \case
+      NamedArgumentNewFunction p -> p ^. namedArgumentFunctionDef . signName
+      NamedArgumentItemPun p -> over S.nameConcrete fromUnqualified' (p ^. namedArgumentReferencedSymbol . scopedIdenFinal)
+    args0 :: HashSet S.Symbol = hashSet (namedArgumentRefSymbol <$> appargs)
     goBlock ::
       forall r.
       (Members '[State (HashSet S.Symbol), Output (ArgumentBlock 'Scoped)] r) =>
@@ -738,7 +742,7 @@ createArgumentBlocks appargs =
             HashSet.intersection
               (HashMap.keysSet _nameBlock)
               (HashSet.map (^. S.nameConcrete) args)
-          argNames :: HashMap Symbol S.Symbol = hashMap . map (\n -> (n ^. S.nameConcrete, n)) $ toList args
+          argNames :: HashMap Symbol S.Symbol = indexedByHash (^. S.nameConcrete) args
           getName sym = fromJust (argNames ^. at sym)
       whenJust (nonEmpty namesInBlock) $ \(namesInBlock1 :: NonEmpty Symbol) -> do
         let block' =
@@ -755,7 +759,12 @@ createArgumentBlocks appargs =
           NamedArgumentAssign
             { _namedArgName = sym,
               _namedArgAssignKw = Irrelevant dummyKw,
-              _namedArgValue = Concrete.ExpressionIdentifier (ScopedIden name Nothing)
+              _namedArgValue =
+                Concrete.ExpressionIdentifier
+                  ScopedIden
+                    { _scopedIdenFinal = name,
+                      _scopedIdenAlias = Nothing
+                    }
             }
           where
             name :: S.Name = over S.nameConcrete NameUnqualified sym

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -245,5 +245,9 @@ tests =
     posTest
       "Public import"
       $(mkRelDir "PublicImports")
-      $(mkRelFile "Main.juvix")
+      $(mkRelFile "Main.juvix"),
+    posTest
+      "Named argument puns"
+      $(mkRelDir ".")
+      $(mkRelFile "Puns.juvix")
   ]

--- a/tests/positive/Puns.juvix
+++ b/tests/positive/Puns.juvix
@@ -8,12 +8,18 @@ type S :=
   mkS {
     fieldA : A;
     fieldB : B;
-    fieldC : A
+    fieldC : A;
+    fieldD : B;
+    fieldE : B
   };
 
 f (fieldA : A) (fieldB : B) : S :=
-  mkS@{
+  let
+    fieldD := b;
+  in mkS@{
     fieldC := fieldA;
     fieldA;
-    fieldB
+    fieldB;
+    fieldE := b;
+    fieldD
   };

--- a/tests/positive/Puns.juvix
+++ b/tests/positive/Puns.juvix
@@ -1,0 +1,19 @@
+module Puns;
+
+type A := a;
+
+type B := b;
+
+type S :=
+  mkS {
+    fieldA : A;
+    fieldB : B;
+    fieldC : A
+  };
+
+f (fieldA : A) (fieldB : B) : S :=
+  mkS@{
+    fieldC := fieldA;
+    fieldA;
+    fieldB
+  };


### PR DESCRIPTION
Since it is common to want to assign a named argument a variable of the same name, we add special syntax for it. E.g.
```
f (fieldA : A) (fieldB : B) : S :=
  mkS@{
    fieldC := fieldA; -- normal named argument
    fieldA;  -- pun
    fieldB   -- pun
  };
```
