### PR TITLE
Support traces in the anoma node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           cd $HOME
           git clone https://github.com/anoma/anoma.git
           cd anoma
-          git checkout 98e3660b91cd55f1d9424dcff9420425ae98f5f8
+          git checkout 513fab7d951042e991d75921ef34b0287138f758
           mix local.hex --force
           mix escript.install hex protobuf --force
           echo "$HOME/.mix/escripts" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           cd $HOME
           git clone https://github.com/anoma/anoma.git
           cd anoma
-          git checkout 513fab7d951042e991d75921ef34b0287138f758
+          git checkout da44f1881442b4b09f61e20bf503e8c69b03b035
           mix local.hex --force
           mix escript.install hex protobuf --force
           echo "$HOME/.mix/escripts" >> $GITHUB_PATH

--- a/src/Anoma/Effect/Base.hs
+++ b/src/Anoma/Effect/Base.hs
@@ -155,12 +155,6 @@ grpcCliProcess method = do
         std_out = CreatePipe
       }
 
--- | Assumes the node and client are already running
--- runAnomaTest :: forall r a. (Members '[Reader ListenPort, Logger, EmbedIO, Error SimpleError] r) => AnomaPath -> Sem (Anoma ': r) a -> Sem r a
--- runAnomaTest anomapath body = runReader anomapath . runProcess $
---   (`interpret` inject body) $ \case
---     GetAnomaProcesses -> error "unsupported"
---     AnomaRpc method i -> anomaRpc' method i
 runAnoma :: forall r a. (Members '[Logger, EmbedIO, Error SimpleError] r) => AnomaPath -> Sem (Anoma ': r) a -> Sem r a
 runAnoma anomapath body = runReader anomapath . runProcess $
   withSpawnAnomaNode $ \grpcport _nodeOut nodeH ->

--- a/src/Anoma/Effect/RunNockma.hs
+++ b/src/Anoma/Effect/RunNockma.hs
@@ -60,4 +60,4 @@ runNockma i = do
           { _runNockmaResult = result,
             _runNockmaTraces = traces
           }
-    ResponseError err -> throw (SimpleError (mkAnsiText err))
+    ResponseError err -> throw (SimpleError (mkAnsiText (err ^. errorError)))

--- a/src/Anoma/Rpc/RunNock.hs
+++ b/src/Anoma/Rpc/RunNock.hs
@@ -42,6 +42,37 @@ $( deriveJSON
      ''RunNock
  )
 
