### PR TITLE
Support ByteArray and List arguments to anoma prove CLI

### DIFF
--- a/app/Commands/Dev/Anoma/Base.hs
+++ b/app/Commands/Dev/Anoma/Base.hs
@@ -6,9 +6,11 @@ import Commands.Base hiding (Atom)
 import Commands.Dev.Anoma.Prove.Options.ProveArg
 import Data.ByteString qualified as BS
 import Data.ByteString.Base64 qualified as Base64
+import Data.ByteString.Char8 qualified as BC
 import Juvix.Compiler.Nockma.Encoding.ByteString
 import Juvix.Compiler.Nockma.Pretty
 import Juvix.Compiler.Nockma.Translation.FromSource qualified as Nockma
+import Juvix.Compiler.Nockma.Translation.FromTree (foldTermsOrNil)
 
 cellOrFail ::
   forall x r a.
@@ -46,6 +48,11 @@ runNock programAppPath pargs = do
 prepareArg :: forall r. (Members '[Error SimpleError, Files, App] r) => ProveArg -> Sem r Anoma.RunNockmaArg
 prepareArg = \case
   ProveArgNat n -> return (Anoma.RunNockmaArgTerm (toNock n))
+  ProveArgList f -> do
+    bs <- readAppFile f
+    let bss = map Base64.decodeLenient (BC.split '\n' bs)
+    atoms <- map TermAtom <$> mapM decodeAtom bss
+    return (Anoma.RunNockmaArgTerm (foldTermsOrNil atoms))
   ProveArgFile ArgFileSpec {..} -> do
     bs <- asBytes <$> readAppFile _argFileSpecFile
     toArg bs
@@ -59,18 +66,18 @@ prepareArg = \case
           let cell :: Nockma.Term Natural = (fromIntegral @_ @Natural (BS.length bs)) # payload
           return (Anoma.RunNockmaArgTerm cell)
 
-      decodeAtom :: ByteString -> Sem r (Nockma.Atom Natural)
-      decodeAtom =
-        asSimpleErrorShow @NockNaturalNaturalError
-          . byteStringToAtom @Natural
-
       asBytes :: ByteString -> ByteString
       asBytes = case _argFileSpecEncoding of
         EncodingBytes -> id
         EncodingBase64 -> Base64.decodeLenient
+  where
+    readAppFile :: AppPath File -> Sem r ByteString
+    readAppFile f = fromAppPathFile f >>= readFileBS'
 
-      readAppFile :: AppPath File -> Sem r ByteString
-      readAppFile f = fromAppPathFile f >>= readFileBS'
+    decodeAtom :: ByteString -> Sem r (Nockma.Atom Natural)
+    decodeAtom =
+      asSimpleErrorShow @NockNaturalNaturalError
+        . byteStringToAtom @Natural
 
 -- | Calls Anoma.Protobuf.Mempool.AddTransaction
 addTransaction ::

--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArg.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArg.hs
@@ -2,9 +2,7 @@ module Commands.Dev.Anoma.Prove.Options.ProveArg
   ( ProveArg (..),
     ArgFileSpec (..),
     EncodingLayout (..),
-    Encoding (..),
-    encodingLayout,
-    encodingJammed,
+    DecodingLayout (..),
     parseProveArg,
   )
 where
@@ -21,21 +19,23 @@ newtype ProveArg' = ProveArg'
   { _proveArg :: Sigma ProveArgTag ProveArgTypeSym0
   }
 
-data Encoding = Encoding
-  { _encodingLayout :: EncodingLayout,
-    _encodingJammed :: Bool
-  }
-  deriving stock (Data)
-
 data EncodingLayout
   = EncodingBytes
   | EncodingBase64
   deriving stock (Data)
 
-makeLenses ''Encoding
+data DecodingLayout
+  = -- | Argument should be decoded as an Atom
+    DecodingAtom
+  | -- | Argument is jammed and should not be decoded
+    DecodingJammed
+  | -- | Argument should be decoded as a ByteArray
+    DecodingByteArray
+  deriving stock (Data)
 
 data ArgFileSpec = ArgFileSpec
-  { _argFileSpecEncoding :: Encoding,
+  { _argFileSpecEncoding :: EncodingLayout,
+    _argFileSpecDecoding :: DecodingLayout,
     _argFileSpecFile :: AppPath File
   }
   deriving stock (Data)
@@ -51,21 +51,19 @@ parseProveArg = fromProveArg' <$> parseProveArg'
     fromProveArg' :: ProveArg' -> ProveArg
     fromProveArg' (ProveArg' (ty :&: a)) = case ty of
       SProveArgTagNat -> ProveArgNat a
-      SProveArgTagBase64 -> fileHelper a EncodingBase64 True
-      SProveArgTagBytes -> fileHelper a EncodingBytes True
-      SProveArgTagBase64UnJammed -> fileHelper a EncodingBase64 False
-      SProveArgTagBytesUnJammed -> fileHelper a EncodingBytes False
+      SProveArgTagByteArray -> fileHelper a EncodingBytes DecodingByteArray
+      SProveArgTagBase64 -> fileHelper a EncodingBase64 DecodingJammed
+      SProveArgTagBytes -> fileHelper a EncodingBytes DecodingJammed
+      SProveArgTagBase64UnJammed -> fileHelper a EncodingBase64 DecodingAtom
+      SProveArgTagBytesUnJammed -> fileHelper a EncodingBytes DecodingAtom
       where
-        fileHelper :: AppPath File -> EncodingLayout -> Bool -> ProveArg
-        fileHelper f l jammed =
+        fileHelper :: AppPath File -> EncodingLayout -> DecodingLayout -> ProveArg
+        fileHelper f l d =
           ProveArgFile
             ArgFileSpec
-              { _argFileSpecEncoding =
-                  Encoding
-                    { _encodingLayout = l,
-                      _encodingJammed = jammed
-                    },
-                _argFileSpecFile = f
+              { _argFileSpecEncoding = l,
+                _argFileSpecFile = f,
+                _argFileSpecDecoding = d
               }
 
 parseProveArg' :: Parser ProveArg'
@@ -105,6 +103,7 @@ parseProveArg' =
     pProveArgType :: SProveArgTag t -> Parse (ProveArgType t)
     pProveArgType p = do
       ret <- case p of
+        SProveArgTagByteArray -> pAppPath
         SProveArgTagBytes -> pAppPath
         SProveArgTagBase64 -> pAppPath
         SProveArgTagBase64UnJammed -> pAppPath

--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArg.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArg.hs
@@ -42,6 +42,7 @@ data ArgFileSpec = ArgFileSpec
 
 data ProveArg
   = ProveArgNat Natural
+  | ProveArgList (AppPath File)
   | ProveArgFile ArgFileSpec
   deriving stock (Data)
 
@@ -51,6 +52,7 @@ parseProveArg = fromProveArg' <$> parseProveArg'
     fromProveArg' :: ProveArg' -> ProveArg
     fromProveArg' (ProveArg' (ty :&: a)) = case ty of
       SProveArgTagNat -> ProveArgNat a
+      SProveArgTagList -> ProveArgList a
       SProveArgTagByteArray -> fileHelper a EncodingBytes DecodingByteArray
       SProveArgTagBase64 -> fileHelper a EncodingBase64 DecodingJammed
       SProveArgTagBytes -> fileHelper a EncodingBytes DecodingJammed
@@ -105,6 +107,7 @@ parseProveArg' =
       ret <- case p of
         SProveArgTagByteArray -> pAppPath
         SProveArgTagBytes -> pAppPath
+        SProveArgTagList -> pAppPath
         SProveArgTagBase64 -> pAppPath
         SProveArgTagBase64UnJammed -> pAppPath
         SProveArgTagBytesUnJammed -> pAppPath

--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
@@ -8,6 +8,7 @@ import Prelude qualified
 -- | Due to parsing, the order of constructors is relevant (because bytes is a prefix of bytes-unjammed)
 data ProveArgTag
   = ProveArgTagNat
+  | ProveArgTagByteArray
   | ProveArgTagBytesUnJammed
   | ProveArgTagBase64UnJammed
   | ProveArgTagBase64
@@ -17,6 +18,7 @@ data ProveArgTag
 instance Show ProveArgTag where
   show = \case
     ProveArgTagNat -> "nat"
+    ProveArgTagByteArray -> "bytearray"
     ProveArgTagBase64 -> "base64"
     ProveArgTagBytes -> "bytes"
     ProveArgTagBytesUnJammed -> "bytes-unjammed"
@@ -25,6 +27,7 @@ instance Show ProveArgTag where
 type ProveArgType :: ProveArgTag -> GHCType
 type family ProveArgType s = res where
   ProveArgType 'ProveArgTagNat = Natural
+  ProveArgType 'ProveArgTagByteArray = AppPath File
   ProveArgType 'ProveArgTagBase64 = AppPath File
   ProveArgType 'ProveArgTagBytes = AppPath File
   ProveArgType 'ProveArgTagBytesUnJammed = AppPath File
@@ -43,6 +46,7 @@ proveArgTagHelp = itemize (tagHelp <$> allElements)
           unjammedAtom :: AnsiDoc = annotate bold "unjammed atom"
           (mvar, explain) = first sty $ case t of
             ProveArgTagNat -> ("NATURAL", "is passed verbatim as a nockma atom")
+            ProveArgTagByteArray -> ("FILE", "is a file containing bytes that respresent a ByteArray")
             ProveArgTagBase64 -> ("FILE", "is a file containing a base64 encoded nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBytes -> ("FILE", "is a file containing bytes of a nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBase64UnJammed -> ("FILE", "is a file containing a base64 encoded nockma atom that represents an" <+> unjammedAtom)

--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
@@ -49,8 +49,8 @@ proveArgTagHelp = itemize (tagHelp <$> allElements)
           unjammedAtom :: AnsiDoc = annotate bold "unjammed atom"
           (mvar, explain) = first sty $ case t of
             ProveArgTagNat -> ("NATURAL", "is passed verbatim as a nockma atom")
-            ProveArgTagByteArray -> ("FILE", "is a file containing bytes that respresent a ByteArray")
-            ProveArgTagList -> ("FILE", "is a file containing a newline delimited list of byte64 bytes that respresents a list of jammed nouns")
+            ProveArgTagByteArray -> ("FILE", "is a file containing bytes that represent a ByteArray")
+            ProveArgTagList -> ("FILE", "is a file containing a newline delimited list of byte64 bytes that represents a list of jammed nouns")
             ProveArgTagBase64 -> ("FILE", "is a file containing a base64 encoded nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBytes -> ("FILE", "is a file containing bytes of a nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBase64UnJammed -> ("FILE", "is a file containing a base64 encoded nockma atom that represents an" <+> unjammedAtom)

--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
@@ -9,6 +9,7 @@ import Prelude qualified
 data ProveArgTag
   = ProveArgTagNat
   | ProveArgTagByteArray
+  | ProveArgTagList
   | ProveArgTagBytesUnJammed
   | ProveArgTagBase64UnJammed
   | ProveArgTagBase64
@@ -19,6 +20,7 @@ instance Show ProveArgTag where
   show = \case
     ProveArgTagNat -> "nat"
     ProveArgTagByteArray -> "bytearray"
+    ProveArgTagList -> "list"
     ProveArgTagBase64 -> "base64"
     ProveArgTagBytes -> "bytes"
     ProveArgTagBytesUnJammed -> "bytes-unjammed"
@@ -28,6 +30,7 @@ type ProveArgType :: ProveArgTag -> GHCType
 type family ProveArgType s = res where
   ProveArgType 'ProveArgTagNat = Natural
   ProveArgType 'ProveArgTagByteArray = AppPath File
+  ProveArgType 'ProveArgTagList = AppPath File
   ProveArgType 'ProveArgTagBase64 = AppPath File
   ProveArgType 'ProveArgTagBytes = AppPath File
   ProveArgType 'ProveArgTagBytesUnJammed = AppPath File
@@ -47,6 +50,7 @@ proveArgTagHelp = itemize (tagHelp <$> allElements)
           (mvar, explain) = first sty $ case t of
             ProveArgTagNat -> ("NATURAL", "is passed verbatim as a nockma atom")
             ProveArgTagByteArray -> ("FILE", "is a file containing bytes that respresent a ByteArray")
+            ProveArgTagList -> ("FILE", "is a file containing a newline delimited list of byte64 bytes that respresents a list of jammed nouns")
             ProveArgTagBase64 -> ("FILE", "is a file containing a base64 encoded nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBytes -> ("FILE", "is a file containing bytes of a nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBase64UnJammed -> ("FILE", "is a file containing a base64 encoded nockma atom that represents an" <+> unjammedAtom)

--- a/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
+++ b/app/Commands/Dev/Anoma/Prove/Options/ProveArgTag.hs
@@ -50,7 +50,7 @@ proveArgTagHelp = itemize (tagHelp <$> allElements)
           (mvar, explain) = first sty $ case t of
             ProveArgTagNat -> ("NATURAL", "is passed verbatim as a nockma atom")
             ProveArgTagByteArray -> ("FILE", "is a file containing bytes that represent a ByteArray")
-            ProveArgTagList -> ("FILE", "is a file containing a newline delimited list of byte64 bytes that represents a list of jammed nouns")
+            ProveArgTagList -> ("FILE", "is a file containing a newline delimited list of base64 encoded jammed nouns that represent a Nock list of jammed nouns")
             ProveArgTagBase64 -> ("FILE", "is a file containing a base64 encoded nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBytes -> ("FILE", "is a file containing bytes of a nockma atom that represents a" <+> jammedNoun)
             ProveArgTagBase64UnJammed -> ("FILE", "is a file containing a base64 encoded nockma atom that represents an" <+> unjammedAtom)

--- a/src/Anoma/Effect/RunNockma.hs
+++ b/src/Anoma/Effect/RunNockma.hs
@@ -6,6 +6,7 @@ where
 
 import Anoma.Effect.Base
 import Anoma.Rpc.RunNock
+import Data.ByteString.Base64 qualified as Base64
 import Juvix.Compiler.Nockma.Encoding
 import Juvix.Compiler.Nockma.Language qualified as Nockma
 import Juvix.Data.CodeAnn
@@ -18,7 +19,7 @@ data RunNockmaArg
   = -- | An argument that must be jammed before it is sent
     RunNockmaArgTerm (Nockma.Term Natural)
   | -- | An argument that is already jammed and must not be jammed again before it is sent
-    RunNockmaArgJammed (Nockma.Atom Natural)
+    RunNockmaArgJammed ByteString
 
 data RunNockmaInput = RunNockmaInput
   { _runNockmaProgram :: Nockma.Term Natural,
@@ -66,4 +67,4 @@ runNockma i = do
     prepareArgument =
       NockInputJammed . \case
         RunNockmaArgTerm t -> encodeJam64 t
-        RunNockmaArgJammed a -> naturalToBase64 (a ^. Nockma.atom)
+        RunNockmaArgJammed a -> decodeUtf8 (Base64.encode a)

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -11,6 +11,7 @@ module Juvix.Compiler.Nockma.Translation.FromTree
     FunctionCtx (..),
     FunctionId (..),
     closurePath,
+    foldTermsOrNil,
     foldTermsOrQuotedNil,
     sub,
     nockNatLiteral,


### PR DESCRIPTION
This PR adds support for two additional argument types fro the prove CLI:

```
  --arg ARG_TYPE:ARG       An argument to the program:
                           • bytearray:FILE where FILE is a file containing bytes that represent a ByteArray
                           • list:FILE where FILE is a file containing a newline delimited list of base64 encoded jammed nouns that represent a Nock list of jammed nouns
```

I tested these arguments with the following programs:

First a program that accepts an ed25519 signing key, this returns `64`.

```
module Kudos.ReadSigningKey;

import Stdlib.Prelude open;
import Applib open;

main (signingKey : ByteArray) : Nat := size signingKey;
```

Secondly a program that accepts a list of encoded atoms, decodes them and takes the sum.

```
module Kudos.TestList;

import Stdlib.Prelude open;
import Applib open;

main (xsEncoded : List (Encoded Nat)) : Nat :=
  let
    xs := map Encode.decode xsEncoded;
  in for (acc := 0) (x in xs) {
    acc + x
  };
```

I tested this with the input containing the jammed atoms representing 1, 1 and 2:

```
DA==
DA==
SA==
```