### PR TITLE
Make top-level definitions mutually recursive

### DIFF
--- a/src/Juvix/Compiler/Concrete/Extra.hs
+++ b/src/Juvix/Compiler/Concrete/Extra.hs
@@ -10,6 +10,8 @@ module Juvix.Compiler.Concrete.Extra
     isBodyExpression,
     isFunctionLike,
     isLhsFunctionLike,
+    isFunctionRecursive,
+    isLhsFunctionRecursive,
     symbolParsed,
   )
 where
@@ -116,3 +118,15 @@ isLhsFunctionLike FunctionLhs {..} = notNull (_funLhsTypeSig ^. typeSigArgs)
 isFunctionLike :: FunctionDef 'Parsed -> Bool
 isFunctionLike d@FunctionDef {..} =
   isLhsFunctionLike (d ^. functionDefLhs) || (not . isBodyExpression) _functionDefBody
+
+isFunctionRecursive :: FunctionDef 'Parsed -> Bool
+isFunctionRecursive d = case d ^. functionDefLhs . funLhsIsTop of
+  FunctionTop -> isLhsFunctionRecursive (d ^. functionDefLhs)
+  FunctionNotTop -> isFunctionLike d
+
+isLhsFunctionRecursive :: FunctionLhs 'Parsed -> Bool
+isLhsFunctionRecursive d = case d ^. funLhsIsTop of
+  FunctionTop -> case d ^. funLhsName of
+    FunctionDefNamePattern {} -> False
+    FunctionDefName {} -> True
+  FunctionNotTop -> isLhsFunctionLike d

--- a/src/Juvix/Compiler/Concrete/Gen.hs
+++ b/src/Juvix/Compiler/Concrete/Gen.hs
@@ -38,7 +38,8 @@ simplestFunctionDef funName funBody =
             _funLhsBuiltin = Nothing,
             _funLhsTerminating = Nothing,
             _funLhsInstance = Nothing,
