### PR TITLE
Store the `DocTable` in the .jvo file

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -1340,6 +1340,7 @@ checkTopModule m@Module {..} = checkedModule
             return (e, body', path', doc')
       localModules <- getLocalModules e
       _moduleId <- getModuleId (topModulePathKey (path' ^. S.nameConcrete))
+      doctbl <- getDocTable _moduleId
       let md =
             Module
               { _modulePath = path',
@@ -1359,7 +1360,8 @@ checkTopModule m@Module {..} = checkedModule
                 _scopedModuleFilePath = P.getModuleFilePath m,
                 _scopedModuleExportInfo = e,
                 _scopedModuleLocalModules = localModules,
-                _scopedModuleInfoTable = tab
+                _scopedModuleInfoTable = tab,
+                _scopedModuleDocTable = doctbl
               }
       return (md, smd, sc)
 
@@ -1830,6 +1832,7 @@ checkLocalModule md@Module {..} = do
         ScopedModule
           { _scopedModulePath = set nameConcrete (moduleNameToTopModulePath (NameUnqualified _modulePath)) moduleName,
             _scopedModuleName = moduleName,
+            _scopedModuleDocTable = mempty,
             _scopedModuleFilePath = P.getModuleFilePath md,
             _scopedModuleExportInfo = moduleExportInfo,
             _scopedModuleLocalModules = localModules,

--- a/src/Juvix/Compiler/Pipeline/Driver.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver.hs
@@ -44,6 +44,7 @@ import Juvix.Compiler.Store.Language
 import Juvix.Compiler.Store.Language qualified as Store
 import Juvix.Compiler.Store.Options qualified as StoredModule
 import Juvix.Compiler.Store.Options qualified as StoredOptions
+import Juvix.Compiler.Store.Scoped.Language qualified as Scoped
 import Juvix.Data.CodeAnn
 import Juvix.Data.SHA256 qualified as SHA256
 import Juvix.Extra.Serialize qualified as Serialize
@@ -268,7 +269,9 @@ processModuleCacheMiss entryIx = do
   tid <- myThreadId
   logDecision tid (entryIx ^. entryIxImportNode) p
   case p of
-    ProcessModuleReuse r -> return r
+    ProcessModuleReuse r -> do
+      highlightMergeDocTable (r ^. pipelineResult . Store.moduleInfoScopedModule . Scoped.scopedModuleDocTable)
+      return r
     ProcessModuleRecompile recomp -> recomp ^. recompileDo
 
 processProject :: (Members '[ModuleInfoCache, Reader EntryPoint, Reader ImportTree] r) => Sem r [(ImportNode, PipelineResult ModuleInfo)]

--- a/src/Juvix/Compiler/Store/Scoped/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Store/Scoped/Data/InfoTable.hs
@@ -83,3 +83,9 @@ instance Monoid InfoTable where
 combinePrecedenceGraphs :: PrecedenceGraph -> PrecedenceGraph -> PrecedenceGraph
 combinePrecedenceGraphs g1 g2 =
   HashMap.unionWith HashSet.union g1 g2
+
+filterByTopModule :: ModuleId -> HashMap NameId b -> HashMap NameId b
+filterByTopModule m = HashMap.filterWithKey (\k _v -> sameModule k)
+  where
+    sameModule :: NameId -> Bool
+    sameModule n = m == n ^. nameIdModuleId

--- a/src/Juvix/Compiler/Store/Scoped/Language.hs
+++ b/src/Juvix/Compiler/Store/Scoped/Language.hs
@@ -29,6 +29,9 @@ data ScopedModule = ScopedModule
     _scopedModuleName :: S.Name,
     _scopedModuleFilePath :: Path Abs File,
     _scopedModuleExportInfo :: ExportInfo,
+    -- | It contains documentation for stuff defined in this module if this
+    -- corresponds to a top module. It is empty for local modules
+    _scopedModuleDocTable :: DocTable,
     _scopedModuleLocalModules :: HashMap S.NameId ScopedModule,
     _scopedModuleInfoTable :: InfoTable
   }


### PR DESCRIPTION
This allows the ide to display documentation for identifiers defined in other modules.