### PR TITLE
HTML generation: make the light theme lighter

### DIFF
--- a/app/Commands/Html/Options.hs
+++ b/app/Commands/Html/Options.hs
@@ -47,7 +47,7 @@ parseHtml = do
       (eitherReader parseTheme)
       ( long "theme"
           <> metavar "THEME"
-          <> value Latte
+          <> value LatteLight
           <> showDefault
           <> help ("Theme for syntax highlighting. " <> availableStr)
           <> completeWith (map show allThemes)

--- a/assets/css/latte-light.css
+++ b/assets/css/latte-light.css
@@ -1,0 +1,30 @@
+/* Lighter version of the latte color palette based on https://github.com/catppuccin/catppuccin#-palette */
+
+:root {
+    --ctp-rosewater: #dc8a78;
+    --ctp-flamingo: #dd7878;
+    --ctp-pink: #ea76cb;
+    --ctp-mauve: #8839ef;
+    --ctp-red: #d20f39;
+    --ctp-maroon: #e64553;
+    --ctp-peach: #fe640b;
+    --ctp-yellow: #df8e1d;
+    --ctp-green: #40a02b;
+    --ctp-teal: #179299;
+    --ctp-sky: #04a5e5;
+    --ctp-sapphire: #209fb5;
+    --ctp-blue: #1e66f5;
+    --ctp-lavender: #7287fd;
+    --ctp-text: #4c4f69;
+    --ctp-subtext1: #5c5f77;
+    --ctp-subtext0: #6c6f85;
+    --ctp-overlay2: #7c7f93;
+    --ctp-overlay1: #8c8fa1;
+    --ctp-overlay0: #9ca0b0;
+    --ctp-surface2: #acb0be;
+    --ctp-surface1: #bcc0cc;
+    --ctp-surface0: #ccd0da;
+    --ctp-base: #fbfcff;
+    --ctp-mantle: #f0f3f9;
+    --ctp-crust: #dce0e8;
+}

--- a/assets/css/latte.css
+++ b/assets/css/latte.css
@@ -24,7 +24,7 @@
   --ctp-surface2: #acb0be;
   --ctp-surface1: #bcc0cc;
   --ctp-surface0: #ccd0da;
-  --ctp-base: #f5f7f9;
+  --ctp-base: #fafcff;
   --ctp-mantle: #eaedf3;
   --ctp-crust: #dce0e8;
 }

--- a/assets/css/latte.css
+++ b/assets/css/latte.css
@@ -24,7 +24,7 @@
   --ctp-surface2: #acb0be;
   --ctp-surface1: #bcc0cc;
   --ctp-surface0: #ccd0da;
-  --ctp-base: #f9fafd;
-  --ctp-mantle: #eaedf3;
+  --ctp-base: #eff1f5;
+  --ctp-mantle: #e6e9ef;
   --ctp-crust: #dce0e8;
 }

--- a/assets/css/latte.css
+++ b/assets/css/latte.css
@@ -24,7 +24,7 @@
   --ctp-surface2: #acb0be;
   --ctp-surface1: #bcc0cc;
   --ctp-surface0: #ccd0da;
-  --ctp-base: #fafcff;
+  --ctp-base: #f9fafd;
   --ctp-mantle: #eaedf3;
   --ctp-crust: #dce0e8;
 }

--- a/assets/css/latte.css
+++ b/assets/css/latte.css
@@ -24,7 +24,7 @@
   --ctp-surface2: #acb0be;
   --ctp-surface1: #bcc0cc;
   --ctp-surface0: #ccd0da;
-  --ctp-base: #eff1f5;
-  --ctp-mantle: #e6e9ef;
+  --ctp-base: #f5f7f9;
+  --ctp-mantle: #eaedf3;
   --ctp-crust: #dce0e8;
 }

--- a/src/Juvix/Compiler/Backend/Html/Data/Options.hs
+++ b/src/Juvix/Compiler/Backend/Html/Data/Options.hs
@@ -40,6 +40,7 @@ defaultHtmlOptions =
 data Theme
   = Nord
   | Macchiato
+  | LatteLight
   | Latte
   | Frappe
   | Mocha
@@ -49,6 +50,7 @@ instance Show Theme where
   show = \case
     Nord -> "nord"
     Macchiato -> "macchiato"
+    LatteLight -> "latte-light"
     Latte -> "latte"
     Frappe -> "frappe"
     Mocha -> "mocha"
@@ -62,6 +64,7 @@ themeLight :: Theme -> ThemeLight
 themeLight = \case
   Nord -> Dark
   Macchiato -> Dark
+  LatteLight -> Light
   Latte -> Light
   Frappe -> Dark
   Mocha -> Dark

--- a/src/Juvix/Compiler/Backend/Html/Extra.hs
+++ b/src/Juvix/Compiler/Backend/Html/Extra.hs
@@ -69,6 +69,9 @@ juvixNordCss = cssLink "juvix-nord.css"
 nordCss :: (Members '[Reader HtmlOptions] r) => Sem r Html
 nordCss = cssLink "nord.css"
 
+latteLightCss :: (Members '[Reader HtmlOptions] r) => Sem r Html
+latteLightCss = cssLink "latte-light.css"
+
 latteCss :: (Members '[Reader HtmlOptions] r) => Sem r Html
 latteCss = cssLink "latte.css"
 
@@ -87,6 +90,7 @@ flavourCss = do
   case theme of
     Nord -> nordCss
     Macchiato -> macchiatoCss
+    LatteLight -> latteLightCss
     Latte -> latteCss
     Frappe -> frappeCss
     Mocha -> mochaCss
@@ -97,6 +101,7 @@ themeCss = do
   case theme of
     Nord -> juvixNordCss
     Macchiato -> juvixCatppuchinCss
+    LatteLight -> juvixCatppuchinCss
     Latte -> juvixCatppuchinCss
     Frappe -> juvixCatppuchinCss
     Mocha -> juvixCatppuchinCss


### PR DESCRIPTION
* Closes #3141 
* Adds the `latte-light` theme with lighter background and makes it the default. This is a bit subjective, but in my opinion the light theme should not have a background darker than the browser window pane. It should be close to white.