-            _funLhsCoercion = Nothing
+            _funLhsCoercion = Nothing,
+            _funLhsIsTop = FunctionNotTop
           }
    in FunctionDef
         { _functionDefBody = SigBodyExpression funBody,

--- a/src/Juvix/Compiler/Concrete/Language/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Language/Base.hs
@@ -760,6 +760,15 @@ instance Serialize FunctionDefNameScoped
 
 instance NFData FunctionDefNameScoped
 
+data FunctionIsTop
+  = FunctionTop
+  | FunctionNotTop
+  deriving stock (Eq, Ord, Show, Generic)
+
+instance Serialize FunctionIsTop
+
+instance NFData FunctionIsTop
+
 data FunctionDef (s :: Stage) = FunctionDef
   { _functionDefDoc :: Maybe (Judoc s),
     _functionDefPragmas :: Maybe ParsedPragmas,
@@ -2957,7 +2966,8 @@ data FunctionLhs (s :: Stage) = FunctionLhs
     _funLhsInstance :: Maybe KeywordRef,
     _funLhsCoercion :: Maybe KeywordRef,
     _funLhsName :: FunctionSymbolType s,
-    _funLhsTypeSig :: TypeSig s
+    _funLhsTypeSig :: TypeSig s,
+    _funLhsIsTop :: FunctionIsTop
   }
   deriving stock (Generic)
 

--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping.hs
@@ -432,7 +432,7 @@ reserveDerivingSymbol ::
   Sem r ()
 reserveDerivingSymbol f = do
   let lhs = f ^. derivingFunLhs
-  when (P.isLhsFunctionLike lhs) $
+  when (P.isLhsFunctionRecursive lhs) $
     void (reserveFunctionSymbol lhs)
 
 reserveFunctionLikeSymbol ::
@@ -440,7 +440,7 @@ reserveFunctionLikeSymbol ::
   FunctionDef 'Parsed ->
   Sem r ()
 reserveFunctionLikeSymbol f =
-  when (P.isFunctionLike f) $
+  when (P.isFunctionRecursive f) $
     void (reserveFunctionSymbol (f ^. functionDefLhs))
 
 bindFixitySymbol ::
@@ -1198,7 +1198,7 @@ checkDeriving Deriving {..} = do
   typeSig' <- withLocalScope (checkTypeSig _funLhsTypeSig)
   name' <-
     if
-        | P.isLhsFunctionLike lhs -> getReservedDefinitionSymbol name
+        | P.isLhsFunctionRecursive lhs -> getReservedDefinitionSymbol name
         | otherwise -> reserveFunctionSymbol lhs
   let defname' =
         FunctionDefNameScoped
@@ -1262,10 +1262,9 @@ checkTypeSig TypeSig {..} = do
 checkFunctionDef ::
   forall r.
   (Members '[HighlightBuilder, Reader ScopeParameters, Error ScoperError, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, Reader PackageId, State ScoperSyntax, Reader BindingStrategy] r) =>
-  Bool ->
   FunctionDef 'Parsed ->
   Sem r (FunctionDef 'Scoped)
-checkFunctionDef isTop fdef@FunctionDef {..} = do
+checkFunctionDef fdef@FunctionDef {..} = do
   let FunctionLhs {..} = _functionDefLhs
   sigDoc' <- mapM checkJudoc _functionDefDoc
   (sig', sigBody') <- withLocalScope $ do
@@ -1277,7 +1276,7 @@ checkFunctionDef isTop fdef@FunctionDef {..} = do
     FunctionDefName name -> do
       name' <-
         if
-            | isTop || P.isFunctionLike fdef -> getReservedDefinitionSymbol name
+            | P.isFunctionRecursive fdef -> getReservedDefinitionSymbol name
             | otherwise -> reserveFunctionSymbol (fdef ^. functionDefLhs)
       return
         FunctionDefNameScoped
@@ -1635,7 +1634,7 @@ checkModuleBody body = do
   body' <-
     fmap flattenSections
       . syntaxBlock
-      $ checkSections True (mkSections body)
+      $ checkSections (mkSections body)
   exported <- get >>= exportScope
   return (exported, body')
   where
@@ -1673,10 +1672,9 @@ checkModuleBody body = do
 checkSections ::
   forall r.
   (Members '[HighlightBuilder, Error ScoperError, Reader ScopeParameters, State Scope, State ScoperState, InfoTableBuilder, Reader InfoTable, NameIdGen, State ScoperSyntax, Reader PackageId] r) =>
-  Bool ->
   StatementSections 'Parsed ->
   Sem r (StatementSections 'Scoped)
-checkSections isTop sec = topBindings helper
+checkSections sec = topBindings helper
   where
     helper ::
       forall r'.
@@ -1782,9 +1780,7 @@ checkSections isTop sec = topBindings helper
             reserveDefinition :: Definition 'Parsed -> Sem r' (Maybe (Module 'Parsed 'ModuleLocal))
             reserveDefinition = \case
               DefinitionSyntax s -> resolveSyntaxDef s $> Nothing
-              DefinitionFunctionDef d
-                | isTop -> reserveFunctionSymbol (d ^. functionDefLhs) >> return Nothing
-                | otherwise -> reserveFunctionLikeSymbol d >> return Nothing
+              DefinitionFunctionDef d -> reserveFunctionLikeSymbol d >> return Nothing
               DefinitionDeriving d -> reserveDerivingSymbol d >> return Nothing
               DefinitionAxiom d -> reserveAxiomSymbol d >> return Nothing
               DefinitionProjectionDef d -> reserveProjectionSymbol d >> return Nothing
@@ -1840,7 +1836,7 @@ checkSections isTop sec = topBindings helper
             goDefinition :: Definition 'Parsed -> Sem r' (Definition 'Scoped)
             goDefinition = \case
               DefinitionSyntax s -> DefinitionSyntax <$> checkSyntaxDef s
-              DefinitionFunctionDef d -> DefinitionFunctionDef <$> checkFunctionDef isTop d
+              DefinitionFunctionDef d -> DefinitionFunctionDef <$> checkFunctionDef d
               DefinitionDeriving d -> DefinitionDeriving <$> checkDeriving d
               DefinitionAxiom d -> DefinitionAxiom <$> checkAxiomDef d
               DefinitionInductive d -> DefinitionInductive <$> checkInductiveDef d
@@ -2348,7 +2344,7 @@ checkLetStatements ::
 checkLetStatements =
   ignoreSyntax
     . fmap fromSections
-    . checkSections False
+    . checkSections
     . mkLetSections
     . toList
   where
@@ -3038,7 +3034,7 @@ checkNamedArgumentFunctionDef ::
   NamedArgumentFunctionDef 'Parsed ->
   Sem r (NamedArgumentFunctionDef 'Scoped)
 checkNamedArgumentFunctionDef NamedArgumentFunctionDef {..} = do
-  def <- localBindings . ignoreSyntax $ checkFunctionDef False _namedArgumentFunctionDef
+  def <- localBindings . ignoreSyntax $ checkFunctionDef _namedArgumentFunctionDef
   return
     NamedArgumentFunctionDef
       { _namedArgumentFunctionDef = def

--- a/src/Juvix/Compiler/Pipeline/Package/Loader.hs
+++ b/src/Juvix/Compiler/Pipeline/Package/Loader.hs
@@ -97,7 +97,8 @@ toConcrete t p = run . runReader l $ do
                 _funLhsBuiltin = Nothing,
                 _funLhsName = FunctionDefName name',
                 _funLhsInstance = Nothing,
-                _funLhsTypeSig
+                _funLhsTypeSig,
+                _funLhsIsTop = FunctionTop
               }
       return
         ( StatementFunctionDef

--- a/tests/Compilation/positive/test090.juvix
+++ b/tests/Compilation/positive/test090.juvix
@@ -21,12 +21,13 @@ module Resource;
 
     x : Delta.Nat := Resource.x + Resource0.x;
     a : Delta.Nat := x * Resource.Gamma.x + test090.x;
+    b : Delta.Nat := 1900;
   end;
 
   open Resource.Delta;
 
-  a : Delta.Nat := a;
+  b : Delta.Nat := a;
 end;
 
 -- result: 31
-main : Delta.Nat := Resource.a;
+main : Delta.Nat := Resource.b;


### PR DESCRIPTION
All top-level definitions are now back to being recursive, except definitions with pattern-matching on the left-hand side, e.g.,
```
(x, y) := ...;
```
is not recursive on the top level.
