### PR TITLE
Release 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 <img align="right" width="300" height="300" alt="Juvix Mascot" src="../assets/images/tara-smiling.svg" />
 </a>
 
+## [v0.6.7](https://github.com/anoma/juvix/tree/v0.6.7) (2024-11-06)
+
+[Full Changelog](https://github.com/anoma/juvix/compare/v0.6.6...v0.6.7)
+
 ## [v0.6.6](https://github.com/anoma/juvix/tree/v0.6.6) (2024-09-03)
 
 [Full Changelog](https://github.com/anoma/juvix/compare/v0.6.5...v0.6.6)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: juvix
-version: 0.6.6
+version: 0.6.7
 license: GPL-3.0-only
 license-file: LICENSE.md
 copyright: (c) 2022- Heliax AG.

--- a/tests/smoke/Commands/version-help-doctor.smoke.yaml
+++ b/tests/smoke/Commands/version-help-doctor.smoke.yaml
@@ -7,7 +7,7 @@ tests:
     stdout:
       matches:
         regex: |-
-          ^Juvix version 0.6.6-([a-f0-9]{7}).*
+          ^Juvix version 0.6.7-([a-f0-9]{7}).*
 
   - name: cli-numeric-version
     command:


### PR DESCRIPTION
This PR updates:

- [x] Package version
- [x] Smoke test

The CHANGELOG generator we use:
https://github.com/github-changelog-generator/github-changelog-generator
has stopped working with errors like the following:

```
Warning: PR 3148 merge commit was not found in the release branch or tagged git history and no rebased SHA comment was found
```

So we'll defer populating the CHANGELOG summary until after the release
