### PR TITLE
Fix Anoma in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ env:
   SKIP: ormolu,format-juvix-files,typecheck-juvix-examples
   CAIRO_VM_VERSION: 06e8ddbfa14eef85f56c4d7b7631c17c9b0a248e
   RISC0_VM_VERSION: v1.0.1
-  ANOMA_VERSION: 44dbbd0376ef15731c8f69988905af23a65fceff
+  # This is the top commit hash in the branch lukasz/juvix-integration-tracking
+  # of the anoma repository.
+  ANOMA_VERSION: 1213cd83b6b0912c98a12e88a40f93ce9b6da094
   JUST_ARGS: runtimeCcArg=$CC runtimeLibtoolArg=$LIBTOOL
   STACK_BUILD_ARGS: --pedantic -j4 --ghc-options=-j
 


### PR DESCRIPTION
Makes `ANOMA_VERSION` point to the latest commit in the `lukasz/juvix-integration-tracking` branch. We need to manually keep this branch up-to-date, but controlling the branch solves the problem with disappearing commits (e.g., after force-push).
