### PR TITLE
Avoid double jamming prove arguments in Anoma CLI commands

### DIFF
--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
@@ -34,8 +34,8 @@ proveArgTagHelp = itemize (tagHelp <$> allElements)
       let mvar, explain :: AnsiDoc
           (mvar, explain) = first sty $ case t of
             ProveArgTagNat -> ("NATURAL", "is passed verbatim as a nockma atom")
-            ProveArgTagBase64 -> ("FILE", "is a file with a base64 encoded nockma atom")
-            ProveArgTagBytes -> ("FILE", "is a file with a byte encoded nockma atom")
+            ProveArgTagBase64 -> ("FILE", "is a file containing a base64 encoded nockma atom that represents a jammed noun")
+            ProveArgTagBytes -> ("FILE", "is a file containing bytes of a nockma atom that represents a jammed noun")
           sty = annotate (bold <> colorDull Blue)
           tagvar :: AnsiDoc
           tagvar = sty (show t <> ":" <> mvar)

--- a/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/ByteString.hs
@@ -5,6 +5,7 @@ import Data.Bit (Bit)
 import Data.Bit qualified as Bit
 import Data.Bits
 import Data.ByteString qualified as BS
+import Data.ByteString.Base64 qualified as Base64
 import Data.ByteString.Builder qualified as BS
 import Juvix.Compiler.Nockma.Encoding.Base
 import Juvix.Compiler.Nockma.Encoding.Effect.BitReader
@@ -31,6 +32,9 @@ byteStringToNatural = fromInteger . byteStringToIntegerLE
 
 naturalToByteString :: Natural -> ByteString
 naturalToByteString = naturalToByteStringLE
+
+naturalToBase64 :: Natural -> Text
+naturalToBase64 = decodeUtf8 . Base64.encode . naturalToByteString
 
 byteStringToIntegerLE :: ByteString -> Integer
 byteStringToIntegerLE = BS.foldr (\b acc -> acc `shiftL` 8 .|. fromIntegral b) 0

--- a/test/Anoma/Client/Positive.hs
+++ b/test/Anoma/Client/Positive.hs
@@ -46,7 +46,7 @@ proveAndSubmit program proveArgs = do
     runNockma
       RunNockmaInput
         { _runNockmaProgram = program,
-          _runNockmaArgs = proveArgs
+          _runNockmaArgs = map RunNockmaArgTerm proveArgs
         }
   step "Submitting transaction candidate"
   addTransaction

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -102,7 +102,7 @@ mkAnomaNodeTest a@AnomaTest {..} =
           let rinput =
                 RunNockmaInput
                   { _runNockmaProgram = program,
-                    _runNockmaArgs = _anomaArgs
+                    _runNockmaArgs = map RunNockmaArgTerm _anomaArgs
                   }
           out <- runNockma rinput
           runM


### PR DESCRIPTION
This PR changes the way program arguments are processed by  the `juvix dev nockma run {with-client, ephemeral-client}` and `juvix dev anoma prove` CLI commands.

Files provided in `--arg 'bytes:..'` and `--arg 'base64:..'` flags are now assumed to be jammed and are not jammed again before they are submitted to the Anoma client.

## Changes in anoma-apps

The Anoma apps in anoma-apps use the `prove` CLI command and so the signatures of their `main` functions will change:

For example, in [HelloWorld.juvix](https://github.com/anoma/anoma-apps/blob/6132630209dacb47b8511b2d5b60859af46f2437/HelloWorld/HelloWorld.juvix) the logic is passed as a jammed noun in an argument to prove. 

Previously the argument was jammed again before being sent and so had to be decoded in the `main` function before being used (the Anoma client cues (i.e decodes) the argument once before calling the program).

```
main (encodedLogic : Encoded Logic) (message : String) : TransactionRequest
```

After the change in this PR, the logic argument is not jammed again before being sent to the Anoma client and so the signature of the main function should be changed to:

```
main (logic : Logic) (message : String) : TransactionRequest
```
