### PR TITLE
Fix bug where highlighting is not kept when the file has a type error and imports some other file

### DIFF
--- a/app/Commands/Dev/Highlight.hs
+++ b/app/Commands/Dev/Highlight.hs
@@ -13,3 +13,4 @@ runCommand HighlightOptions {..} = silenceProgressLog . runPipelineOptions $ do
       inputFile
       <$> runPipelineHighlight entry upToInternalTyped
   renderStdOutRaw (Highlight.highlight _highlightBackend hinput)
+  newline

--- a/src/Juvix/Compiler/Concrete/Data/Highlight.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight.hs
@@ -1,6 +1,6 @@
 module Juvix.Compiler.Concrete.Data.Highlight
   ( module Juvix.Compiler.Concrete.Data.Highlight,
-    module Juvix.Compiler.Concrete.Data.Highlight.Input,
+    module Juvix.Compiler.Concrete.Data.Highlight.Builder,
     module Juvix.Compiler.Concrete.Data.Highlight.Properties,
   )
 where
@@ -8,7 +8,7 @@ where
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as ByteString
 import Data.Text.Encoding qualified as Text
-import Juvix.Compiler.Concrete.Data.Highlight.Input
+import Juvix.Compiler.Concrete.Data.Highlight.Builder
 import Juvix.Compiler.Concrete.Data.Highlight.PrettyJudoc
 import Juvix.Compiler.Concrete.Data.Highlight.Properties
 import Juvix.Compiler.Concrete.Data.Highlight.RenderEmacs
