### PR TITLE
Lock Rust version on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
         if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.79.0
+          toolchain: 1.81.0
           cache-on-failure: false
 
       # cargo-risczero version needs to be updated to the latest version if the


### PR DESCRIPTION
We used the latest stable version. This can break the CI with breaking changes introduced in Rust. Recently, Juvix Cairo VM build started failing after automatic update to a new version of the Rust toolchain.
