### PR TITLE
`juvix dev nockma run --anoma-dir ./anoma --args` are given as a nockma list

### DIFF
--- a/app/Commands/Dev/Nockma/Run.hs
+++ b/app/Commands/Dev/Nockma/Run.hs
@@ -20,7 +20,7 @@ runCommand opts = do
     t@(TermCell {}) -> case opts ^. nockmaRunAnomaDir of
       Just path -> do
         anomaDir <- AnomaPath <$> fromAppPathDir path
-        runInAnoma anomaDir t (unfoldTuple parsedArgs)
+        runInAnoma anomaDir t (fromMaybe [] (unfoldList <$> parsedArgs))
       Nothing -> do
         let formula = anomaCallTuple parsedArgs
         (counts, res) <-

--- a/app/Commands/Dev/Nockma/Run/Options.hs
+++ b/app/Commands/Dev/Nockma/Run/Options.hs
@@ -21,7 +21,7 @@ parseNockmaRunOptions = do
         somePreFileOpt
         ( long "args"
             <> metavar "ARGS_FILE"
-            <> help "Path to file containing args"
+            <> help "Path to file containing args. When run on anoma, the args file should contain a list (i.e. to pass 2 and [1 4] as args, the contents should be [2 [1 4] 0])."
             <> action "file"
         )
     pure AppPath {_pathIsInput = True, ..}


### PR DESCRIPTION
When we run nockma code in the anoma node, the arguments should be given as a nockma list. I.e. a nil terminated tuple.