### PR TITLE
Remove axioms info from Core InfoTable

### DIFF
--- a/src/Juvix/Compiler/Core/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTable.hs
@@ -21,8 +21,6 @@ type InductiveInfo = InductiveInfo' Node
 
 type ConstructorInfo = ConstructorInfo' Node
 
-type AxiomInfo = AxiomInfo' Node
-
 type ParameterInfo = ParameterInfo' Node
 
 type SpecialisationInfo = SpecialisationInfo' Node

--- a/src/Juvix/Compiler/Core/Data/InfoTable/Base.hs
+++ b/src/Juvix/Compiler/Core/Data/InfoTable/Base.hs
@@ -10,7 +10,6 @@ data InfoTable' n = InfoTable
     _infoIdentifiers :: HashMap Symbol (IdentifierInfo' n),
     _infoInductives :: HashMap Symbol (InductiveInfo' n),
     _infoConstructors :: HashMap Tag (ConstructorInfo' n),
-    _infoAxioms :: HashMap Text (AxiomInfo' n),
     _infoSpecialisations :: HashMap Symbol [SpecialisationInfo' n],
     _infoLiteralIntToNat :: Maybe Symbol,
     _infoLiteralIntToInt :: Maybe Symbol,
@@ -73,14 +72,6 @@ data ParameterInfo' n = ParameterInfo
   }
   deriving stock (Generic)
 
-data AxiomInfo' n = AxiomInfo
-  { _axiomName :: Text,
-    _axiomLocation :: Maybe Location,
-    _axiomType :: n,
-    _axiomPragmas :: Pragmas
-  }
-  deriving stock (Generic)
-
 data SpecialisationInfo' n = SpecialisationInfo
   { _specSignature :: ([n], [Int]),
     _specSymbol :: Symbol
@@ -111,10 +102,6 @@ instance (Serialize n) => Serialize (ParameterInfo' n)
 
 instance (NFData n) => NFData (ParameterInfo' n)
 
-instance (Serialize n) => Serialize (AxiomInfo' n)
-
-instance (NFData n) => NFData (AxiomInfo' n)
-
 instance (Serialize n) => Serialize (SpecialisationInfo' n)
 
 instance (NFData n) => NFData (SpecialisationInfo' n)
@@ -124,7 +111,6 @@ makeLenses ''IdentifierInfo'
 makeLenses ''InductiveInfo'
 makeLenses ''ConstructorInfo'
 makeLenses ''ParameterInfo'
-makeLenses ''AxiomInfo'
 makeLenses ''SpecialisationInfo'
 
 instance Semigroup (InfoTable' n) where
@@ -136,7 +122,6 @@ instance Semigroup (InfoTable' n) where
         _infoIdentifiers = t1 ^. infoIdentifiers <> t2 ^. infoIdentifiers,
         _infoInductives = t1 ^. infoInductives <> t2 ^. infoInductives,
         _infoConstructors = t1 ^. infoConstructors <> t2 ^. infoConstructors,
-        _infoAxioms = t1 ^. infoAxioms <> t2 ^. infoAxioms,
         _infoSpecialisations = t1 ^. infoSpecialisations <> t2 ^. infoSpecialisations,
         _infoLiteralIntToNat = (t1 ^. infoLiteralIntToNat) <|> (t2 ^. infoLiteralIntToNat),
         _infoLiteralIntToInt = (t1 ^. infoLiteralIntToInt) <|> (t2 ^. infoLiteralIntToInt),
@@ -152,7 +137,6 @@ instance Monoid (InfoTable' n) where
         _infoIdentifiers = mempty,
         _infoInductives = mempty,
         _infoConstructors = mempty,
-        _infoAxioms = mempty,
         _infoSpecialisations = mempty,
         _infoLiteralIntToNat = Nothing,
         _infoLiteralIntToInt = Nothing,

--- a/src/Juvix/Compiler/Core/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Core/Pretty/Base.hs
@@ -581,7 +581,6 @@ instance PrettyCode InfoTable where
     tys <- ppInductives (sortOn (^. inductiveSymbol) $ toList (tbl ^. infoInductives))
     sigs <- ppSigs (sortOn (^. identifierSymbol) $ toList (tbl ^. infoIdentifiers))
     ctx' <- ppContext (tbl ^. identContext)
-    axioms <- vsep <$> mapM ppCode (tbl ^. infoAxioms)
     main <- maybe (return "") (\s -> (<> line) . (line <>) <$> ppName KNameFunction (identName' tbl s)) (tbl ^. infoMain)
     return
       ( header "Inductives:"
@@ -589,9 +588,6 @@ instance PrettyCode InfoTable where
           <> line
           <> header "Identifiers:"
           <> sigs
-          <> line
-          <> header "Axioms:"
-          <> axioms
           <> line
           <> header "Context:"
           <> ctx'
@@ -672,12 +668,6 @@ instance PrettyCode InfoTable where
               BuiltinBool -> False
             Just _ -> False
             Nothing -> True
-
-instance PrettyCode AxiomInfo where
-  ppCode ii = do
-    name <- ppName KNameAxiom (ii ^. axiomName)
-    ty <- ppCode (ii ^. axiomType)
-    return (kwAxiom <+> name <+> kwColon <+> ty <> kwSemicolon)
 
 instance PrettyCode Stripped.ArgumentInfo where
   ppCode :: (Member (Reader Options) r) => Stripped.ArgumentInfo -> Sem r (Doc Ann)

--- a/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
+++ b/src/Juvix/Compiler/Core/Transformation/RemoveTypeArgs.hs
@@ -152,9 +152,6 @@ convertInductive md ii =
     tyargs = typeArgs (ii ^. inductiveKind)
     ty' = convertNode md (ii ^. inductiveKind)
 
-convertAxiom :: Module -> AxiomInfo -> AxiomInfo
-convertAxiom md = over axiomType (convertNode md)
-
 -- | Remove type arguments and type abstractions.
 --
 -- Also adjusts the types, removing quantification over types and replacing all
@@ -176,7 +173,6 @@ convertAxiom md = over axiomType (convertNode md)
 removeTypeArgs :: Module -> Module
 removeTypeArgs md =
   filterOutTypeSynonyms
-    . mapAxioms (convertAxiom md)
     . mapInductives (convertInductive md)
     . mapConstructors (convertConstructor md)
     . mapIdents (convertIdent md)

--- a/src/Juvix/Compiler/Store/Core/Data/InfoTable.hs
+++ b/src/Juvix/Compiler/Store/Core/Data/InfoTable.hs
@@ -15,8 +15,6 @@ type InductiveInfo = InductiveInfo' Node
 
 type ConstructorInfo = ConstructorInfo' Node
 
-type AxiomInfo = AxiomInfo' Node
-
 type ParameterInfo = ParameterInfo' Node
 
 type SpecialisationInfo = SpecialisationInfo' Node

--- a/src/Juvix/Compiler/Store/Core/Extra.hs
+++ b/src/Juvix/Compiler/Store/Core/Extra.hs
@@ -15,7 +15,6 @@ toCore InfoTable {..} =
       _infoIdentifiers = fmap goIdentifierInfo _infoIdentifiers,
       _infoInductives = fmap goInductiveInfo _infoInductives,
       _infoConstructors = fmap goConstructorInfo _infoConstructors,
-      _infoAxioms = fmap goAxiomInfo _infoAxioms,
       _infoSpecialisations = fmap (map goSpecialisationInfo) _infoSpecialisations,
       _infoLiteralIntToNat,
       _infoLiteralIntToInt,
@@ -48,13 +47,6 @@ toCore InfoTable {..} =
     goConstructorInfo ConstructorInfo {..} =
       Core.ConstructorInfo
         { _constructorType = toCoreNode _constructorType,
-          ..
-        }
-
-    goAxiomInfo :: AxiomInfo -> Core.AxiomInfo
-    goAxiomInfo AxiomInfo {..} =
-      Core.AxiomInfo
-        { _axiomType = toCoreNode _axiomType,
           ..
         }
 
@@ -102,7 +94,6 @@ fromCore Core.InfoTable {..} =
       _infoIdentifiers = fmap goIdentifierInfo _infoIdentifiers,
       _infoInductives = fmap goInductiveInfo _infoInductives,
       _infoConstructors = fmap goConstructorInfo _infoConstructors,
-      _infoAxioms = fmap goAxiomInfo _infoAxioms,
       _infoSpecialisations = fmap (map goSpecialisationInfo) _infoSpecialisations,
       _infoLiteralIntToNat,
       _infoLiteralIntToInt,
@@ -135,13 +126,6 @@ fromCore Core.InfoTable {..} =
     goConstructorInfo Core.ConstructorInfo {..} =
       ConstructorInfo
         { _constructorType = fromCoreNode _constructorType,
-          ..
-        }
-
-    goAxiomInfo :: Core.AxiomInfo -> AxiomInfo
-    goAxiomInfo Core.AxiomInfo {..} =
-      AxiomInfo
-        { _axiomType = fromCoreNode _axiomType,
           ..
         }
 


### PR DESCRIPTION
Axioms are translated to identifiers or inductives. The `infoAxioms` was never actually used.
