### PR TITLE
anoma start should start the consensus engine

### DIFF
--- a/include/anoma/start.exs
+++ b/include/anoma/start.exs
@@ -2,4 +2,5 @@
   Logger.configure(level: :none)
   eclient = Anoma.Client.Examples.EClient.create_example_client
   IO.puts("#{eclient.client.grpc_port} #{eclient.node.node_id}")
+  Anoma.Node.Utility.Consensus.start_link(node_id: eclient.node.node_id, interval: 10000)
 )


### PR DESCRIPTION
The consensus engine is responsible for executing transactions in the mempool and making blocks.