### PR TITLE
Remove global `--unroll` limit flag

### DIFF
--- a/app/GlobalOptions.hs
+++ b/app/GlobalOptions.hs
@@ -25,7 +25,6 @@ data GlobalOptions = GlobalOptions
     _globalNoCoverage :: Bool,
     _globalNoStdlib :: Bool,
     _globalNoCheck :: Bool,
-    _globalUnrollLimit :: Int,
     _globalNumThreads :: NumThreads,
     _globalFieldSize :: Maybe Natural,
     _globalOffline :: Bool,
@@ -52,7 +51,7 @@ instance CanonicalProjection GlobalOptions Core.CoreOptions where
   project GlobalOptions {..} =
     Core.CoreOptions
       { Core._optCheckCoverage = not _globalNoCoverage,
-        Core._optUnrollLimit = _globalUnrollLimit,
+        Core._optUnrollLimit = defaultUnrollLimit,
         Core._optFieldSize = fromMaybe defaultFieldSize _globalFieldSize,
         Core._optOptimizationLevel = defaultOptimizationLevel,
         Core._optInliningDepth = defaultInliningDepth
@@ -74,7 +73,6 @@ defaultGlobalOptions =
       _globalNoCoverage = False,
       _globalNoStdlib = False,
       _globalNoCheck = False,
-      _globalUnrollLimit = defaultUnrollLimit,
       _globalFieldSize = Nothing,
       _globalDevShowThreadIds = False,
       _globalOffline = False
@@ -139,13 +137,6 @@ parseGlobalFlags = do
       ( long "field-size"
           <> value Nothing
           <> help "Field type size [cairo,small,11] (default: small)"
-      )
-  _globalUnrollLimit <-
-    option
-      (fromIntegral <$> naturalNumberOpt)
-      ( long "unroll"
-          <> value defaultUnrollLimit
-          <> help ("Recursion unrolling limit (default: " <> show defaultUnrollLimit <> ")")
       )
   _globalOffline <-
     switch
@@ -219,7 +210,6 @@ entryPointFromGlobalOptions root mainFile opts = do
         _entryPointNoCoverage = opts ^. globalNoCoverage,
         _entryPointNoStdlib = opts ^. globalNoStdlib,
         _entryPointNoCheck = opts ^. globalNoCheck,
-        _entryPointUnrollLimit = opts ^. globalUnrollLimit,
         _entryPointGenericOptions = project opts,
         _entryPointBuildDir = maybe (def ^. entryPointBuildDir) (CustomBuildDir . Abs) mabsBuildDir,
         _entryPointOffline = opts ^. globalOffline,
@@ -241,7 +231,6 @@ entryPointFromGlobalOptionsNoFile root opts = do
         _entryPointNoCoverage = opts ^. globalNoCoverage,
         _entryPointNoStdlib = opts ^. globalNoStdlib,
         _entryPointNoCheck = opts ^. globalNoCheck,
-        _entryPointUnrollLimit = opts ^. globalUnrollLimit,
         _entryPointGenericOptions = project opts,
         _entryPointBuildDir = maybe (def ^. entryPointBuildDir) (CustomBuildDir . Abs) mabsBuildDir,
         _entryPointOffline = opts ^. globalOffline,


### PR DESCRIPTION
- Closes #2660.

The global `--unroll` flag was only relevant for the GEB and VampIR backends. Now that these backends don't exist anymore, we can just remove the flag. The option is still kept as an option for Core as it might become relevant again at some point.