### PR TITLE
Add deriving for Eq

### DIFF
--- a/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
+++ b/src/Juvix/Compiler/Backend/Html/Translation/FromTyped.hs
@@ -423,6 +423,7 @@ goStatement = \case
   StatementInductive t -> goInductive t
   StatementOpenModule t -> goOpen t
   StatementFunctionDef t -> goFunctionDef t
+  StatementDeriving t -> goDeriving t
   StatementSyntax syn -> goSyntax syn
   StatementImport t -> goImport t
   StatementModule m -> goLocalModule m
@@ -537,13 +538,15 @@ goAxiom axiom = do
     axiomHeader :: Sem r Html
     axiomHeader = ppCodeHtml defaultOptions (set axiomDoc Nothing axiom)
 
+goDeriving :: forall r. (Members '[Reader HtmlOptions] r) => Deriving 'Scoped -> Sem r Html
+goDeriving def = do
+  sig <- ppHelper (ppCode def)
+  defHeader (def ^. derivingFunLhs . funLhsName) sig Nothing
+
 goFunctionDef :: forall r. (Members '[Reader HtmlOptions] r) => FunctionDef 'Scoped -> Sem r Html
 goFunctionDef def = do
-  sig' <- funSig
-  defHeader (def ^. signName) sig' (def ^. signDoc)
-  where
-    funSig :: Sem r Html
-    funSig = ppHelper (ppCode (functionDefLhs def))
+  sig <- ppHelper (ppCode (functionDefLhs def))
+  defHeader (def ^. signName) sig (def ^. signDoc)
 
 goInductive :: forall r. (Members '[Reader HtmlOptions] r) => InductiveDef 'Scoped -> Sem r Html
 goInductive def = do

--- a/src/Juvix/Compiler/Backend/Markdown/Translation/FromTyped/Source.hs
+++ b/src/Juvix/Compiler/Backend/Markdown/Translation/FromTyped/Source.hs
@@ -213,12 +213,13 @@ indModuleFilter :: forall s. [Concrete.Statement s] -> [Concrete.Statement s]
 indModuleFilter =
   filter
     ( \case
-        Concrete.StatementSyntax _ -> True
-        Concrete.StatementFunctionDef _ -> True
-        Concrete.StatementImport _ -> True
-        Concrete.StatementInductive _ -> True
         Concrete.StatementModule o -> o ^. Concrete.moduleOrigin == LocalModuleSource
-        Concrete.StatementOpenModule _ -> True
-        Concrete.StatementAxiom _ -> True
-        Concrete.StatementProjectionDef _ -> True
+        Concrete.StatementSyntax {} -> True
+        Concrete.StatementFunctionDef {} -> True
+        Concrete.StatementDeriving {} -> True
+        Concrete.StatementImport {} -> True
+        Concrete.StatementInductive {} -> True
+        Concrete.StatementOpenModule {} -> True
+        Concrete.StatementAxiom {} -> True
+        Concrete.StatementProjectionDef {} -> True
     )

--- a/src/Juvix/Compiler/Builtins.hs
+++ b/src/Juvix/Compiler/Builtins.hs
@@ -1,6 +1,7 @@
 module Juvix.Compiler.Builtins
   ( module Juvix.Compiler.Builtins.Nat,
     module Juvix.Compiler.Builtins.IO,
+    module Juvix.Compiler.Builtins.Eq,
     module Juvix.Compiler.Builtins.Int,
     module Juvix.Compiler.Builtins.Bool,
     module Juvix.Compiler.Builtins.List,
@@ -24,6 +25,7 @@ import Juvix.Compiler.Builtins.ByteArray
 import Juvix.Compiler.Builtins.Cairo
 import Juvix.Compiler.Builtins.Control
 import Juvix.Compiler.Builtins.Debug
+import Juvix.Compiler.Builtins.Eq
 import Juvix.Compiler.Builtins.Field
 import Juvix.Compiler.Builtins.IO
 import Juvix.Compiler.Builtins.Int

--- a/src/Juvix/Compiler/Builtins/Eq.hs
+++ b/src/Juvix/Compiler/Builtins/Eq.hs
@@ -9,14 +9,14 @@ checkEqDef :: forall r. (Members '[Reader BuiltinsTable, Error ScoperError] r) =
 checkEqDef d = do
   let err :: forall a. Text -> Sem r a
       err = builtinsErrorText (getLoc d)
-  unless (isSmallUniverse' (d ^. inductiveType)) (err "Lists should be in the small universe")
   let eqTxt = prettyText BuiltinEq
+  unless (isSmallUniverse' (d ^. inductiveType)) (err (eqTxt <> " should be in the small universe"))
   case d ^. inductiveParameters of
     [_] -> return ()
-    _ -> err (eqTxt <> "should have exactly one type parameter")
+    _ -> err (eqTxt <> " should have exactly one type parameter")
   case d ^. inductiveConstructors of
     [c1] -> checkMkEq c1
-    _ -> err (eqTxt <> "should have exactly two constructors")
+    _ -> err (eqTxt <> " should have exactly two constructors")
 
 checkMkEq :: ConstructorDef -> Sem r ()
 checkMkEq _ = return ()

--- a/src/Juvix/Compiler/Builtins/Eq.hs
+++ b/src/Juvix/Compiler/Builtins/Eq.hs
@@ -1,0 +1,25 @@
+module Juvix.Compiler.Builtins.Eq where
+
+import Juvix.Compiler.Internal.Builtins
+import Juvix.Compiler.Internal.Extra
+import Juvix.Prelude
+import Juvix.Prelude.Pretty
+
+checkEqDef :: forall r. (Members '[Reader BuiltinsTable, Error ScoperError] r) => InductiveDef -> Sem r ()
+checkEqDef d = do
+  let err :: forall a. Text -> Sem r a
+      err = builtinsErrorText (getLoc d)
+  unless (isSmallUniverse' (d ^. inductiveType)) (err "Lists should be in the small universe")
+  let eqTxt = prettyText BuiltinEq
+  case d ^. inductiveParameters of
+    [_] -> return ()
+    _ -> err (eqTxt <> "should have exactly one type parameter")
+  case d ^. inductiveConstructors of
+    [c1] -> checkMkEq c1
+    _ -> err (eqTxt <> "should have exactly two constructors")
+
+checkMkEq :: ConstructorDef -> Sem r ()
+checkMkEq _ = return ()
+
+checkIsEq :: FunctionDef -> Sem r ()
+checkIsEq _ = return ()

--- a/src/Juvix/Compiler/Concrete/Data/Builtins.hs
+++ b/src/Juvix/Compiler/Concrete/Data/Builtins.hs
@@ -59,6 +59,7 @@ builtinConstructors = \case
   BuiltinEcPoint -> [BuiltinMkEcPoint]
   BuiltinAnomaResource -> [BuiltinMkAnomaResource]
   BuiltinAnomaAction -> [BuiltinMkAnomaAction]
+  BuiltinEq -> [BuiltinMkEq]
 
 data BuiltinInductive
   = BuiltinNat
@@ -67,6 +68,7 @@ data BuiltinInductive
   | BuiltinList
   | BuiltinMaybe
   | BuiltinPair
+  | BuiltinEq
   | BuiltinPoseidonState
   | BuiltinEcPoint
   | BuiltinAnomaResource
@@ -87,6 +89,7 @@ instance Pretty BuiltinInductive where
     BuiltinList -> Str.list
     BuiltinMaybe -> Str.maybe_
     BuiltinPair -> Str.pair
+    BuiltinEq -> Str.eq
     BuiltinPoseidonState -> Str.cairoPoseidonState
     BuiltinEcPoint -> Str.cairoEcPoint
     BuiltinAnomaResource -> Str.anomaResource
@@ -109,6 +112,7 @@ instance Pretty BuiltinConstructor where
     BuiltinMkEcPoint -> Str.cairoMkEcPoint
     BuiltinMkAnomaResource -> Str.anomaMkResource
     BuiltinMkAnomaAction -> Str.anomaMkAction
+    BuiltinMkEq -> Str.mkEq
 
 data BuiltinConstructor
   = BuiltinNatZero
@@ -119,6 +123,7 @@ data BuiltinConstructor
   | BuiltinIntNegSuc
   | BuiltinListNil
   | BuiltinListCons
+  | BuiltinMkEq
   | BuiltinMaybeNothing
   | BuiltinMaybeJust
   | BuiltinPairConstr
@@ -161,6 +166,7 @@ data BuiltinFunction
   | BuiltinIntLe
   | BuiltinIntLt
   | BuiltinFromNat
+  | BuiltinIsEqual
   | BuiltinFromInt
   | BuiltinSeq
   | BuiltinMonadBind
@@ -202,6 +208,7 @@ instance Pretty BuiltinFunction where
     BuiltinFromNat -> Str.fromNat
     BuiltinFromInt -> Str.fromInt
     BuiltinSeq -> Str.builtinSeq
+    BuiltinIsEqual -> Str.isEqual
     BuiltinMonadBind -> Str.builtinMonadBind
 
 data BuiltinAxiom
@@ -434,6 +441,7 @@ isNatBuiltin = \case
   BuiltinNatLt -> True
   BuiltinNatEq -> True
   --
+  BuiltinIsEqual -> False
   BuiltinAssert -> False
   BuiltinBoolIf -> False
   BuiltinBoolOr -> False
@@ -486,6 +494,7 @@ isIntBuiltin = \case
   BuiltinFromNat -> False
   BuiltinFromInt -> False
   BuiltinSeq -> False
+  BuiltinIsEqual -> False
   BuiltinMonadBind -> False
 
 isCastBuiltin :: BuiltinFunction -> Bool
@@ -493,6 +502,7 @@ isCastBuiltin = \case
   BuiltinFromNat -> True
   BuiltinFromInt -> True
   --
+  BuiltinIsEqual -> False
   BuiltinAssert -> False
   BuiltinIntEq -> False
   BuiltinIntPlus -> False
@@ -532,6 +542,7 @@ isIgnoredBuiltin f
         .&&. (not . isIntBuiltin)
         .&&. (not . isCastBuiltin)
         .&&. (/= BuiltinMonadBind)
+        .&&. (/= BuiltinIsEqual)
         $ f
 
     explicit :: Bool
@@ -562,6 +573,8 @@ isIgnoredBuiltin f
       BuiltinNatLe -> False
       BuiltinNatLt -> False
       BuiltinNatEq -> False
+      -- Eq
+      BuiltinIsEqual -> False
       -- Monad
       BuiltinMonadBind -> False
       -- Ignored

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -153,19 +153,17 @@ anameFromScopedIden s =
       _anameVerbatim = s ^. scopedIdenSrcName . nameVerbatim
     }
 
-getInfo :: (Members '[InfoTableBuilder, Reader InfoTable] r) => (InfoTable -> Maybe a) -> Sem r a
-getInfo f = do
-  tab1 <- ask
-  fromMaybe (fromJust (f tab1)) . f <$> getBuilderInfoTable
+lookupInfo :: (Members '[InfoTableBuilder, Reader InfoTable] r) => (InfoTable -> Maybe a) -> Sem r a
+lookupInfo f = fromJust <$> lookupInfo' f
 
-lookupInfo :: (Members '[InfoTableBuilder, Reader InfoTable] r) => (InfoTable -> Maybe a) -> Sem r (Maybe a)
-lookupInfo f = do
+lookupInfo' :: (Members '[InfoTableBuilder, Reader InfoTable] r) => (InfoTable -> Maybe a) -> Sem r (Maybe a)
+lookupInfo' f = do
   tab1 <- ask
   tab2 <- getBuilderInfoTable
   return (f tab1 <|> f tab2)
 
 lookupFixity :: (Members '[InfoTableBuilder, Reader InfoTable] r) => S.NameId -> Sem r FixityDef
-lookupFixity uid = getInfo (^. infoFixities . at uid)
+lookupFixity uid = lookupInfo (^. infoFixities . at uid)
 
 getPrecedenceGraph :: (Members '[InfoTableBuilder, Reader InfoTable] r) => Sem r PrecedenceGraph
 getPrecedenceGraph = do

--- a/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/InfoTableBuilder.hs
@@ -158,8 +158,8 @@ lookupInfo f = fromJust <$> lookupInfo' f
 
 lookupInfo' :: (Members '[InfoTableBuilder, Reader InfoTable] r) => (InfoTable -> Maybe a) -> Sem r (Maybe a)
 lookupInfo' f = do
-  tab1 <- ask
-  tab2 <- getBuilderInfoTable
+  tab1 <- getBuilderInfoTable
+  tab2 <- ask
   return (f tab1 <|> f tab2)
 
 lookupFixity :: (Members '[InfoTableBuilder, Reader InfoTable] r) => S.NameId -> Sem r FixityDef

--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
@@ -15,6 +15,7 @@ where
 
 import Juvix.Compiler.Concrete.Data.NameSignature.Error
 import Juvix.Compiler.Concrete.Gen qualified as Gen
+import Juvix.Compiler.Concrete.Language.Base
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Error
 import Juvix.Prelude
 
@@ -64,9 +65,7 @@ instance (SingI s) => HasNameSignature s (AxiomDef s) where
   addArgs a = addArgs (a ^. axiomTypeSig)
 
 instance (SingI s) => HasNameSignature s (FunctionLhs s) where
-  addArgs a = do
-    mapM_ addSigArg (a ^. funLhsArgs)
-    whenJust (a ^. funLhsRetType) addExpressionType
+  addArgs FunctionLhs {..} = addArgs _funLhsTypeSig
 
 instance (SingI s) => HasNameSignature s (FunctionDef s) where
   addArgs = addArgs . functionDefLhs

--- a/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
+++ b/src/Juvix/Compiler/Concrete/Data/NameSignature/Builder.hs
@@ -63,8 +63,13 @@ instance (SingI s) => HasNameSignature s (AxiomDef s) where
   addArgs :: (Members '[NameSignatureBuilder s] r) => AxiomDef s -> Sem r ()
   addArgs a = addArgs (a ^. axiomTypeSig)
 
+instance (SingI s) => HasNameSignature s (FunctionLhs s) where
+  addArgs a = do
+    mapM_ addSigArg (a ^. funLhsArgs)
+    whenJust (a ^. funLhsRetType) addExpressionType
+
 instance (SingI s) => HasNameSignature s (FunctionDef s) where
-  addArgs a = addArgs (a ^. signTypeSig)
+  addArgs = addArgs . functionDefLhs
 
 instance (SingI s) => HasNameSignature s (InductiveDef s, ConstructorDef s) where
   addArgs ::

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -9,6 +9,7 @@ module Juvix.Compiler.Concrete.Extra
     getPatternAtomIden,
     isBodyExpression,
     isFunctionLike,
+    isLhsFunctionLike,
     symbolParsed,
   )
 where
@@ -46,6 +47,7 @@ groupStatements = \case
     -- blank line
     g :: Statement s -> Statement s -> Bool
     g a b = case (a, b) of
+      (StatementDeriving _, _) -> False
       (StatementSyntax _, StatementSyntax _) -> True
       (StatementSyntax (SyntaxFixity _), _) -> False
       (StatementSyntax (SyntaxOperator o), s) -> definesSymbol (o ^. opSymbol) s
@@ -108,6 +110,9 @@ isBodyExpression = \case
   SigBodyExpression {} -> True
   SigBodyClauses {} -> False
 
-isFunctionLike :: FunctionDef a -> Bool
-isFunctionLike = \case
-  FunctionDef {..} -> not (null (_signTypeSig ^. typeSigArgs)) || not (isBodyExpression _signBody)
+isLhsFunctionLike :: FunctionLhs 'Parsed -> Bool
+isLhsFunctionLike FunctionLhs {..} = notNull _funLhsArgs
+
+isFunctionLike :: FunctionDef 'Parsed -> Bool
+isFunctionLike d@FunctionDef {..} =
+  isLhsFunctionLike (functionDefLhs d) || (not . isBodyExpression) _signBody

--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -111,7 +111,7 @@ isBodyExpression = \case
   SigBodyClauses {} -> False
 
 isLhsFunctionLike :: FunctionLhs 'Parsed -> Bool
-isLhsFunctionLike FunctionLhs {..} = notNull _funLhsArgs
+isLhsFunctionLike FunctionLhs {..} = notNull (_funLhsTypeSig ^. typeSigArgs)
 
 isFunctionLike :: FunctionDef 'Parsed -> Bool
 isFunctionLike d@FunctionDef {..} =

--- a/src/Juvix/Compiler/Concrete/Keywords.hs
+++ b/src/Juvix/Compiler/Concrete/Keywords.hs
@@ -36,6 +36,7 @@ import Juvix.Data.Keyword.All
     kwCase,
     kwCoercion,
     kwColon,
+    kwDeriving,
     kwDo,
     kwElse,
     kwEnd,
@@ -85,6 +86,7 @@ reservedKeywords :: [Keyword]
 reservedKeywords =
   [ delimSemicolon,
     kwAssign,
+    kwDeriving,
     kwAt,
     kwAtQuestion,
     kwAxiom,

--- a/src/Juvix/Compiler/Concrete/Language.hs
+++ b/src/Juvix/Compiler/Concrete/Language.hs
@@ -31,6 +31,7 @@ statementLabel = \case
   StatementOpenModule {} -> Nothing
   StatementProjectionDef {} -> Nothing
   StatementFunctionDef f -> Just (f ^. signName . symbolTypeLabel)
+  StatementDeriving f -> Just (f ^. derivingFunLhs . funLhsName . symbolTypeLabel)
   StatementImport i -> Just (i ^. importModulePath . to modulePathTypeLabel)
   StatementInductive i -> Just (i ^. inductiveName . symbolTypeLabel)
   StatementModule i -> Just (i ^. modulePath . to modulePathTypeLabel)

--- a/src/Juvix/Compiler/Concrete/Language/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Language/Base.hs
@@ -888,7 +888,7 @@ deriving stock instance Ord (RhsRecord 'Parsed)
 
 deriving stock instance Ord (RhsRecord 'Scoped)
 
-data RhsGadt (s :: Stage) = RhsGadt
+newtype RhsGadt (s :: Stage) = RhsGadt
   { _rhsGadtTypeSig :: TypeSig s
   }
   deriving stock (Generic)
@@ -3387,7 +3387,7 @@ instance (SingI s) => HasLoc (FunctionLhs s) where
     (getLoc <$> _funLhsBuiltin)
       ?<> (getLoc <$> _funLhsTerminating)
       ?<> ( getLocSymbolType _funLhsName
-              <>? (getLocExpressionType <$> _funLhsRetType)
+              <>? (getLocExpressionType <$> _funLhsTypeSig ^. typeSigRetType)
           )
 
 instance (SingI s) => HasLoc (FunctionDef s) where

--- a/src/Juvix/Compiler/Concrete/Print/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Print/Base.hs
@@ -1142,6 +1142,11 @@ instance (SingI s) => PrettyPrint (SigArg s) where
         defaultVal = ppCode <$> _sigArgDefault
     ppCode l <> arg <+?> defaultVal <> ppCode r
 
+instance (SingI s) => PrettyPrint (Deriving s) where
+  ppCode Deriving {..} =
+    ppCode _derivingKw
+      <+> ppCode _derivingFunLhs
+
 instance (SingI s) => PrettyPrint (TypeSig s) where
   ppCode TypeSig {..} = do
     let margs' = fmap ppCode <$> nonEmpty _typeSigArgs
@@ -1536,6 +1541,7 @@ instance (SingI s) => PrettyPrint (Statement s) where
   ppCode = \case
     StatementSyntax s -> ppCode s
     StatementFunctionDef f -> ppCode f
+    StatementDeriving f -> ppCode f
     StatementImport i -> ppCode i
     StatementInductive i -> ppCode i
     StatementModule m -> ppCode m

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -353,7 +353,7 @@ getReservedDefinitionSymbol ::
 getReservedDefinitionSymbol s = do
   m <- gets (^. scopeLocalSymbols)
   let s' = fromMaybe err (m ^. at s)
-      err = error ("impossible. Contents of scope:\n" <> ppTrace (toList m))
+      err = impossibleError ("Symbol " <> ppTrace s <> " not found in the scope. Contents of scope:\n" <> ppTrace (toList m))
   return s'
 
 ignoreSyntax :: Sem (State ScoperSyntax ': r) a -> Sem r a
@@ -404,10 +404,10 @@ reserveConstructorSymbol d c b = do
 
 reserveFunctionSymbol ::
   (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder, Reader InfoTable] r) =>
-  FunctionDef 'Parsed ->
+  FunctionLhs 'Parsed ->
   Sem r S.Symbol
 reserveFunctionSymbol f =
-  reserveSymbolSignatureOf SKNameFunction f (toBuiltinPrim <$> f ^. signBuiltin) (f ^. signName)
+  reserveSymbolSignatureOf SKNameFunction f (toBuiltinPrim <$> f ^. funLhsBuiltin) (f ^. funLhsName)
 
 reserveAxiomSymbol ::
   (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder, Reader InfoTable] r) =>
@@ -419,37 +419,22 @@ reserveAxiomSymbol a =
     kindPretty :: NameKind
     kindPretty = maybe KNameAxiom getNameKind (a ^? axiomBuiltin . _Just . withLocParam)
 
+reserveDerivingSymbol ::
+  (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder, Reader InfoTable] r) =>
+  Deriving 'Parsed ->
+  Sem r ()
+reserveDerivingSymbol f = do
+  let lhs = f ^. derivingFunLhs
+  when (P.isLhsFunctionLike lhs) $
+    void (reserveFunctionSymbol lhs)
+
 reserveFunctionLikeSymbol ::
   (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, State ScoperState, Reader BindingStrategy, InfoTableBuilder, Reader InfoTable] r) =>
   FunctionDef 'Parsed ->
   Sem r ()
 reserveFunctionLikeSymbol f =
   when (P.isFunctionLike f) $
-    void (reserveFunctionSymbol f)
-
-bindFunctionSymbol ::
-  (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, InfoTableBuilder, Reader InfoTable, State ScoperState, Reader BindingStrategy] r) =>
-  Symbol ->
-  Sem r S.Symbol
-bindFunctionSymbol = getReservedDefinitionSymbol
-
-bindInductiveSymbol ::
-  (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, InfoTableBuilder, Reader InfoTable, State ScoperState, Reader BindingStrategy] r) =>
-  Symbol ->
-  Sem r S.Symbol
-bindInductiveSymbol = getReservedDefinitionSymbol
-
-bindAxiomSymbol ::
-  (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, InfoTableBuilder, Reader InfoTable, State ScoperState, Reader BindingStrategy] r) =>
-  Symbol ->
-  Sem r S.Symbol
-bindAxiomSymbol = getReservedDefinitionSymbol
-
-bindConstructorSymbol ::
-  (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, InfoTableBuilder, Reader InfoTable, State ScoperState, Reader BindingStrategy] r) =>
-  Symbol ->
-  Sem r S.Symbol
-bindConstructorSymbol = getReservedDefinitionSymbol
+    void (reserveFunctionSymbol (functionDefLhs f))
 
 bindFixitySymbol ::
   (Members '[Error ScoperError, NameIdGen, State ScoperSyntax, State Scope, InfoTableBuilder, Reader InfoTable, State ScoperState, Reader BindingStrategy] r) =>
@@ -726,7 +711,11 @@ lookupQualifiedSymbol ::
   ([Symbol], Symbol) ->
   Sem r (HashSet PreSymbolEntry, HashSet ModuleSymbolEntry, HashSet FixitySymbolEntry)
 lookupQualifiedSymbol sms = do
-  (es, (ms, fs)) <- runOutputHashSet . runOutputHashSet . execOutputHashSet $ go sms
+  (es, (ms, fs)) <-
+    runOutputHashSet
+      . runOutputHashSet
+      . execOutputHashSet
+      $ go sms
   return (es, ms, fs)
   where
     go ::
@@ -1063,44 +1052,109 @@ resolveIteratorSyntaxDef s@IteratorSyntaxDef {..} = do
 (@$>) :: (Functor m) => (a -> m ()) -> a -> m a
 (@$>) f a = f a $> a
 
-checkTypeSig ::
-  forall r.
-  (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader PackageId, State ScoperSyntax, Reader BindingStrategy] r) =>
-  TypeSig 'Parsed ->
-  Sem r (TypeSig 'Scoped)
-checkTypeSig TypeSig {..} = do
-  a' <- mapM checkArg _typeSigArgs
-  t' <- mapM checkParseExpressionAtoms _typeSigRetType
-  return TypeSig {_typeSigArgs = a', _typeSigRetType = t', ..}
-  where
-    checkSigArgNames :: SigArgNames 'Parsed -> Sem r (SigArgNames 'Scoped)
-    checkSigArgNames = \case
-      SigArgNamesInstance -> return SigArgNamesInstance
-      SigArgNames ns -> fmap SigArgNames . forM ns $ \case
-        ArgumentSymbol s -> ArgumentSymbol <$> bindVariableSymbol s
-        ArgumentWildcard w -> return (ArgumentWildcard w)
-
-    checkArg :: SigArg 'Parsed -> Sem r (SigArg 'Scoped)
-    checkArg arg@SigArg {..} = do
-      names' <- checkSigArgNames _sigArgNames
-      ty' <- mapM checkParseExpressionAtoms _sigArgType
-      default' <- case _sigArgDefault of
-        Nothing -> return Nothing
-        Just ArgDefault {..} ->
-          let err = throw (ErrWrongDefaultValue WrongDefaultValue {_wrongDefaultValue = arg})
-           in case _sigArgImplicit of
-                Explicit -> err
-                ImplicitInstance -> err
-                Implicit -> do
-                  val' <- checkParseExpressionAtoms _argDefaultValue
-                  return (Just ArgDefault {_argDefaultValue = val', ..})
-      return
-        SigArg
-          { _sigArgNames = names',
-            _sigArgType = ty',
-            _sigArgDefault = default',
+checkDeriving ::
+  ( Members
+      '[ State Scope,
+         Error ScoperError,
+         State ScoperState,
+         Reader ScopeParameters,
+         Reader InfoTable,
+         Reader PackageId,
+         HighlightBuilder,
+         InfoTableBuilder,
+         NameIdGen,
+         State ScoperSyntax,
+         Reader BindingStrategy
+       ]
+      r
+  ) =>
+  Deriving 'Parsed ->
+  Sem r (Deriving 'Scoped)
+checkDeriving Deriving {..} = do
+  let lhs@FunctionLhs {..} = _derivingFunLhs
+  (args', ret') <- withLocalScope $ do
+    args' <- mapM checkSigArg _funLhsArgs
+    ret' <- mapM checkParseExpressionAtoms _funLhsRetType
+    return (args', ret')
+  name' <-
+    if
+        | P.isLhsFunctionLike lhs -> getReservedDefinitionSymbol _funLhsName
+        | otherwise -> reserveFunctionSymbol lhs
+  let lhs' =
+        FunctionLhs
+          { _funLhsArgs = args',
+            _funLhsRetType = ret',
+            _funLhsName = name',
             ..
           }
+  return
+    Deriving
+      { _derivingFunLhs = lhs',
+        ..
+      }
+
+checkSigArg ::
+  ( Members
+      '[ State Scope,
+         Error ScoperError,
+         State ScoperState,
+         Reader ScopeParameters,
+         Reader InfoTable,
+         Reader PackageId,
+         HighlightBuilder,
+         InfoTableBuilder,
+         NameIdGen,
+         State ScoperSyntax,
+         Reader BindingStrategy
+       ]
+      r
+  ) =>
+  SigArg 'Parsed ->
+  Sem r (SigArg 'Scoped)
+checkSigArg arg@SigArg {..} = do
+  names' <- checkSigArgNames _sigArgNames
+  ty' <- mapM checkParseExpressionAtoms _sigArgType
+  default' <- case _sigArgDefault of
+    Nothing -> return Nothing
+    Just ArgDefault {..} ->
+      let err = throw (ErrWrongDefaultValue WrongDefaultValue {_wrongDefaultValue = arg})
+       in case _sigArgImplicit of
+            Explicit -> err
+            ImplicitInstance -> err
+            Implicit -> do
+              val' <- checkParseExpressionAtoms _argDefaultValue
+              return (Just ArgDefault {_argDefaultValue = val', ..})
+  return
+    SigArg
+      { _sigArgNames = names',
+        _sigArgType = ty',
+        _sigArgDefault = default',
+        ..
+      }
+
+checkSigArgNames ::
+  ( Members
+      '[ State Scope,
+         Error ScoperError,
+         State ScoperState,
+         Reader ScopeParameters,
+         Reader InfoTable,
+         Reader PackageId,
+         HighlightBuilder,
+         InfoTableBuilder,
+         NameIdGen,
+         State ScoperSyntax,
+         Reader BindingStrategy
+       ]
+      r
+  ) =>
+  SigArgNames 'Parsed ->
+  Sem r (SigArgNames 'Scoped)
+checkSigArgNames = \case
+  SigArgNamesInstance -> return SigArgNamesInstance
+  SigArgNames ns -> fmap SigArgNames . forM ns $ \case
+    ArgumentSymbol s -> ArgumentSymbol <$> bindVariableSymbol s
+    ArgumentWildcard w -> return (ArgumentWildcard w)
 
 checkFunctionDef ::
   forall r.
@@ -1115,8 +1169,8 @@ checkFunctionDef fdef@FunctionDef {..} = do
     return (a', b')
   sigName' <-
     if
-        | P.isFunctionLike fdef -> bindFunctionSymbol _signName
-        | otherwise -> reserveFunctionSymbol fdef
+        | P.isFunctionLike fdef -> getReservedDefinitionSymbol _signName
+        | otherwise -> reserveFunctionSymbol (functionDefLhs fdef)
   let def =
         FunctionDef
           { _signName = sigName',
@@ -1165,13 +1219,27 @@ checkInductiveParameters params = do
 
 checkInductiveDef ::
   forall r.
-  (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader PackageId, State ScoperSyntax, Reader BindingStrategy] r) =>
+  ( Members
+      '[ HighlightBuilder,
+         Reader ScopeParameters,
+         Error ScoperError,
+         State Scope,
+         State ScoperState,
+         InfoTableBuilder,
+         Reader InfoTable,
+         NameIdGen,
+         Reader PackageId,
+         State ScoperSyntax,
+         Reader BindingStrategy
+       ]
+      r
+  ) =>
   InductiveDef 'Parsed ->
   Sem r (InductiveDef 'Scoped)
 checkInductiveDef InductiveDef {..} = do
   (inductiveName', constructorNames' :: NonEmpty S.Symbol) <- topBindings $ do
-    i <- bindInductiveSymbol _inductiveName
-    cs <- mapM (bindConstructorSymbol . (^. constructorName)) _inductiveConstructors
+    i <- getReservedDefinitionSymbol _inductiveName
+    cs <- mapM (getReservedDefinitionSymbol . (^. constructorName)) _inductiveConstructors
     return (i, cs)
   (inductiveParameters', inductiveType', inductiveTypeApplied', inductiveDoc', inductiveConstructors') <- withLocalScope $ do
     inductiveParameters' <- mapM checkInductiveParameters _inductiveParameters
@@ -1470,6 +1538,7 @@ checkModuleBody body = do
             toStatement :: Definition s -> Statement s
             toStatement = \case
               DefinitionSyntax d -> StatementSyntax d
+              DefinitionDeriving d -> StatementDeriving d
               DefinitionAxiom d -> StatementAxiom d
               DefinitionFunctionDef d -> StatementFunctionDef d
               DefinitionInductive d -> StatementInductive d
@@ -1605,6 +1674,7 @@ checkSections sec = topBindings helper
             reserveDefinition = \case
               DefinitionSyntax s -> resolveSyntaxDef s $> Nothing
               DefinitionFunctionDef d -> reserveFunctionLikeSymbol d >> return Nothing
+              DefinitionDeriving d -> reserveDerivingSymbol d >> return Nothing
               DefinitionAxiom d -> reserveAxiomSymbol d >> return Nothing
               DefinitionProjectionDef d -> reserveProjectionSymbol d >> return Nothing
               DefinitionInductive d -> Just <$> reserveInductive d
@@ -1660,6 +1730,7 @@ checkSections sec = topBindings helper
             goDefinition = \case
               DefinitionSyntax s -> DefinitionSyntax <$> checkSyntaxDef s
               DefinitionFunctionDef d -> DefinitionFunctionDef <$> checkFunctionDef d
+              DefinitionDeriving d -> DefinitionDeriving <$> checkDeriving d
               DefinitionAxiom d -> DefinitionAxiom <$> checkAxiomDef d
               DefinitionInductive d -> DefinitionInductive <$> checkInductiveDef d
               DefinitionProjectionDef d -> DefinitionProjectionDef <$> checkProjectionDef d
@@ -1800,6 +1871,7 @@ mkSections = \case
     fromStatement = \case
       StatementAxiom a -> Left (DefinitionAxiom a)
       StatementFunctionDef n -> Left (DefinitionFunctionDef n)
+      StatementDeriving n -> Left (DefinitionDeriving n)
       StatementInductive i -> Left (DefinitionInductive i)
       StatementSyntax s -> Left (DefinitionSyntax s)
       StatementProjectionDef s -> Left (DefinitionProjectionDef s)
@@ -1834,9 +1906,9 @@ checkLocalModule ::
   Sem r (Module 'Scoped 'ModuleLocal)
 checkLocalModule md@Module {..} = do
   tab1 <- ask @InfoTable
-  tab2 <- getInfoTable
+  tab2 <- getBuilderInfoTable
   (tab, (moduleExportInfo, moduleBody', moduleDoc')) <-
-    withLocalScope $ runReader (tab1 <> tab2) $ runInfoTableBuilder mempty $ do
+    withLocalScope . runReader (tab1 <> tab2) . runInfoTableBuilder mempty $ do
       inheritScope
       (e, b) <- checkModuleBody _moduleBody
       doc' <- mapM checkJudoc _moduleDoc
@@ -2122,7 +2194,8 @@ checkAxiomDef ::
   AxiomDef 'Parsed ->
   Sem r (AxiomDef 'Scoped)
 checkAxiomDef AxiomDef {..} = do
-  axiomName' <- bindAxiomSymbol _axiomName
+  axiomType' <- withLocalScope (checkParseExpressionAtoms _axiomType)
+  axiomName' <- getReservedDefinitionSymbol _axiomName
   axiomDoc' <- withLocalScope (mapM checkJudoc _axiomDoc)
   axiomSig' <- withLocalScope (checkTypeSig _axiomTypeSig)
   let a = AxiomDef {_axiomName = axiomName', _axiomTypeSig = axiomSig', _axiomDoc = axiomDoc', ..}
@@ -2185,6 +2258,7 @@ checkLetStatements =
               DefinitionFunctionDef d -> LetFunctionDef d
               DefinitionSyntax syn -> fromSyn syn
               DefinitionInductive {} -> impossible
+              DefinitionDeriving {} -> impossible
               DefinitionProjectionDef {} -> impossible
               DefinitionAxiom {} -> impossible
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Error.hs
@@ -61,6 +61,7 @@ data ScoperError
   | ErrBuiltinErrorMessage BuiltinErrorMessage
   | ErrDoLastStatement DoLastStatement
   | ErrDoBindImplicitPattern DoBindImplicitPattern
+  | ErrDerivingTypeWrongForm DerivingTypeWrongForm
   deriving stock (Generic)
 
 instance ToGenericError ScoperError where
@@ -113,6 +114,7 @@ instance ToGenericError ScoperError where
     ErrBuiltinErrorMessage e -> genericError e
     ErrDoLastStatement e -> genericError e
     ErrDoBindImplicitPattern e -> genericError e
+    ErrDerivingTypeWrongForm e -> genericError e
 
 builtinsErrorMsg :: (Members '[Error ScoperError] r) => Interval -> AnsiText -> Sem r a
 builtinsErrorMsg loc msg =

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -647,16 +647,17 @@ instance PrettyCode InfoTable where
           shouldPrintInductive :: Maybe BuiltinType -> Bool
           shouldPrintInductive = \case
             Just (BuiltinTypeInductive i) -> case i of
-              BuiltinList -> False
-              BuiltinMaybe -> False
               BuiltinPair -> True
               BuiltinPoseidonState -> True
               BuiltinEcPoint -> True
+              BuiltinAnomaResource -> True
+              BuiltinAnomaAction -> True
+              BuiltinList -> False
+              BuiltinEq -> False
+              BuiltinMaybe -> False
               BuiltinNat -> False
               BuiltinInt -> False
               BuiltinBool -> False
-              BuiltinAnomaResource -> True
-              BuiltinAnomaAction -> True
             Just _ -> False
             Nothing -> True
 

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -217,6 +217,7 @@ goConstructor sym ctor = do
     ctorTag = \case
       Just Internal.BuiltinBoolTrue -> return (BuiltinTag TagTrue)
       Just Internal.BuiltinBoolFalse -> return (BuiltinTag TagFalse)
+      Just Internal.BuiltinMkEq -> freshTag
       Just Internal.BuiltinNatZero -> freshTag
       Just Internal.BuiltinNatSuc -> freshTag
       Just Internal.BuiltinIntOfNat -> freshTag

--- a/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
+++ b/src/Juvix/Compiler/Core/Translation/Stripped/FromCore.hs
@@ -54,6 +54,7 @@ fromCore fsize tab =
       BuiltinIntLe -> False
       BuiltinIntLt -> False
       BuiltinSeq -> False
+      BuiltinIsEqual -> False
       BuiltinMonadBind -> True -- TODO revise
       BuiltinFromNat -> True
       BuiltinFromInt -> True
@@ -62,19 +63,20 @@ fromCore fsize tab =
     shouldKeepConstructor = \case
       BuiltinListNil -> True
       BuiltinListCons -> True
+      BuiltinMkEq -> True
       BuiltinMkPoseidonState -> True
       BuiltinMkEcPoint -> True
       BuiltinMaybeNothing -> True
       BuiltinMaybeJust -> True
       BuiltinPairConstr -> True
+      BuiltinMkAnomaResource -> True
+      BuiltinMkAnomaAction -> True
       BuiltinNatZero -> False
       BuiltinNatSuc -> False
       BuiltinBoolTrue -> False
       BuiltinBoolFalse -> False
       BuiltinIntOfNat -> False
       BuiltinIntNegSuc -> False
-      BuiltinMkAnomaResource -> True
-      BuiltinMkAnomaAction -> True
 
     shouldKeepType :: BuiltinType -> Bool
     shouldKeepType = \case
@@ -141,6 +143,7 @@ fromCore fsize tab =
         BuiltinByteArrayLength -> False
       BuiltinTypeInductive i -> case i of
         BuiltinList -> True
+        BuiltinEq -> True
         BuiltinMaybe -> True
         BuiltinPair -> True
         BuiltinPoseidonState -> True

--- a/src/Juvix/Compiler/Internal/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Internal/Data/InfoTable.hs
@@ -44,10 +44,11 @@ functionInfoFromFunctionDef isLocal FunctionDef {..} =
     }
 
 inductiveInfoFromInductiveDef :: InductiveDef -> InductiveInfo
-inductiveInfoFromInductiveDef InductiveDef {..} =
+inductiveInfoFromInductiveDef d@InductiveDef {..} =
   InductiveInfo
     { _inductiveInfoName = _inductiveName,
       _inductiveInfoType = _inductiveType,
+      _inductiveInfoLoc = getLoc d,
       _inductiveInfoBuiltin = _inductiveBuiltin,
       _inductiveInfoParameters = _inductiveParameters,
       _inductiveInfoConstructors = map (^. inductiveConstructorName) _inductiveConstructors,

--- a/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
@@ -178,7 +178,7 @@ goInductive p i = do
     mapM_ goInductiveParameter (i ^. inductiveParameters)
     goExpression (i ^. inductiveType)
 
--- BuiltinBool and BuiltinNat are required by the Internal to Core translation
+-- | BuiltinBool and BuiltinNat are required by the Internal to Core translation
 -- when translating literal integers to Nats.
 checkBuiltinInductiveStartNode :: forall r. (Members '[State StartNodes, State BuilderState] r) => InductiveDef -> Sem r ()
 checkBuiltinInductiveStartNode i = whenJust (i ^. inductiveBuiltin) go
@@ -199,6 +199,7 @@ checkBuiltinInductiveStartNode i = whenJust (i ^. inductiveBuiltin) go
       BuiltinEcPoint -> return ()
       BuiltinAnomaResource -> return ()
       BuiltinAnomaAction -> return ()
+      BuiltinEq -> return ()
 
     addInductiveStartNode :: Sem r ()
     addInductiveStartNode = addStartNode (i ^. inductiveName)

--- a/src/Juvix/Compiler/Internal/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Internal/Pretty/Base.hs
@@ -39,6 +39,9 @@ instance PrettyCode Name where
     showNameId <- asks (^. optShowNameIds)
     return (prettyName showNameId n)
 
+instance PrettyCode DerivingTrait where
+  ppCode = return . ppCodeAnn
+
 instance PrettyCode ArgInfo where
   ppCode ArgInfo {..} = do
     name <- maybe (return kwWildcard) ppCode _argInfoName

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -428,7 +428,6 @@ goDeriving Deriving {..} = do
             _derivingParameters = funArgs,
             _derivingPragmas
           }
-  -- deriveTrait der _derivingPragmas ret name funArgs (n, traitArgs)
   deriveTrait der deriveArgs
 
 deriveTrait ::

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -728,26 +728,18 @@ argToPattern arg@SigArg {..} = do
 
 goDefType ::
   forall r.
-  ( Members
-      '[ Reader DefaultArgsStack,
-         NameIdGen,
-         Error ScoperError,
-         Reader Pragmas,
-         Reader S.InfoTable
-       ]
-      r
-  ) =>
+  (Members '[Reader DefaultArgsStack, NameIdGen, Error ScoperError, Reader Pragmas, Reader S.InfoTable] r) =>
   FunctionLhs 'Scoped ->
   Sem r Internal.Expression
 goDefType FunctionLhs {..} = do
-  args <- concatMapM (fmap toList . argToParam) _funLhsArgs
-  ret <- maybe freshHole goExpression _funLhsRetType
+  args <- concatMapM (fmap toList . argToParam) (_funLhsTypeSig ^. typeSigArgs)
+  ret <- maybe freshHole goExpression (_funLhsTypeSig ^. typeSigRetType)
   return (Internal.foldFunType args ret)
   where
     freshHole :: Sem r Internal.Expression
     freshHole = do
       i <- freshNameId
-      let loc = maybe (getLoc _funLhsName) getLoc (lastMay _funLhsArgs)
+      let loc = maybe (getLoc _funLhsName) getLoc (lastMay (_funLhsTypeSig ^. typeSigArgs))
           h = mkHole loc i
       return $ Internal.ExpressionHole h
 

--- a/src/Juvix/Compiler/Pipeline/Package/Loader.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader.hs
@@ -87,7 +87,8 @@ toConcrete t p = run . runReader l $ do
           _signTypeSig =
             TypeSig
               { _typeSigArgs = [],
-                ..
+                _typeSigRetType,
+                _typeSigColonKw
               }
       return
         ( StatementFunctionDef
@@ -98,11 +99,9 @@ toConcrete t p = run . runReader l $ do
                 _signDoc = Nothing,
                 _signCoercion = Nothing,
                 _signBuiltin = Nothing,
-                _signArgs = [],
-                _signRetType,
                 _signName,
-                _signColonKw,
-                _signBody
+                _signBody,
+                _signTypeSig
               }
         )
 

--- a/src/Juvix/Compiler/Pipeline/Package/Loader.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader.hs
@@ -98,7 +98,11 @@ toConcrete t p = run . runReader l $ do
                 _signDoc = Nothing,
                 _signCoercion = Nothing,
                 _signBuiltin = Nothing,
-                ..
+                _signArgs = [],
+                _signRetType,
+                _signName,
+                _signColonKw,
+                _signBody
               }
         )
 

--- a/src/Juvix/Compiler/Store/Internal/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Store/Internal/Data/InfoTable.hs
@@ -52,6 +52,7 @@ data InductiveInfo = InductiveInfo
     _inductiveInfoConstructors :: [ConstrName],
     _inductiveInfoPositive :: Bool,
     _inductiveInfoTrait :: Bool,
+    _inductiveInfoLoc :: Interval,
     _inductiveInfoPragmas :: Pragmas
   }
   deriving stock (Generic)
@@ -59,6 +60,9 @@ data InductiveInfo = InductiveInfo
 instance Serialize InductiveInfo
 
 instance NFData InductiveInfo
+
+instance HasLoc InductiveInfo where
+  getLoc InductiveInfo {..} = _inductiveInfoLoc
 
 data InfoTable = InfoTable
   { _infoConstructors :: HashMap Name ConstructorInfo,

--- a/src/Juvix/Data/Effect/Fail.hs
+++ b/src/Juvix/Data/Effect/Fail.hs
@@ -1,19 +1,24 @@
 -- | An effect similar to Polysemy Fail but without an error message
-module Juvix.Data.Effect.Fail where
+module Juvix.Data.Effect.Fail
+  ( module Juvix.Data.Effect.Fail,
+    module Effectful.Fail,
+  )
+where
 
 import Control.Exception qualified as X
+import Control.Monad.Fail qualified as Fail
+import Effectful.Fail (Fail)
+import Effectful.Fail qualified as Fail
 import Juvix.Prelude.Base
 
-data Fail :: Effect where
-  Fail :: Fail m a
-
-makeSem ''Fail
+fail :: (Member Fail r) => Sem r a
+fail = Fail.fail "fail"
 
 -- | Run a 'Fail' effect purely.
 runFail ::
   Sem (Fail ': r) a ->
   Sem r (Maybe a)
-runFail = fmap (^? _Right) . reinterpret (runError @()) (\Fail -> throw ())
+runFail = fmap (^? _Right) . reinterpret (runError @()) (\Fail.Fail {} -> throw ())
 {-# INLINE runFail #-}
 
 -- | Run a 'Fail' effect purely with a default value.

--- a/src/Juvix/Data/Keyword/All.hs
+++ b/src/Juvix/Data/Keyword/All.hs
@@ -7,6 +7,9 @@ where
 import Juvix.Data.Keyword
 import Juvix.Extra.Strings qualified as Str
 
+kwDeriving :: Keyword
+kwDeriving = asciiKw Str.deriving_
+
 kwAs :: Keyword
 kwAs = asciiKw Str.as
 

--- a/src/Juvix/Extra/Strings.hs
+++ b/src/Juvix/Extra/Strings.hs
@@ -452,6 +452,9 @@ builtinSeq = "seq"
 as :: (IsString s) => s
 as = "as"
 
+deriving_ :: (IsString s) => s
+deriving_ = "deriving"
+
 builtin :: (IsString s) => s
 builtin = "builtin"
 
@@ -538,6 +541,9 @@ seqq_ = ">>>"
 
 sseq_ :: (IsString s) => s
 sseq_ = "seq"
+
+isEqual :: (IsString s) => s
+isEqual = "isEqual"
 
 eq :: (IsString s) => s
 eq = "eq"
@@ -1144,6 +1150,9 @@ anomaMkResource = "mkResource"
 
 anomaMkAction :: (IsString s) => s
 anomaMkAction = "mkAction"
+
+mkEq :: (IsString s) => s
+mkEq = "mkEq"
 
 rustFn :: (IsString s) => s
 rustFn = "fn"

--- a/src/Juvix/Prelude.hs
+++ b/src/Juvix/Prelude.hs
@@ -1,7 +1,6 @@
 module Juvix.Prelude
   ( module Juvix.Prelude.Base,
     module Juvix.Prelude.Lens,
-    module Juvix.Prelude.Stream,
     module Juvix.Prelude.Generic,
     module Juvix.Prelude.Trace,
     module Juvix.Prelude.Path,
@@ -16,5 +15,4 @@ import Juvix.Prelude.Generic
 import Juvix.Prelude.Lens
 import Juvix.Prelude.Path
 import Juvix.Prelude.Prepath
-import Juvix.Prelude.Stream
 import Juvix.Prelude.Trace

--- a/src/Juvix/Prelude/Effects/StreamOf.hs
+++ b/src/Juvix/Prelude/Effects/StreamOf.hs
@@ -9,7 +9,6 @@ where
 import Data.Stream
 import Juvix.Prelude.Base.Foundation
 import Juvix.Prelude.Effects.Base
-import Juvix.Prelude.Stream
 
 data StreamOf (i :: GHCType) :: Effect
 

--- a/src/Juvix/Prelude/Stream.hs
+++ b/src/Juvix/Prelude/Stream.hs
@@ -1,27 +1,6 @@
-module Juvix.Prelude.Stream where
+module Juvix.Prelude.Stream
+  ( module Data.Stream,
+  )
+where
 
-import Data.Stream qualified as Stream
-import Juvix.Prelude.Base.Foundation
-
-allNaturals :: Stream Natural
-allNaturals = Stream.iterate succ 0
-
-allWords :: Stream Text
-allWords = pack . toList <$> allFiniteSequences ('a' :| ['b' .. 'z'])
-
--- | Returns all non-empty finite sequences
-allFiniteSequences :: forall a. NonEmpty a -> Stream (NonEmpty a)
-allFiniteSequences elems = build 0 []
-  where
-    build :: Integer -> [NonEmpty a] -> Stream (NonEmpty a)
-    build n = \case
-      [] -> build (succ n) (toList (ofLength (succ n)))
-      s : ss -> Stream.Cons s (build n ss)
-    ofLength :: Integer -> NonEmpty (NonEmpty a)
-    ofLength n
-      | n < 1 = impossible
-      | n == 1 = pure <$> elems
-      | otherwise = do
-          seq <- ofLength (n - 1)
-          e <- elems
-          return (pure e <> seq)
+import Data.Stream

--- a/test/Compilation/Positive.hs
+++ b/test/Compilation/Positive.hs
@@ -495,5 +495,10 @@ tests =
         "Test084: issue3030"
         $(mkRelDir ".")
         $(mkRelFile "test084.juvix")
-        $(mkRelFile "out/test084.out")
+        $(mkRelFile "out/test084.out"),
+      posTest
+        "Test085: Deriving Eq"
+        $(mkRelDir ".")
+        $(mkRelFile "test085.juvix")
+        $(mkRelFile "out/test085.out")
     ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -298,5 +298,10 @@ scoperErrorTests =
       "Import cycles (issue3161)"
       $(mkRelDir "issue3161")
       $(mkRelFile "Stdlib/Trait/Partial.juvix")
-      $ wantsError ErrImportCycleNew
+      $ wantsError ErrImportCycleNew,
+    negTest
+      "Deriving statement wrong form"
+      $(mkRelDir ".")
+      $(mkRelFile "WrongDeriving.juvix")
+      $ wantsError ErrDerivingTypeWrongForm
   ]

--- a/tests/Compilation/positive/out/test085.out
+++ b/tests/Compilation/positive/out/test085.out
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/tests/Compilation/positive/out/test085.out
+++ b/tests/Compilation/positive/out/test085.out
@@ -2,3 +2,6 @@ true
 true
 true
 true
+true
+false
+false

--- a/tests/Compilation/positive/test085.juvix
+++ b/tests/Compilation/positive/test085.juvix
@@ -1,0 +1,16 @@
+-- Deriving Eq
+module test085;
+
+import Stdlib.Data.Fixity open;
+import Stdlib.Data.Bool open;
+import Stdlib.Data.Pair open;
+import Stdlib.Trait.Eq open;
+import Stdlib.System.IO open;
+
+syntax alias isEqual := Eq.eq;
+
+main : IO :=
+  printLn (isEqual true true)
+    >>> printLn (not (isEqual false true))
+    >>> printLn (isEqual (false, true) (false, true))
+    >>> printLn (not (isEqual (false, true) (false, false)));

--- a/tests/Compilation/positive/test085.juvix
+++ b/tests/Compilation/positive/test085.juvix
@@ -1,6 +1,7 @@
 -- Deriving Eq
 module test085;
 
+import Stdlib.Data.Nat open hiding {isEqual};
 import Stdlib.Data.Fixity open;
 import Stdlib.Data.Bool open;
 import Stdlib.Data.Pair open;
@@ -9,8 +10,23 @@ import Stdlib.System.IO open;
 
 syntax alias isEqual := Eq.eq;
 
+type Tree A :=
+  | Leaf
+  | Node (Tree A) A (Tree A);
+
+{-# inline: case #-}
+deriving instance
+treeEqI {A} {{Eq A}} : Eq (Tree A);
+
+t1 : Tree Nat := Node (Node Leaf 0 Leaf) 1 Leaf;
+t2 : Tree Nat := Node (Node Leaf 1 Leaf) 1 Leaf;
+t3 : Tree Nat := Node Leaf 1 (Node Leaf 0 Leaf);
+
 main : IO :=
   printLn (isEqual true true)
     >>> printLn (not (isEqual false true))
     >>> printLn (isEqual (false, true) (false, true))
-    >>> printLn (not (isEqual (false, true) (false, false)));
+    >>> printLn (not (isEqual (false, true) (false, false)))
+    >>> printLn (isEqual t1 t1)
+    >>> printLn (isEqual t1 t2)
+    >>> printLn (isEqual t1 t3);

--- a/tests/negative/WrongDeriving.juvix
+++ b/tests/negative/WrongDeriving.juvix
@@ -1,0 +1,5 @@
+module WrongDeriving;
+
+axiom A : Type;
+
+deriving instance i : A;


### PR DESCRIPTION
This pr adds automatic implementation of `Eq` instances for inductive types. To create such an instance the user will use the same syntax as a regular instance with two differences.
1. It is prefixed with the `deriving` keyword.
2. It has no body.

E.g. 
```
deriving instance
eqProductI {A B} {{Eq A}} {{Eq B}} : Eq (Pair A B);
```

This desugars into an instance that returns true when the constructors match and all arguments are equal according to their respective instances. There is no special handling of type errors occurring in the generated code. I.e. if the user forgets a necessary instance argument in the type signature, a type error will occur in the generated code.

## Stdlib PR
- https://github.com/anoma/juvix-stdlib/pull/148

# Future work
* In the future we should look at https://www.dreixel.net/research/pdf/gdmh_nocolor.pdf
* See also: https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/compiler/generic-deriving