### PR TITLE
Fix scanning of names with `import` prefix

### DIFF
--- a/app/Commands/Dev/ImportTree/ScanFile.hs
+++ b/app/Commands/Dev/ImportTree/ScanFile.hs
@@ -6,7 +6,7 @@ import Juvix.Compiler.Concrete.Print
 import Juvix.Compiler.Concrete.Translation.ImportScanner
 import Juvix.Compiler.Concrete.Translation.ImportScanner.Base
 
-runCommand :: (Members '[App, EmbedIO] r) => ScanFileOptions -> Sem r ()
+runCommand :: (Members AppEffects r) => ScanFileOptions -> Sem r ()
 runCommand ScanFileOptions {..} =
   runFilesIO
     . runAppError @ParserError

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -108,7 +108,7 @@ quit _ = liftIO (throwIO Interrupt)
 
 loadEntryPoint :: EntryPoint -> Repl ()
 loadEntryPoint ep = do
-  artif <- liftIO (runReplPipelineIO ep)
+  artif <- runReplPipelineIO ep
   let newCtx =
         ReplContext
           { _replContextArtifacts = artif,

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -88,7 +88,7 @@ bareIdentifier = do
   return (h : t)
 
 dottedIdentifier :: Parser e (NonEmpty String)
-dottedIdentifier = nonEmpty' <$> sepBy1 bareIdentifier dot
+dottedIdentifier = lexeme (nonEmpty' <$> sepBy1 bareIdentifier dot)
   where
     dot :: Parser e ()
     dot = $(char '.')
@@ -99,7 +99,7 @@ pImport = do
     return ImportScan {..}
   where
     helper :: Parser e (NonEmpty String)
-    helper = do
+    helper = P.try $ do
       lexeme $(string Str.import_)
       dottedIdentifier
 

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -99,8 +99,9 @@ pImport = do
     return ImportScan {..}
   where
     helper :: Parser e (NonEmpty String)
-    helper = P.try $ do
-      lexeme $(string Str.import_)
+    helper = do
+      iden <- lexeme bareIdentifier
+      guard (iden == Str.import_)
       dottedIdentifier
 
 pToken :: Parser e Token

--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree.hs
@@ -16,6 +16,7 @@ mkImportTree ::
       '[ Reader ImportScanStrategy,
          Error JuvixError,
          PathResolver,
+         Logger,
          Files
        ]
       r
@@ -56,7 +57,7 @@ mkImportTree mentrypointModulePath =
 
     getNodeImports ::
       forall r'.
-      (Members '[Reader ImportScanStrategy, Files, Error ParserError] r') =>
+      (Members '[Reader ImportScanStrategy, Files, Logger, Error ParserError] r') =>
       ImportNode ->
       Sem r' (HashSet ImportScan)
     getNodeImports n = (^. scanResultImports) <$> scanFileImports (n ^. importNodeAbsFile)
@@ -68,6 +69,7 @@ mkImportTree mentrypointModulePath =
              Reader ImportScanStrategy,
              Error ParserError,
              Files,
+             Logger,
              PathResolver,
              Visit ImportNode
            ]
@@ -98,6 +100,7 @@ withImportTree ::
       '[ Reader ImportScanStrategy,
          Error JuvixError,
          PathResolver,
+         Logger,
          Files
        ]
       r

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -169,6 +169,7 @@ compileReplInputIO fp txt = do
   hasInternet <- not <$> asks (^. entryPointOffline)
   runError
     . runConcurrent
+    . runLoggerIO defaultLoggerOptions
     . runReader defaultNumThreads
     . evalInternet hasInternet
     . runTaggedLockPermissive

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -213,6 +213,7 @@ runReplPipelineIOEither' lockMode entry = do
         | otherwise = runPathResolverArtifacts
   eith <-
     runM
+      . runLoggerIO defaultLoggerOptions
       . runConcurrent
       . runReader defaultNumThreads
       . evalInternet hasInternet

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -257,5 +257,9 @@ tests =
     posTest
       "Record field iterator"
       $(mkRelDir ".")
-      $(mkRelFile "RecordIterator.juvix")
+      $(mkRelFile "RecordIterator.juvix"),
+    posTest
+      "Scan name with 'import' prefix"
+      $(mkRelDir "issue2929")
+      $(mkRelFile "main.juvix")
   ]

--- a/tests/positive/issue2929/Package.juvix
+++ b/tests/positive/issue2929/Package.juvix
@@ -1,0 +1,8 @@
+module Package;
+
+import PackageDescription.V2 open;
+
+package : Package :=
+  defaultPackage@?{
+    name := "issue2929"
+  };

--- a/tests/positive/issue2929/important.juvix
+++ b/tests/positive/issue2929/important.juvix
@@ -1,0 +1,3 @@
+module important;
+
+axiom imports : Type;

--- a/tests/positive/issue2929/main.juvix
+++ b/tests/positive/issue2929/main.juvix
@@ -1,0 +1,5 @@
+module main;
+
+import important;
+
+axiom imports : important.imports;


### PR DESCRIPTION
1. When the flatparse scanner fails and we fallback to megaparsec, a warning is issued.
2. The flatparse scanner has been fixed so it is not confused when a name starts with `import`.