### PR TITLE
Add `dev nockma  encode` command

### DIFF
--- a/app/Commands/Dev/Nockma.hs
+++ b/app/Commands/Dev/Nockma.hs
@@ -1,6 +1,7 @@
 module Commands.Dev.Nockma where
 
 import Commands.Base
+import Commands.Dev.Nockma.Encode as Encode
 import Commands.Dev.Nockma.Eval as Eval
 import Commands.Dev.Nockma.Format as Format
 import Commands.Dev.Nockma.Options
@@ -13,3 +14,4 @@ runCommand = \case
   NockmaEval opts -> Eval.runCommand opts
   NockmaFormat opts -> Format.runCommand opts
   NockmaRun opts -> Run.runCommand opts
+  NockmaEncode opts -> Encode.runCommand opts

--- a/app/Commands/Dev/Nockma/Encode.hs
+++ b/app/Commands/Dev/Nockma/Encode.hs
@@ -5,6 +5,8 @@ import Commands.Dev.Nockma.Encode.Options
 import Data.ByteString qualified as B
 import Juvix.Compiler.Nockma.Encoding
 import Juvix.Compiler.Nockma.Language (Term)
+import Juvix.Compiler.Nockma.Pretty qualified as Nockma
+import Juvix.Compiler.Nockma.Translation.FromSource.Base
 
 runCommand :: forall r. (Members AppEffects r) => NockmaEncodeOptions -> Sem r ()
 runCommand opts = runSimpleErrorIO $ do
@@ -15,7 +17,16 @@ runCommand opts = runSimpleErrorIO $ do
     EncodeBase64 -> do
       bs <- getContents
       decodeCue64 bs
+    EncodeText -> fromTextEncoding
+    EncodeDebug -> fromTextEncoding
   case opts ^. nockmaEncodeTo of
     EncodeBytes -> do
       renderStdOutRaw (jamToByteString from)
     EncodeBase64 -> renderStdOut (encodeJam64 from)
+    EncodeText -> renderStdOut (Nockma.ppSerialize from)
+    EncodeDebug -> renderStdOut (Nockma.ppPrint from)
+  where
+    fromTextEncoding :: (Members '[App, EmbedIO] r') => Sem r' (Term Natural)
+    fromTextEncoding = do
+      bs <- getContents
+      getRight (parseText bs)

--- a/app/Commands/Dev/Nockma/Encode.hs
+++ b/app/Commands/Dev/Nockma/Encode.hs
@@ -1,0 +1,21 @@
+module Commands.Dev.Nockma.Encode where
+
+import Commands.Base
+import Commands.Dev.Nockma.Encode.Options
+import Data.ByteString qualified as B
+import Juvix.Compiler.Nockma.Encoding
+import Juvix.Compiler.Nockma.Language (Term)
+
+runCommand :: forall r. (Members AppEffects r) => NockmaEncodeOptions -> Sem r ()
+runCommand opts = runSimpleErrorIO $ do
+  from :: Term Natural <- case opts ^. nockmaEncodeFrom of
+    EncodeBytes -> do
+      bs <- liftIO B.getContents
+      decodeCue bs
+    EncodeBase64 -> do
+      bs <- getContents
+      decodeCue64 bs
+  case opts ^. nockmaEncodeTo of
+    EncodeBytes -> do
+      renderStdOutRaw (jamToByteString from)
+    EncodeBase64 -> renderStdOut (encodeJam64 from)

