### PR TITLE
Set std_in to NoStream on the Anoma client process

### DIFF
--- a/src/Anoma/Effect/Base.hs
+++ b/src/Anoma/Effect/Base.hs
@@ -56,6 +56,7 @@ anomaCreateProcess = do
   return
     (proc "mix" ["run", "--no-halt", "-e", unpack (T.strip (decodeUtf8 anomaStartExs))])
       { std_out = CreatePipe,
+        std_in = NoStream,
         cwd = Just (toFilePath anomapath)
       }
 


### PR DESCRIPTION
This PR sets `std_in` to `NoStream` on the Anoma client process.

https://hackage.haskell.org/package/process-1.6.25.0/docs/System-Process.html#t:StdStream

We do not read from the Anoma client process stdin so we do not need to open a handle to stdin.

This fixes an issue where the Anoma client stdin does not get cleaned up correctly on exit which causes subsequent input to the terminal to be corrupted.