### PR TITLE
Use ormolu from stackage in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install hpack
+        run: sudo apt install -y haskell-hpack
+
+      - name: Generate juvix.cabal
+        run: hpack
+
       - uses: mrkkrp/ormolu-action@v11
         with:
           version: 0.5.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: extractions/setup-just@v2
 
       - name: Install hpack
         run: sudo apt install -y hpack
@@ -56,7 +57,7 @@ jobs:
         run: stack install ormolu --resolver=lts-21.25
 
       - name: Run ormolu
-        run: make check-ormolu
+        run: just format check
 
       - name: Cache stack
         id: stack-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,16 @@ jobs:
       - name: Generate juvix.cabal
         run: hpack
 
-      - name: Cache stack
-        id: stack-cache
+      - name: Cache ormolu
+        id: ormolu-cache
         uses: actions/cache@v3
         with:
           path: |
-            ~/.stack
-          key: ${{ runner.os }}-stack-${{ env.STACK_RESOLVER }}
+            ~/.local/bin/ormolu
+          key: ${{ runner.os }}-ormolu-${{ env.STACK_RESOLVER }}
 
       - name: Install ormolu
+        if: steps.ormolu-cache.outputs.cache-hit != 'true'
         run: stack install ormolu --resolver=${{ env.STACK_RESOLVER }}
 
       - name: Run ormolu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,15 @@ jobs:
       - name: Generate juvix.cabal
         run: hpack
 
-      - name: Install Ormolu
+      - name: Install ormolu
         run: stack install ormolu
 
       - name: Run ormolu
         run: make check-ormolu
+
+     - name: Report formatting error
+        if: failure()
+        run: echo "Some Haskell files are not formatted. Please run 'just format'."
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Generate juvix.cabal
         run: hpack
 
+      - name: Install Ormolu
+        run: stack install ormolu
+
       - name: Run ormolu
         run: ormolu
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
 
   ormolu:
     runs-on: ubuntu-latest
+    env:
+      STACK_RESOLVER: lts-21.25
     steps:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@v2
@@ -59,18 +61,17 @@ jobs:
         with:
           path: |
             ~/.stack
-          # key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
-          key: ${{ runner.os }}-stack-21.25
+          key: ${{ runner.os }}-stack-${{ env.STACK_RESOLVER }}
 
       - name: Install ormolu
-        run: stack install ormolu --resolver=lts-21.25
+        run: stack install ormolu --resolver=${{ env.STACK_RESOLVER }}
 
       - name: Run ormolu
         run: just format check
 
       - name: Report formatting error
         if: failure()
-        run: echo "Some Haskell files are not formatted. Please run 'just format'."
+        run: echo "Some Haskell files are not formatted. Please run 'just format'"
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,6 @@ jobs:
       - uses: mrkkrp/ormolu-action@v11
         with:
           version: 0.5.3.0
-          extra-args: >-
-            --ghc-opt -XDerivingStrategies
-            --ghc-opt -XImportQualifiedPost
-            --ghc-opt -XMultiParamTypeClasses
-            --ghc-opt -XPatternSynonyms
-            --ghc-opt -XStandaloneDeriving
-            --ghc-opt -XTemplateHaskell
-            --ghc-opt -XUnicodeSyntax
-            --ghc-opt -XBangPatterns
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install hpack
-        run: sudo apt install -y haskell-hpack
+        run: sudo apt install -y hpack
 
       - name: Generate juvix.cabal
         run: hpack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,6 @@ jobs:
       - name: Generate juvix.cabal
         run: hpack
 
-      - name: Install ormolu
-        run: stack install ormolu --resolver=lts-21.25
-
-      - name: Run ormolu
-        run: just format check
-
       - name: Cache stack
         id: stack-cache
         uses: actions/cache@v3
@@ -67,6 +61,12 @@ jobs:
             ~/.stack
           # key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
           key: ${{ runner.os }}-stack-21.25
+
+      - name: Install ormolu
+        run: stack install ormolu --resolver=lts-21.25
+
+      - name: Run ormolu
+        run: just format check
 
       - name: Report formatting error
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: stack install ormolu
 
       - name: Run ormolu
-        run: ormolu
+        run: make check-ormolu
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: hpack
 
       - name: Install ormolu
