### PR TITLE
Recursive markdown generation

### DIFF
--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -49,7 +49,7 @@ targetFromOptions opts = do
 -- | Formats the project on the root
 formatProject ::
   forall r.
-  (Members '[App, EmbedIO, TaggedLock, Logger, ScopeEff, Files, Output FormattedFileInfo] r) =>
+  (Members (ScopeEff ': Output FormattedFileInfo ': AppEffects) r) =>
   Sem r FormatResult
 formatProject = silenceProgressLog . runPipelineOptions . runPipelineSetup $ do
   res :: [ProcessedNode ScoperResult] <- processProjectUpToScoping
@@ -61,7 +61,7 @@ formatProject = silenceProgressLog . runPipelineOptions . runPipelineSetup $ do
   formatPkgRes <- formatPackageDotJuvix
   return (formatRes <> formatPkgRes)
 
-formatPackageDotJuvix :: forall r. (Members '[App, Files, Logger, Output FormattedFileInfo, ScopeEff] r) => Sem r FormatResult
+formatPackageDotJuvix :: forall r. (Members (Output FormattedFileInfo ': ScopeEff ': AppEffects) r) => Sem r FormatResult
 formatPackageDotJuvix = do
   pkgDotJuvix <- askPackageDotJuvixPath
   ifM (fileExists' pkgDotJuvix) (format pkgDotJuvix) (return mempty)

--- a/app/Commands/Html.hs
+++ b/app/Commands/Html.hs
@@ -19,27 +19,26 @@ runGenOnlySourceHtml HtmlOptions {..} = do
   res <- runPipelineNoOptions _htmlInputFile upToScopingEntry
   let m = res ^. Scoper.resultModule
   outputDir <- fromAppPathDir _htmlOutputDir
-  liftIO $
-    Html.genSourceHtml
-      GenSourceHtmlArgs
-        { _genSourceHtmlArgsAssetsDir = _htmlAssetsPrefix,
-          _genSourceHtmlArgsHtmlKind = Html.HtmlOnly,
-          _genSourceHtmlArgsOnlyCode = _htmlOnlyCode,
-          _genSourceHtmlArgsParamBase = "",
-          _genSourceHtmlArgsUrlPrefix = _htmlUrlPrefix,
-          _genSourceHtmlArgsIdPrefix = _htmlIdPrefix,
-          _genSourceHtmlArgsNoPath = _htmlNoPath,
-          _genSourceHtmlArgsFolderStructure = _htmlFolderStructure,
-          _genSourceHtmlArgsExt = _htmlExt,
-          _genSourceHtmlArgsStripPrefix = _htmlStripPrefix,
-          _genSourceHtmlArgsConcreteOpts = Concrete.defaultOptions,
-          _genSourceHtmlArgsModule = m,
-          _genSourceHtmlArgsComments = Scoper.getScoperResultComments res,
-          _genSourceHtmlArgsOutputDir = outputDir,
-          _genSourceHtmlArgsNoFooter = _htmlNoFooter,
-          _genSourceHtmlArgsNonRecursive = _htmlNonRecursive,
-          _genSourceHtmlArgsTheme = _htmlTheme
-        }
+  Html.genSourceHtml
+    GenSourceHtmlArgs
+      { _genSourceHtmlArgsAssetsDir = _htmlAssetsPrefix,
+        _genSourceHtmlArgsHtmlKind = Html.HtmlOnly,
+        _genSourceHtmlArgsOnlyCode = _htmlOnlyCode,
+        _genSourceHtmlArgsParamBase = "",
+        _genSourceHtmlArgsUrlPrefix = _htmlUrlPrefix,
+        _genSourceHtmlArgsIdPrefix = _htmlIdPrefix,
+        _genSourceHtmlArgsNoPath = _htmlNoPath,
+        _genSourceHtmlArgsFolderStructure = _htmlFolderStructure,
+        _genSourceHtmlArgsExt = _htmlExt,
+        _genSourceHtmlArgsStripPrefix = _htmlStripPrefix,
+        _genSourceHtmlArgsConcreteOpts = Concrete.defaultOptions,
+        _genSourceHtmlArgsModule = m,
+        _genSourceHtmlArgsComments = Scoper.getScoperResultComments res,
+        _genSourceHtmlArgsOutputDir = outputDir,
+        _genSourceHtmlArgsNoFooter = _htmlNoFooter,
+        _genSourceHtmlArgsNonRecursive = _htmlNonRecursive,
+        _genSourceHtmlArgsTheme = _htmlTheme
+      }
 
 resultToJudocCtx :: InternalTypedResult -> Html.JudocCtx
 resultToJudocCtx res =

--- a/app/Commands/Markdown.hs
+++ b/app/Commands/Markdown.hs
@@ -1,62 +1,92 @@
-module Commands.Markdown where
+module Commands.Markdown (runCommand) where
 
 import Commands.Base
 import Commands.Markdown.Options
-import Data.Text.IO qualified as Text
+import Juvix.Compiler.Backend.Markdown.Error
 import Juvix.Compiler.Backend.Markdown.Translation.FromTyped.Source
 import Juvix.Compiler.Backend.Markdown.Translation.FromTyped.Source qualified as MK
 import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
-import Juvix.Compiler.Concrete.Language qualified as Concrete
-import Juvix.Compiler.Concrete.Pretty qualified as Concrete
+import Juvix.Compiler.Concrete.Language as Concrete
+import Juvix.Compiler.Concrete.Pretty as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
+import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
 import Juvix.Extra.Assets (writeAssets)
 
+data Mode
+  = Project (Path Abs Dir)
+  | SingleFile (Path Abs File)
+
+getMode :: forall r. (Members '[App, EmbedIO] r) => Maybe (AppPath FileOrDir) -> Sem r Mode
+getMode mf = runFailDefaultM projectMode $ do
+  optFile <- failMaybe mf
+  either SingleFile Project <$> fromAppPathFileOrDir optFile
+  where
+    projectMode :: Sem r Mode
+    projectMode = Project . (^. rootRootDir) <$> askRoot
+
 runCommand ::
+  forall r.
   (Members AppEffects r) =>
   MarkdownOptions ->
   Sem r ()
 runCommand opts = do
-  let inputFile = opts ^. markdownInputFile
-  scopedM <- runPipelineNoOptions inputFile upToScopingEntry
-  let m = scopedM ^. Scoper.resultModule
-  outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
-  let res =
-        MK.fromJuvixMarkdown'
-          ProcessJuvixBlocksArgs
-            { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
-              _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
-              _processJuvixBlocksArgsIdPrefix =
-                opts ^. markdownIdPrefix,
-              _processJuvixBlocksArgsNoPath =
-                opts ^. markdownNoPath,
-              _processJuvixBlocksArgsExt =
-                opts ^. markdownExt,
-              _processJuvixBlocksArgsStripPrefix =
-                opts ^. markdownStripPrefix,
-              _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
-              _processJuvixBlocksArgsModule = m,
-              _processJuvixBlocksArgsOutputDir = outputDir,
-              _processJuvixBlocksArgsFolderStructure =
-                opts ^. markdownFolderStructure
-            }
-  case res of
-    Left err -> exitJuvixError (JuvixError err)
-    Right md
-      | opts ^. markdownStdout -> liftIO . putStrLn $ md
-      | otherwise -> do
-          ensureDir outputDir
-          when (opts ^. markdownWriteAssets) $
-            liftIO $
-              writeAssets outputDir
+  mode :: Mode <- getMode (opts ^. markdownInputFile)
+  let inputFile = case mode of
+        Project {} -> Nothing
+        SingleFile f ->
+          Just
+            AppPath
+              { _pathPath = preFileFromAbs f,
+                _pathIsInput = True
+              }
+  let shouldRecurse :: ImportNode -> Bool
+      shouldRecurse node = case mode of
+        Project p -> p == node ^. importNodePackageRoot
+        SingleFile {} -> False
+  (scopedM, others) :: (Scoper.ScoperResult, [Scoper.ScoperResult]) <-
+    runPipelineEither () inputFile (processRecursivelyUpTo shouldRecurse upToScopingEntry)
+      >>= fmap ((^. pipelineResult) . snd) . getRight
+  mapM_ goScoperResult (scopedM : others)
+  where
+    goScoperResult :: Scoper.ScoperResult -> Sem r ()
+    goScoperResult scopedM = do
+      let m :: Module 'Scoped 'ModuleTop = scopedM ^. Scoper.resultModule
+      outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
+      let args =
+            ProcessJuvixBlocksArgs
+              { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
+                _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
+                _processJuvixBlocksArgsIdPrefix =
+                  opts ^. markdownIdPrefix,
+                _processJuvixBlocksArgsNoPath =
+                  opts ^. markdownNoPath,
+                _processJuvixBlocksArgsExt =
+                  opts ^. markdownExt,
+                _processJuvixBlocksArgsStripPrefix =
+                  opts ^. markdownStripPrefix,
+                _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
+                _processJuvixBlocksArgsModule = m,
+                _processJuvixBlocksArgsOutputDir = outputDir,
+                _processJuvixBlocksArgsFolderStructure =
+                  opts ^. markdownFolderStructure
+              }
 
-          let mdFile :: Path Rel File
-              mdFile =
-                relFile
-                  ( Concrete.topModulePathToDottedPath
-                      (m ^. Concrete.modulePath . S.nameConcrete)
-                      <.> markdownFileExt
-                  )
-              absPath :: Path Abs File
-              absPath = outputDir <//> mdFile
+      md :: Text <- runAppError @MarkdownBackendError (MK.fromJuvixMarkdown args)
+      if
+          | opts ^. markdownStdout -> putStrLn md
+          | otherwise -> do
+              ensureDir outputDir
+              when (opts ^. markdownWriteAssets) $
+                writeAssets outputDir
 
-          liftIO $ Text.writeFile (toFilePath absPath) md
+              let mdFile :: Path Rel File
+                  mdFile =
+                    relFile
+                      ( Concrete.topModulePathToDottedPath
+                          (m ^. Concrete.modulePath . S.nameConcrete)
+                          <.> markdownFileExt
+                      )
+                  absPath :: Path Abs File
+                  absPath = outputDir <//> mdFile
+
+              writeFileEnsureLn absPath md

--- a/app/Commands/Markdown.hs
+++ b/app/Commands/Markdown.hs
@@ -14,143 +14,59 @@ import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Cont
 import Juvix.Data.CodeAnn
 import Juvix.Extra.Assets (writeAssets)
 
--- data Mode
---   = Project (Path Abs Dir)
---   | SingleFile (Path Abs File)
-
--- getMode :: forall r. (Members '[App, EmbedIO] r) => Maybe (AppPath FileOrDir) -> Sem r Mode
--- getMode mf = runFailDefaultM projectMode $ do
---   optFile <- failMaybe mf
---   either SingleFile Project <$> fromAppPathFileOrDir optFile
---   where
---     projectMode :: Sem r Mode
---     projectMode = Project . (^. rootRootDir) <$> askRoot
-
--- runCommand ::
---   forall r.
---   (Members AppEffects r) =>
---   MarkdownOptions ->
---   Sem r ()
--- runCommand opts = silenceProgressLog . runPipelineOptions . runPipelineSetup $ do
---   mode :: Mode <- getMode (opts ^. markdownInputFile)
---   let inputFile = case mode of
---         Project {} -> Nothing
---         SingleFile f ->
---           Just
---             AppPath
---               { _pathPath = preFileFromAbs f,
---                 _pathIsInput = True
---               }
---   let shouldRecurse :: ImportNode -> Bool
---       shouldRecurse node = case mode of
---         Project p -> p == node ^. importNodePackageRoot
---         SingleFile {} -> False
---   (scopedM, others) :: (Scoper.ScoperResult, [Scoper.ScoperResult]) <-
---     runPipelineEither () inputFile (processRecursivelyUpTo shouldRecurse upToScopingEntry)
---       >>= fmap ((^. pipelineResult) . snd) . getRight
---   mapM_ goScoperResult (scopedM : others)
---   where
---     goScoperResult :: Scoper.ScoperResult -> Sem r ()
---     goScoperResult scopedM = do
---       let m :: Module 'Scoped 'ModuleTop = scopedM ^. Scoper.resultModule
---       outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
---       let args =
---             ProcessJuvixBlocksArgs
---               { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
---                 _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
---                 _processJuvixBlocksArgsIdPrefix =
---                   opts ^. markdownIdPrefix,
---                 _processJuvixBlocksArgsNoPath =
---                   opts ^. markdownNoPath,
---                 _processJuvixBlocksArgsExt =
---                   opts ^. markdownExt,
---                 _processJuvixBlocksArgsStripPrefix =
---                   opts ^. markdownStripPrefix,
---                 _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
---                 _processJuvixBlocksArgsModule = m,
---                 _processJuvixBlocksArgsOutputDir = outputDir,
---                 _processJuvixBlocksArgsFolderStructure =
---                   opts ^. markdownFolderStructure
---               }
-
---       md :: Text <- runAppError @MarkdownBackendError (MK.fromJuvixMarkdown args)
---       if
---           | opts ^. markdownStdout -> putStrLn md
---           | otherwise -> do
---               ensureDir outputDir
---               when (opts ^. markdownWriteAssets) $
---                 writeAssets outputDir
-
---               let mdFile :: Path Rel File
---                   mdFile =
---                     relFile
---                       ( Concrete.topModulePathToDottedPath
---                           (m ^. Concrete.modulePath . S.nameConcrete)
---                           <.> markdownFileExt
---                       )
---                   absPath :: Path Abs File
---                   absPath = outputDir <//> mdFile
-
---               writeFileEnsureLn absPath md
-
 runCommand ::
   forall r.
   (Members AppEffects r) =>
   MarkdownOptions ->
   Sem r ()
-runCommand opts = silenceProgressLog . runPipelineOptions . runPipelineSetup $ do
-  -- mode :: Mode <- getMode (opts ^. markdownInputFile)
-  -- let inputFile = case mode of
-  --       Project {} -> Nothing
-  --       SingleFile f ->
-  --         Just
-  --           AppPath
-  --             { _pathPath = preFileFromAbs f,
-  --               _pathIsInput = True
-  --             }
+runCommand opts = runPipelineOptions . runPipelineSetup $ do
   res :: [ProcessedNode ScoperResult] <- processProjectUpToScoping
   forM_ res (goScoperResult opts . (^. processedNodeData))
 
 goScoperResult :: (Members AppEffects r) => MarkdownOptions -> Scoper.ScoperResult -> Sem r ()
 goScoperResult opts scopedM = do
   let m :: Module 'Scoped 'ModuleTop = scopedM ^. Scoper.resultModule
-  outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
-  logProgress (mkAnsiText @(Doc CodeAnn) ("Processing" <+> Concrete.docNoCommentsDefault (m ^. modulePath)))
-  let args =
-        ProcessJuvixBlocksArgs
-          { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
-            _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
-            _processJuvixBlocksArgsIdPrefix =
-              opts ^. markdownIdPrefix,
-            _processJuvixBlocksArgsNoPath =
-              opts ^. markdownNoPath,
-            _processJuvixBlocksArgsExt =
-              opts ^. markdownExt,
-            _processJuvixBlocksArgsStripPrefix =
-              opts ^. markdownStripPrefix,
-            _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
-            _processJuvixBlocksArgsModule = m,
-            _processJuvixBlocksArgsOutputDir = outputDir,
-            _processJuvixBlocksArgsFolderStructure =
-              opts ^. markdownFolderStructure
-          }
-
-  md :: Text <- runAppError @MarkdownBackendError (MK.fromJuvixMarkdown args)
   if
-      | opts ^. markdownStdout -> putStrLn md
+      | isNothing (m ^. moduleMarkdownInfo) ->
+          logInfo (mkAnsiText @(Doc CodeAnn) ("Skipping" <+> Concrete.docNoCommentsDefault (m ^. modulePath)))
       | otherwise -> do
-          ensureDir outputDir
-          when (opts ^. markdownWriteAssets) $
-            writeAssets outputDir
+          outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
+          logProgress (mkAnsiText @(Doc CodeAnn) ("Processing" <+> Concrete.docNoCommentsDefault (m ^. modulePath)))
+          let args =
+                ProcessJuvixBlocksArgs
+                  { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
+                    _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
+                    _processJuvixBlocksArgsIdPrefix =
+                      opts ^. markdownIdPrefix,
+                    _processJuvixBlocksArgsNoPath =
+                      opts ^. markdownNoPath,
+                    _processJuvixBlocksArgsExt =
+                      opts ^. markdownExt,
+                    _processJuvixBlocksArgsStripPrefix =
+                      opts ^. markdownStripPrefix,
+                    _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
+                    _processJuvixBlocksArgsModule = m,
+                    _processJuvixBlocksArgsOutputDir = outputDir,
+                    _processJuvixBlocksArgsFolderStructure =
+                      opts ^. markdownFolderStructure
+                  }
 
-          let mdFile :: Path Rel File
-              mdFile =
-                relFile
-                  ( Concrete.topModulePathToDottedPath
-                      (m ^. Concrete.modulePath . S.nameConcrete)
-                      <.> markdownFileExt
-                  )
-              absPath :: Path Abs File
-              absPath = outputDir <//> mdFile
+          md :: Text <- runAppError @MarkdownBackendError (MK.fromJuvixMarkdown args)
+          if
+              | opts ^. markdownStdout -> putStrLn md
+              | otherwise -> do
+                  ensureDir outputDir
+                  when (opts ^. markdownWriteAssets) $
+                    writeAssets outputDir
 
-          writeFileEnsureLn absPath md
+                  let mdFile :: Path Rel File
+                      mdFile =
+                        relFile
+                          ( Concrete.topModulePathToDottedPath
+                              (m ^. Concrete.modulePath . S.nameConcrete)
+                              <.> markdownFileExt
+                          )
+                      absPath :: Path Abs File
+                      absPath = outputDir <//> mdFile
+
+                  writeFileEnsureLn absPath md

--- a/app/Commands/Markdown.hs
+++ b/app/Commands/Markdown.hs
@@ -8,85 +8,149 @@ import Juvix.Compiler.Backend.Markdown.Translation.FromTyped.Source qualified as
 import Juvix.Compiler.Concrete.Data.ScopedName qualified as S
 import Juvix.Compiler.Concrete.Language as Concrete
 import Juvix.Compiler.Concrete.Pretty as Concrete
+import Juvix.Compiler.Concrete.Print.Base qualified as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
-import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context
+import Juvix.Data.CodeAnn
 import Juvix.Extra.Assets (writeAssets)
 
-data Mode
-  = Project (Path Abs Dir)
-  | SingleFile (Path Abs File)
+-- data Mode
+--   = Project (Path Abs Dir)
+--   | SingleFile (Path Abs File)
 
-getMode :: forall r. (Members '[App, EmbedIO] r) => Maybe (AppPath FileOrDir) -> Sem r Mode
-getMode mf = runFailDefaultM projectMode $ do
-  optFile <- failMaybe mf
-  either SingleFile Project <$> fromAppPathFileOrDir optFile
-  where
-    projectMode :: Sem r Mode
-    projectMode = Project . (^. rootRootDir) <$> askRoot
+-- getMode :: forall r. (Members '[App, EmbedIO] r) => Maybe (AppPath FileOrDir) -> Sem r Mode
+-- getMode mf = runFailDefaultM projectMode $ do
+--   optFile <- failMaybe mf
+--   either SingleFile Project <$> fromAppPathFileOrDir optFile
+--   where
+--     projectMode :: Sem r Mode
+--     projectMode = Project . (^. rootRootDir) <$> askRoot
+
+-- runCommand ::
+--   forall r.
+--   (Members AppEffects r) =>
+--   MarkdownOptions ->
+--   Sem r ()
+-- runCommand opts = silenceProgressLog . runPipelineOptions . runPipelineSetup $ do
+--   mode :: Mode <- getMode (opts ^. markdownInputFile)
+--   let inputFile = case mode of
+--         Project {} -> Nothing
+--         SingleFile f ->
+--           Just
+--             AppPath
+--               { _pathPath = preFileFromAbs f,
+--                 _pathIsInput = True
+--               }
+--   let shouldRecurse :: ImportNode -> Bool
+--       shouldRecurse node = case mode of
+--         Project p -> p == node ^. importNodePackageRoot
+--         SingleFile {} -> False
+--   (scopedM, others) :: (Scoper.ScoperResult, [Scoper.ScoperResult]) <-
+--     runPipelineEither () inputFile (processRecursivelyUpTo shouldRecurse upToScopingEntry)
+--       >>= fmap ((^. pipelineResult) . snd) . getRight
+--   mapM_ goScoperResult (scopedM : others)
+--   where
+--     goScoperResult :: Scoper.ScoperResult -> Sem r ()
+--     goScoperResult scopedM = do
+--       let m :: Module 'Scoped 'ModuleTop = scopedM ^. Scoper.resultModule
+--       outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
+--       let args =
+--             ProcessJuvixBlocksArgs
+--               { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
+--                 _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
+--                 _processJuvixBlocksArgsIdPrefix =
+--                   opts ^. markdownIdPrefix,
+--                 _processJuvixBlocksArgsNoPath =
+--                   opts ^. markdownNoPath,
+--                 _processJuvixBlocksArgsExt =
+--                   opts ^. markdownExt,
+--                 _processJuvixBlocksArgsStripPrefix =
+--                   opts ^. markdownStripPrefix,
+--                 _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
+--                 _processJuvixBlocksArgsModule = m,
+--                 _processJuvixBlocksArgsOutputDir = outputDir,
+--                 _processJuvixBlocksArgsFolderStructure =
+--                   opts ^. markdownFolderStructure
+--               }
+
+--       md :: Text <- runAppError @MarkdownBackendError (MK.fromJuvixMarkdown args)
+--       if
+--           | opts ^. markdownStdout -> putStrLn md
+--           | otherwise -> do
+--               ensureDir outputDir
+--               when (opts ^. markdownWriteAssets) $
+--                 writeAssets outputDir
+
+--               let mdFile :: Path Rel File
+--                   mdFile =
+--                     relFile
+--                       ( Concrete.topModulePathToDottedPath
+--                           (m ^. Concrete.modulePath . S.nameConcrete)
+--                           <.> markdownFileExt
+--                       )
+--                   absPath :: Path Abs File
+--                   absPath = outputDir <//> mdFile
+
+--               writeFileEnsureLn absPath md
 
 runCommand ::
   forall r.
   (Members AppEffects r) =>
   MarkdownOptions ->
   Sem r ()
-runCommand opts = do
-  mode :: Mode <- getMode (opts ^. markdownInputFile)
-  let inputFile = case mode of
-        Project {} -> Nothing
-        SingleFile f ->
-          Just
-            AppPath
-              { _pathPath = preFileFromAbs f,
-                _pathIsInput = True
-              }
-  let shouldRecurse :: ImportNode -> Bool
-      shouldRecurse node = case mode of
-        Project p -> p == node ^. importNodePackageRoot
-        SingleFile {} -> False
-  (scopedM, others) :: (Scoper.ScoperResult, [Scoper.ScoperResult]) <-
-    runPipelineEither () inputFile (processRecursivelyUpTo shouldRecurse upToScopingEntry)
-      >>= fmap ((^. pipelineResult) . snd) . getRight
-  mapM_ goScoperResult (scopedM : others)
-  where
-    goScoperResult :: Scoper.ScoperResult -> Sem r ()
-    goScoperResult scopedM = do
-      let m :: Module 'Scoped 'ModuleTop = scopedM ^. Scoper.resultModule
-      outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
-      let args =
-            ProcessJuvixBlocksArgs
-              { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
-                _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
-                _processJuvixBlocksArgsIdPrefix =
-                  opts ^. markdownIdPrefix,
-                _processJuvixBlocksArgsNoPath =
-                  opts ^. markdownNoPath,
-                _processJuvixBlocksArgsExt =
-                  opts ^. markdownExt,
-                _processJuvixBlocksArgsStripPrefix =
-                  opts ^. markdownStripPrefix,
-                _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
-                _processJuvixBlocksArgsModule = m,
-                _processJuvixBlocksArgsOutputDir = outputDir,
-                _processJuvixBlocksArgsFolderStructure =
-                  opts ^. markdownFolderStructure
-              }
+runCommand opts = silenceProgressLog . runPipelineOptions . runPipelineSetup $ do
+  -- mode :: Mode <- getMode (opts ^. markdownInputFile)
+  -- let inputFile = case mode of
+  --       Project {} -> Nothing
+  --       SingleFile f ->
+  --         Just
+  --           AppPath
+  --             { _pathPath = preFileFromAbs f,
+  --               _pathIsInput = True
+  --             }
+  res :: [ProcessedNode ScoperResult] <- processProjectUpToScoping
+  forM_ res (goScoperResult opts . (^. processedNodeData))
 
-      md :: Text <- runAppError @MarkdownBackendError (MK.fromJuvixMarkdown args)
-      if
-          | opts ^. markdownStdout -> putStrLn md
-          | otherwise -> do
-              ensureDir outputDir
-              when (opts ^. markdownWriteAssets) $
-                writeAssets outputDir
+goScoperResult :: (Members AppEffects r) => MarkdownOptions -> Scoper.ScoperResult -> Sem r ()
+goScoperResult opts scopedM = do
+  let m :: Module 'Scoped 'ModuleTop = scopedM ^. Scoper.resultModule
+  outputDir <- fromAppPathDir (opts ^. markdownOutputDir)
+  logProgress (mkAnsiText @(Doc CodeAnn) ("Processing" <+> Concrete.docNoCommentsDefault (m ^. modulePath)))
+  let args =
+        ProcessJuvixBlocksArgs
+          { _processJuvixBlocksArgsConcreteOpts = Concrete.defaultOptions,
+            _processJuvixBlocksArgsUrlPrefix = opts ^. markdownUrlPrefix,
+            _processJuvixBlocksArgsIdPrefix =
+              opts ^. markdownIdPrefix,
+            _processJuvixBlocksArgsNoPath =
+              opts ^. markdownNoPath,
+            _processJuvixBlocksArgsExt =
+              opts ^. markdownExt,
+            _processJuvixBlocksArgsStripPrefix =
+              opts ^. markdownStripPrefix,
+            _processJuvixBlocksArgsComments = Scoper.getScoperResultComments scopedM,
+            _processJuvixBlocksArgsModule = m,
+            _processJuvixBlocksArgsOutputDir = outputDir,
+            _processJuvixBlocksArgsFolderStructure =
+              opts ^. markdownFolderStructure
+          }
 
-              let mdFile :: Path Rel File
-                  mdFile =
-                    relFile
-                      ( Concrete.topModulePathToDottedPath
-                          (m ^. Concrete.modulePath . S.nameConcrete)
-                          <.> markdownFileExt
-                      )
-                  absPath :: Path Abs File
-                  absPath = outputDir <//> mdFile
+  md :: Text <- runAppError @MarkdownBackendError (MK.fromJuvixMarkdown args)
+  if
+      | opts ^. markdownStdout -> putStrLn md
+      | otherwise -> do
+          ensureDir outputDir
+          when (opts ^. markdownWriteAssets) $
+            writeAssets outputDir
 
-              writeFileEnsureLn absPath md
+          let mdFile :: Path Rel File
+              mdFile =
+                relFile
+                  ( Concrete.topModulePathToDottedPath
+                      (m ^. Concrete.modulePath . S.nameConcrete)
+                      <.> markdownFileExt
+                  )
+              absPath :: Path Abs File
+              absPath = outputDir <//> mdFile
+
+          writeFileEnsureLn absPath md

--- a/app/Commands/Markdown/Options.hs
+++ b/app/Commands/Markdown/Options.hs
@@ -3,7 +3,7 @@ module Commands.Markdown.Options where
 import CommonOptions
 
 data MarkdownOptions = MarkdownOptions
-  { _markdownInputFile :: Maybe (AppPath File),
+  { _markdownInputFile :: Maybe (AppPath FileOrDir),
     _markdownOutputDir :: AppPath Dir,
     _markdownUrlPrefix :: Text,
     _markdownIdPrefix :: Text,
@@ -33,7 +33,16 @@ parseJuvixMarkdown = do
           <> showDefault
           <> help "Prefix used for HTML element IDs"
       )
-  _markdownInputFile <- optional (parseInputFile FileExtJuvixMarkdown)
+  _markdownInputFile <-
+    optional
+      ( argument
+          someInputPreFileOrDirOpt
+          ( metavar "JUVIX_MD_FILE_OR_PROJECT"
+              <> help ("Path to a " <> show FileExtJuvixMarkdown <> " file or to a directory containing a Juvix project.")
+              <> completer (extCompleter FileExtJuvixMarkdown)
+              <> action "directory"
+          )
+      )
   _markdownOutputDir <-
     parseGenericOutputDir
       ( value "markdown"

--- a/app/CommonOptions.hs
+++ b/app/CommonOptions.hs
@@ -22,7 +22,6 @@ import Juvix.Compiler.Tree.Data.TransformationId.Parser qualified as Tree
 import Juvix.Data.Field
 import Juvix.Data.Keyword.All qualified as Kw
 import Juvix.Prelude
-import Juvix.Prelude as Juvix
 import Juvix.Prelude.Parsing qualified as P
 import Juvix.Prelude.Pretty hiding (group, list)
 import Options.Applicative hiding (helpDoc)
@@ -50,7 +49,7 @@ parseInputFilesMod :: NonEmpty FileExt -> Mod ArgumentFields (Prepath File) -> P
 parseInputFilesMod exts' mods = do
   let exts = NonEmpty.toList exts'
       mvars = intercalate "|" (map toMetavar exts)
-      dotExts = intercalate ", " (map Prelude.show exts)
+      dotExts = intercalate ", " (map show exts)
       helpMsg = "Path to a " <> dotExts <> " file"
       completers = foldMap (completer . extCompleter) exts
   _pathPath <-
@@ -130,7 +129,7 @@ parseNumThreads = do
         <> value defaultNumThreads
         <> showDefault
         <> help "Number of physical threads to run"
-        <> completer (listCompleter (Juvix.show NumThreadsAuto : [Juvix.show j | j <- [1 .. numCapabilities]]))
+        <> completer (listCompleter (show NumThreadsAuto : [show j | j <- [1 .. numCapabilities]]))
     )
 
 parseProgramInputFile :: Parser (AppPath File)
@@ -186,6 +185,16 @@ parseGenericOutputDir m = do
 somePreDirOpt :: ReadM (Prepath Dir)
 somePreDirOpt = mkPrepath <$> str
 
+someInputPreFileOrDirOpt :: ReadM (AppPath FileOrDir)
+someInputPreFileOrDirOpt = mkInputAppPath . mkPrepath <$> str
+  where
+    mkInputAppPath :: Prepath f -> AppPath f
+    mkInputAppPath p =
+      AppPath
+        { _pathPath = p,
+          _pathIsInput = True
+        }
+
 somePreFileOrDirOpt :: ReadM (Prepath FileOrDir)
 somePreFileOrDirOpt = mkPrepath <$> str
 
@@ -240,13 +249,13 @@ enumReader :: forall a. (Bounded a, Enum a, Show a) => Proxy a -> ReadM a
 enumReader _ = eitherReader $ \val ->
   case lookup val assocs of
     Just x -> return x
-    Nothing -> Left ("Invalid value " <> val <> ". Valid values are: " <> (Juvix.show (allElements @a)))
+    Nothing -> Left ("Invalid value " <> val <> ". Valid values are: " <> (show (allElements @a)))
   where
     assocs :: [(String, a)]
     assocs = [(Prelude.show x, x) | x <- allElements @a]
 
 enumCompleter :: forall a. (Bounded a, Enum a, Show a) => Proxy a -> Completer
-enumCompleter _ = listCompleter [Juvix.show e | e <- allElements @a]
+enumCompleter _ = listCompleter [show e | e <- allElements @a]
 
 extCompleter :: FileExt -> Completer
 extCompleter ext = mkCompleter $ \word -> do

--- a/src/Juvix/Compiler/Backend/Markdown/Translation/FromTyped/Source.hs
+++ b/src/Juvix/Compiler/Backend/Markdown/Translation/FromTyped/Source.hs
@@ -39,9 +39,6 @@ data ProcessingState = ProcessingState
 makeLenses ''ProcessJuvixBlocksArgs
 makeLenses ''ProcessingState
 
-fromJuvixMarkdown' :: ProcessJuvixBlocksArgs -> Either MarkdownBackendError Text
-fromJuvixMarkdown' = run . runError . fromJuvixMarkdown
-
 fromJuvixMarkdown ::
   (Members '[Error MarkdownBackendError] r) =>
   ProcessJuvixBlocksArgs ->

--- a/src/Juvix/Compiler/Pipeline/Driver.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver.hs
@@ -16,6 +16,8 @@ module Juvix.Compiler.Pipeline.Driver
     processRecursivelyUpTo,
     processImports,
     processModuleToStoredCore,
+    processProjectUpToScoping,
+    processProjectUpToParsing,
   )
 where
 
@@ -23,9 +25,13 @@ import Data.HashMap.Strict qualified as HashMap
 import Juvix.Compiler.Concrete.Data.Highlight
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Print.Base (docNoCommentsDefault)
+import Juvix.Compiler.Concrete.Translation.FromParsed (scopeCheck)
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping (getModuleId)
+import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping.Data.Context qualified as Scoper
+import Juvix.Compiler.Concrete.Translation.FromSource (fromSource)
 import Juvix.Compiler.Concrete.Translation.FromSource qualified as Parser
+import Juvix.Compiler.Concrete.Translation.FromSource.Data.Context (ParserResult)
 import Juvix.Compiler.Concrete.Translation.FromSource.Data.ParserState (parserStateImports)
 import Juvix.Compiler.Concrete.Translation.FromSource.Data.ParserState qualified as Parser
 import Juvix.Compiler.Concrete.Translation.FromSource.TopModuleNameChecker
@@ -40,11 +46,13 @@ import Juvix.Compiler.Pipeline.JvoCache
 import Juvix.Compiler.Pipeline.Loader.PathResolver
 import Juvix.Compiler.Pipeline.ModuleInfoCache
 import Juvix.Compiler.Store.Core.Extra
+import Juvix.Compiler.Store.Extra
 import Juvix.Compiler.Store.Extra qualified as Store
 import Juvix.Compiler.Store.Language
 import Juvix.Compiler.Store.Language qualified as Store
 import Juvix.Compiler.Store.Options qualified as StoredModule
 import Juvix.Compiler.Store.Options qualified as StoredOptions
+import Juvix.Compiler.Store.Scoped.Language (ScopedModuleTable)
 import Juvix.Compiler.Store.Scoped.Language qualified as Scoped
 import Juvix.Data.CodeAnn
 import Juvix.Data.SHA256 qualified as SHA256
@@ -275,11 +283,128 @@ processModuleCacheMiss entryIx = do
       return r
     ProcessModuleRecompile recomp -> recomp ^. recompileDo
 
-processProject :: (Members '[PathResolver, ModuleInfoCache, Reader EntryPoint, Reader ImportTree] r) => Sem r [(ImportNode, PipelineResult ModuleInfo)]
+processProject ::
+  (Members '[PathResolver, ModuleInfoCache, Reader EntryPoint, Reader ImportTree] r) =>
+  Sem r [ProcessedNode ()]
 processProject = do
   rootDir <- asks (^. entryPointRoot)
-  nodes <- toList <$> asks (importTreeProjectNodes rootDir)
-  forWithM nodes (mkEntryIndex >=> processModule)
+  nodes <- asks (importTreeProjectNodes rootDir)
+  map mkProcessed <$> forWithM nodes (mkEntryIndex >=> processModule)
+  where
+    mkProcessed :: (ImportNode, PipelineResult ModuleInfo) -> ProcessedNode ()
+    mkProcessed (_processedNode, _processedNodeInfo) =
+      ProcessedNode
+        { _processedNodeData = (),
+          ..
+        }
+
+processProjectWith ::
+  forall a r.
+  ( Members
+      '[ Error JuvixError,
+         ModuleInfoCache,
+         PathResolver,
+         Reader EntryPoint,
+         Reader ImportTree,
+         Files
+       ]
+      r
+  ) =>
+  ( forall r'.
+    ( Members
+        '[ Error JuvixError,
+           Files,
+           Reader PackageId,
+           HighlightBuilder,
+           PathResolver
+         ]
+        r'
+    ) =>
+    ProcessedNode () ->
+    Sem r' a
+  ) ->
+  Sem r [ProcessedNode a]
+processProjectWith procNode = do
+  l <- processProject
+  pkgId <- asks (^. entryPointPackageId)
+  runReader pkgId $
+    sequence
+      [ do
+          d <-
+            withResolverRoot (n ^. processedNode . importNodePackageRoot)
+              . evalHighlightBuilder
+              $ procNode n
+          return (set processedNodeData d n)
+        | n <- l
+      ]
+
+processProjectUpToScoping ::
+  forall r.
+  ( Members
+      '[ Files,
+         Error JuvixError,
+         PathResolver,
+         ModuleInfoCache,
+         Reader EntryPoint,
+         Reader ImportTree
+       ]
+      r
+  ) =>
+  Sem r [ProcessedNode ScoperResult]
+processProjectUpToScoping = processProjectWith processNodeUpToScoping
+
+processProjectUpToParsing ::
+  forall r.
+  ( Members
+      '[ Files,
+         Error JuvixError,
+         PathResolver,
+         ModuleInfoCache,
+         Reader EntryPoint,
+         Reader ImportTree
+       ]
+      r
+  ) =>
+  Sem r [ProcessedNode ParserResult]
+processProjectUpToParsing = processProjectWith processNodeUpToParsing
+
+processNodeUpToParsing ::
+  ( Members
+      '[ PathResolver,
+         Error JuvixError,
+         Files,
+         HighlightBuilder,
+         Reader PackageId
+       ]
+      r
+  ) =>
+  ProcessedNode () ->
+  Sem r ParserResult
+processNodeUpToParsing node =
+  runTopModuleNameChecker $
+    fromSource Nothing (Just (node ^. processedNode . importNodeAbsFile))
+
+processNodeUpToScoping ::
+  ( Members
+      '[ PathResolver,
+         Error JuvixError,
+         Files,
+         HighlightBuilder,
+         Reader PackageId
+       ]
+      r
+  ) =>
+  ProcessedNode () ->
+  Sem r ScoperResult
+processNodeUpToScoping node = do
+  parseRes <- processNodeUpToParsing node
+  pkg <- ask
+  let modules = node ^. processedNodeInfo . pipelineResultImports
+      scopedModules :: ScopedModuleTable = getScopedModuleTable modules
+      tmp :: TopModulePathKey = relPathtoTopModulePathKey (node ^. processedNode . importNodeFile)
+      moduleid :: ModuleId = run (runReader pkg (getModuleId tmp))
+  evalTopNameIdGen moduleid $
+    scopeCheck pkg scopedModules parseRes
 
 processRecursivelyUpTo ::
   forall a r.

--- a/src/Juvix/Compiler/Pipeline/Driver/Data.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver/Data.hs
@@ -4,7 +4,9 @@ module Juvix.Compiler.Pipeline.Driver.Data
   )
 where
 
+import Juvix.Compiler.Pipeline.Loader.PathResolver.ImportTree.Base
 import Juvix.Compiler.Pipeline.Result
+import Juvix.Compiler.Store.Language
 import Juvix.Compiler.Store.Language qualified as Store
 import Juvix.Prelude
 import Juvix.Prelude.Pretty
@@ -15,7 +17,17 @@ data CompileResult = CompileResult
     _compileResultChanged :: Bool
   }
 
+data ProcessedNode a = ProcessedNode
+  { _processedNode :: ImportNode,
+    _processedNodeInfo :: PipelineResult ModuleInfo,
+    _processedNodeData :: a
+  }
+
 makeLenses ''CompileResult
+makeLenses ''ProcessedNode
+
+instance Functor ProcessedNode where
+  fmap = over processedNodeData
 
 instance Semigroup CompileResult where
   sconcat l =

--- a/src/Juvix/Compiler/Pipeline/Run.hs
+++ b/src/Juvix/Compiler/Pipeline/Run.hs
@@ -57,8 +57,7 @@ runPipelineHtmlEither ::
   EntryPoint ->
   Sem r (Either JuvixError (Typed.InternalTypedResult, [Typed.InternalTypedResult]))
 runPipelineHtmlEither entry = do
-  x <- runIOEitherPipeline' entry $ do
-    processRecursiveUpToTyped
+  x <- runIOEitherPipeline' entry processRecursivelyUpToTyped
   return . mapRight snd $ snd x
 
 runIOEitherHelper ::

--- a/src/Juvix/Extra/Assets.hs
+++ b/src/Juvix/Extra/Assets.hs
@@ -37,13 +37,13 @@ assetsWithAbsPathAndContent baseDir =
       let absPath = absDirAssetsByKind baseDir kind <//> relPart
   ]
 
-writeAssets :: Path Abs Dir -> IO ()
+writeAssets :: forall m. (MonadIO m) => Path Abs Dir -> m ()
 writeAssets baseDir = do
   putStrLn $ "Copying assets files to " <> pack (toFilePath baseDir)
   mapM_ writeAssetFile (assetsWithAbsPathAndContent baseDir)
   where
-    writeAssetFile :: (Path Abs File, ByteString) -> IO ()
+    writeAssetFile :: (Path Abs File, ByteString) -> m ()
     writeAssetFile (p, content) = do
       let dirFile = parent p
       createDirIfMissing True dirFile
-      BS.writeFile (toFilePath p) content
+      liftIO (BS.writeFile (toFilePath p) content)

--- a/test/BackendMarkdown/Negative.hs
+++ b/test/BackendMarkdown/Negative.hs
@@ -48,7 +48,7 @@ testDescr NegTest {..} =
                 _processJuvixBlocksArgsOutputDir =
                   root <//> $(mkRelDir "markdown")
               }
