### PR TITLE
Precompute debug operations info in linear time

### DIFF
--- a/src/Juvix/Compiler/Core/Extra/Utils.hs
+++ b/src/Juvix/Compiler/Core/Extra/Utils.hs
@@ -184,7 +184,7 @@ isDebugOp = \case
       OpTrace -> True
       OpFail -> True
       OpSeq -> True
-      OpAssert -> False
+      OpAssert -> True
       OpAnomaByteArrayFromAnomaContents -> False
       OpAnomaByteArrayToAnomaContents -> False
       OpAnomaDecode -> False

--- a/src/Juvix/Compiler/Core/Info/DebugOpsInfo.hs
+++ b/src/Juvix/Compiler/Core/Info/DebugOpsInfo.hs
@@ -1,0 +1,38 @@
+module Juvix.Compiler.Core.Info.DebugOpsInfo where
+
+import Juvix.Compiler.Core.Extra
+import Juvix.Compiler.Core.Info qualified as Info
+
+newtype DebugOpsInfo = DebugOpsInfo
+  { _infoHasDebugOps :: Bool
+  }
+
+instance IsInfo DebugOpsInfo
+
+kDebugOpsInfo :: Key DebugOpsInfo
+kDebugOpsInfo = Proxy
+
+makeLenses ''DebugOpsInfo
+
+-- | Computes debug operations info for each subnode.
+computeDebugOpsInfo :: Node -> Node
+computeDebugOpsInfo = umap go
+  where
+    go :: Node -> Node
+    go node
+      | isDebugOp node =
+          modifyInfo (Info.insert (DebugOpsInfo True)) node
+      | otherwise =
+          modifyInfo (Info.insert dbi) node
+      where
+        dbi =
+          DebugOpsInfo
+            . or
+            . map (hasDebugOps . (^. childNode))
+            $ children node
+
+getDebugOpsInfo :: Node -> DebugOpsInfo
+getDebugOpsInfo = fromJust . Info.lookup kDebugOpsInfo . getInfo
+
+hasDebugOps :: Node -> Bool
+hasDebugOps = (^. infoHasDebugOps) . getDebugOpsInfo


### PR DESCRIPTION
After

* https://github.com/anoma/juvix/pull/2973

let-folding stopped being linear in the size of the input program. All transformations should be linear whenever possible. This PR makes let-folding linear again.
