### PR TITLE
Remove mainFunctionWrapper in nock backend

### DIFF
--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -865,16 +865,12 @@ allTests =
             v1 :: Term Natural = [nock| 222 |]
             k2 :: Term Natural = [nock| [1 2 3 nil] |]
             v2 :: Term Natural = [nock| [4 5 6 nil] |]
-            -- The keys of the storage are of the form [id key nil].
-            -- The id is captured from the arguments tuple of the function.
-            sk1 :: Term Natural = [nock| [[333 1 2 3 nil] 333 nil] |]
-            sk2 :: Term Natural = [nock| [[333 1 2 3 nil] [1 2 3 nil] nil] |]
          in mkAnomaTest'
               AnomaTestModeDebugOnly
               ( Storage
                   ( hashMap
-                      [ (StorageKey sk1, v1),
-                        (StorageKey sk2, v2)
+                      [ (StorageKey k1, v1),
+                        (StorageKey k2, v2)
                       ]
                   )
               )


### PR DESCRIPTION
This PR removes the mainFunctionWrapper and anomaGet argument capturing from the nock backend.

The mainFunctionWrapper was used to capture the argument of main to use as the `id` field of a anomaGet (scry) call.

The `id` argument is no longer passed into the main function in all cases. anomaGet must support being called with the `id` argument explicitly, it is now part of the scry key.