### PR TITLE
Fix dependency graph creation in filterUnreachable

### DIFF
--- a/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
+++ b/src/Juvix/Compiler/Core/Data/IdentDependencyInfo.hs
@@ -42,12 +42,16 @@ createSymbolDependencyInfo tab = createDependencyInfo graph startVertices
               <> getSymbols' tab (lookupTabIdentifierNode tab _identifierSymbol)
         )
         (tab ^. infoIdentifiers)
-        <> foldr
-          ( \ConstructorInfo {..} ->
-              HashMap.insertWith (<>) _constructorInductive (getSymbols' tab _constructorType)
+        <> HashMap.unionWith
+          (<>)
+          ( foldr
+              ( \ConstructorInfo {..} ->
+                  HashMap.insertWith (<>) _constructorInductive (getSymbols' tab _constructorType)
+              )
+              mempty
+              (tab ^. infoConstructors)
           )
-          mempty
-          (tab ^. infoConstructors)
+          (fmap (const mempty) (tab ^. infoInductives))
 
     startVertices :: HashSet Symbol
     startVertices = HashSet.fromList syms

--- a/src/Juvix/Compiler/Core/Data/Module.hs
+++ b/src/Juvix/Compiler/Core/Data/Module.hs
@@ -65,7 +65,7 @@ lookupSpecialisationInfo Module {..} sym =
     lookupTabSpecialisationInfo' _moduleInfoTable sym
       <|> lookupTabSpecialisationInfo' _moduleImportsTable sym
 
-impossibleSymbolNotFound :: Symbol -> a
+impossibleSymbolNotFound :: (HasCallStack) => Symbol -> a
 impossibleSymbolNotFound sym = impossibleError ("Could not find symbol " <> ppTrace sym)
 
 lookupInductiveInfo :: Module -> Symbol -> InductiveInfo


### PR DESCRIPTION
The graph library silently ignores vertices for which no edges are declared. This resulted in inductive types with no constructors being filtered out. This happened when an inductive type originated from an axiom, had no constructors added in Internal-to-Core, and was not translated to a primitive Core type -- like the AnomaSet type axiom.