@@ -40,11 +40,11 @@ buildProperties :: HighlightInput -> LocProperties
 buildProperties HighlightInput {..} =
   LocProperties
     { _propertiesFace =
-        map goFaceParsedItem _highlightParsed
+        map goFaceParsedItem _highlightParsedItems
           <> mapMaybe goFaceName _highlightNames
           <> map goFaceError _highlightErrors,
       _propertiesGoto = map goGotoProperty _highlightNames,
-      _propertiesDoc = mapMaybe (goDocProperty _highlightDoc _highlightTypes) _highlightNames
+      _propertiesDoc = mapMaybe (goDocProperty _highlightDocTable _highlightTypes) _highlightNames
     }
 
 goFaceError :: Interval -> WithLoc PropertyFace

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/Builder.hs
@@ -1,0 +1,48 @@
+module Juvix.Compiler.Concrete.Data.Highlight.Builder
+  ( module Juvix.Compiler.Concrete.Data.Highlight.Input,
+    module Juvix.Compiler.Concrete.Data.ParsedItem,
+    module Juvix.Compiler.Concrete.Data.Highlight.Builder,
+  )
+where
+
+import Juvix.Compiler.Concrete.Data.Highlight.Input
+import Juvix.Compiler.Concrete.Data.ParsedItem
+import Juvix.Compiler.Concrete.Data.ScopedName
+import Juvix.Compiler.Concrete.Language.Base
+import Juvix.Compiler.Internal.Language qualified as Internal
+import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context
+import Juvix.Prelude
+
+data HighlightBuilder :: Effect where
+  HighlightError :: Interval -> HighlightBuilder m ()
+  HighlightDoc :: NameId -> Maybe (Judoc 'Scoped) -> HighlightBuilder m ()
+  HighlightName :: AName -> HighlightBuilder m ()
+  HighlightParsedItem :: ParsedItem -> HighlightBuilder m ()
+  HighlightType :: NameId -> Internal.Expression -> HighlightBuilder m ()
+
+makeSem ''HighlightBuilder
+
+runHighlightBuilder :: Sem (HighlightBuilder ': r) a -> Sem r (HighlightInput, a)
+runHighlightBuilder = reinterpret (runStateShared emptyHighlightInput) $ \case
+  HighlightError e -> modifyShared (over highlightErrors (e :))
+  HighlightName a -> modifyShared (over (highlightNames) (a :))
+  HighlightParsedItem p -> modifyShared (over (highlightParsedItems) (p :))
+  HighlightDoc k md -> modifyShared (set (highlightDocTable . at k) md)
+  HighlightType uid ty -> modifyShared (set (highlightTypes . typesTable . at uid) (Just ty))
+
+ignoreHighlightBuilder :: Sem (HighlightBuilder ': r) a -> Sem r a
+ignoreHighlightBuilder = fmap snd . runHighlightBuilder
+
+runJuvixError :: (Members '[HighlightBuilder] r) => Sem (Error JuvixError ': r) a -> Sem r (Either JuvixError a)
+runJuvixError m = do
+  x <- runError m
+  case x of
+    r@Right {} -> return r
+    l@(Left err) -> do
+      let errs =
+            (^. genericErrorIntervals)
+              . run
+              . runReader defaultGenericOptions
+              $ genericError err
+      mapM_ highlightError errs
+      return l

--- a/src/Juvix/Compiler/Concrete/Data/Highlight/Input.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Highlight/Input.hs
@@ -6,13 +6,14 @@ where
 
 import Juvix.Compiler.Concrete.Data.ParsedItem
 import Juvix.Compiler.Concrete.Data.ScopedName
+import Juvix.Compiler.Concrete.Language.Base
 import Juvix.Compiler.Internal.Translation.FromInternal.Analysis.TypeChecking.Data.Context qualified as Internal
 import Juvix.Compiler.Store.Scoped.Data.InfoTable qualified as Scoped
 import Juvix.Prelude
 
 data HighlightInput = HighlightInput
-  { _highlightParsed :: [ParsedItem],
-    _highlightDoc :: Scoped.DocTable,
+  { _highlightParsedItems :: [ParsedItem],
+    _highlightDocTable :: Scoped.DocTable,
     _highlightNames :: [AName],
     _highlightTypes :: Internal.TypesTable,
     _highlightErrors :: [Interval]
@@ -23,8 +24,8 @@ makeLenses ''HighlightInput
 emptyHighlightInput :: HighlightInput
 emptyHighlightInput =
   HighlightInput
-    { _highlightParsed = [],
-      _highlightDoc = mempty,
+    { _highlightParsedItems = [],
+      _highlightDocTable = mempty,
       _highlightNames = [],
       _highlightTypes = mempty,
       _highlightErrors = []
@@ -34,26 +35,8 @@ filterInput :: Path Abs File -> HighlightInput -> HighlightInput
 filterInput absPth HighlightInput {..} =
   HighlightInput
     { _highlightNames = filterByLoc absPth _highlightNames,
-      _highlightParsed = filterByLoc absPth _highlightParsed,
+      _highlightParsedItems = filterByLoc absPth _highlightParsedItems,
       _highlightErrors = filterByLoc absPth _highlightErrors,
       _highlightTypes,
-      _highlightDoc
+      _highlightDocTable
     }
-
-type HighlightBuilder = State HighlightInput
-
-runHighlightBuilder :: Sem (HighlightBuilder ': r) a -> Sem r (HighlightInput, a)
-runHighlightBuilder = runState emptyHighlightInput
-
-ignoreHighlightBuilder :: Sem (HighlightBuilder ': r) a -> Sem r a
-ignoreHighlightBuilder = evalState emptyHighlightInput
-
-runJuvixError :: (Members '[HighlightBuilder] r) => Sem (Error JuvixError ': r) a -> Sem r (Either JuvixError a)
-runJuvixError m = do
-  x <- runError m
-  case x of
-    r@Right {} -> return r
-    l@(Left err) -> do
-      let errs = run (runReader defaultGenericOptions (genericError err)) ^. genericErrorIntervals
-      modify (over highlightErrors (errs ++))
-      return l

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -401,7 +401,6 @@ instance (SingI s) => PrettyPrint (DoubleBracesExpression s) where
 instance (SingI s) => PrettyPrint (DoLet s) where
   ppCode DoLet {..} = do
     let letFunDefs' = blockIndent (ppBlock _doLetStatements)
-    -- blockIndent d = hardline <> indent d <> line
     ppCode _doLetKw
       <> letFunDefs'
       <> ppCode _doLetInKw

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -10,7 +10,7 @@ import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
 import Data.List.NonEmpty qualified as NonEmpty
 import GHC.Base (maxInt, minInt)
-import Juvix.Compiler.Concrete.Data.Highlight.Input
+import Juvix.Compiler.Concrete.Data.Highlight.Builder
 import Juvix.Compiler.Concrete.Data.InfoTableBuilder
 import Juvix.Compiler.Concrete.Data.Name qualified as N
 import Juvix.Compiler.Concrete.Data.NameSignature

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/ParserResultBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/ParserResultBuilder.hs
@@ -1,6 +1,6 @@
 module Juvix.Compiler.Concrete.Translation.FromSource.ParserResultBuilder where
 
-import Juvix.Compiler.Concrete.Data.Highlight.Input
+import Juvix.Compiler.Concrete.Data.Highlight.Builder
 import Juvix.Compiler.Concrete.Data.Literal
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromSource.Data.ParserState
@@ -84,7 +84,7 @@ runParserResultBuilder s =
   reinterpret (runState s) $ \case
     RegisterImport i -> modify' (over parserStateImports (i :))
     RegisterItem i -> do
-      modify (over highlightParsed (i :))
+      highlightParsedItem i
       registerItem' i
     RegisterSpaceSpan g -> do
       modify' (over parserStateComments (g :))

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/Megaparsec.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/Megaparsec.hs
@@ -4,7 +4,7 @@ module Juvix.Compiler.Concrete.Translation.ImportScanner.Megaparsec
   )
 where
 
-import Juvix.Compiler.Concrete.Data.Highlight.Input
+import Juvix.Compiler.Concrete.Data.Highlight.Builder
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromSource
 import Juvix.Compiler.Concrete.Translation.FromSource.Data.ParserState

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal.hs
@@ -3,7 +3,7 @@ module Juvix.Compiler.Internal.Translation.FromInternal
   )
 where
 
-import Juvix.Compiler.Concrete.Data.Highlight.Input
+import Juvix.Compiler.Concrete.Data.Highlight.Builder
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context
 import Juvix.Compiler.Internal.Data.InfoTable as Internal
 import Juvix.Compiler.Internal.Translation.FromConcrete.Data.Context as Internal

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/CheckerNew.hs
@@ -125,7 +125,7 @@ registerConstructor ctr = do
 registerNameIdType :: (Members '[HighlightBuilder, ResultBuilder] r) => NameId -> Expression -> Sem r ()
 registerNameIdType uid ty = do
   addIdenType uid ty
-  modify (over (highlightTypes . typesTable) (HashMap.insert uid ty))
+  highlightType uid ty
 
 checkCoercionCycles ::
   (Members '[ResultBuilder, Error TypeCheckerError] r) =>

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -22,7 +22,7 @@ import Juvix.Compiler.Casm.Data.Builtins qualified as Casm
 import Juvix.Compiler.Casm.Data.Result qualified as Casm
 import Juvix.Compiler.Casm.Pipeline qualified as Casm
 import Juvix.Compiler.Casm.Translation.FromReg qualified as Casm
-import Juvix.Compiler.Concrete.Data.Highlight.Input
+import Juvix.Compiler.Concrete.Data.Highlight.Builder
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromParsed qualified as Scoper
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser

--- a/src/Juvix/Compiler/Pipeline/DriverParallel.hs
+++ b/src/Juvix/Compiler/Pipeline/DriverParallel.hs
@@ -9,6 +9,7 @@ where
 
 import Data.HashMap.Strict qualified as HashMap
 import Effectful.Concurrent
+import Juvix.Compiler.Concrete.Data.Highlight.Builder (HighlightBuilder)
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Translation.FromSource.TopModuleNameChecker
 import Juvix.Compiler.Concrete.Translation.ImportScanner (ImportScanStrategy)
@@ -151,6 +152,7 @@ evalModuleInfoCache ::
   forall r a.
   ( Members
       '[ Reader EntryPoint,
+         HighlightBuilder,
          IOE,
          ProgressLog,
          Reader ImportTree,

--- a/src/Juvix/Compiler/Pipeline/Repl.hs
+++ b/src/Juvix/Compiler/Pipeline/Repl.hs
@@ -168,6 +168,7 @@ compileReplInputIO fp txt = do
     . runLoggerIO defaultLoggerOptions
     . runReader defaultNumThreads
     . evalInternet hasInternet
+    . ignoreHighlightBuilder
     . runTaggedLockPermissive
     . runLogIO
     . runFilesIO

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -67,9 +67,7 @@ runIOEitherHelper ::
   EntryPoint ->
   Sem (PipelineEff r) a ->
   Sem r (HighlightInput, (Either JuvixError (ResolverState, PipelineResult a)))
-runIOEitherHelper entry a =
-  runIOEitherPipeline' entry $ do
-    processFileUpTo a
+runIOEitherHelper entry = runIOEitherPipeline' entry . processFileUpTo
 
 runIOEitherPipeline ::
   forall a r.

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -145,6 +145,7 @@ evalModuleInfoCacheHelper ::
          TaggedLock,
          TopModuleNameChecker,
          Error JuvixError,
+         HighlightBuilder,
          PathResolver,
          Reader ImportScanStrategy,
          Reader NumThreads,

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -2,7 +2,7 @@
 
 module Juvix.Formatter where
 
-import Juvix.Compiler.Concrete.Data.Highlight.Input (ignoreHighlightBuilder)
+import Juvix.Compiler.Concrete.Data.Highlight.Builder (ignoreHighlightBuilder)
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Print (ppOutDefault)
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping (ScoperResult, getModuleId, scopeCheck)


### PR DESCRIPTION
Example file:
```
module error;

import empty; -- error only happens if we have at least one import

type T := t;

x : T := t t; -- type error
```
If one loads this file into emacs (or vscode) they'll get a type error as expected, but name colors and go-to information is lost, which is annoying. This pr fixes this.
I'm not sure why, but this bug only occurs when there is at least one import.
