### PR TITLE
Improve parsing error for missing @ in named application

### DIFF
--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -543,7 +543,7 @@ goFunctionDef def = do
   defHeader (def ^. signName) sig' (def ^. signDoc)
   where
     funSig :: Sem r Html
-    funSig = ppHelper (ppFunctionSignature def)
+    funSig = ppHelper (ppCode (functionDefLhs def))
 
 goInductive :: forall r. (Members '[Reader HtmlOptions] r) => InductiveDef 'Scoped -> Sem r Html
 goInductive def = do

--- a/src/Juvix/Compiler/Concrete/Language/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Language/Base.hs
@@ -2801,7 +2801,19 @@ deriving stock instance Ord (JudocAtom 'Parsed)
 
 deriving stock instance Ord (JudocAtom 'Scoped)
 
+data FunctionLhs = FunctionLhs
+  { _funLhsInstance :: Maybe KeywordRef,
+    _funLhsCoercion :: Maybe KeywordRef,
+    _funLhsName :: FunctionName 'Parsed,
+    _funLhsArgs :: [SigArg 'Parsed],
+    _funLhsColonKw :: Irrelevant (Maybe KeywordRef),
+    _funLhsRetType :: Maybe (ExpressionType 'Parsed),
+    _funLhsTerminating :: Maybe KeywordRef,
+    _funLhsAfterLastArgOff :: Int
+  }
+
 makeLenses ''SideIfs
+makeLenses ''FunctionLhs
 makeLenses ''Statements
 makeLenses ''NamedArgumentFunctionDef
 makeLenses ''NamedArgumentPun

--- a/src/Juvix/Compiler/Concrete/Language/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Language/Base.hs
@@ -2801,15 +2801,15 @@ deriving stock instance Ord (JudocAtom 'Parsed)
 
 deriving stock instance Ord (JudocAtom 'Scoped)
 
-data FunctionLhs = FunctionLhs
-  { _funLhsInstance :: Maybe KeywordRef,
-    _funLhsCoercion :: Maybe KeywordRef,
-    _funLhsName :: FunctionName 'Parsed,
-    _funLhsArgs :: [SigArg 'Parsed],
-    _funLhsColonKw :: Irrelevant (Maybe KeywordRef),
-    _funLhsRetType :: Maybe (ExpressionType 'Parsed),
+data FunctionLhs (s :: Stage) = FunctionLhs
+  { _funLhsBuiltin :: Maybe (WithLoc BuiltinFunction),
     _funLhsTerminating :: Maybe KeywordRef,
-    _funLhsAfterLastArgOff :: Int
+    _funLhsInstance :: Maybe KeywordRef,
+    _funLhsCoercion :: Maybe KeywordRef,
+    _funLhsName :: FunctionName s,
+    _funLhsArgs :: [SigArg s],
+    _funLhsColonKw :: Irrelevant (Maybe KeywordRef),
+    _funLhsRetType :: Maybe (ExpressionType s)
   }
 
 makeLenses ''SideIfs
@@ -2899,6 +2899,19 @@ makeLenses ''NameItem
 makeLenses ''RecordInfo
 makeLenses ''MarkdownInfo
 makePrisms ''NamedArgumentNew
+
+functionDefLhs :: FunctionDef s -> FunctionLhs s
+functionDefLhs FunctionDef {..} =
+  FunctionLhs
+    { _funLhsBuiltin = _signBuiltin,
+      _funLhsTerminating = _signTerminating,
+      _funLhsInstance = _signInstance,
+      _funLhsCoercion = _signCoercion,
+      _funLhsName = _signName,
+      _funLhsArgs = _signArgs,
+      _funLhsColonKw = _signColonKw,
+      _funLhsRetType = _signRetType
+    }
 
 fixityFieldHelper :: SimpleGetter (ParsedFixityFields s) (Maybe a) -> SimpleGetter (ParsedFixityInfo s) (Maybe a)
 fixityFieldHelper l = to (^? fixityFields . _Just . l . _Just)

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/ParserResultBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/ParserResultBuilder.hs
@@ -68,6 +68,13 @@ registerLiteral l =
 registerItem' :: (Member (State ParserState) r) => ParsedItem -> Sem r ()
 registerItem' i = modify' (over parserStateParsedItems (i :))
 
+evalParserResultBuilder ::
+  (Member HighlightBuilder r) =>
+  ParserState ->
+  Sem (ParserResultBuilder ': r) a ->
+  Sem r a
+evalParserResultBuilder s = fmap snd . runParserResultBuilder s
+
 execParserResultBuilder ::
   (Member HighlightBuilder r) =>
   ParserState ->

--- a/src/Juvix/Data/CodeAnn.hs
+++ b/src/Juvix/Data/CodeAnn.hs
@@ -245,7 +245,7 @@ kwDot :: Doc Ann
 kwDot = delimiter "."
 
 kwAt :: Doc Ann
-kwAt = delimiter Str.at_
+kwAt = keyword Str.at_
 
 code :: Doc Ann -> Doc Ann
 code = annotate AnnCode

--- a/test/Parsing/Negative.hs
+++ b/test/Parsing/Negative.hs
@@ -83,6 +83,13 @@ parserErrorTests =
         ErrMegaparsec {} -> Nothing
         _ -> wrongError,
     negTest
+      "Missing @ in named application"
+      $(mkRelDir ".")
+      $(mkRelFile "NamedApplicationMissingAt.juvix")
+      $ \case
+        ErrNamedApplicationMissingAt {} -> Nothing
+        _ -> wrongError,
+    negTest
       "Error on local instances"
       $(mkRelDir ".")
       $(mkRelFile "ErrorOnLocalInstances.juvix")

--- a/tests/negative/NamedApplicationMissingAt.juvix
+++ b/tests/negative/NamedApplicationMissingAt.juvix
@@ -1,0 +1,8 @@
+module NamedApplicationMissingAt;
+
+type T := t;
+
+fun (a : T)
+ : T := t;
+
+main : T := fun {a := t};


### PR DESCRIPTION
- Closes #2796 

Example:
```
module NamedApplicationMissingAt;

type T := t;

fun (a : T)
 : T := t;

main : T := fun {a := t};
```

The error displays as:
![image](https://github.com/user-attachments/assets/e36232cb-9ec3-462c-8ee4-8332924b4b07)
