### PR TITLE
Anoma client verbose request response

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ extra-source-files:
 dependencies:
   - aeson-better-errors == 0.9.*
   - aeson == 2.2.*
+  - aeson-pretty == 0.8.*
   - ansi-terminal == 1.1.*
   - base == 4.19.*
   - base16-bytestring == 1.0.*

--- a/src/Juvix/Prelude/Aeson.hs
+++ b/src/Juvix/Prelude/Aeson.hs
@@ -7,6 +7,7 @@ module Juvix.Prelude.Aeson
 where
 
 import Data.Aeson
+import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.TH
 import Data.Aeson.Text
@@ -21,6 +22,9 @@ readJSONFile f = do
 
 jsonEncodeToText :: (ToJSON a) => a -> Text
 jsonEncodeToText = Lazy.toStrict . encodeToLazyText
+
+jsonEncodeToPrettyText :: (ToJSON a) => a -> Text
+jsonEncodeToPrettyText = decodeUtf8Lenient . BS.toStrict . encodePretty
 
 jsonAppendFields :: [(Key, Value)] -> Value -> Value
 jsonAppendFields keyValues = \case


### PR DESCRIPTION
Use:

```
juvix --log-level=verbose dev nockma run --anoma-dir ~/heliax/anoma Identity.nockma --args args.debug.nockma
```

To print out the JSON request and response payload used in the Anoma Client RPC call.