+data NockError = NockError
+  { _errorError :: Text,
+    _errorTraces :: [Text]
+  }
+
+$( deriveToJSON
+     defaultOptions
+       { fieldLabelModifier = \case
+           "_errorError" -> "error"
+           "_errorTraces" -> "output"
+           _ -> impossibleError "All fields must be covered"
+       }
+     ''NockError
+ )
+
+instance FromJSON NockError where
+  parseJSON =
+    $( mkParseJSON
+         defaultOptions
+           { fieldLabelModifier = \case
+               "_errorError" -> "error"
+               "_errorTraces" -> "output"
+               _ -> impossibleError "All fields must be covered"
+           }
+         ''NockError
+     )
+      . addDefaultValues' defaultValues
+    where
+      defaultValues :: HashMap Key Value
+      defaultValues = hashMap [("output", Aeson.Array mempty)]
+
 data NockSuccess = NockSuccess
   { _successResult :: Text,
     _successTraces :: [Text]
@@ -75,7 +106,7 @@ instance FromJSON NockSuccess where
 
 data Response
   = ResponseSuccess NockSuccess
-  | ResponseError Text
+  | ResponseError NockError
 
 $( deriveJSON
      defaultOptions
@@ -91,3 +122,4 @@ $( deriveJSON
 
 makeLenses ''Response
 makeLenses ''NockSuccess
+makeLenses ''NockError

--- a/src/Anoma/Rpc/RunNock.hs
+++ b/src/Anoma/Rpc/RunNock.hs
@@ -1,6 +1,7 @@
 module Anoma.Rpc.RunNock where
 
 import Anoma.Rpc.Base
+import Anoma.Rpc.RunNock.JsonOptions
 import Juvix.Prelude
 import Juvix.Prelude.Aeson as Aeson
 
@@ -47,27 +48,11 @@ data NockError = NockError
     _errorTraces :: [Text]
   }
 
-$( deriveToJSON
-     defaultOptions
-       { fieldLabelModifier = \case
-           "_errorError" -> "error"
-           "_errorTraces" -> "output"
-           _ -> impossibleError "All fields must be covered"
-       }
-     ''NockError
- )
+$(deriveToJSON nockErrorOptions ''NockError)
 
 instance FromJSON NockError where
   parseJSON =
-    $( mkParseJSON
-         defaultOptions
-           { fieldLabelModifier = \case
-               "_errorError" -> "error"
-               "_errorTraces" -> "output"
-               _ -> impossibleError "All fields must be covered"
-           }
-         ''NockError
-     )
+    $(mkParseJSON nockErrorOptions ''NockError)
       . addDefaultValues' defaultValues
     where
       defaultValues :: HashMap Key Value
@@ -78,27 +63,11 @@ data NockSuccess = NockSuccess
     _successTraces :: [Text]
   }
 
-$( deriveToJSON
-     defaultOptions
-       { fieldLabelModifier = \case
-           "_successResult" -> "result"
-           "_successTraces" -> "output"
-           _ -> impossibleError "All fields must be covered"
-       }
-     ''NockSuccess
- )
+$(deriveToJSON nockSuccessOptions ''NockSuccess)
 
 instance FromJSON NockSuccess where
   parseJSON =
-    $( mkParseJSON
-         defaultOptions
-           { fieldLabelModifier = \case
-               "_successResult" -> "result"
-               "_successTraces" -> "output"
-               _ -> impossibleError "All fields must be covered"
-           }
-         ''NockSuccess
-     )
+    $(mkParseJSON nockSuccessOptions ''NockSuccess)
       . addDefaultValues' defaultValues
     where
       defaultValues :: HashMap Key Value

--- a/src/Anoma/Rpc/RunNock.hs
+++ b/src/Anoma/Rpc/RunNock.hs
@@ -2,7 +2,7 @@ module Anoma.Rpc.RunNock where
 
 import Anoma.Rpc.Base
 import Juvix.Prelude
-import Juvix.Prelude.Aeson
+import Juvix.Prelude.Aeson as Aeson
 
 runNockGrpcUrl :: GrpcMethodUrl
 runNockGrpcUrl =
@@ -47,7 +47,7 @@ data NockSuccess = NockSuccess
     _successTraces :: [Text]
   }
 
