### PR TITLE
Fix bug in symbol dependency graph generation in Core

### DIFF
--- a/app/Commands/Dev/DevCompile/Core.hs
+++ b/app/Commands/Dev/DevCompile/Core.hs
@@ -8,7 +8,7 @@ import Juvix.Compiler.Core.Pretty
 import Juvix.Compiler.Core.Transformation qualified as Core
 
 compileTransformations :: [Core.TransformationId]
-compileTransformations = [Core.CombineInfoTables, Core.FilterUnreachable, Core.DisambiguateNames]
+compileTransformations = [Core.CombineInfoTables, Core.DisambiguateNames, Core.FilterUnreachable]
 
 runCommand ::
   forall r.

--- a/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
@@ -44,7 +44,7 @@ createSymbolDependencyInfo tab = createDependencyInfo graph startVertices
         (tab ^. infoIdentifiers)
         <> foldr
           ( \ConstructorInfo {..} ->
-              HashMap.insert _constructorInductive (getSymbols' tab _constructorType)
+              HashMap.insertWith (<>) _constructorInductive (getSymbols' tab _constructorType)
           )
           mempty
           (tab ^. infoConstructors)


### PR DESCRIPTION
The graph was missing some edges, which led to too many symbols being filtered out by the `filter-unreachable` transformation.
