### PR TITLE
Fix flatparse location

### DIFF
--- a/app/Commands/Dev/ImportTree/ScanFile.hs
+++ b/app/Commands/Dev/ImportTree/ScanFile.hs
@@ -16,4 +16,7 @@ runCommand ScanFileOptions {..} =
       forM_ (scanRes ^. scanResultImports) $ \impor -> do
         opts <- askGenericOptions
         renderStdOut (ppOutNoComments opts impor)
+        when _scanFilePrintLoc $ do
+          renderStdOut @Text " "
+          renderStdOut (ppOutNoComments opts (getLoc impor))
         newline

--- a/app/Commands/Dev/ImportTree/ScanFile/Options.hs
+++ b/app/Commands/Dev/ImportTree/ScanFile/Options.hs
@@ -5,6 +5,7 @@ import Juvix.Compiler.Concrete.Translation.ImportScanner
 
 data ScanFileOptions = ScanFileOptions
   { _scanFileFile :: AppPath File,
+    _scanFilePrintLoc :: Bool,
     _scanFileStrategy :: ImportScanStrategy
   }
   deriving stock (Data)
@@ -15,4 +16,9 @@ parseScanFile :: Parser ScanFileOptions
 parseScanFile = do
   _scanFileFile <- parseInputFiles (FileExtJuvix :| [FileExtJuvixMarkdown])
   _scanFileStrategy <- optImportScanStrategy
+  _scanFilePrintLoc <-
+    switch
+      ( long "print-loc"
+          <> help "Print the location of each import"
+      )
   pure ScanFileOptions {..}

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/Base.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/Base.hs
@@ -52,3 +52,5 @@ data Token
   | TokenImport ImportScanParsed
   | TokenReserved
   | TokenCode
+
+makePrisms ''Token

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -50,8 +50,8 @@ scanner fp bs = do
         allFileLocs :: [FileLoc]
         allFileLocs =
           [ FileLoc
-              { _locLine = Pos (fromIntegral l),
-                _locCol = Pos (fromIntegral c),
+              { _locLine = Pos (1 + fromIntegral l),
+                _locCol = Pos (1 + fromIntegral c),
                 _locOffset = Pos (fromIntegral p)
               }
             | (FP.Pos p, (l, c)) <- zipExact importsPositions (posLineCols bs importsPositions)

--- a/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/ImportScanner/FlatParse.hs
@@ -69,14 +69,9 @@ scanner fp bs = do
 pPreScanResult :: Parser e [ImportScanParsed]
 pPreScanResult = do
   whiteSpaceAndComments
-  imports <- mapMaybe getImport <$> many pToken
+  imports <- (^.. each . _TokenImport) <$> many pToken
   eof
   return imports
-  where
-    getImport :: Token -> Maybe ImportScanParsed
-    getImport = \case
-      TokenImport i -> Just i
-      _ -> Nothing
 
 bareIdentifier :: ParserT st e String
 bareIdentifier = do

--- a/src/Juvix/Prelude/FlatParse/Lexer.hs
+++ b/src/Juvix/Prelude/FlatParse/Lexer.hs
@@ -11,7 +11,5 @@ import Juvix.Prelude.FlatParse
 whiteSpace1 :: Parser e ()
 whiteSpace1 = skipSome whiteSpaceChar
 
--- TODO is Ascii version much faster?
 whiteSpaceChar :: Parser e ()
--- whiteSpaceChar = skipSatisfyAscii L.isWhiteSpace
 whiteSpaceChar = skipSatisfy L.isWhiteSpace


### PR DESCRIPTION
- :warning: Depends on #3263 

The flatparse line and column numbers are 0-based, whereas we use 1-based numbers. This pr fixes that.