-        run: stack install ormolu
+        run: stack install ormolu --resolver=lts-21.25
 
       - name: Run ormolu
         run: make check-ormolu
@@ -63,8 +63,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-           ~/.stack
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
+            ~/.stack
+          # key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-stack-21.25
 
       - name: Report formatting error
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
       - name: Run ormolu
         run: make check-ormolu
 
+     - name: Cache stack
+        id: stack-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.stack
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
+
      - name: Report formatting error
         if: failure()
         run: echo "Some Haskell files are not formatted. Please run 'just format'."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: mrkkrp/ormolu-action@v11
         with:
           version: 0.5.3.0
+          respect-cabal-files: true
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,8 @@ jobs:
       - name: Generate juvix.cabal
         run: hpack
 
-      - uses: mrkkrp/ormolu-action@v11
-        with:
-          version: 0.5.3.0
-          respect-cabal-files: true
+      - name: Run ormolu
+        run: ormolu
 
   build-and-test-linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,15 @@ jobs:
       - name: Run ormolu
         run: make check-ormolu
 
-     - name: Cache stack
+      - name: Cache stack
         id: stack-cache
         uses: actions/cache@v3
         with:
           path: |
-            ~/.stack
+           ~/.stack
           key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
 
-     - name: Report formatting error
+      - name: Report formatting error
         if: failure()
         run: echo "Some Haskell files are not formatted. Please run 'just format'."
 

--- a/Makefile
+++ b/Makefile
@@ -90,15 +90,7 @@ ORMOLUMODE?=inplace
 .PHONY: ormolu
 ormolu:
 	@${ORMOLU} ${ORMOLUFLAGS} \
-		--ghc-opt -XStandaloneDeriving \
-		--ghc-opt -XUnicodeSyntax \
-		--ghc-opt -XDerivingStrategies \
-		--ghc-opt -XPatternSynonyms \
-		--ghc-opt -XMultiParamTypeClasses  \
-		--ghc-opt -XTemplateHaskell \
-		--ghc-opt -XImportQualifiedPost \
-		--ghc-opt -XBangPatterns \
-			--mode ${ORMOLUMODE} \
+		--mode ${ORMOLUMODE} \
 		$(ORMOLUFILES)
 
 .PHONY: format

--- a/justfile
+++ b/justfile
@@ -56,9 +56,9 @@ bashDebugArg := if enableDebug == '' { '' } else { 'x' }
 default:
     @just --list
 
-@_ormoluCmd filesCmd:
+@_ormoluCmd filesCmd mode:
     {{ trim(filesCmd) }} \
-     | xargs -r {{ ormolu }} --mode inplace
+     | xargs -r {{ ormolu }} --mode {{ mode }}
 
 # Formats all Haskell files in the project. `format changed` formats only changed files. `format FILES` formats individual files.
 format *opts:
@@ -74,11 +74,15 @@ format *opts:
 
     case $opts in
         "")
-            just _ormoluCmd "git ls-files '*.hs'"
+            just _ormoluCmd "git ls-files '*.hs'" inplace
             ;;
         changed)
             just _ormoluCmd \
-              "(git --no-pager diff --name-only --diff-filter=AM && git --no-pager diff --cached --name-only --diff-filter=AM) | grep '\\.hs\$'"
+              "(git --no-pager diff --name-only --diff-filter=AM && git --no-pager diff --cached --name-only --diff-filter=AM) | grep '\\.hs\$'" \
+              inplace
+            ;;
+        check)
+            just _ormoluCmd "git ls-files '*.hs'" check
             ;;
         *)
             just _ormoluCmd "echo {{ opts }}"

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1563,8 +1563,8 @@ checkSections sec = topBindings helper
                                 failMaybe $
                                   mkRec
                                     ^? constructorRhs
-                                    . _ConstructorRhsRecord
-                                    . to mkRecordNameSignature
+                                      . _ConstructorRhsRecord
+                                      . to mkRecordNameSignature
                               let info =
                                     RecordInfo
                                       { _recordInfoSignature = fs,


### PR DESCRIPTION
1. Adds the command `just format check`, which checks that all Haskell files are formatted.
2. In CI, we use install ormolu from stackage and run it. This will facilitate consistency between CI and local setups.