### PR TITLE
Fix `main` detection

### DIFF
--- a/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromParsed/Analysis/Scoping/Data/Context.hs
@@ -20,5 +20,8 @@ makeLenses ''ScoperResult
 mainModule :: Lens' ScoperResult (Module 'Scoped 'ModuleTop)
 mainModule = resultModule
 
+getScoperResultIsMainFile :: ScoperResult -> Bool
+getScoperResultIsMainFile = (^. resultParserResult . Parsed.resultIsMainFile)
+
 getScoperResultComments :: ScoperResult -> Comments
 getScoperResultComments = Parsed.getParserResultComments . (^. resultParserResult)

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -71,10 +71,11 @@ type PragmasStash = State (Maybe ParsedPragmas)
 
 fromSource ::
   (Members '[HighlightBuilder, TopModuleNameChecker, Files, Error JuvixError] r) =>
+  Bool ->
   Maybe Text ->
   Maybe (Path Abs File) ->
   Sem r ParserResult
-fromSource mstdin minputfile = mapError (JuvixError @ParserError) $ do
+fromSource _resultIsMainFile mstdin minputfile = mapError (JuvixError @ParserError) $ do
   (_resultParserState, _resultModule) <- runParserResultBuilder mempty getParsedModuleTop
   return ParserResult {..}
   where

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource/Data/Context.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource/Data/Context.hs
@@ -6,7 +6,8 @@ import Juvix.Prelude
 
 data ParserResult = ParserResult
   { _resultModule :: Module 'Parsed 'ModuleTop,
-    _resultParserState :: ParserState
+    _resultParserState :: ParserState,
+    _resultIsMainFile :: Bool
   }
 
 makeLenses ''ParserResult

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete/Data/Context.hs
@@ -16,5 +16,8 @@ data InternalResult = InternalResult
 
 makeLenses ''InternalResult
 
+getInternalResultIsMainFile :: InternalResult -> Bool
+getInternalResultIsMainFile = Concrete.getScoperResultIsMainFile . (^. resultScoper)
+
 getInternalResultComments :: InternalResult -> Comments
 getInternalResultComments = Concrete.getScoperResultComments . (^. resultScoper)

--- a/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromInternal/Analysis/TypeChecking/Data/Context.hs
@@ -27,5 +27,8 @@ newtype ImportContext = ImportContext
 makeLenses ''InternalTypedResult
 makeLenses ''ImportContext
 
+getInternalTypedResultIsMainFile :: InternalTypedResult -> Bool
+getInternalTypedResultIsMainFile = Internal.getInternalResultIsMainFile . (^. resultInternal)
+
 getInternalTypedResultComments :: InternalTypedResult -> Comments
 getInternalTypedResultComments = Internal.getInternalResultComments . (^. resultInternal)

--- a/src/Juvix/Compiler/Pipeline.hs
+++ b/src/Juvix/Compiler/Pipeline.hs
@@ -100,7 +100,7 @@ upToParsing ::
   Sem r Parser.ParserResult
 upToParsing = do
   e <- ask
-  Parser.fromSource (e ^. entryPointStdin) (e ^. entryPointModulePath)
+  Parser.fromSource (e ^. entryPointModulePath == e ^. entryPointMainFile) (e ^. entryPointStdin) (e ^. entryPointModulePath)
 
 --------------------------------------------------------------------------------
 -- Workflows from parsed source

--- a/src/Juvix/Compiler/Pipeline/Driver.hs
+++ b/src/Juvix/Compiler/Pipeline/Driver.hs
@@ -381,7 +381,7 @@ processNodeUpToParsing ::
   Sem r ParserResult
 processNodeUpToParsing node =
   runTopModuleNameChecker $
-    fromSource Nothing (Just (node ^. processedNode . importNodeAbsFile))
+    fromSource False Nothing (Just (node ^. processedNode . importNodeAbsFile))
 
 processNodeUpToScoping ::
   ( Members

--- a/src/Juvix/Compiler/Pipeline/EntryPoint.hs
+++ b/src/Juvix/Compiler/Pipeline/EntryPoint.hs
@@ -50,6 +50,7 @@ data EntryPoint = EntryPoint
     _entryPointInliningDepth :: Int,
     _entryPointGenericOptions :: GenericOptions,
     _entryPointModulePath :: Maybe (Path Abs File),
+    _entryPointMainFile :: Maybe (Path Abs File),
     _entryPointSymbolPruningMode :: SymbolPruningMode,
     _entryPointOffline :: Bool,
     _entryPointFieldSize :: Natural,
@@ -76,7 +77,8 @@ defaultInliningDepth = 3
 defaultEntryPoint :: PackageId -> Root -> Maybe (Path Abs File) -> EntryPoint
 defaultEntryPoint pkg root mainFile =
   (defaultEntryPointNoFile pkg root)
-    { _entryPointModulePath = mainFile
+    { _entryPointModulePath = mainFile,
+      _entryPointMainFile = mainFile
     }
 
 defaultEntryPointNoFile :: PackageId -> Root -> EntryPoint
@@ -101,6 +103,7 @@ defaultEntryPointNoFile pkg root =
       _entryPointOptimizationLevel = defaultOptimizationLevel,
       _entryPointInliningDepth = defaultInliningDepth,
       _entryPointModulePath = Nothing,
+      _entryPointMainFile = Nothing,
       _entryPointSymbolPruningMode = FilterUnreachable,
       _entryPointOffline = False,
       _entryPointFieldSize = defaultFieldSize,


### PR DESCRIPTION
The `main` function is now detected by name only in the main compiled file. Any `main` functions in imported modules are not registered as `main` in Core (this caused compiler crashes because unreachable definitions in modules with `main` were filtered out).
