### PR TITLE
Do not try flatparse scanner for .md files

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -12,10 +12,7 @@ import Juvix.Prelude.FlatParse qualified as FP
 import Juvix.Prelude.FlatParse.Lexer qualified as L
 
 scanBSImports :: Path Abs File -> ByteString -> Maybe ScanResult
-scanBSImports fp
-  -- FlatParse only supports .juvix files
-  | isJuvixFile fp = fromResult . scanner fp
-  | otherwise = const Nothing
+scanBSImports fp = fromResult . scanner fp
   where
     fromResult :: Result () ok -> Maybe ok
     fromResult = \case


### PR DESCRIPTION
- In https://github.com/anoma/juvix/pull/2925, the flatparse scanner always fails for .md files and silently falls back to megaparsec.
- In https://github.com/anoma/juvix/pull/2929, a warning is introduced that informs the user when the fallback parser is being used. This is causing a warning every time we scan a markdown file.
- This pr fixes the problem by changing the default strategy to directly use megaparsec when a .md file is given.