### PR TITLE
Fix StdlibRandomNextBytes call

### DIFF
--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -281,7 +281,7 @@ evalProfile inistack initerm =
                 TermAtom a -> goRandomInitGen a
                 _ -> error "StdlibRandomInitGen must be called with an atom"
               StdlibRandomNextBytes -> case args' of
-                TermCell (Cell (TermAtom n) g) -> goRandomNextBytes n g
+                TermCell (Cell g (TermAtom n)) -> goRandomNextBytes n g
                 _ -> error "StdlibRandomNextBytes must be called with a cell containing an atom and a term"
               StdlibRandomSplit -> goRandomSplit args'
           where

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -722,8 +722,8 @@ compile = \case
           next <-
             callStdlib
               StdlibRandomNextBytes
-              [ opAddress "args-n" (argRefAddress ++ [L]),
-                opAddress "args-g" (argRefAddress ++ [R])
+              [ opAddress "args-g" (argRefAddress ++ [R]),
+                opAddress "args-n" (argRefAddress ++ [L])
               ]
           withTemp next $ \nextRef -> do
             nextRefPath <- tempRefPath nextRef

--- a/test/Nockma/Eval/Positive.hs
+++ b/test/Nockma/Eval/Positive.hs
@@ -413,8 +413,8 @@ anomaStdlibInterceptOnlyTests =
              "call next bytes in sequence"
              ( do
                  gen <- callStdlib StdlibRandomInitGen [nockNatLiteral 777]
-                 rgen1 <- callStdlib StdlibRandomNextBytes [nockNatLiteral 1, gen]
-                 rgen2 <- callStdlib StdlibRandomNextBytes [nockNatLiteral 1, rgen1 >># OpAddress # [R]]
+                 rgen1 <- callStdlib StdlibRandomNextBytes [gen, nockNatLiteral 1]
+                 rgen2 <- callStdlib StdlibRandomNextBytes [rgen1 >># OpAddress # [R], nockNatLiteral 1]
                  return ((rgen1 >># OpAddress # [L]) # (rgen2 >># OpAddress # [L]))
              )
              (eqNock [nock| [44 251] |]),
@@ -423,8 +423,8 @@ anomaStdlibInterceptOnlyTests =
              ( do
                  gen <- callStdlib StdlibRandomInitGen [nockNatLiteral 777]
                  g1g2 <- callStdlib StdlibRandomSplit [gen]
-                 n1 <- callStdlib StdlibRandomNextBytes [nockNatLiteral 1, g1g2 >># OpAddress # [L]]
-                 n2 <- callStdlib StdlibRandomNextBytes [nockNatLiteral 1, g1g2 >># OpAddress # [R]]
+                 n1 <- callStdlib StdlibRandomNextBytes [g1g2 >># OpAddress # [L], nockNatLiteral 1]
+                 n2 <- callStdlib StdlibRandomNextBytes [g1g2 >># OpAddress # [R], nockNatLiteral 1]
                  return ((n1 >># OpAddress # [L]) # (n2 >># OpAddress # [L]))
              )
              ( eqNock


### PR DESCRIPTION
The hoon code that generates the stdlib call is:

https://github.com/anoma/juvix/blob/1a8b6324631be26a197404601a69e4bf61be3870/src/Juvix/Compiler/Nockma/AnomaLib.hs#L101

i.e the random number generator is the first argument and the width is the second argument. We have the arguments transposed in the corresponding Juvix builtin API so the call was failing.

This PR transposes the argumetns in the stdlib call so the builtin API and hoon generated nock code are compatible.