### PR TITLE
Update Anoma client to `testnet-v1` APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ env:
   SKIP: ormolu,format-juvix-files,typecheck-juvix-examples
   CAIRO_VM_VERSION: 06e8ddbfa14eef85f56c4d7b7631c17c9b0a248e
   RISC0_VM_VERSION: v1.0.1
+  ANOMA_VERSION: 5adbfa3fe15604e20bc345dab0d74c415956ce15
   JUST_ARGS: runtimeCcArg=$CC runtimeLibtoolArg=$LIBTOOL
   STACK_BUILD_ARGS: --pedantic -j4 --ghc-options=-j
 
@@ -150,7 +151,7 @@ jobs:
           cd $HOME
           git clone https://github.com/anoma/anoma.git
           cd anoma
-          git checkout da44f1881442b4b09f61e20bf503e8c69b03b035
+          git checkout ${{ env.ANOMA_VERSION }}
           mix local.hex --force
           mix escript.install hex protobuf --force
           echo "$HOME/.mix/escripts" >> $GITHUB_PATH

--- a/app/Commands/Dev/Anoma/Options.hs
+++ b/app/Commands/Dev/Anoma/Options.hs
@@ -67,6 +67,7 @@ parseAnomaCommand =
                           "",
                           "url: <ANOMA_CLIENT_URL>",
                           "port: <ANOMA_CLIENT_GRPC_PORT>",
+                          "nodeid: <ANOMA_CLIENT_NODE_ID>",
                           "",
                           "The gRPC response (a Nockma program) is saved to a file named <input>.proved.nockma, where <input> is the base name of the input file.",
                           "Use the -o/--output option to specify a custom output filename.",

--- a/app/Commands/Dev/Nockma/Run/WithClient.hs
+++ b/app/Commands/Dev/Nockma/Run/WithClient.hs
@@ -14,7 +14,8 @@ runCommand opts =
     grpcInfo =
       AnomaClientInfo
         { _anomaClientInfoUrl = opts ^. nockmaRunWithClientUrl,
-          _anomaClientInfoPort = opts ^. nockmaRunWithClientGrpcPort
+          _anomaClientInfoPort = opts ^. nockmaRunWithClientGrpcPort,
+          _anomaClientInfoNodeId = opts ^. nockmaRunWithClientNodeId
         }
     runArgs =
       RunCommandArgs

--- a/app/Commands/Dev/Nockma/Run/WithClient/Options.hs
+++ b/app/Commands/Dev/Nockma/Run/WithClient/Options.hs
@@ -5,6 +5,7 @@ import CommonOptions
 data NockmaRunWithClientOptions = NockmaRunWithClientOptions
   { _nockmaRunWithClientFile :: AppPath File,
     _nockmaRunWithClientGrpcPort :: Int,
+    _nockmaRunWithClientNodeId :: Text,
     _nockmaRunWithClientUrl :: String,
     _nockmaRunWithClientArgs :: Maybe (AppPath File)
   }
@@ -23,6 +24,13 @@ parseNockmaRunWithClientOptions = do
           <> short 'p'
           <> help ("The GRPC port of a running Anoma client")
           <> metavar "PORT"
+      )
+  _nockmaRunWithClientNodeId <-
+    strOption
+      ( long "node-id"
+          <> short 'i'
+          <> help ("The node id associated with the running Anoma client")
+          <> metavar "NODE_ID"
       )
   _nockmaRunWithClientUrl <- do
     let defaultUrl :: String = "localhost"

--- a/app/Commands/Extra/Compile.hs
+++ b/app/Commands/Extra/Compile.hs
@@ -7,7 +7,7 @@ import Data.ByteString qualified as BS
 import Data.FileEmbed qualified as FE
 import Juvix.Extra.Clang
 import Juvix.Extra.Paths
