### PR TITLE
Add `--vscode` option

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -144,7 +144,13 @@ reAppIO args@RunAppIOArgs {..} =
         . mkAnsiText
         . run
         . runReader (project' @GenericOptions g)
-        $ Error.render (not (_runAppIOArgsGlobalOptions ^. globalNoColors)) (g ^. globalIdeEndErrorChar) e
+        $ Error.render renderType (g ^. globalIdeEndErrorChar) e
+      where
+        renderType :: Error.RenderType
+        renderType
+          | g ^. globalVSCode = Error.RenderVSCode
+          | g ^. globalNoColors = Error.RenderText
+          | otherwise = Error.RenderAnsi
 
 getEntryPoint' ::
   (Members '[App, EmbedIO, TaggedLock] r) =>

--- a/app/Commands/Repl.hs
+++ b/app/Commands/Repl.hs
@@ -427,7 +427,13 @@ catchAll = Repline.dontCrash . catchJuvixError
             . hPutStrLn stderr
             . run
             . runReader (project' @GenericOptions opts)
-            $ Error.render (not (opts ^. globalNoColors) && hasAnsi) Nothing e
+            $ Error.render (renderType opts hasAnsi) Nothing e
+          where
+            renderType :: GlobalOptions -> Bool -> Error.RenderType
+            renderType opts hasAnsi
+              | opts ^. globalVSCode = Error.RenderVSCode
+              | opts ^. globalNoColors || not hasAnsi = Error.RenderText
+              | otherwise = Error.RenderAnsi
 
         catchErrorS :: ReplS () -> ReplS ()
         catchErrorS = (`Except.catchError` printErrorS)

--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -15,6 +15,7 @@ import Juvix.Data.Field
 
 data GlobalOptions = GlobalOptions
   { _globalNoColors :: Bool,
+    _globalVSCode :: Bool,
     _globalShowNameIds :: Bool,
     _globalBuildDir :: Maybe (AppPath Dir),
     _globalIdeEndErrorChar :: Maybe Char,
@@ -60,6 +61,7 @@ defaultGlobalOptions :: GlobalOptions
 defaultGlobalOptions =
   GlobalOptions
     { _globalNoColors = False,
+      _globalVSCode = False,
       _globalNumThreads = defaultNumThreads,
       _globalShowNameIds = False,
       _globalIdeEndErrorChar = Nothing,
@@ -84,6 +86,11 @@ parseGlobalFlags = do
     switch
       ( long "no-colors"
           <> help "Disable ANSI formatting"
+      )
+  _globalVSCode <-
+    switch
+      ( long "vscode"
+          <> help "Enable VSCode compatible output"
       )
   _globalBuildDir <-
     optional


### PR DESCRIPTION
* Add a `--vscode` option which causes the error messages to be printed without newlines, in a way compatible with the problem matcher of the VSCode extension
* Related VSCode extension PR: https://github.com/anoma/vscode-juvix/pull/153