-          res = fromJuvixMarkdown' opts
+          res = run (runError @MarkdownBackendError (fromJuvixMarkdown opts))
       case res of
         Left err -> whenJust (_checkErr (JuvixError err)) assertFailure
         Right _ -> assertFailure "Unexpected success"

--- a/test/BackendMarkdown/Positive.hs
+++ b/test/BackendMarkdown/Positive.hs
@@ -1,6 +1,7 @@
 module BackendMarkdown.Positive where
 
 import Base
+import Juvix.Compiler.Backend.Markdown.Error
 import Juvix.Compiler.Backend.Markdown.Translation.FromTyped.Source
 import Juvix.Compiler.Concrete qualified as Concrete
 import Juvix.Compiler.Concrete.Translation.FromParsed.Analysis.Scoping qualified as Scoper
@@ -53,7 +54,7 @@ testDescr PosTest {..} =
                     root <//> $(mkRelDir "markdown")
                 }
 
-        let res = fromJuvixMarkdown' opts
+        let res = run (runError @MarkdownBackendError (fromJuvixMarkdown opts))
         case res of
           Left err -> assertFailure (show err)
           Right md -> do

--- a/tests/smoke/Commands/markdown.smoke.yaml
+++ b/tests/smoke/Commands/markdown.smoke.yaml
@@ -9,7 +9,7 @@ tests:
       - markdown
       - --help
     stdout:
-      contains: JUVIX_MARKDOWN_FILE
+      contains: JUVIX_MD_FILE_OR_PROJECT
     exit-status: 0
 
   - name: markdown-stdout


### PR DESCRIPTION
- Closes #3130

Now the `markdown` command accepts the path of a project folder. In that case, it will generate the markdown for all files in that project. Similarly, if no input file or folder are provided, it will process all the files in the project found from the cwd.