-import System.Environment
+import System.Environment qualified as E
 import System.Process qualified as P
 
 runCommandMain :: forall r. (Members '[EmbedIO, App] r) => CompileOptionsMain -> Sem r ()
@@ -159,7 +159,7 @@ clangWasmWasiCompile o = do
     sysrootEnvVar :: Sem r (Path Abs Dir)
     sysrootEnvVar =
       absDir
-        <$> fromMaybeM (exitFailMsg msg) (liftIO (lookupEnv "WASI_SYSROOT_PATH"))
+        <$> fromMaybeM (exitFailMsg msg) (liftIO (E.lookupEnv "WASI_SYSROOT_PATH"))
       where
         msg :: Text
         msg = "Missing environment variable WASI_SYSROOT_PATH"

--- a/app/TopCommand.hs
+++ b/app/TopCommand.hs
@@ -15,13 +15,13 @@ import Commands.Markdown qualified as Markdown
 import Commands.Repl qualified as Repl
 import Commands.Typecheck qualified as Typecheck
 import Juvix.Extra.Version
-import System.Environment (getProgName)
+import System.Environment qualified as E
 import TopCommand.Options
 
 showHelpText :: (MonadIO m) => m ()
 showHelpText = do
   let p = prefs showHelpOnEmpty
-  progn <- liftIO getProgName
+  progn <- liftIO E.getProgName
   let helpText = parserFailure p descr (ShowHelpText Nothing) []
       (msg, _) = renderFailure helpText progn
   putStrLn (pack msg)

--- a/include/anoma/start.exs
+++ b/include/anoma/start.exs
@@ -1,1 +1,4 @@
-IO.puts("#{inspect(Anoma.Client.Examples.EClient.create_example_client.client.grpc_port)}")
+(
+  eclient = Anoma.Client.Examples.EClient.create_example_client
+  IO.puts("#{eclient.client.grpc_port} #{eclient.node.node_id}")
+)

--- a/src/Anoma/Effect/Base.hs
+++ b/src/Anoma/Effect/Base.hs
@@ -18,6 +18,7 @@ import Anoma.Client.Base
 import Anoma.Rpc.Base
 import Data.ByteString qualified as B
 import Data.Text qualified as T
+import Effectful.Environment
 import Juvix.Compiler.Nockma.Translation.FromTree (AnomaResult)
 import Juvix.Data.CodeAnn
 import Juvix.Prelude
@@ -94,7 +95,7 @@ grpcCliListProcess = do
     )
 
 runAnomaEphemeral :: forall r a. (Members '[Logger, EmbedIO, Error SimpleError] r) => AnomaPath -> Sem (Anoma ': r) a -> Sem r a
-runAnomaEphemeral anomapath body = runReader anomapath . runProcess $ do
+runAnomaEphemeral anomapath body = runEnvironment . runReader anomapath . runProcess $ do
   cproc <- anomaClientCreateProcess LaunchModeAttached
   withCreateProcess cproc $ \_stdin mstdout _stderr _procHandle -> do
     grpcServer <- setupAnomaClientProcess (fromJust mstdout)

--- a/src/Juvix/Compiler/Core/Transformation/MatchToCase.hs
+++ b/src/Juvix/Compiler/Core/Transformation/MatchToCase.hs
@@ -289,10 +289,10 @@ goMatchToCase recur node = case node of
           (argPatsIx ^. indexedThing)
       where
         argPatsIx :: Indexed [Pattern]
