### PR TITLE
Use `nockmaEq` instead of Eq instance to detect `nil` terminator

### DIFF
--- a/src/Juvix/Compiler/Nockma/Language.hs
+++ b/src/Juvix/Compiler/Nockma/Language.hs
@@ -569,7 +569,7 @@ unfoldList = ensureNockmList . nonEmpty . unfoldTuple
       Nothing -> err
       Just l -> case l ^. _unsnoc1 of
         (ini, lst)
-          | lst == nockNilTagged "unfoldList" -> ini
+          | nockmaEq lst (nockNilTagged "unfoldList") -> ini
           | otherwise -> err
       where
         err :: x


### PR DESCRIPTION
`unfoldList` should work with for lists like:

* `[5 0]`
* `[5 nil]`
* `[5 tag@myNilTag 0]`
* etc.

currently `unfoldList` will work only for list `nil` terminators that are tagged with `unfoldList`. `nockmaEq` compares nock terms ignoring debug annotations, so the above lists will work correctly.