### PR TITLE
Fix linux static build by pinning ghc-musl container version

### DIFF
--- a/.github/workflows/linux-static-binary.yaml
+++ b/.github/workflows/linux-static-binary.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build static binary
     runs-on: ubuntu-latest
-    container: quay.io/benz0li/ghc-musl:9.8.2
+    container: docker.io/benz0li/ghc-musl@sha256:0c491f49df224947847084159c85f60590c4c0324ecdf0efb366f82ed3b20023
     steps:
       - name: checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
The linux nightly build stopped working on 2024-10-22 after the ghc-musl:9.8.2 image was rebuilt.

With the following error:

```
Preprocessing executable 'juvix' for juvix-0.6.6..
Building executable 'juvix' for juvix-0.6.6..
[  1 of 199] Compiling Commands.Extra.Package
[  2 of 199] Compiling CommonOptions

<no location info>: error:
    Error loading shared library -lncursesw: No such file or directory
```

I've fixed this by pinning the container image using the container hash from before the failure. We must use the `docker.io` repository because `quay.io` does not seem to store old manifest files.

The linux nightly build is now working after this change:

https://github.com/anoma/juvix-nightly-builds/actions/runs/11579013347/job/32234216197