### PR TITLE
Isabelle/HOL translation: add 'O' and 'OO' to reserved names

### DIFF
--- a/src/Juvix/Compiler/Backend/Isabelle/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Isabelle/Translation/FromTyped.hs
@@ -923,6 +923,8 @@ goModule onlyTypes infoTable Internal.Module {..} =
           "let",
           "list",
           "nat",
+          "O",
+          "OO",
           "of",
           "option",
           "theory",


### PR DESCRIPTION
As requested by Jonathan, adds 'O' and 'OO' to the list reserved Isabelle/HOL names.