--- a/app/Commands/Dev/Nockma/Encode/Options.hs
+++ b/app/Commands/Dev/Nockma/Encode/Options.hs
@@ -1,0 +1,63 @@
+module Commands.Dev.Nockma.Encode.Options where
+
+import CommonOptions
+import Prelude (show)
+
+data EncodeType
+  = EncodeBase64
+  | EncodeBytes
+  deriving stock (Eq, Enum, Bounded, Ord, Data)
+
+defaultEncodeType :: EncodeType
+defaultEncodeType = EncodeBase64
+
+instance Show EncodeType where
+  show = \case
+    EncodeBase64 -> "base64"
+    EncodeBytes -> "bytes"
+
+data NockmaEncodeOptions = NockmaEncodeOptions
+  { _nockmaEncodeFrom :: EncodeType,
+    _nockmaEncodeTo :: EncodeType
+  }
+  deriving stock (Data)
+
+makeLenses ''NockmaEncodeOptions
+
+parseNockmaEncodeOptions :: Parser NockmaEncodeOptions
+parseNockmaEncodeOptions = do
+  _nockmaEncodeFrom <-
+    option
+      (enumReader Proxy)
+      ( long "to"
+          <> metavar "ENCODING"
+          <> completer (enumCompleter @EncodeType Proxy)
+          <> value defaultEncodeType
+          <> helpDoc
+            ( "Choose the source encoding.\n"
+                <> enumHelp
+                  ( \case
+                      EncodeBase64 -> "Jam and Base 64 encoding"
+                      EncodeBytes -> "Jam encoding"
+                  )
+            )
+      )
+
+  _nockmaEncodeTo <-
+    option
+      (enumReader Proxy)
+      ( long "from"
+          <> metavar "ENCODING"
+          <> completer (enumCompleter @EncodeType Proxy)
+          <> value defaultEncodeType
+          <> helpDoc
+            ( "Choose the target encoding.\n"
+                <> enumHelp
+                  ( \case
+                      EncodeBase64 -> "Jam and Base 64 encoding"
+                      EncodeBytes -> "Jam encoding"
+                  )
+            )
+      )
+
+  pure NockmaEncodeOptions {..}

--- a/app/Commands/Dev/Nockma/Encode/Options.hs
+++ b/app/Commands/Dev/Nockma/Encode/Options.hs
@@ -6,15 +6,19 @@ import Prelude (show)
 data EncodeType
   = EncodeBase64
   | EncodeBytes
+  | EncodeDebug
+  | EncodeText
   deriving stock (Eq, Enum, Bounded, Ord, Data)
-
-defaultEncodeType :: EncodeType
-defaultEncodeType = EncodeBase64
 
 instance Show EncodeType where
   show = \case
     EncodeBase64 -> "base64"
     EncodeBytes -> "bytes"
