### PR TITLE
Use ByteArray for Anoma cryptographic builtins

### DIFF
--- a/src/Juvix/Compiler/Builtins/Anoma.hs
+++ b/src/Juvix/Compiler/Builtins/Anoma.hs
@@ -50,12 +50,12 @@ registerAnomaVerifyDetached f = do
       u = ExpressionUniverse smallUniverseNoLoc
       l = getLoc f
   decodeT <- freshVar l "signedDataT"
-  nat <- getBuiltinName (getLoc f) BuiltinNat
+  byteArray <- getBuiltinName (getLoc f) BuiltinByteArray
   bool_ <- getBuiltinName (getLoc f) BuiltinBool
   let freeVars = HashSet.fromList [decodeT]
   unless
-    ((ftype ==% (u <>--> nat --> decodeT --> nat --> bool_)) freeVars)
-    (error "anomaVerifyDetached must be of type {A : Type} -> Nat -> A -> Nat -> Bool")
+    ((ftype ==% (u <>--> byteArray --> decodeT --> byteArray --> bool_)) freeVars)
+    (error "anomaVerifyDetached must be of type {A : Type} -> ByteArray -> A -> ByteArray -> Bool")
   registerBuiltin BuiltinAnomaVerifyDetached (f ^. axiomName)
 
 registerAnomaSign :: (Members '[Builtins, NameIdGen] r) => AxiomDef -> Sem r ()
@@ -91,9 +91,9 @@ registerAnomaSignDetached f = do
       u = ExpressionUniverse smallUniverseNoLoc
       l = getLoc f
   dataT <- freshVar l "dataT"
-  nat <- getBuiltinName (getLoc f) BuiltinNat
+  byteArray <- getBuiltinName (getLoc f) BuiltinByteArray
   let freeVars = HashSet.fromList [dataT]
   unless
-    ((ftype ==% (u <>--> dataT --> nat --> nat)) freeVars)
-    (error "anomaSignDetached must be of type {A : Type} -> A -> Nat -> Nat")
+    ((ftype ==% (u <>--> dataT --> byteArray --> byteArray)) freeVars)
+    (error "anomaSignDetached must be of type {A : Type} -> A -> ByteArray -> ByteArray")
   registerBuiltin BuiltinAnomaSignDetached (f ^. axiomName)

--- a/src/Juvix/Compiler/Builtins/Anoma.hs
+++ b/src/Juvix/Compiler/Builtins/Anoma.hs
@@ -64,11 +64,11 @@ registerAnomaSign f = do
       u = ExpressionUniverse smallUniverseNoLoc
       l = getLoc f
   dataT <- freshVar l "dataT"
-  nat <- getBuiltinName (getLoc f) BuiltinNat
+  byteArray <- getBuiltinName (getLoc f) BuiltinByteArray
   let freeVars = HashSet.fromList [dataT]
   unless
-    ((ftype ==% (u <>--> dataT --> nat --> nat)) freeVars)
-    (error "anomaSign must be of type {A : Type} -> A -> Nat -> Nat")
+    ((ftype ==% (u <>--> dataT --> byteArray --> byteArray)) freeVars)
+    (error "anomaSign must be of type {A : Type} -> A -> ByteArray -> ByteArray")
   registerBuiltin BuiltinAnomaSign (f ^. axiomName)
 
 registerAnomaVerifyWithMessage :: (Members '[Builtins, NameIdGen] r) => AxiomDef -> Sem r ()
@@ -77,12 +77,12 @@ registerAnomaVerifyWithMessage f = do
       u = ExpressionUniverse smallUniverseNoLoc
       l = getLoc f
   dataT <- freshVar l "dataT"
-  nat <- getBuiltinName (getLoc f) BuiltinNat
+  byteArray <- getBuiltinName (getLoc f) BuiltinByteArray
   maybe_ <- getBuiltinName (getLoc f) BuiltinMaybe
   let freeVars = HashSet.fromList [dataT]
   unless
-    ((ftype ==% (u <>--> nat --> nat --> maybe_ @@ dataT)) freeVars)
-    (error "anomaVerify must be of type {A : Type} -> Nat -> Nat -> Maybe A")
+    ((ftype ==% (u <>--> byteArray --> byteArray --> maybe_ @@ dataT)) freeVars)
+    (error "anomaVerify must be of type {A : Type} -> byteArray -> byteArray -> Maybe A")
   registerBuiltin BuiltinAnomaVerifyWithMessage (f ^. axiomName)
 
 registerAnomaSignDetached :: (Members '[Builtins, NameIdGen] r) => AxiomDef -> Sem r ()

--- a/src/Juvix/Compiler/Core/Evaluator.hs
+++ b/src/Juvix/Compiler/Core/Evaluator.hs
@@ -519,45 +519,61 @@ geval opts herr tab env0 = eval' env0
         uint8FromIntOp =
           unary $ \node ->
             let !v = eval' env node
-             in nodeFromUInt8
-                  . fromIntegral
-                  . fromMaybe (evalError "expected integer" v)
-                  . integerFromNode
-                  $ v
+             in if
+                    | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
+                        mkBuiltinApp' OpUInt8FromInt [v]
+                    | otherwise ->
+                        nodeFromUInt8
+                          . fromIntegral
+                          . fromMaybe (evalError "expected integer" v)
+                          . integerFromNode
+                          $ v
         {-# INLINE uint8FromIntOp #-}
 
         uint8ToIntOp :: [Node] -> Node
         uint8ToIntOp =
           unary $ \node ->
             let !v = eval' env node
-             in nodeFromInteger
-                  . toInteger
-                  . fromMaybe (evalError "expected uint8" v)
-                  . uint8FromNode
-                  $ v
+             in if
+                    | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
+                        mkBuiltinApp' OpUInt8ToInt [v]
+                    | otherwise ->
+                        nodeFromInteger
+                          . toInteger
+                          . fromMaybe (evalError "expected uint8" v)
+                          . uint8FromNode
+                          $ v
         {-# INLINE uint8ToIntOp #-}
 
         byteArrayFromListByteOp :: [Node] -> Node
         byteArrayFromListByteOp =
           unary $ \node ->
             let !v = eval' env node
-             in nodeFromByteString
-                  . BS.pack
-                  . fromMaybe (evalError "expected list byte" v)
-                  . listUInt8FromNode
-                  $ v
+             in if
+                    | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
+                        mkBuiltinApp' OpByteArrayFromListByte [v]
+                    | otherwise ->
+                        nodeFromByteString
+                          . BS.pack
+                          . fromMaybe (evalError "expected list byte" v)
+                          . listUInt8FromNode
+                          $ v
         {-# INLINE byteArrayFromListByteOp #-}
 
         byteArrayLengthOp :: [Node] -> Node
         byteArrayLengthOp =
           unary $ \node ->
             let !v = eval' env node
-             in nodeFromInteger
-                  . fromIntegral
-                  . BS.length
-                  . fromMaybe (evalError "expected bytestring" v)
-                  . byteStringFromNode
-                  $ v
+             in if
+                    | opts ^. evalOptionsNormalize || opts ^. evalOptionsNoFailure ->
+                        mkBuiltinApp' OpByteArrayLength [v]
+                    | otherwise ->
+                        nodeFromInteger
+                          . fromIntegral
+                          . BS.length
+                          . fromMaybe (evalError "ByteArrayLengthOp expected bytestring" v)
+                          . byteStringFromNode
+                          $ v
         {-# INLINE byteArrayLengthOp #-}
 
     {-# INLINE applyBuiltin #-}

--- a/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
@@ -61,28 +61,6 @@ mkEmptyAtom x =
       _atom = x
     }
 
--- mkEmptyCell :: Term a -> Term a -> Cell a
--- mkEmptyCell l r =
---   Cell'
---     { _cellRight = r,
---       _cellLeft = l,
---       _cellInfo = emptyCellInfo
---     }
-
--- byteArrayToByteString :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Atom a -> Atom a -> Sem r ByteString
--- byteArrayToByteString lenAtom bytesAtom = do
---   len <- nockNatural lenAtom
---   atomToByteStringLen (fromJust (safeNaturalToInt len)) bytesAtom
-
--- --- Transform an Int to an Atom. The function returns ann atom representing the absolute value of the input Int.
--- intToAtom :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Int -> Sem r (Atom a)
--- intToAtom i = mkEmptyAtom <$> fromNatural (integerToNatural (toInteger i))
-
--- byteStringToByteArray :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => ByteString -> Sem r (Cell a)
--- byteStringToByteArray bs = do
---   len <- TermAtom <$> intToAtom (BS.length bs)
---   mkEmptyCell len . TermAtom <$> byteStringToAtom bs
-
 -- | Pad a ByteString with zeros up to a specified length
 padByteString :: Int -> ByteString -> ByteString
 padByteString n bs

--- a/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
@@ -61,6 +61,28 @@ mkEmptyAtom x =
       _atom = x
     }
 
+-- mkEmptyCell :: Term a -> Term a -> Cell a
+-- mkEmptyCell l r =
+--   Cell'
+--     { _cellRight = r,
+--       _cellLeft = l,
+--       _cellInfo = emptyCellInfo
+--     }
+
+-- byteArrayToByteString :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Atom a -> Atom a -> Sem r ByteString
+-- byteArrayToByteString lenAtom bytesAtom = do
+--   len <- nockNatural lenAtom
+--   atomToByteStringLen (fromJust (safeNaturalToInt len)) bytesAtom
+
+-- --- Transform an Int to an Atom. The function returns ann atom representing the absolute value of the input Int.
+-- intToAtom :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => Int -> Sem r (Atom a)
+-- intToAtom i = mkEmptyAtom <$> fromNatural (integerToNatural (toInteger i))
+
+-- byteStringToByteArray :: (NockNatural a, Member (Error (ErrNockNatural a)) r) => ByteString -> Sem r (Cell a)
+-- byteStringToByteArray bs = do
+--   len <- TermAtom <$> intToAtom (BS.length bs)
+--   mkEmptyCell len . TermAtom <$> byteStringToAtom bs
+
 -- | Pad a ByteString with zeros up to a specified length
 padByteString :: Int -> ByteString -> ByteString
 padByteString n bs

--- a/src/Juvix/Compiler/Nockma/Encoding/Ed25519.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Ed25519.hs
@@ -3,7 +3,16 @@ module Juvix.Compiler.Nockma.Encoding.Ed25519 where
 import Data.ByteString qualified as BS
 import Juvix.Prelude.Base
 
+signatureLength :: Int
+signatureLength = 64
+
+publicKeyLength :: Int
+publicKeyLength = 32
+
+privateKeyLength :: Int
+privateKeyLength = 64
+
 -- | Remove the Ed25519 signature from a signed message.
 -- The signaure of an Ed25519 message is the first 64 bytes of the signed message.
 removeSignature :: ByteString -> ByteString
-removeSignature = BS.drop 64
+removeSignature = BS.drop signatureLength

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -292,15 +292,6 @@ evalProfile inistack initerm =
                   TermAtom x -> x
                   TermCell {} -> error "expect list element to be an atom"
 
-            signatureLength :: Int
-            signatureLength = 64
-
-            publicKeyLength :: Int
-            publicKeyLength = 32
-
-            privateKeyLength :: Int
-            privateKeyLength = 64
-
             goVerifyDetached :: Atom a -> Atom a -> Atom a -> Sem r (Term a)
             goVerifyDetached sigT messageT pubKeyT = do
               sig <- Signature <$> atomToByteStringLen signatureLength sigT

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -259,6 +259,9 @@ evalProfile inistack initerm =
               let xs = checkTermToList args'
               let len = integerToNatural (toInteger (length xs))
               TermAtom . mkEmptyAtom <$> fromNatural len
+            StdlibLengthBytes -> case args' of
+              TermAtom a -> TermAtom <$> goLengthBytes a
+              _ -> error "expected an atom"
           where
             goCat :: Atom a -> Atom a -> Sem r (Term a)
             goCat arg1 arg2 = TermAtom . setAtomHint AtomHintString <$> atomConcatenateBytes arg1 arg2
@@ -267,6 +270,11 @@ evalProfile inistack initerm =
             goFoldBytes c = do
               bs <- mapM nockNatural (checkTermToListAtom c)
               byteStringToAtom (BS.pack (fromIntegral <$> bs))
+
+            goLengthBytes :: Atom a -> Sem r (Atom a)
+            goLengthBytes x = do
+              bs <- atomToByteString x
+              return (mkEmptyAtom (fromIntegral (BS.length bs)))
 
             checkTermToList :: Term a -> [Term a]
             checkTermToList = \case

--- a/src/Juvix/Compiler/Nockma/StdlibFunction.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction.hs
@@ -29,6 +29,13 @@ stdlibPath = \case
   StdlibLengthList -> [nock| [9 1.406 0 31] |]
   -- Obtained from the urbit dojo using:
   --
+  -- =>  anoma  !=(~(met block 3))
+  --
+  -- The `3` here is because we want to treat each atom as sequences of 2^3
+  -- bits, i.e bytes.
+  StdlibLengthBytes -> [nock| [8 [9 10 0 7] 9 190 10 [6 7 [0 3] 1 3] 0 2] |]
+  -- Obtained from the urbit dojo using:
+  --
   -- =>  anoma  !=(~(cat block 3))
   --
   -- The `3` here is because we want to treat each atom as sequences of 2^3

--- a/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
+++ b/src/Juvix/Compiler/Nockma/StdlibFunction/Base.hs
@@ -23,6 +23,7 @@ instance Pretty StdlibFunction where
     StdlibCatBytes -> "cat"
     StdlibFoldBytes -> "fold-bytes"
     StdlibLengthList -> "length-list"
+    StdlibLengthBytes -> "length-bytes"
 
 data StdlibFunction
   = StdlibDec
@@ -43,6 +44,7 @@ data StdlibFunction
   | StdlibCatBytes
   | StdlibFoldBytes
   | StdlibLengthList
+  | StdlibLengthBytes
   deriving stock (Show, Lift, Eq, Bounded, Enum, Generic)
 
 instance Hashable StdlibFunction

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -542,8 +542,8 @@ compile = \case
     byteArrayPayload :: Text -> Term Natural -> Term Natural
     byteArrayPayload msg ba = ba >># opAddress msg [R]
 
-    mkByteArray :: Int -> Term Natural -> Term Natural
-    mkByteArray len payload = nockNatLiteral (integerToNatural (toInteger len)) # payload
+    mkByteArray :: Term Natural -> Term Natural -> Term Natural
+    mkByteArray len payload = len # payload
 
     goAnomaVerifyDetached :: [Term Natural] -> Term Natural
     goAnomaVerifyDetached = \case
@@ -558,14 +558,31 @@ compile = \case
 
     goAnomaSign :: [Term Natural] -> Term Natural
     goAnomaSign = \case
-      [message, privKey] -> callStdlib StdlibSign [goAnomaEncode [message], privKey]
+      [message, privKey] ->
+        opReplace
+          "callMkByteArrayOnSignResult"
+          (closurePath ArgsTuple)
+          ( callStdlib
+              StdlibSign
+              [ goAnomaEncode [message],
+                byteArrayPayload "anomaSignPrivKeyTail" privKey
+              ]
+          )
+          (opAddress "stack" emptyPath)
+          >># goReturnByteArray
       _ -> impossible
+      where
+        goReturnByteArray :: Term Natural
+        goReturnByteArray = mkByteArray (callStdlib StdlibLengthBytes [signResult]) signResult
+
+        signResult :: Term Natural
+        signResult = opAddress "sign-result" (closurePath ArgsTuple)
 
     goAnomaSignDetached :: [Term Natural] -> Term Natural
     goAnomaSignDetached = \case
       [message, privKeyByteArray] ->
         mkByteArray
-          E.signatureLength
+          (nockNatLiteral (integerToNatural (toInteger E.signatureLength)))
           ( callStdlib
               StdlibSignDetached
               [ goAnomaEncode [message],
@@ -584,7 +601,7 @@ compile = \case
         opReplace
           "callDecodeFromVerify-args"
           (closurePath ArgsTuple)
-          (callStdlib StdlibVerify [signedMessage, pubKey])
+          (callStdlib StdlibVerify [byteArrayPayload "signedMessageByteArray" signedMessage, byteArrayPayload "pubKeyByteArray" pubKey])
           (opAddress "stack" emptyPath)
           >># goDecodeResult
       _ -> impossible

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -567,7 +567,8 @@ allTests =
         $(mkRelFile "test077.juvix")
         []
         $ checkOutput
-          [ [nock| true |]
+          [ [nock| 64 |],
+            [nock| true |]
           ],
       let toSignAndVerify :: Term Natural = [nock| [1 2 nil] |]
        in mkAnomaCallTest

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -278,7 +278,11 @@ juvixCallingConventionTests =
            compilerTest "fold bytes [0, 1, 0] == 256" (callStdlib StdlibFoldBytes [OpQuote # makeList (toNock @Natural <$> [0, 1, 0])]) (eqNock [nock| 256 |]),
            compilerTest "length [] == 0" (callStdlib StdlibLengthList [OpQuote # makeList []]) (eqNock [nock| 0 |]),
            compilerTest "length [10] == 1" (callStdlib StdlibLengthList [OpQuote # makeList [[nock| 10 |]]]) (eqNock [nock| 1 |]),
-           compilerTest "length [[1 2, 3], 0] == 2" (callStdlib StdlibLengthList [OpQuote # makeList [[nock| [1 2 3] |], [nock| 0 |]]]) (eqNock [nock| 2 |])
+           compilerTest "length [[1 2, 3], 0] == 2" (callStdlib StdlibLengthList [OpQuote # makeList [[nock| [1 2 3] |], [nock| 0 |]]]) (eqNock [nock| 2 |]),
+           compilerTest "length-bytes 256 == 2" (callStdlib StdlibLengthBytes [nockNatLiteral 256]) (eqNock [nock| 2 |]),
+           compilerTest "length-bytes 255 == 1" (callStdlib StdlibLengthBytes [nockNatLiteral 255]) (eqNock [nock| 1 |]),
+           compilerTest "length-bytes 1 == 1" (callStdlib StdlibLengthBytes [nockNatLiteral 1]) (eqNock [nock| 1 |]),
+           compilerTest "length-bytes 0 == 0" (callStdlib StdlibLengthBytes [nockNatLiteral 0]) (eqNock [nock| 0 |])
          ]
 
 unitTests :: [Test]

--- a/tests/Anoma/Compilation/positive/test077.juvix
+++ b/tests/Anoma/Compilation/positive/test077.juvix
@@ -3,24 +3,127 @@ module test077;
 import Stdlib.Prelude open;
 import Stdlib.Debug.Trace open;
 
+builtin bytearray
+axiom ByteArray : Type;
+
+builtin bytearray-from-list-byte
+axiom mkByteArray : List Byte -> ByteArray;
+
+builtin bytearray-length
+axiom byteArrayLength : ByteArray -> Nat;
+
 builtin anoma-sign-detached
-axiom anomaSignDetached : {A : Type}
-  -> A
-  -> Nat
-  -> Nat;
+axiom anomaSignDetached : {A : Type} -> A -> ByteArray -> ByteArray;
 
 builtin anoma-verify-detached
-axiom anomaVerifyDetached : {A : Type}
-  -> Nat
-  -> A
-  -> Nat
-  -> Bool;
+axiom anomaVerifyDetached : {A : Type} -> ByteArray -> A -> ByteArray -> Bool;
 
-privKey : Nat :=
-  0x3181f891cd2323ffe802dd8f36f7e77cd072e3bd8f49884e8b38a297646351e9015535fa1125ec092c85758756d51bf29eed86a118942135c1657bf4cb5c6fc9;
+main : Bool :=
+  let
+    msg : Nat := 1;
+    sig : ByteArray := anomaSignDetached msg privKey;
+  in trace (byteArrayLength sig) >-> anomaVerifyDetached (anomaSignDetached msg privKey) msg pubKey;
 
-pubKey : Nat :=
-  0x3181f891cd2323ffe802dd8f36f7e77cd072e3bd8f49884e8b38a297646351e9;
+privKey : ByteArray :=
+  mkByteArray
+    [ 0xa9
+    ; 0xde
+    ; 0xd6
+    ; 0x29
+    ; 0x93
+    ; 0xfb
+    ; 0x52
+    ; 0x61
+    ; 0xfb
+    ; 0x59
+    ; 0xf7
+    ; 0xd4
+    ; 0x78
+    ; 0x42
+    ; 0xe5
+    ; 0xa7
+    ; 0x81
+    ; 0xf6
+    ; 0xe
+    ; 0x48
+    ; 0xb5
+    ; 0x83
+    ; 0xae
+    ; 0xf
+    ; 0x89
+    ; 0x85
+    ; 0x85
+    ; 0xda
+    ; 0x4b
+    ; 0x43
+    ; 0xec
+    ; 0x88
+    ; 0xbf
+    ; 0x1
+    ; 0x72
+    ; 0x9a
+    ; 0x6d
+    ; 0xa0
+    ; 0x83
+    ; 0xa5
+    ; 0x2f
+    ; 0x23
+    ; 0x43
+    ; 0x4e
+    ; 0x90
+    ; 0x87
+    ; 0x88
+    ; 0x51
+    ; 0xf0
+    ; 0x8a
+    ; 0x49
+    ; 0x5c
+    ; 0x8c
+    ; 0xb7
+    ; 0x97
+    ; 0x9b
+    ; 0x28
+    ; 0x88
+    ; 0xae
+    ; 0x12
+    ; 0x97
+    ; 0x9d
+    ; 0xc1
+    ; 0x35
+    ];
 
-main : Bool := let msg : Nat := 1 in
-  anomaVerifyDetached (anomaSignDetached msg privKey) msg pubKey;
+pubKey : ByteArray :=
+  mkByteArray
+    [ 0xbf
+    ; 0x1
+    ; 0x72
+    ; 0x9a
+    ; 0x6d
+    ; 0xa0
+    ; 0x83
+    ; 0xa5
+    ; 0x2f
+    ; 0x23
+    ; 0x43
+    ; 0x4e
+    ; 0x90
+    ; 0x87
+    ; 0x88
+    ; 0x51
+    ; 0xf0
+    ; 0x8a
+    ; 0x49
+    ; 0x5c
+    ; 0x8c
+    ; 0xb7
+    ; 0x97
+    ; 0x9b
+    ; 0x28
+    ; 0x88
+    ; 0xae
+    ; 0x12
+    ; 0x97
+    ; 0x9d
+    ; 0xc1
+    ; 0x35
+    ];

--- a/tests/Anoma/Compilation/positive/test078.juvix
+++ b/tests/Anoma/Compilation/positive/test078.juvix
@@ -18,12 +18,10 @@ axiom anomaSign : {A : Type} -> A -> ByteArray -> ByteArray;
 builtin anoma-verify-with-message
 axiom anomaVerifyWithMessage : {A : Type} -> ByteArray -> ByteArray -> Maybe A;
 
-main' (input : List Nat) : List Nat :=
+main (input : List Nat) : List Nat :=
   let
     signedMessage : ByteArray := anomaSign input privKey;
   in fromMaybe [] <| anomaVerifyWithMessage signedMessage pubKey;
-
-main : List Nat := main' [1; 2; 3];
 
 privKey : ByteArray :=
   mkByteArray

--- a/tests/Anoma/Compilation/positive/test078.juvix
+++ b/tests/Anoma/Compilation/positive/test078.juvix
@@ -1,22 +1,131 @@
 module test078;
 
 import Stdlib.Prelude open;
+import Stdlib.Debug.Trace open;
+
+builtin bytearray
+axiom ByteArray : Type;
+
+builtin bytearray-from-list-byte
+axiom mkByteArray : List Byte -> ByteArray;
+
+builtin bytearray-length
+axiom byteArrayLength : ByteArray -> Nat;
 
 builtin anoma-sign
-axiom anomaSign : {A : Type} -> A -> Nat -> Nat;
+axiom anomaSign : {A : Type} -> A -> ByteArray -> ByteArray;
 
 builtin anoma-verify-with-message
-axiom anomaVerifyWithMessage : {A : Type}
-  -> Nat
-  -> Nat
-  -> Maybe A;
+axiom anomaVerifyWithMessage : {A : Type} -> ByteArray -> ByteArray -> Maybe A;
 
-privKey : Nat :=
-  0x3181f891cd2323ffe802dd8f36f7e77cd072e3bd8f49884e8b38a297646351e9015535fa1125ec092c85758756d51bf29eed86a118942135c1657bf4cb5c6fc9;
+main' (input : List Nat) : List Nat :=
+  let
+    signedMessage : ByteArray := anomaSign input privKey;
+  in trace (byteArrayLength signedMessage) >-> fromMaybe []
+    <| anomaVerifyWithMessage signedMessage pubKey;
 
-pubKey : Nat :=
-  0x3181f891cd2323ffe802dd8f36f7e77cd072e3bd8f49884e8b38a297646351e9;
+main : List Nat := main' [1; 2; 3];
 
-main (input : List Nat) : List Nat :=
-  fromMaybe []
-    <| anomaVerifyWithMessage (anomaSign input privKey) pubKey;
+privKey : ByteArray :=
+  mkByteArray
+    [ 0x24
+    ; 0xbd
+    ; 0x9b
+    ; 0x1e
+    ; 0x60
+    ; 0x29
+    ; 0x76
+    ; 0x7b
+    ; 0x76
+    ; 0xa4
+    ; 0x8c
+    ; 0x24
+    ; 0x96
+    ; 0xcc
+    ; 0xf9
+    ; 0x81
+    ; 0x6e
+    ; 0x26
+    ; 0xa1
+    ; 0x7c
+    ; 0xfb
+    ; 0xbc
+    ; 0xb8
+    ; 0x33
+    ; 0x1
+    ; 0x71
+    ; 0x66
+    ; 0xe3
+    ; 0x35
+    ; 0x68
+    ; 0x4a
+    ; 0x22
+    ; 0xef
+    ; 0x84
+    ; 0x90
+    ; 0xee
+    ; 0x90
+    ; 0x3e
+    ; 0x7c
+    ; 0x1d
+    ; 0x9
+    ; 0x87
+    ; 0xf8
+    ; 0xf7
+    ; 0xe2
+    ; 0x23
+    ; 0xc2
+    ; 0xde
+    ; 0x4e
+    ; 0x4a
+    ; 0x17
+    ; 0xca
+    ; 0x29
+    ; 0x75
+    ; 0x5
+    ; 0x80
+    ; 0xa6
+    ; 0x67
+    ; 0xc
+    ; 0xcd
+    ; 0xdb
+    ; 0xae
+    ; 0xc5
+    ; 0xc3
+    ];
+
+pubKey : ByteArray :=
+  mkByteArray
+    [ 0xef
+    ; 0x84
+    ; 0x90
+    ; 0xee
+    ; 0x90
+    ; 0x3e
+    ; 0x7c
+    ; 0x1d
+    ; 0x9
+    ; 0x87
+    ; 0xf8
+    ; 0xf7
+    ; 0xe2
+    ; 0x23
+    ; 0xc2
+    ; 0xde
+    ; 0x4e
+    ; 0x4a
+    ; 0x17
+    ; 0xca
+    ; 0x29
+    ; 0x75
+    ; 0x5
+    ; 0x80
+    ; 0xa6
+    ; 0x67
+    ; 0xc
+    ; 0xcd
+    ; 0xdb
+    ; 0xae
+    ; 0xc5
+    ; 0xc3
+    ];

--- a/tests/Anoma/Compilation/positive/test078.juvix
+++ b/tests/Anoma/Compilation/positive/test078.juvix
@@ -21,8 +21,7 @@ axiom anomaVerifyWithMessage : {A : Type} -> ByteArray -> ByteArray -> Maybe A;
 main' (input : List Nat) : List Nat :=
   let
     signedMessage : ByteArray := anomaSign input privKey;
-  in trace (byteArrayLength signedMessage) >-> fromMaybe []
-    <| anomaVerifyWithMessage signedMessage pubKey;
+  in fromMaybe [] <| anomaVerifyWithMessage signedMessage pubKey;
 
 main : List Nat := main' [1; 2; 3];
 

--- a/tests/Core/positive/test062.jvc
+++ b/tests/Core/positive/test062.jvc
@@ -8,9 +8,14 @@ type tClosure : Type {
    ctorCl : (Int -> Int) -> tClosure;
 };
 
-def privKey : Int := 11617894433197913967256772080085224292574263152640782716628013903136761875218972825378605552167075549144813844196048766885080313195607865362963533894031960;
+def cons : UInt8 -> BuiltinList -> BuiltinList := \x \l builtinListCons UInt8 x l;
+def nil : BuiltinList := builtinListNil UInt8;
 
-def pubKey : Int := 100334094580390620383139794340338190270834129828455530198518726236886616013505;
+def privKey : ByteArray := bytearray-from-list-byte (cons 162u8 (cons 93u8 (cons 186u8 (cons 174u8 (cons 61u8 (cons 123u8 (cons 31u8 (cons 32u8 (cons 2u8 (cons 255u8 (cons 32u8 (cons 34u8 (cons 195u8 (cons 2u8 (cons 116u8 (cons 15u8 (cons 93u8 (cons 36u8 (cons 230u8 (cons 90u8 (cons 163u8 (cons 149u8 (cons 249u8 (cons 41u8 (cons 148u8 (cons 34u8 (cons 86u8 (cons 102u8 (cons 53u8 (cons 44u8 (cons 16u8 (cons 80u8 (cons 253u8 (cons 178u8 (cons 149u8 (cons 247u8 (cons 146u8 (cons 59u8 (cons 105u8 (cons 89u8 (cons 57u8 (cons 42u8 (cons 212u8 (cons 65u8 (cons 142u8 (cons 237u8 (cons 232u8 (cons 88u8 (cons 112u8 (cons 95u8 (cons 142u8 (cons 49u8 (cons 238u8 (cons 122u8 (cons 220u8 (cons 193u8 (cons 206u8 (cons 180u8 (cons 48u8 (cons 147u8 (cons 80u8 (cons 41u8 (cons 143u8 (cons 207u8 nil))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
+def pubKey : ByteArray := bytearray-from-list-byte (cons 253u8 (cons 178u8 (cons 149u8 (cons 247u8 (cons 146u8 (cons 59u8 (cons 105u8 (cons 89u8 (cons 57u8 (cons 42u8 (cons 212u8 (cons 65u8 (cons 142u8 (cons 237u8 (cons 232u8 (cons 88u8 (cons 112u8 (cons 95u8 (cons 142u8 (cons 49u8 (cons 238u8 (cons 122u8 (cons 220u8 (cons 193u8 (cons 206u8 (cons 180u8 (cons 48u8 (cons 147u8 (cons 80u8 (cons 41u8 (cons 143u8 (cons 207u8 nil))))))))))))))))))))))))))))))));
+
+def privKeyInt : Int := 11617894433197913967256772080085224292574263152640782716628013903136761875218972825378605552167075549144813844196048766885080313195607865362963533894031960;
+def pubKeyInt : Int := 100334094580390620383139794340338190270834129828455530198518726236886616013505;
 
 def v1 : t := ctor 10;
 def v2 : t := ctor 0;
@@ -25,7 +30,7 @@ def projectClosure := \t match t with {
 
 writeLn (anoma-decode (anoma-encode v1) = v1)
 >> writeLn (projectClosure (anoma-decode (anoma-encode v3)) 10 = 20)
->> writeLn (anoma-verify-with-message (anoma-sign v1 privKey) pubKey = just v1)
->> writeLn (anoma-verify-with-message (anoma-sign v1 privKey) privKey = nothing)
+>> writeLn (anoma-verify-with-message (anoma-sign v1 privKeyInt) pubKeyInt = just v1)
+>> writeLn (anoma-verify-with-message (anoma-sign v1 privKeyInt) privKeyInt = nothing)
 >> writeLn (anoma-verify-detached (anoma-sign-detached v1 privKey) v1 pubKey)
 >> writeLn (anoma-verify-detached (anoma-sign-detached v1 privKey) v2 pubKey)

--- a/tests/Core/positive/test062.jvc
+++ b/tests/Core/positive/test062.jvc
@@ -14,9 +14,6 @@ def nil : BuiltinList := builtinListNil UInt8;
 def privKey : ByteArray := bytearray-from-list-byte (cons 162u8 (cons 93u8 (cons 186u8 (cons 174u8 (cons 61u8 (cons 123u8 (cons 31u8 (cons 32u8 (cons 2u8 (cons 255u8 (cons 32u8 (cons 34u8 (cons 195u8 (cons 2u8 (cons 116u8 (cons 15u8 (cons 93u8 (cons 36u8 (cons 230u8 (cons 90u8 (cons 163u8 (cons 149u8 (cons 249u8 (cons 41u8 (cons 148u8 (cons 34u8 (cons 86u8 (cons 102u8 (cons 53u8 (cons 44u8 (cons 16u8 (cons 80u8 (cons 253u8 (cons 178u8 (cons 149u8 (cons 247u8 (cons 146u8 (cons 59u8 (cons 105u8 (cons 89u8 (cons 57u8 (cons 42u8 (cons 212u8 (cons 65u8 (cons 142u8 (cons 237u8 (cons 232u8 (cons 88u8 (cons 112u8 (cons 95u8 (cons 142u8 (cons 49u8 (cons 238u8 (cons 122u8 (cons 220u8 (cons 193u8 (cons 206u8 (cons 180u8 (cons 48u8 (cons 147u8 (cons 80u8 (cons 41u8 (cons 143u8 (cons 207u8 nil))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
 def pubKey : ByteArray := bytearray-from-list-byte (cons 253u8 (cons 178u8 (cons 149u8 (cons 247u8 (cons 146u8 (cons 59u8 (cons 105u8 (cons 89u8 (cons 57u8 (cons 42u8 (cons 212u8 (cons 65u8 (cons 142u8 (cons 237u8 (cons 232u8 (cons 88u8 (cons 112u8 (cons 95u8 (cons 142u8 (cons 49u8 (cons 238u8 (cons 122u8 (cons 220u8 (cons 193u8 (cons 206u8 (cons 180u8 (cons 48u8 (cons 147u8 (cons 80u8 (cons 41u8 (cons 143u8 (cons 207u8 nil))))))))))))))))))))))))))))))));
 
-def privKeyInt : Int := 11617894433197913967256772080085224292574263152640782716628013903136761875218972825378605552167075549144813844196048766885080313195607865362963533894031960;
-def pubKeyInt : Int := 100334094580390620383139794340338190270834129828455530198518726236886616013505;
-
 def v1 : t := ctor 10;
 def v2 : t := ctor 0;
 def f1 : Int -> Int := \x 2 * x;
@@ -30,7 +27,7 @@ def projectClosure := \t match t with {
 
 writeLn (anoma-decode (anoma-encode v1) = v1)
 >> writeLn (projectClosure (anoma-decode (anoma-encode v3)) 10 = 20)
->> writeLn (anoma-verify-with-message (anoma-sign v1 privKeyInt) pubKeyInt = just v1)
->> writeLn (anoma-verify-with-message (anoma-sign v1 privKeyInt) privKeyInt = nothing)
+>> writeLn (anoma-verify-with-message (anoma-sign v1 privKey) pubKey = just v1)
+>> writeLn (anoma-verify-with-message (anoma-sign v1 privKey) privKey = nothing)
 >> writeLn (anoma-verify-detached (anoma-sign-detached v1 privKey) v1 pubKey)
 >> writeLn (anoma-verify-detached (anoma-sign-detached v1 privKey) v2 pubKey)


### PR DESCRIPTION
This PR adds support for ByteArray in the Anoma cryptographic functions.

```
builtin anoma-sign
axiom anomaSign : {A : Type} -> A -> ByteArray -> ByteArray;

builtin anoma-verify-with-message
axiom anomaVerifyWithMessage : {A : Type} -> ByteArray -> ByteArray -> Maybe A;

builtin anoma-sign-detached
axiom anomaSignDetached : {A : Type} -> A -> ByteArray -> ByteArray;

builtin anoma-verify-detached
axiom anomaVerifyDetached : {A : Type} -> ByteArray -> A -> ByteArray -> Bool;
```

The Anoma / Hoon Stdlib function `length` needs to be exposed as a StdlibFunction because a ByteArray stores its length and the value returned by `anomaSign` is not a fixed length.