### PR TITLE
Add `PartialDo` effect

### DIFF
--- a/src/Juvix/Data/Effect.hs
+++ b/src/Juvix/Data/Effect.hs
@@ -1,5 +1,6 @@
 module Juvix.Data.Effect
   ( module Juvix.Data.Effect.Fail,
+    module Juvix.Data.Effect.PartialDo,
     module Juvix.Data.Effect.Files,
     module Juvix.Data.Effect.Cache,
     module Juvix.Data.Effect.NameIdGen,
@@ -18,5 +19,6 @@ import Juvix.Data.Effect.Forcing
 import Juvix.Data.Effect.Internet
 import Juvix.Data.Effect.Log
 import Juvix.Data.Effect.NameIdGen
+import Juvix.Data.Effect.PartialDo
 import Juvix.Data.Effect.TaggedLock
 import Juvix.Data.Effect.Visit

--- a/src/Juvix/Data/Effect/PartialDo.hs
+++ b/src/Juvix/Data/Effect/PartialDo.hs
@@ -1,0 +1,16 @@
+module Juvix.Data.Effect.PartialDo where
+
+import Effectful.Fail qualified as Eff
+import Juvix.Data.Effect.Fail
+import Juvix.Prelude.Base
+
+type PartialDo = Eff.Fail
+
+runPartialDo :: Sem (PartialDo ': r) a -> Sem r (Either String a)
+runPartialDo = Eff.runFail
+
+runPartialDoFail :: (Members '[Fail] r) => Sem (PartialDo ': r) a -> Sem r a
+runPartialDoFail m = runPartialDo m >>= either (const fail) return
+
+runPartialDoError :: (Members '[Error String] r) => Sem (PartialDo ': r) a -> Sem r a
+runPartialDoError m = runPartialDo m >>= either throw return


### PR DESCRIPTION
This effect is a different name for [Effectful's `Fail`](https://hackage.haskell.org/package/effectful-core-2.3.1.0/docs/Effectful-Fail.html). It gives an instance of [`MonadFail`](https://hackage.haskell.org/package/base-4.18.1.0/docs/Control-Monad-Fail.html#t:MonadFail) to `Sem`