+    EncodeDebug -> "debug"
+    EncodeText -> "text"
+
+instance Pretty EncodeType where
+  pretty = pretty . Prelude.show
 
 data NockmaEncodeOptions = NockmaEncodeOptions
   { _nockmaEncodeFrom :: EncodeType,
@@ -24,6 +28,22 @@ data NockmaEncodeOptions = NockmaEncodeOptions
 
 makeLenses ''NockmaEncodeOptions
 
+base64Help :: AnsiDoc
+base64Help = "Jam and Base 64 encoding"
+
+bytesHelp :: AnsiDoc
+bytesHelp = "Jam encoding"
+
+encodingHelp :: Doc AnsiStyle
+encodingHelp =
+  enumHelp
+    ( \case
+        EncodeBase64 -> base64Help
+        EncodeBytes -> bytesHelp
+        EncodeDebug -> "Nockma code with annotations"
+        EncodeText -> "Nockma code without annotations"
+    )
+
 parseNockmaEncodeOptions :: Parser NockmaEncodeOptions
 parseNockmaEncodeOptions = do
   _nockmaEncodeFrom <-
@@ -32,14 +52,9 @@ parseNockmaEncodeOptions = do
       ( long "to"
           <> metavar "ENCODING"
           <> completer (enumCompleter @EncodeType Proxy)
-          <> value defaultEncodeType
           <> helpDoc
             ( "Choose the source encoding.\n"
-                <> enumHelp
-                  ( \case
-                      EncodeBase64 -> "Jam and Base 64 encoding"
-                      EncodeBytes -> "Jam encoding"
-                  )
+                <> encodingHelp
             )
       )
 
@@ -49,15 +64,9 @@ parseNockmaEncodeOptions = do
       ( long "from"
           <> metavar "ENCODING"
           <> completer (enumCompleter @EncodeType Proxy)
-          <> value defaultEncodeType
           <> helpDoc
             ( "Choose the target encoding.\n"
-                <> enumHelp
-                  ( \case
-                      EncodeBase64 -> "Jam and Base 64 encoding"
-                      EncodeBytes -> "Jam encoding"
-                  )
+                <> encodingHelp
             )
       )
-
   pure NockmaEncodeOptions {..}

--- a/app/Commands/Dev/Nockma/Options.hs
+++ b/app/Commands/Dev/Nockma/Options.hs
@@ -1,5 +1,6 @@
 module Commands.Dev.Nockma.Options where
 
+import Commands.Dev.Nockma.Encode.Options
 import Commands.Dev.Nockma.Eval.Options
 import Commands.Dev.Nockma.Format.Options
 import Commands.Dev.Nockma.Repl.Options
@@ -11,6 +12,7 @@ data NockmaCommand
   | NockmaEval NockmaEvalOptions
   | NockmaFormat NockmaFormatOptions
   | NockmaRun NockmaRunOptions
+  | NockmaEncode NockmaEncodeOptions
   deriving stock (Data)
 
 parseNockmaCommand :: Parser NockmaCommand
@@ -20,9 +22,19 @@ parseNockmaCommand =
       [ commandRepl,
         commandFromAsm,
         commandFormat,
+        commandEncode,
         commandRun
       ]
   where
+    commandEncode :: Mod CommandFields NockmaCommand
+    commandEncode = command "encode" runInfo
+      where
+        runInfo :: ParserInfo NockmaCommand
+        runInfo =
+          info
+            (NockmaEncode <$> parseNockmaEncodeOptions)
+            (progDesc "Encode and decode nockma terms")
+
     commandRun :: Mod CommandFields NockmaCommand
     commandRun = command "run" runInfo
       where

--- a/src/Anoma/Effect/RunNockma.hs
+++ b/src/Anoma/Effect/RunNockma.hs
@@ -6,12 +6,14 @@ where
 
 import Anoma.Effect.Base
 import Anoma.Rpc.RunNock
-import Juvix.Compiler.Nockma.Encoding (decodeCue64, encodeJam64)
+import Data.ByteString.Base64 qualified as Base64
+import Juvix.Compiler.Nockma.Encoding
+import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Language qualified as Nockma
+import Juvix.Data.CodeAnn
 import Juvix.Prelude
 import Juvix.Prelude.Aeson (Value)
 import Juvix.Prelude.Aeson qualified as Aeson
-import Juvix.Prelude.Pretty
 
 data RunNockmaInput = RunNockmaInput
   { _runNockmaProgram :: AnomaResult,
@@ -29,9 +31,6 @@ decodeJam64 encoded =
         Left (err :: NockNaturalNaturalError) -> throw (simpleErrorCodeAnn err)
         Right (Left (err :: DecodingError)) -> throw (simpleErrorCodeAnn err)
         Right (Right r) -> return r
-
-encodeJam64 :: Nockma.Term Natural -> Text
-encodeJam64 = decodeUtf8 . Base64.encode . jamToByteString
 
 fromJSON :: (Members '[Error SimpleError, Logger] r) => (Aeson.FromJSON a) => Value -> Sem r a
 fromJSON v = case Aeson.fromJSON v of

--- a/src/Anoma/Effect/RunNockma.hs
+++ b/src/Anoma/Effect/RunNockma.hs
@@ -6,12 +6,8 @@ where
 
 import Anoma.Effect.Base
 import Anoma.Rpc.RunNock
-import Data.ByteString.Base64 qualified as Base64
-import Juvix.Compiler.Nockma.Encoding.Cue (DecodingError, cueFromByteString'')
-import Juvix.Compiler.Nockma.Encoding.Jam (jamToByteString)
-import Juvix.Compiler.Nockma.Language (NockNaturalNaturalError)
+import Juvix.Compiler.Nockma.Encoding (decodeCue64, encodeJam64)
 import Juvix.Compiler.Nockma.Language qualified as Nockma
-import Juvix.Data.CodeAnn (simpleErrorCodeAnn)
 import Juvix.Prelude
 import Juvix.Prelude.Aeson (Value)
 import Juvix.Prelude.Aeson qualified as Aeson
@@ -60,5 +56,5 @@ runNockma prog inputs = do
   res :: Response <- anomaRpc runNockGrpcUrl (Aeson.toJSON msg) >>= fromJSON
   logVerbose (mkAnsiText ("Response Payload:\n" <> Aeson.jsonEncodeToPrettyText res))
   case res of
-    ResponseProof x -> decodeJam64 x
+    ResponseProof x -> decodeCue64 x
     ResponseError err -> throw (SimpleError (mkAnsiText err))

--- a/src/Anoma/Effect/RunNockma.hs
+++ b/src/Anoma/Effect/RunNockma.hs
@@ -6,9 +6,7 @@ where
 
 import Anoma.Effect.Base
 import Anoma.Rpc.RunNock
-import Data.ByteString.Base64 qualified as Base64
 import Juvix.Compiler.Nockma.Encoding
-import Juvix.Compiler.Nockma.Language
 import Juvix.Compiler.Nockma.Language qualified as Nockma
 import Juvix.Data.CodeAnn
 import Juvix.Prelude
@@ -21,16 +19,6 @@ data RunNockmaInput = RunNockmaInput
   }
 
 makeLenses ''RunNockmaInput
-
-decodeJam64 :: (Members '[Error SimpleError] r) => Text -> Sem r (Nockma.Term Natural)
-decodeJam64 encoded =
-  case Base64.decode (encodeUtf8 encoded) of
-    Left err -> throw (SimpleError (mkAnsiText err))
-    Right bs' ->
-      case cueFromByteString'' bs' of
-        Left (err :: NockNaturalNaturalError) -> throw (simpleErrorCodeAnn err)
-        Right (Left (err :: DecodingError)) -> throw (simpleErrorCodeAnn err)
-        Right (Right r) -> return r
 
 fromJSON :: (Members '[Error SimpleError, Logger] r) => (Aeson.FromJSON a) => Value -> Sem r a
 fromJSON v = case Aeson.fromJSON v of

--- a/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
@@ -11,11 +11,8 @@ import Data.Bits
 import Data.ByteString.Base64 qualified as Base64
 import Juvix.Compiler.Nockma.Encoding.Base
 import Juvix.Compiler.Nockma.Encoding.ByteString
-import Juvix.Compiler.Nockma.Encoding.Cue
 import Juvix.Compiler.Nockma.Encoding.Effect.BitWriter
 import Juvix.Compiler.Nockma.Language
-import Juvix.Data.CodeAnn
-import Juvix.Data.Error.GenericError
 import Juvix.Prelude.Base
 
 newtype JamState a = JamState
@@ -116,13 +113,3 @@ jam t = do
 
 encodeJam64 :: Term Natural -> Text
 encodeJam64 = decodeUtf8 . Base64.encode . jamToByteString
-
-decodeJam64 :: (Members '[Error SimpleError] r) => Text -> Sem r (Term Natural)
-decodeJam64 encoded =
-  case Base64.decode (encodeUtf8 encoded) of
-    Left err -> throw (SimpleError (mkAnsiText err))
-    Right bs' ->
-      case cueFromByteString'' bs' of
-        Left (err :: NockNaturalNaturalError) -> throw (simpleErrorCodeAnn err)
-        Right (Left (err :: DecodingError)) -> throw (simpleErrorCodeAnn err)
-        Right (Right r) -> return r

--- a/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
@@ -11,8 +11,11 @@ import Data.Bits
 import Data.ByteString.Base64 qualified as Base64
 import Juvix.Compiler.Nockma.Encoding.Base
 import Juvix.Compiler.Nockma.Encoding.ByteString
+import Juvix.Compiler.Nockma.Encoding.Cue
 import Juvix.Compiler.Nockma.Encoding.Effect.BitWriter
 import Juvix.Compiler.Nockma.Language
+import Juvix.Data.CodeAnn
+import Juvix.Data.Error.GenericError
 import Juvix.Prelude.Base
 
 newtype JamState a = JamState
@@ -113,3 +116,13 @@ jam t = do
 
 encodeJam64 :: Term Natural -> Text
 encodeJam64 = decodeUtf8 . Base64.encode . jamToByteString
+
+decodeJam64 :: (Members '[Error SimpleError] r) => Text -> Sem r (Term Natural)
+decodeJam64 encoded =
+  case Base64.decode (encodeUtf8 encoded) of
+    Left err -> throw (SimpleError (mkAnsiText err))
+    Right bs' ->
+      case cueFromByteString'' bs' of
+        Left (err :: NockNaturalNaturalError) -> throw (simpleErrorCodeAnn err)
+        Right (Left (err :: DecodingError)) -> throw (simpleErrorCodeAnn err)
+        Right (Right r) -> return r

--- a/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Jam.hs
@@ -8,6 +8,7 @@ module Juvix.Compiler.Nockma.Encoding.Jam where
 
 import Data.Bit as Bit
 import Data.Bits
+import Data.ByteString.Base64 qualified as Base64
 import Juvix.Compiler.Nockma.Encoding.Base
 import Juvix.Compiler.Nockma.Encoding.ByteString
 import Juvix.Compiler.Nockma.Encoding.Effect.BitWriter
@@ -109,3 +110,6 @@ jam t = do
   let i = fromInteger . vectorBitsToInteger . jamToBits $ t
   ai <- fromNatural i
   return (Atom ai emptyAtomInfo)
+
+encodeJam64 :: Term Natural -> Text
+encodeJam64 = decodeUtf8 . Base64.encode . jamToByteString

--- a/src/Juvix/Prelude/Base/Foundation.hs
+++ b/src/Juvix/Prelude/Base/Foundation.hs
@@ -182,7 +182,7 @@ import Data.Text qualified as Text
 import Data.Text.Encoding
 import Data.Text.IO hiding (appendFile, getContents, getLine, hGetContents, hGetLine, hPutStr, hPutStrLn, interact, putStr, putStrLn, readFile, writeFile)
 import Data.Text.IO qualified as Text
-import Data.Text.IO.Utf8 hiding (getLine, hGetLine, hPutStr, hPutStrLn, putStr, putStrLn, readFile, writeFile)
+import Data.Text.IO.Utf8 hiding (getContents, getLine, hGetLine, hPutStr, hPutStrLn, putStr, putStrLn, readFile, writeFile)
 import Data.Text.IO.Utf8 qualified as Utf8
 import Data.Text.Lazy.Builder qualified as LazyText
 import Data.Traversable
@@ -567,6 +567,9 @@ indexFrom :: Int -> [a] -> [Indexed a]
 indexFrom i = zipWith Indexed [i ..]
 
 makeLenses ''Indexed
+
+getContents :: (MonadIO m) => m Text
+getContents = liftIO Utf8.getContents
 
 hClose :: (MonadIO m) => Handle -> m ()
 hClose = liftIO . IO.hClose


### PR DESCRIPTION

- New command `juvix dev nockma encode --help`
```
Usage: juvix dev nockma encode --to ENCODING --from ENCODING

  Encode and decode nockma terms

Available options:
  --to ENCODING            Choose the source encoding.
                           • base64: Jam and Base 64 encoding
                           • bytes: Jam encoding
                           • debug: Nockma code with annotations
                           • text: Nockma code without annotations
  --from ENCODING          Choose the target encoding.
                           • base64: Jam and Base 64 encoding
                           • bytes: Jam encoding
                           • debug: Nockma code with annotations
                           • text: Nockma code without annotations
```