### PR TITLE
Use tagged version of ghc-musl in static linux build

### DIFF
--- a/.github/workflows/linux-static-binary.yaml
+++ b/.github/workflows/linux-static-binary.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build static binary
     runs-on: ubuntu-latest
-    container: docker.io/benz0li/ghc-musl@sha256:0c491f49df224947847084159c85f60590c4c0324ecdf0efb366f82ed3b20023
+    container: quay.io/benz0li/ghc-musl:9.8.2
     steps:
       - name: checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
The issue with alpine ncurses packaging has been fixed upstream and the ghc-musl containers have been rebuilt. Therefore we can resume using the tagged releases of the ghc-musl container.

https://github.com/benz0li/ghc-musl/issues/10

Thanks @benz0li for help with diagnosing and fixing this issue.