### PR TITLE
Include the juvix version in the build directory path

### DIFF
--- a/src/Juvix/Compiler/Pipeline/Package/Base.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Base.hs
@@ -96,7 +96,7 @@ instance FromJSON RawPackage where
 
 resolveBuildDir :: BuildDir -> SomeBase Dir
 resolveBuildDir = \case
-  DefaultBuildDir -> Rel (relBuildDir)
+  DefaultBuildDir -> Rel relBuildDir
   CustomBuildDir d -> d
 
 resolveAbsBuildDir :: Path Abs Dir -> BuildDir -> Path Abs Dir

--- a/src/Juvix/Extra/Paths/Base.hs
+++ b/src/Juvix/Extra/Paths/Base.hs
@@ -1,6 +1,7 @@
 module Juvix.Extra.Paths.Base where
 
 import Data.FileEmbed qualified as FE
+import Juvix.Extra.Version
 import Juvix.Prelude.Base
 import Juvix.Prelude.Path
 import Language.Haskell.TH.Syntax
@@ -60,7 +61,7 @@ packageFilePath :: Path Rel File
 packageFilePath = $(mkRelFile "Package.juvix")
 
 relBuildDir :: Path Rel Dir
-relBuildDir = $(mkRelDir ".juvix-build")
+relBuildDir = $(mkRelDir ".juvix-build") <//> versionDir
 
 relStdlibDir :: Path Rel Dir
 relStdlibDir = $(mkRelDir "stdlib")

--- a/tests/positive/Dependencies/.libs/Extra/Package.juvix
+++ b/tests/positive/Dependencies/.libs/Extra/Package.juvix
@@ -6,5 +6,5 @@ package : Package :=
   defaultPackage@?{
     name := "extra";
     version := mkVersion 1 0 0;
-    dependencies := [path ".juvix-build/stdlib"; path "../Base"]
+    dependencies := [defaultStdlib; path "../Base"]
   };

--- a/tests/smoke/Commands/compile-dependencies-package-juvix.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies-package-juvix.smoke.yaml
@@ -40,7 +40,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -104,7 +104,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -172,7 +172,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -217,7 +217,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -277,7 +277,7 @@ tests:
           defaultPackage@?{name := "Dep1";
             version := mkVersion 0 1 0;
             dependencies :=
-               [path ".juvix-build/stdlib/";
+               [defaultStdlib;
                 git "dep2" "$temp/dep2" "main"]};
         EOF
 
@@ -300,32 +300,33 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib/";
+               [defaultStdlib;
                 git "dep1" "$temp/dep1" "main"];
             main := just "HelloWorld.juvix"};
         EOF
 
         checksum=$(sha256sum Package.juvix | cut -d " " -f 1)
+        version=$(juvix --numeric-version)
 
         cat <<-EOF > juvix.lock.yaml
         version: 2
         checksum: $checksum
         dependencies:
-          - path: .juvix-build/stdlib/
+          - path: .juvix-build/$version/stdlib/
             dependencies: []
           - git:
               url: $temp/dep1
               ref: $dep1hash
               name: dep1
             dependencies:
-              - path: .juvix-build/stdlib/
+              - path: .juvix-build/$version/stdlib/
                 dependencies: []
               - git:
                   url: $temp/dep2
                   ref: $dep2hash
                   name: dep2
                 dependencies:
-                  - path: .juvix-build/stdlib/
+                  - path: .juvix-build/$version/stdlib/
                     dependencies: []
         EOF
 
@@ -414,7 +415,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "main"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -507,7 +508,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash1"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -538,7 +539,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash2"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -560,6 +561,8 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+
+        version=$(juvix --numeric-version)
 
         # create dependency2
         mkdir $temp/dep2
@@ -611,20 +614,20 @@ tests:
           defaultPackage@?{name := "Dep1";
             version := mkVersion 0 1 0;
             dependencies :=
-               [path ".juvix-build/stdlib/";
+               [defaultStdlib;
                 git "dep2" "$temp/dep2" "main"]};
         EOF
 
         cat <<-EOF > juvix.lock.yaml
         dependencies:
-          - path: .juvix-build/stdlib/
+          - path: .juvix-build/$version/stdlib/
             dependencies: []
           - git:
               url: $temp/dep2
               ref: $dep2hash
               name: dep2
             dependencies:
-              - path: .juvix-build/stdlib/
+              - path: .juvix-build/$version/stdlib/
                 dependencies: []
         EOF
 
@@ -647,7 +650,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib/";
+               [defaultStdlib;
                 git "dep1" "$temp/dep1" "$dep1hash"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -721,7 +724,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash1"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -757,7 +760,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash2"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -806,7 +809,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "invalid-ref"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -851,7 +854,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "main"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -896,7 +899,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "main"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -966,7 +969,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash"];
             main := just "HelloWorld.juvix"};
         EOF
@@ -1017,7 +1020,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep1" "main";
                 git "dep1" "$temp/dep2" "main"];
             main := just "HelloWorld.juvix"};
