### PR TITLE
Support unjammed arguments

### DIFF
--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
@@ -5,12 +5,13 @@ module Commands.Dev.Anoma.Prove.Options.ProveArgTag where
 import CommonOptions
 import Prelude qualified
 
+-- | Due to parsing, the order of constructors is relevant (because bytes is a prefix of bytes-unjammed)
 data ProveArgTag
   = ProveArgTagNat
-  | ProveArgTagBase64
-  | ProveArgTagBytes
   | ProveArgTagBytesUnJammed
   | ProveArgTagBase64UnJammed
+  | ProveArgTagBase64
+  | ProveArgTagBytes
   deriving stock (Eq, Bounded, Enum, Data)
 
 instance Show ProveArgTag where

--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
@@ -9,6 +9,8 @@ data ProveArgTag
   = ProveArgTagNat
   | ProveArgTagBase64
   | ProveArgTagBytes
+  | ProveArgTagBytesUnJammed
+  | ProveArgTagBase64UnJammed
   deriving stock (Eq, Bounded, Enum, Data)
 
 instance Show ProveArgTag where
@@ -16,12 +18,16 @@ instance Show ProveArgTag where
     ProveArgTagNat -> "nat"
     ProveArgTagBase64 -> "base64"
     ProveArgTagBytes -> "bytes"
+    ProveArgTagBytesUnJammed -> "bytes-unjammed"
+    ProveArgTagBase64UnJammed -> "base64-unjammed"
 
 type ProveArgType :: ProveArgTag -> GHCType
 type family ProveArgType s = res where
   ProveArgType 'ProveArgTagNat = Natural
   ProveArgType 'ProveArgTagBase64 = AppPath File
   ProveArgType 'ProveArgTagBytes = AppPath File
+  ProveArgType 'ProveArgTagBytesUnJammed = AppPath File
+  ProveArgType 'ProveArgTagBase64UnJammed = AppPath File
 
 $(genDefunSymbols [''ProveArgType])
 $(genSingletons [''ProveArgTag])
@@ -32,10 +38,14 @@ proveArgTagHelp = itemize (tagHelp <$> allElements)
     tagHelp :: ProveArgTag -> AnsiDoc
     tagHelp t =
       let mvar, explain :: AnsiDoc
+          jammedNoun :: AnsiDoc = annotate bold "jammed noun"
+          unjammedAtom :: AnsiDoc = annotate bold "unjammed atom"
           (mvar, explain) = first sty $ case t of
             ProveArgTagNat -> ("NATURAL", "is passed verbatim as a nockma atom")
-            ProveArgTagBase64 -> ("FILE", "is a file containing a base64 encoded nockma atom that represents a jammed noun")
-            ProveArgTagBytes -> ("FILE", "is a file containing bytes of a nockma atom that represents a jammed noun")
+            ProveArgTagBase64 -> ("FILE", "is a file containing a base64 encoded nockma atom that represents a" <+> jammedNoun)
+            ProveArgTagBytes -> ("FILE", "is a file containing bytes of a nockma atom that represents a" <+> jammedNoun)
+            ProveArgTagBase64UnJammed -> ("FILE", "is a file containing a base64 encoded nockma atom that represents an" <+> unjammedAtom)
+            ProveArgTagBytesUnJammed -> ("FILE", "is a file containing bytes of a nockma atom that represents an" <+> unjammedAtom)
           sty = annotate (bold <> colorDull Blue)
           tagvar :: AnsiDoc
           tagvar = sty (show t <> ":" <> mvar)


### PR DESCRIPTION
```
  --arg ARG_TYPE:ARG       An argument to the program:
                           • nat:NATURAL where NATURAL is passed verbatim as a nockma atom
                           • base64:FILE where FILE is a file containing a base64 encoded nockma atom that represents a jammed noun
                           • bytes:FILE where FILE is a file containing bytes of a nockma atom that represents a jammed noun

*-- the options below are NEW --*

                           • bytes-unjammed:FILE where FILE is a file containing bytes of a nockma atom that represents an unjammed atom
                           • base64-unjammed:FILE where FILE is a file containing a base64 encoded nockma atom that represents an unjammed atom
```