### PR TITLE
Improve formatting of `juvix dev import-tree print`

### DIFF
--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/ImportTree/Base.hs
@@ -6,6 +6,7 @@ module Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
     importTreeEdges,
     importTreeNodes,
     importTreeProjectNodes,
+    importTreeNodesByPackage,
     ImportTreeBuilder,
     runImportTreeBuilder,
     ignoreImportTreeBuilder,
@@ -88,6 +89,12 @@ withImportNode fromNode m = do
   internalRegisterNode fromNode
   (`interpret` m) $ \case
     ImportTreeAddEdge importScan toNode -> internalRegisterEdge importScan fromNode toNode
+
+importTreeNodesByPackage :: ImportTree -> HashMap (Path Abs Dir) (HashSet ImportNode)
+importTreeNodesByPackage tree = run . execState mempty $
+  forM_ (tree ^. importTreeNodes) $ \node ->
+    modify @(HashMap (Path Abs Dir) (HashSet ImportNode))
+      (over (at (node ^. importNodePackageRoot)) (Just . maybe (HashSet.singleton node) (HashSet.insert node)))
 
 importTree :: SimpleGetter ImportTree (HashMap ImportNode (HashSet ImportNode))
 importTree = fimportTree


### PR DESCRIPTION
Example:

Before:
```
Import Tree:
============

* Package at /home/jan/.config/juvix/0.6.5/package-base/
Juvix/Builtin/V1.juvix imports Juvix/Builtin/V1/Bool.juvix
Juvix/Builtin/V1.juvix imports Juvix/Builtin/V1/Fixity.juvix
Juvix/Builtin/V1.juvix imports Juvix/Builtin/V1/List.juvix
Juvix/Builtin/V1.juvix imports Juvix/Builtin/V1/Maybe.juvix
Juvix/Builtin/V1.juvix imports Juvix/Builtin/V1/Nat.juvix
Juvix/Builtin/V1.juvix imports Juvix/Builtin/V1/String.juvix
Juvix/Builtin/V1.juvix imports Juvix/Builtin/V1/Trait/Natural.juvix
Juvix/Builtin/V1/List.juvix imports Juvix/Builtin/V1/Fixity.juvix
Juvix/Builtin/V1/Nat.juvix imports Juvix/Builtin/V1/Nat/Base.juvix
Juvix/Builtin/V1/Nat.juvix imports Juvix/Builtin/V1/Trait/FromNatural.juvix
Juvix/Builtin/V1/Nat.juvix imports Juvix/Builtin/V1/Trait/Natural.juvix
Juvix/Builtin/V1/Nat/Base.juvix imports Juvix/Builtin/V1/Fixity.juvix
Juvix/Builtin/V1/String.juvix imports Juvix/Builtin/V1/Fixity.juvix
Juvix/Builtin/V1/Trait/FromNatural.juvix imports Juvix/Builtin/V1/Nat/Base.juvix
Juvix/Builtin/V1/Trait/Natural.juvix imports Juvix/Builtin/V1/Fixity.juvix
Juvix/Builtin/V1/Trait/Natural.juvix imports Juvix/Builtin/V1/Nat/Base.juvix
Juvix/Builtin/V1/Trait/Natural.juvix imports Juvix/Builtin/V1/Trait/FromNatural.juvix
```

After:
```
Import Tree:
============

* Package at /home/jan/.config/juvix/0.6.5/package-base/
Nodes (10)
Juvix/Builtin/V1/Nat.juvix
Juvix/Builtin/V1/Nat/Base.juvix
Juvix/Builtin/V1/Fixity.juvix
Juvix/Builtin/V1/Trait/Natural.juvix
Juvix/Builtin/V1/Bool.juvix
Juvix/Builtin/V1.juvix
Juvix/Builtin/V1/List.juvix
Juvix/Builtin/V1/String.juvix
Juvix/Builtin/V1/Trait/FromNatural.juvix
Juvix/Builtin/V1/Maybe.juvix

Edges (17)
Juvix/Builtin/V1.juvix imports (7):
  • Juvix/Builtin/V1/Bool.juvix
  • Juvix/Builtin/V1/Fixity.juvix
  • Juvix/Builtin/V1/List.juvix
  • Juvix/Builtin/V1/Maybe.juvix
  • Juvix/Builtin/V1/Nat.juvix
  • Juvix/Builtin/V1/String.juvix
  • Juvix/Builtin/V1/Trait/Natural.juvix

Juvix/Builtin/V1/Bool.juvix imports (0):

Juvix/Builtin/V1/Fixity.juvix imports (0):

Juvix/Builtin/V1/List.juvix imports (1):
  • Juvix/Builtin/V1/Fixity.juvix

Juvix/Builtin/V1/Maybe.juvix imports (0):

Juvix/Builtin/V1/Nat.juvix imports (3):
  • Juvix/Builtin/V1/Nat/Base.juvix
  • Juvix/Builtin/V1/Trait/FromNatural.juvix
  • Juvix/Builtin/V1/Trait/Natural.juvix

Juvix/Builtin/V1/Nat/Base.juvix imports (1):
  • Juvix/Builtin/V1/Fixity.juvix

Juvix/Builtin/V1/String.juvix imports (1):
  • Juvix/Builtin/V1/Fixity.juvix

Juvix/Builtin/V1/Trait/FromNatural.juvix imports (1):
  • Juvix/Builtin/V1/Nat/Base.juvix

Juvix/Builtin/V1/Trait/Natural.juvix imports (3):
  • Juvix/Builtin/V1/Fixity.juvix
  • Juvix/Builtin/V1/Nat/Base.juvix
  • Juvix/Builtin/V1/Trait/FromNatural.juvix
```