### PR TITLE
Separate Comment from pretty Options

### DIFF
--- a/src/Juvix/Compiler/Backend/Isabelle/Pretty.hs
+++ b/src/Juvix/Compiler/Backend/Isabelle/Pretty.hs
@@ -7,13 +7,17 @@ import Juvix.Prelude
 import Prettyprinter.Render.Terminal qualified as Ansi
 
 ppOutDefault :: (PrettyCode c) => [Comment] -> c -> AnsiText
-ppOutDefault comments = mkAnsiText . PPOutput . doc (defaultOptions comments)
-
-ppOut :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> AnsiText
-ppOut o = mkAnsiText . PPOutput . doc (project o)
+ppOutDefault comments =
+  mkAnsiText
+    . PPOutput
+    . doc defaultOptions comments
 
 ppTrace' :: (CanonicalProjection a Options, PrettyCode c) => a -> c -> Text
-ppTrace' opts = Ansi.renderStrict . reAnnotateS stylize . layoutPretty defaultLayoutOptions . doc (project opts)
+ppTrace' opts =
+  Ansi.renderStrict
+    . reAnnotateS stylize
+    . layoutPretty defaultLayoutOptions
+    . doc (project opts) []
 
 ppTrace :: (PrettyCode c) => c -> Text
 ppTrace = ppTrace' traceOptions

--- a/src/Juvix/Compiler/Backend/Isabelle/Pretty/Options.hs
+++ b/src/Juvix/Compiler/Backend/Isabelle/Pretty/Options.hs
@@ -3,19 +3,17 @@ module Juvix.Compiler.Backend.Isabelle.Pretty.Options where
 import Juvix.Prelude
 
 data Options = Options
-  { _optComments :: [Comment]
-  }
 
 makeLenses ''Options
 
-defaultOptions :: [Comment] -> Options
+defaultOptions :: Options
 defaultOptions = Options
 
 traceOptions :: Options
-traceOptions = defaultOptions []
+traceOptions = defaultOptions
 
 fromGenericOptions :: GenericOptions -> Options
-fromGenericOptions _ = defaultOptions []
+fromGenericOptions _ = defaultOptions
 
 instance CanonicalProjection GenericOptions Options where
   project = fromGenericOptions

--- a/src/Juvix/Prelude/Effects/Input.hs
+++ b/src/Juvix/Prelude/Effects/Input.hs
@@ -2,6 +2,7 @@ module Juvix.Prelude.Effects.Input
   ( Input,
     input,
     inputJust,
+    inputWhile,
     peekInput,
     runInputList,
   )
@@ -25,6 +26,14 @@ input =
     \case
       Input [] -> (Nothing, Input [])
       Input (i : is) -> (Just i, Input is)
+
+inputWhile :: (Member (Input i) r) => (i -> Bool) -> Sem r [i]
+inputWhile c =
+  stateStaticRep $
+    \case
+      Input l ->
+        let (sat, rest) = span c l
+         in (sat, Input rest)
 
 peekInput :: (Member (Input i) r) => Sem r (Maybe i)
 peekInput = do


### PR DESCRIPTION
I think it makes more sense to not have `State Options` as they are supposed to be immutable and have a separate `Input` effect for comments.