### PR TITLE
Fix #2924. Use MegaParsec scanner for Markdown files

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -13,7 +13,7 @@ import Juvix.Prelude.FlatParse.Lexer qualified as L
 
 scanBSImports :: Path Abs File -> ByteString -> Maybe ScanResult
 scanBSImports fp
-   -- FlatParse only supports .juvix files
+  -- FlatParse only supports .juvix files
   | isJuvixFile fp = fromResult . scanner fp
   | otherwise = const Nothing
   where

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -13,6 +13,7 @@ import Juvix.Prelude.FlatParse.Lexer qualified as L
 
 scanBSImports :: Path Abs File -> ByteString -> Maybe ScanResult
 scanBSImports fp
+   -- FlatParse only supports .juvix files
   | isJuvixFile fp = fromResult . scanner fp
   | otherwise = const Nothing
   where

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -12,7 +12,9 @@ import Juvix.Prelude.FlatParse qualified as FP
 import Juvix.Prelude.FlatParse.Lexer qualified as L
 
 scanBSImports :: Path Abs File -> ByteString -> Maybe ScanResult
-scanBSImports fp = fromResult . scanner fp
+scanBSImports fp
+  | isJuvixFile fp = fromResult . scanner fp
+  | otherwise = const Nothing
   where
     fromResult :: Result () ok -> Maybe ok
     fromResult = \case

--- a/tests/positive/Markdown/Test.juvix.md
+++ b/tests/positive/Markdown/Test.juvix.md
@@ -1,5 +1,7 @@
 # Example
 
+What is important is seldom urgent. 
+
 A Juvix Markdown file name ends with `.juvix.md`. This kind of file must contain
 a module declaration at the top, as shown below ---in the first code block. 
 

--- a/tests/positive/Markdown/markdown/Test.md
+++ b/tests/positive/Markdown/markdown/Test.md
@@ -1,5 +1,7 @@
 # Example
 
+What is important is seldom urgent.
+
 A Juvix Markdown file name ends with `.juvix.md`. This kind of file must contain
 a module declaration at the top, as shown below ---in the first code block.
 


### PR DESCRIPTION
This PR addresses a bug/missing case present since v0.6.2, introduced specifically by 

- PR #2779, 

That PR involves detecting imports in Juvix files before type checking, and that's the issue.
Detecting/scanning imports is done by running a flat parser (which ignores the Juvix Markdown structure) and when it fails, it runs a Megaparser parse. So, for simplicity,
we could just continue using the same Megaparser as before for Juvix Markdown files.
