### PR TITLE
Fix long opts for nockma encode from/to

### DIFF
--- a/app/Commands/Dev/Nockma/Encode/Options.hs
+++ b/app/Commands/Dev/Nockma/Encode/Options.hs
@@ -49,7 +49,7 @@ parseNockmaEncodeOptions = do
   _nockmaEncodeFrom <-
     option
       (enumReader Proxy)
-      ( long "to"
+      ( long "from"
           <> metavar "ENCODING"
           <> completer (enumCompleter @EncodeType Proxy)
           <> helpDoc
@@ -61,7 +61,7 @@ parseNockmaEncodeOptions = do
   _nockmaEncodeTo <-
     option
       (enumReader Proxy)
-      ( long "from"
+      ( long "to"
           <> metavar "ENCODING"
           <> completer (enumCompleter @EncodeType Proxy)
           <> helpDoc


### PR DESCRIPTION
The `from` and `to` long options for `juvix dev nockma encode` were mislabelled. `from` should be the source encoding and `to` should be the target encoding.