### PR TITLE
Pre-register all type axioms in internal to core

### DIFF
--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -283,19 +283,19 @@ goMutualBlock (Internal.MutualBlock m) = preMutual m >>= goMutual
             | exprIsType (a ^. Internal.axiomType) -> True
             | otherwise -> False
             where
-                exprIsType :: Internal.Expression -> Bool
-                exprIsType = \case
-                  Internal.ExpressionUniverse {} -> True
-                  Internal.ExpressionFunction (Internal.Function l r) -> exprIsType (l ^. Internal.paramType) && exprIsType r
-                  Internal.ExpressionIden {} -> False
-                  Internal.ExpressionApplication {} -> False
-                  Internal.ExpressionLiteral {} -> False
-                  Internal.ExpressionHole {} -> False
-                  Internal.ExpressionInstanceHole {} -> False
-                  Internal.ExpressionLet {} -> False
-                  Internal.ExpressionSimpleLambda {} -> False
-                  Internal.ExpressionLambda {} -> False
-                  Internal.ExpressionCase {} -> False
+              exprIsType :: Internal.Expression -> Bool
+              exprIsType = \case
+                Internal.ExpressionUniverse {} -> True
+                Internal.ExpressionFunction (Internal.Function l r) -> exprIsType (l ^. Internal.paramType) && exprIsType r
+                Internal.ExpressionIden {} -> False
+                Internal.ExpressionApplication {} -> False
+                Internal.ExpressionLiteral {} -> False
+                Internal.ExpressionHole {} -> False
+                Internal.ExpressionInstanceHole {} -> False
+                Internal.ExpressionLet {} -> False
+                Internal.ExpressionSimpleLambda {} -> False
+                Internal.ExpressionLambda {} -> False
+                Internal.ExpressionCase {} -> False
 
         step :: Internal.MutualStatement -> Sem (State PreMutual ': r) ()
         step = \case

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -278,7 +278,24 @@ goMutualBlock (Internal.MutualBlock m) = preMutual m >>= goMutual
         isTypDef = \case
           Internal.StatementInductive {} -> True
           Internal.StatementFunction {} -> False
-          Internal.StatementAxiom a -> isJust (builtinInductive a)
+          Internal.StatementAxiom a
+            | isJust (builtinInductive a) -> True
+            | exprIsType (a ^. Internal.axiomType) -> True
+            | otherwise -> False
+            where
+                exprIsType :: Internal.Expression -> Bool
+                exprIsType = \case
+                  Internal.ExpressionUniverse {} -> True
+                  Internal.ExpressionFunction (Internal.Function l r) -> exprIsType (l ^. Internal.paramType) && exprIsType r
+                  Internal.ExpressionIden {} -> False
+                  Internal.ExpressionApplication {} -> False
+                  Internal.ExpressionLiteral {} -> False
+                  Internal.ExpressionHole {} -> False
+                  Internal.ExpressionInstanceHole {} -> False
+                  Internal.ExpressionLet {} -> False
+                  Internal.ExpressionSimpleLambda {} -> False
+                  Internal.ExpressionLambda {} -> False
+                  Internal.ExpressionCase {} -> False
 
         step :: Internal.MutualStatement -> Sem (State PreMutual ': r) ()
         step = \case

--- a/src/Juvix/Compiler/Core/Translation/FromInternal.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromInternal.hs
@@ -737,7 +737,9 @@ goAxiomInductive ::
   (Members '[InfoTableBuilder, Reader InternalTyped.TypesTable, Reader InternalTyped.FunctionsTable, Reader Internal.InfoTable, NameIdGen] r) =>
   Internal.AxiomDef ->
   Sem r ()
-goAxiomInductive a = whenJust (builtinInductive a) (\m -> m)
+goAxiomInductive a = case builtinInductive a of
+  Nothing -> return ()
+  Just m -> m
 
 fromTopIndex :: Sem (Reader IndexTable ': r) a -> Sem r a
 fromTopIndex = runReader initIndexTable

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -185,6 +185,10 @@ tests =
       $(mkRelDir "Internal")
       $(mkRelFile "Lambda.juvix"),
     posTest
+      "AnomaSet"
+      $(mkRelDir "Internal")
+      $(mkRelFile "AnomaSet.juvix"),
+    posTest
       "Simple mutual inference"
       $(mkRelDir "Internal")
       $(mkRelFile "Mutual.juvix"),

--- a/tests/positive/Internal/AnomaSet.juvix
+++ b/tests/positive/Internal/AnomaSet.juvix
@@ -1,0 +1,26 @@
+module AnomaSet;
+
+type Bool :=
+  | false
+  | true;
+
+builtin list
+type List a :=
+  | nil
+  | cons a (List a);
+
+Logic : Type := Instance -> Bool;
+
+builtin anoma-set
+axiom AnomaSet : Type -> Type;
+
+builtin anoma-set-to-list
+axiom anomaSetToList {A} (set : AnomaSet A) : List A;
+
+type Resource :=
+  mkResource@{
+    logic : Logic;
+  };
+
+positive
+type Instance := mkInstance@{};


### PR DESCRIPTION
- This pr fixes a bug that was not exposed before https://github.com/anoma/juvix/pull/3296. We were only pre-registering axioms with type `Type`. Now we pre-register all axioms that define a builtin type as well as those which have a type generated from `Type` and `->`.