### PR TITLE
Fix `juvix clean --global`

### DIFF
--- a/app/Commands/Clean.hs
+++ b/app/Commands/Clean.hs
@@ -5,9 +5,20 @@ import Commands.Clean.Options
 
 runCommand :: (Members '[Files, App] r) => CleanOptions -> Sem r ()
 runCommand opts
+  | opts ^. cleanOptionsOnlyGlobal = do
+      cleanGlobal
   | opts ^. cleanOptionsGlobal = do
-      configDir <- juvixConfigDir
-      whenM (directoryExists' configDir) (removeDirectoryRecursive' configDir)
+      cleanGlobal
+      cleanLocal
   | otherwise = do
-      buildDir <- askBuildDir
-      whenM (directoryExists' buildDir) (removeDirectoryRecursive' buildDir)
+      cleanLocal
+
+cleanGlobal :: (Members '[Files, App] r) => Sem r ()
+cleanGlobal = do
+  configDir <- juvixConfigDir
+  whenM (directoryExists' configDir) (removeDirectoryRecursive' configDir)
+
+cleanLocal :: (Members '[Files, App] r) => Sem r ()
+cleanLocal = do
+  buildDir <- askBuildDir
+  whenM (directoryExists' buildDir) (removeDirectoryRecursive' buildDir)

--- a/app/Commands/Clean/Options.hs
+++ b/app/Commands/Clean/Options.hs
@@ -3,8 +3,10 @@ module Commands.Clean.Options where
 import CommonOptions
 import Juvix.Extra.Version
 
-newtype CleanOptions = CleanOptions
-  {_cleanOptionsGlobal :: Bool}
+data CleanOptions = CleanOptions
+  { _cleanOptionsGlobal :: Bool,
+    _cleanOptionsOnlyGlobal :: Bool
+  }
   deriving stock (Data)
 
 makeLenses ''CleanOptions
@@ -15,6 +17,11 @@ parseCleanOptions = do
     switch
       ( long "global"
           <> short 'g'
-          <> help ("Remove $XDG_CONFIG_HOME/juvix/" <> unpack versionDoc)
+          <> help ("Remove also $XDG_CONFIG_HOME/juvix/" <> unpack versionDoc)
+      )
+  _cleanOptionsOnlyGlobal <-
+    switch
+      ( long "global-only"
+          <> help ("Remove only $XDG_CONFIG_HOME/juvix/" <> unpack versionDoc)
       )
   pure CleanOptions {..}


### PR DESCRIPTION
* Closes #2992 
* Now `juvix clean --global` implies `juvix clean`. There is a new option `--global-only` which preserves the old behaviour.
