### PR TITLE
Fix RISC0 on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         shell: bash
         run: |
           cargo install cargo-binstall@1.6.9 --force
-          cargo binstall cargo-risczero@1.0.5 --no-confirm --force
+          cargo binstall cargo-risczero@1.1.1 --no-confirm --force
           cargo risczero install
 
       - name: Checkout CairoVM


### PR DESCRIPTION
It seems that whenever a new major version of `cargo-risczero` becomes available, the CI needs to be updated to install this version.