@@ -1080,7 +1083,7 @@ tests:
           defaultPackage@?{name := "HelloWorld";
             version := mkVersion 0 0 1;
             dependencies :=
-               [path ".juvix-build/stdlib";
+               [defaultStdlib;
                 git "dep1" "$temp/dep" "$dep1hash"];
             main := just "HelloWorld.juvix"};
         EOF

--- a/tests/smoke/Commands/compile-dependencies.smoke.yaml
+++ b/tests/smoke/Commands/compile-dependencies.smoke.yaml
@@ -8,6 +8,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -34,7 +35,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -69,6 +70,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -95,7 +97,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -134,6 +136,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -160,7 +163,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -202,7 +205,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -225,6 +228,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency2
         mkdir $temp/dep2
@@ -258,7 +262,7 @@ tests:
         cat <<-EOF > juvix.yaml
         name: Dep1
         dependencies:
-          - .juvix-build/stdlib/
+          - .juvix-build/$version/stdlib/
           - git:
               url: $temp/dep2
               name: dep2
@@ -279,7 +283,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib/
+          - .juvix-build/$version/stdlib/
           - git:
               url: $temp/dep1
               name: dep1
@@ -293,21 +297,21 @@ tests:
         version: 2
         checksum: $checksum
         dependencies:
-          - path: .juvix-build/stdlib/
+          - path: .juvix-build/$version/stdlib/
             dependencies: []
           - git:
               url: $temp/dep1
               ref: $dep1hash
               name: dep1
             dependencies:
-              - path: .juvix-build/stdlib/
+              - path: .juvix-build/$version/stdlib/
                 dependencies: []
               - git:
                   url: $temp/dep2
                   ref: $dep2hash
                   name: dep2
                 dependencies:
-                  - path: .juvix-build/stdlib/
+                  - path: .juvix-build/$version/stdlib/
                     dependencies: []
         EOF
 
@@ -364,6 +368,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -390,7 +395,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -441,6 +446,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -480,7 +486,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -508,7 +514,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -533,6 +539,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency2
         mkdir $temp/dep2
@@ -577,7 +584,7 @@ tests:
         cat <<-EOF > juvix.yaml
         name: Dep1
         dependencies:
-          - .juvix-build/stdlib/
+          - .juvix-build/$version/stdlib/
           - git:
               url: $temp/dep2
               name: dep2
@@ -587,14 +594,14 @@ tests:
 
         cat <<-EOF > juvix.lock.yaml
         dependencies:
-          - path: .juvix-build/stdlib/
+          - path: .juvix-build/$version/stdlib/
             dependencies: []
           - git:
               url: $temp/dep2
               ref: $dep2hash
               name: dep2
             dependencies:
-              - path: .juvix-build/stdlib/
+              - path: .juvix-build/$version/stdlib/
                 dependencies: []
         EOF
 
@@ -611,7 +618,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib/
+          - .juvix-build/$version/stdlib/
           - git:
               url: $temp/dep1
               name: dep1
@@ -643,6 +650,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -682,7 +690,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -715,7 +723,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -737,6 +745,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -761,7 +770,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -794,6 +803,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create project that uses dependency
         mkdir $temp/base
@@ -803,7 +813,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -836,6 +846,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create project that uses dependency
         mkdir $temp/base
@@ -845,7 +856,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -883,6 +894,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -912,7 +924,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -951,6 +963,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create project that uses dependency
         mkdir $temp/base
@@ -960,7 +973,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1
@@ -997,6 +1010,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -1078,6 +1092,7 @@ tests:
       script: |
         temp=$(mktemp -d)
         trap 'rm -rf -- "$temp"' EXIT
+        version=$(juvix --numeric-version)
 
         # create dependency
         mkdir $temp/dep
@@ -1104,7 +1119,7 @@ tests:
         name: HelloWorld
         main: HelloWorld.juvix
         dependencies:
-          - .juvix-build/stdlib
+          - .juvix-build/$version/stdlib
           - git:
               url: $temp/dep
               name: dep1

--- a/tests/smoke/Commands/compile.smoke.yaml
+++ b/tests/smoke/Commands/compile.smoke.yaml
@@ -100,10 +100,11 @@ tests:
       script: |
         rootDir=$(mktemp -d)
         trap 'rm -rf -- "$rootDir"' EXIT
+        version=$(juvix --numeric-version)
 
         cp ./examples/milestone/HelloWorld/HelloWorld.juvix "$rootDir"
         touch "$rootDir/juvix.yaml"
-        echo "dependencies: [.juvix-build/stdlib]" >> "$rootDir/juvix.yaml"
+        echo "dependencies: [.juvix-build/$version/stdlib]" >> "$rootDir/juvix.yaml"
 
         cd "$rootDir"
         juvix --log-level error compile native HelloWorld.juvix


### PR DESCRIPTION
For example, by default the build directory would now be:

```
.juvix-build/0.6.6
```

It is necessary to separate the build files by compiler version because the structure of jvo files may be incompatible between compiler releases.

* Closes https://github.com/anoma/juvix/issues/3019