-        argPatsIx = fromJust (firstJust (mapM getArgs) (indexFrom 0 col))
+        argPatsIx = fromJust (firstJust (mapM getArgs') (indexFrom 0 col))
           where
-            getArgs :: Pattern -> Maybe [Pattern]
-            getArgs = \case
+            getArgs' :: Pattern -> Maybe [Pattern]
+            getArgs' = \case
               PatConstr PatternConstr {..}
                 | _patternConstrTag == tag -> Just _patternConstrArgs
               _ -> Nothing

--- a/src/Juvix/Extra/Clang.hs
+++ b/src/Juvix/Extra/Clang.hs
@@ -2,7 +2,7 @@ module Juvix.Extra.Clang where
 
 import Juvix.Config qualified as Config
 import Juvix.Prelude
-import System.Environment
+import System.Environment qualified as E
 import System.FilePath
 
 data ClangPath
@@ -51,7 +51,7 @@ findClangUsingEnvVar' clangRelPath = do
 
     llvmDistPath :: Sem r (Maybe (Path Abs Dir))
     llvmDistPath = liftIO $ do
-      p <- lookupEnv llvmDistEnvironmentVar
+      p <- E.lookupEnv llvmDistEnvironmentVar
       mapM parseAbsDir p
 
 findClangUsingEnvVar :: forall r. (Member EmbedIO r) => Sem r (Maybe (Path Abs File))

--- a/src/Juvix/Extra/Version.hs
+++ b/src/Juvix/Extra/Version.hs
@@ -7,7 +7,7 @@ import Juvix.Prelude.Path
 import Paths_juvix qualified
 import Prettyprinter as PP
 import Prettyprinter.Render.Text (renderIO)
-import System.Environment (getProgName)
+import System.Environment qualified as E
 
 versionDir :: Path Rel Dir
 versionDir = relDir (unpack versionDoc)
@@ -37,7 +37,7 @@ versionTag :: Text
 versionTag = versionDoc <> "-" <> shortHash
 
 progName :: (MonadIO m) => m Text
-progName = pack . toUpperFirst <$> liftIO getProgName
+progName = pack . toUpperFirst <$> liftIO E.getProgName
 
 progNameVersion :: (MonadIO m) => m Text
 progNameVersion = do

--- a/src/Juvix/Prelude/Effects/Base.hs
+++ b/src/Juvix/Prelude/Effects/Base.hs
@@ -2,6 +2,7 @@ module Juvix.Prelude.Effects.Base
   ( module Juvix.Prelude.Effects.Base,
     module Effectful,
     module Effectful.Concurrent,
+    module Effectful.Environment,
     module Effectful.Reader.Static,
     module Effectful.State.Static.Local,
     module Effectful.Error.Static,
@@ -22,8 +23,9 @@ import Effectful.Concurrent.Async
 import Effectful.Dispatch.Dynamic (LocalEnv, SharedSuffix, impose, interpose, localLift, localLiftUnlift, localLiftUnliftIO, localSeqLift, localSeqUnlift, localSeqUnliftIO, localUnlift, localUnliftIO, withLiftMap, withLiftMapIO)
 import Effectful.Dispatch.Dynamic qualified as E
 import Effectful.Dispatch.Static
+import Effectful.Environment
 import Effectful.Error.Static hiding (runError, runErrorWith)
-import Effectful.Internal.Env (getEnv, putEnv)
+import Effectful.Internal.Env qualified as E
 import Effectful.Process hiding (env)
 import Effectful.Provider
 import Effectful.Reader.Static
@@ -75,7 +77,7 @@ overStaticRep ::
   ) =>
   (StaticRep e -> StaticRep e) ->
   Sem r ()
-overStaticRep f = unsafeEff $ \r -> getEnv r >>= putEnv r . f
+overStaticRep f = unsafeEff $ \r -> E.getEnv r >>= E.putEnv r . f
 
 mapReader ::
   (Member (Reader e1) r) => (e1 -> e2) -> Sem (Reader e2 ': r) a -> Sem r a

--- a/src/Juvix/Prelude/Env.hs
+++ b/src/Juvix/Prelude/Env.hs
@@ -2,7 +2,7 @@ module Juvix.Prelude.Env where
 
 import Juvix.Prelude.Base
 import Juvix.Prelude.Path
-import System.Environment
+import System.Environment as E
 
 -- | Environment variables relevant to Juvix
 data EnvVar
@@ -21,7 +21,7 @@ envVarHint = \case
   EnvAnomaPath -> Just "It should point to the location of the Anoma repository"
 
 getEnvVar :: (MonadIO m) => EnvVar -> m String
-getEnvVar var = fromMaybeM (error (pack msg)) (liftIO (lookupEnv (envVarString var)))
+getEnvVar var = fromMaybeM (error (pack msg)) (liftIO (E.lookupEnv (envVarString var)))
   where
     msg :: String
     msg = "Missing environment variable " <> envVarString var <> maybe "" (". " <>) (envVarHint var)

--- a/src/Juvix/Prelude/Prepath.hs
+++ b/src/Juvix/Prelude/Prepath.hs
@@ -18,7 +18,7 @@ import Juvix.Prelude.Path
 import Juvix.Prelude.Pretty
 import System.Directory (getHomeDirectory)
 import System.Directory qualified as System
-import System.Environment
+import System.Environment as E
 import Prelude (show)
 
 -- | A file/directory path that may contain environmental variables
@@ -88,7 +88,7 @@ expandParts = mconcatMapM fromPart
     fromPart = \case
       PrepathString s -> return s
       PrepathHome -> liftIO getHomeDirectory
-      PrepathVar s -> fromMaybe err <$> liftIO (lookupEnv s)
+      PrepathVar s -> fromMaybe err <$> liftIO (E.lookupEnv s)
         where
           err = error ("The environment variable " <> pack s <> " is not defined")
 


### PR DESCRIPTION
This PR makes changes to make our Anoma client CLI commands compatible with the https://github.com/anoma/anoma/tree/testnet-01 branch.

We must now capture the Anoma client node_id on start because some endpoints (e.g mempool submit) require this node id in the request.

I'm using [Effectful.Environment](https://hackage.haskell.org/package/effectful-2.5.0.0/docs/Effectful-Environment.html) to interact with environment variables as it avoids use of `IOE`. 

In a separate PR we should replace all usages of `System.Environment` with `Effectful.Environment` but I've left existing usages of `System.Environment` in place for the time being.