### PR TITLE
Launch the Anoma node and client from the elixir REPL

### DIFF
--- a/app/Commands/Dev/Anoma/Node.hs
+++ b/app/Commands/Dev/Anoma/Node.hs
@@ -11,5 +11,5 @@ runCommand opts = runAppError @SimpleError
   $ do
     anomaDir :: AnomaPath <- AnomaPath <$> fromAppPathDir (opts ^. nodeAnomaPath)
     runAnoma anomaDir $ do
-      p <- getAnomaProcesses
-      void (waitForProcess (p ^. anomaNodeHandle))
+      p <- getAnomaProcess
+      void (waitForProcess (p ^. anomaProcessHandle))

--- a/include/anoma/start.exs
+++ b/include/anoma/start.exs
@@ -1,1 +1,1 @@
- IO.puts(Anoma.Node.Examples.ENode.start_node().grpc_port)
+IO.puts("#{inspect(Anoma.Client.Examples.EClient.create_example_client.client.grpc_port)}")

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -233,7 +233,7 @@ classify AnomaTest {..} = case _anomaTestNum of
   74 -> ClassExpectedFail
   75 -> ClassWorking
   76 -> ClassWorking
-  77 -> ClassNodeError
+  77 -> ClassWorking
   78 -> ClassNodeError
   79 -> ClassWorking
   80 -> ClassWorking


### PR DESCRIPTION
This PR changes how we launch the Anoma Client to avoid a bug with linking cryptographic APIs.

libsodium cryptographic APIs like sign-detached cannot currently be called from within the Anoma node or client binaries. Until this is solved we must start both the node and client from the elixir REPL. Previously we were starting the node using the REPL and the client using the binary.

This commit changes the `start.exs` script we were using to start the node to now start both a node and a client.

After this change we can enable Anoma compilation test `test077`.

The output of `juvix dev anoma node --anoma-dir ANOMA_DIR` is now:

```
Anoma node and client successfully started
Listening on port 51748
```