-$( deriveJSON
+$( deriveToJSON
      defaultOptions
        { fieldLabelModifier = \case
            "_successResult" -> "result"
@@ -56,6 +56,22 @@ $( deriveJSON
        }
      ''NockSuccess
  )
+
+instance FromJSON NockSuccess where
+  parseJSON =
+    $( mkParseJSON
+         defaultOptions
+           { fieldLabelModifier = \case
+               "_successResult" -> "result"
+               "_successTraces" -> "output"
+               _ -> impossibleError "All fields must be covered"
+           }
+         ''NockSuccess
+     )
+      . addDefaultValues' defaultValues
+    where
+      defaultValues :: HashMap Key Value
+      defaultValues = hashMap [("output", Aeson.Array mempty)]
 
 data Response
   = ResponseSuccess NockSuccess

--- a/src/Anoma/Rpc/RunNock.hs
+++ b/src/Anoma/Rpc/RunNock.hs
@@ -42,8 +42,23 @@ $( deriveJSON
      ''RunNock
  )
 
+data NockSuccess = NockSuccess
+  { _successResult :: Text,
+    _successTraces :: [Text]
+  }
+
+$( deriveJSON
+     defaultOptions
+       { fieldLabelModifier = \case
+           "_successResult" -> "result"
+           "_successTraces" -> "output"
+           _ -> impossibleError "All fields must be covered"
+       }
+     ''NockSuccess
+ )
+
 data Response
-  = ResponseProof Text
+  = ResponseSuccess NockSuccess
   | ResponseError Text
 
 $( deriveJSON
@@ -51,7 +66,7 @@ $( deriveJSON
        { unwrapUnaryRecords = True,
          sumEncoding = ObjectWithSingleField,
          constructorTagModifier = \case
-           "ResponseProof" -> "proof"
+           "ResponseSuccess" -> "success"
            "ResponseError" -> "error"
            _ -> impossibleError "All constructors must be covered"
        }
@@ -59,3 +74,4 @@ $( deriveJSON
  )
 
 makeLenses ''Response
+makeLenses ''NockSuccess

--- a/src/Anoma/Rpc/RunNock.hs
+++ b/src/Anoma/Rpc/RunNock.hs
@@ -7,7 +7,7 @@ import Juvix.Prelude.Aeson
 runNockGrpcUrl :: GrpcMethodUrl
 runNockGrpcUrl =
   mkGrpcMethodUrl $
-    "Anoma" :| ["Protobuf", "Intents", "Prove"]
+    "Anoma" :| ["Protobuf", "NockService", "Prove"]
 
 data NockInput
   = NockInputText Text

--- a/src/Anoma/Rpc/RunNock/JsonOptions.hs
+++ b/src/Anoma/Rpc/RunNock/JsonOptions.hs
@@ -1,0 +1,24 @@
+-- | Options needed to derive JSON instances need to be put in a separate file due to
+-- Template Haskell stage restriction
+module Anoma.Rpc.RunNock.JsonOptions where
+
+import Juvix.Prelude
+import Juvix.Prelude.Aeson as Aeson
+
+nockErrorOptions :: Aeson.Options
+nockErrorOptions =
+  defaultOptions
+    { fieldLabelModifier = \case
+        "_errorError" -> "error"
+        "_errorTraces" -> "output"
+        _ -> impossibleError "All fields must be covered"
+    }
+
+nockSuccessOptions :: Aeson.Options
+nockSuccessOptions =
+  defaultOptions
+    { fieldLabelModifier = \case
+        "_successResult" -> "result"
+        "_successTraces" -> "output"
+        _ -> impossibleError "All fields must be covered"
+    }

--- a/src/Juvix/Prelude/Aeson.hs
+++ b/src/Juvix/Prelude/Aeson.hs
@@ -3,15 +3,18 @@ module Juvix.Prelude.Aeson
     module Data.Aeson,
     module Data.Aeson.TH,
     module Data.Aeson.Text,
+    module Data.Aeson.KeyMap,
   )
 where
 
 import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Aeson.KeyMap
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.TH
 import Data.Aeson.Text
 import Data.ByteString.Lazy qualified as BS
+import Data.HashMap.Strict qualified as HashMap
 import Data.Text.Lazy qualified as Lazy
 import Juvix.Prelude.Base
 
@@ -30,3 +33,14 @@ jsonAppendFields :: [(Key, Value)] -> Value -> Value
 jsonAppendFields keyValues = \case
   Object obj -> Object (KeyMap.fromList keyValues <> obj)
   a -> a
+
+addDefaultValues :: HashMap Key Value -> Object -> Object
+addDefaultValues defVals obj = run . execState obj $
+  forM_ (HashMap.toList defVals) $ \(k, def) -> do
+    modify (insertWith (\_new old -> old) k def)
+
+-- | Fails when the given Value is not an object
+addDefaultValues' :: HashMap Key Value -> Value -> Value
+addDefaultValues' defVals v = case v of
+  Object obj -> Object (addDefaultValues defVals obj)
+  _ -> error "Expected an object"

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -248,7 +248,7 @@ allTests :: TestTree
 allTests =
   testGroup
     "Anoma positive tests"
-    [ -- haskellNockmaTests,
+    [ haskellNockmaTests,
       anomaNodeTests
     ]
   where

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -184,7 +184,7 @@ classify AnomaTest {..} = case _anomaTestNum of
   25 -> ClassWorking
   26 -> ClassWorking
   27 -> ClassMissing
-  28 -> ClassWorking
+  28 -> ClassWrong
   29 -> ClassWorking
   30 -> ClassWorking
   31 -> ClassWorking
@@ -229,7 +229,7 @@ classify AnomaTest {..} = case _anomaTestNum of
   71 -> ClassWorking
   72 -> ClassWorking
   73 -> ClassWorking
-  74 -> ClassWorking
+  74 -> ClassNodeError
   75 -> ClassWorking
   76 -> ClassWorking
   77 -> ClassNodeError
@@ -239,9 +239,9 @@ classify AnomaTest {..} = case _anomaTestNum of
   81 -> ClassWorking
   82 -> ClassWorking
   83 -> ClassWorking
-  84 -> ClassWorking
+  84 -> ClassWrong
   85 -> ClassWorking
-  86 -> ClassWorking
+  86 -> ClassWrong -- this is due to different representation of rng in Anoma
   _ -> error "non-exhaustive test classification"
 
 allTests :: TestTree

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -77,10 +77,6 @@ mkAnomaNodeTest a@AnomaTest {..} =
     assertion :: Assertion
     assertion = do
       program :: Term Natural <- (^. anomaClosure) <$> withRootCopy (compileMain False _anomaRelRoot _anomaMainFile)
-      -- For some reason the evaluation fails if no args are given
-      let args'
-            | null _anomaArgs = [toNock (nockVoid @Natural)]
-            | otherwise = _anomaArgs
       testAnomaPath <- envAnomaPath
       runM
         . ignoreLogger
@@ -90,7 +86,7 @@ mkAnomaNodeTest a@AnomaTest {..} =
           let rinput =
                 RunNockmaInput
                   { _runNockmaProgram = program,
-                    _runNockmaArgs = args'
+                    _runNockmaArgs = _anomaArgs
                   }
           out <- runNockma rinput
           runM
@@ -151,9 +147,6 @@ checkOutput expected = case unsnoc expected of
 
 data TestClass
   = ClassWorking
-  | -- | The test uses trace, so we need to wait until we update the anoma-node
-    -- and parse the traces from the response
-    ClassTrace
   | -- | The anoma node returns a response with an error
     ClassNodeError
   | -- | The anoma node returns a value but it doesn't match the expected value
@@ -166,52 +159,52 @@ classify :: AnomaTest -> TestClass
 classify AnomaTest {..} = case _anomaTestNum of
   1 -> ClassWorking
   2 -> ClassWorking
-  3 -> ClassTrace
+  3 -> ClassWorking
   4 -> ClassMissing
   5 -> ClassWorking
-  6 -> ClassTrace
-  7 -> ClassTrace
+  6 -> ClassWorking
+  7 -> ClassWorking
   8 -> ClassWorking
-  9 -> ClassTrace
+  9 -> ClassWorking
   10 -> ClassWorking
-  11 -> ClassTrace
-  12 -> ClassTrace
-  13 -> ClassTrace
-  14 -> ClassTrace
-  15 -> ClassTrace
+  11 -> ClassWorking
+  12 -> ClassWorking
+  13 -> ClassWorking
+  14 -> ClassWorking
+  15 -> ClassWorking
   16 -> ClassWorking
   17 -> ClassWorking
   18 -> ClassWorking
   19 -> ClassWorking
-  20 -> ClassTrace
-  21 -> ClassTrace
-  22 -> ClassTrace
-  23 -> ClassTrace
+  20 -> ClassWorking
+  21 -> ClassWorking
+  22 -> ClassWorking
+  23 -> ClassWorking
   24 -> ClassWorking
-  25 -> ClassTrace
+  25 -> ClassWorking
   26 -> ClassWorking
   27 -> ClassMissing
-  28 -> ClassTrace
-  29 -> ClassTrace
-  30 -> ClassTrace
+  28 -> ClassWorking
+  29 -> ClassWorking
+  30 -> ClassWorking
   31 -> ClassWorking
-  32 -> ClassTrace
-  33 -> ClassTrace
-  34 -> ClassTrace
-  35 -> ClassTrace
+  32 -> ClassWorking
+  33 -> ClassWorking
+  34 -> ClassWorking
+  35 -> ClassWorking
   36 -> ClassWorking
   37 -> ClassWorking
   38 -> ClassWorking
-  39 -> ClassTrace
+  39 -> ClassWorking
   40 -> ClassWorking
   41 -> ClassWorking
   42 -> ClassMissing
-  43 -> ClassTrace
+  43 -> ClassWorking
   45 -> ClassWorking
   46 -> ClassWorking
   47 -> ClassWorking
   48 -> ClassMissing
-  49 -> ClassTrace
+  49 -> ClassWorking
   50 -> ClassWorking
   51 -> ClassMissing
   52 -> ClassWorking
@@ -223,9 +216,9 @@ classify AnomaTest {..} = case _anomaTestNum of
   58 -> ClassWorking
   59 -> ClassWorking
   60 -> ClassWorking
-  61 -> ClassTrace
+  61 -> ClassWorking
   62 -> ClassWorking
-  63 -> ClassTrace
+  63 -> ClassWorking
   64 -> ClassWorking
   65 -> ClassWorking
   66 -> ClassWorking
@@ -236,19 +229,19 @@ classify AnomaTest {..} = case _anomaTestNum of
   71 -> ClassWorking
   72 -> ClassWorking
   73 -> ClassWorking
-  74 -> ClassTrace
-  75 -> ClassTrace
-  76 -> ClassTrace
+  74 -> ClassWorking
+  75 -> ClassWorking
+  76 -> ClassWorking
   77 -> ClassNodeError
   78 -> ClassNodeError
   79 -> ClassWorking
-  80 -> ClassTrace
-  81 -> ClassTrace
-  82 -> ClassTrace
-  83 -> ClassTrace
-  84 -> ClassTrace
-  85 -> ClassTrace
-  86 -> ClassTrace
+  80 -> ClassWorking
+  81 -> ClassWorking
+  82 -> ClassWorking
+  83 -> ClassWorking
+  84 -> ClassWorking
+  85 -> ClassWorking
+  86 -> ClassWorking
   _ -> error "non-exhaustive test classification"
 
 allTests :: TestTree
@@ -267,8 +260,7 @@ allTests =
       where
         shouldRun :: AnomaTest -> Bool
         shouldRun a =
-          -- classify a == ClassWorking
-          classify a == ClassTrace
+          classify a == ClassWorking
 
     haskellNockmaTests :: TestTree
     haskellNockmaTests =

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -87,10 +87,15 @@ mkAnomaNodeTest a@AnomaTest {..} =
         . runSimpleErrorHUnit
         . runAnoma testAnomaPath
         $ do
-          out <- runNockma program args'
+          let rinput =
+                RunNockmaInput
+                  { _runNockmaProgram = program,
+                    _runNockmaArgs = args'
+                  }
+          out <- runNockma rinput
           runM
-            . runReader out
-            . runReader []
+            . runReader (out ^. runNockmaResult)
+            . runReader (out ^. runNockmaTraces)
             $ _anomaCheck
 
 withRootCopy :: (Prelude.Path Abs Dir -> IO a) -> IO a

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -153,6 +153,7 @@ data TestClass
     ClassWrong
   | -- | We have no test with this number
     ClassMissing
+  | ClassExpectedFail
   deriving stock (Eq, Show)
 
 classify :: AnomaTest -> TestClass
@@ -229,7 +230,7 @@ classify AnomaTest {..} = case _anomaTestNum of
   71 -> ClassWorking
   72 -> ClassWorking
   73 -> ClassWorking
-  74 -> ClassNodeError
+  74 -> ClassExpectedFail
   75 -> ClassWorking
   76 -> ClassWorking
   77 -> ClassNodeError
@@ -241,7 +242,7 @@ classify AnomaTest {..} = case _anomaTestNum of
   83 -> ClassWorking
   84 -> ClassWrong
   85 -> ClassWorking
-  86 -> ClassWrong -- this is due to different representation of rng in Anoma
+  86 -> ClassExpectedFail
   _ -> error "non-exhaustive test classification"
 
 allTests :: TestTree

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -255,7 +255,7 @@ allTests :: TestTree
 allTests =
   testGroup
     "Anoma positive tests"
-    [ haskellNockmaTests,
+    [ -- haskellNockmaTests,
       anomaNodeTests
     ]
   where
@@ -267,7 +267,8 @@ allTests =
       where
         shouldRun :: AnomaTest -> Bool
         shouldRun a =
-          classify a == ClassWorking
+          -- classify a == ClassWorking
+          classify a == ClassTrace
 
     haskellNockmaTests :: TestTree
     haskellNockmaTests =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,6 @@
 module Main (main) where
 
 import Anoma qualified
-import Anoma.Compilation.Positive (allTests)
 import Asm qualified
 import BackendMarkdown qualified
 import Base
@@ -67,4 +66,5 @@ fastTests =
 
 main :: IO ()
 main = do
-  defaultMain allTests
+  tests <- sequence [fastTests, slowTests]
+  defaultMain (testGroup "Juvix tests" tests)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Anoma qualified
+import Anoma.Compilation.Positive (allTests)
 import Asm qualified
 import BackendMarkdown qualified
 import Base
@@ -66,5 +67,4 @@ fastTests =
 
 main :: IO ()
 main = do
-  tests <- sequence [fastTests, slowTests]
-  defaultMain (testGroup "Juvix tests" tests)
+  defaultMain allTests


### PR DESCRIPTION
This pr adds support for getting traces from the anoma node.
I've updated the test suite so that tests that were disabled because of traces are now being run.
There are a few tests that require atention:
1. `test028`: Gives the wrong answer.
2. `test084`: Gives the wrong answer.
4. `test074`: Expected to fail because it uses scry.
5. `test086`: Expected to fail because Anoma representation of prngs is different than the juvix representation.