### PR TITLE
Format exits with success unless `--check` given

### DIFF
--- a/app/Commands/Format.hs
+++ b/app/Commands/Format.hs
@@ -77,13 +77,11 @@ runCommand opts = do
         entry <- getEntryPointStdin
         runReader entry formatStdin
     case res of
-      FormatResultFail -> exitFailure
       FormatResultNotFormatted ->
         {- use exit code 1 for
          * unformatted files when using --check
-         * when running the formatter on a Juvix project
         -}
-        when (opts ^. formatCheck || isTargetProject target) exitFailure
+        when (opts ^. formatCheck) exitFailure
       FormatResultOK -> pure ()
 
 renderModeFromOptions :: FormatTarget -> FormatOptions -> FormattedFileInfo -> FormatRenderMode

--- a/app/Commands/Format/Options.hs
+++ b/app/Commands/Format/Options.hs
@@ -29,7 +29,7 @@ parseFormat = do
   _formatCheck <-
     switch
       ( long "check"
-          <> help "Do not print reformatted sources or unformatted file paths to standard output."
+          <> help "Do not print reformatted sources or unformatted file paths to standard output. Exit code 1 if a file wasn't already formatted."
       )
   _formatInPlace <-
     switch

--- a/src/Juvix/Formatter.hs
+++ b/src/Juvix/Formatter.hs
@@ -31,7 +31,6 @@ makeSem ''ScopeEff
 data FormatResult
   = FormatResultOK
   | FormatResultNotFormatted
-  | FormatResultFail
   deriving stock (Eq)
 
 data SourceCode = SourceCode
@@ -42,8 +41,6 @@ data SourceCode = SourceCode
 makeLenses ''SourceCode
 
 instance Semigroup FormatResult where
-  FormatResultFail <> _ = FormatResultFail
-  _ <> FormatResultFail = FormatResultFail
   FormatResultNotFormatted <> _ = FormatResultNotFormatted
   _ <> FormatResultNotFormatted = FormatResultNotFormatted
   _ <> _ = FormatResultOK

--- a/test/Formatter/Positive.hs
+++ b/test/Formatter/Positive.hs
@@ -31,7 +31,6 @@ makeFormatTest' Scope.PosTest {..} =
             case d of
               Right (_, FormatResultOK) -> return ()
               Right (_, FormatResultNotFormatted) -> assertFailure ("File: " <> show file' <> " is not formatted")
-              Right (_, FormatResultFail) -> assertFailure ("File: " <> show file' <> " is failed to format")
               Left {} -> assertFailure ("Error: ")
         }
 

--- a/tests/smoke/Commands/format.smoke.yaml
+++ b/tests/smoke/Commands/format.smoke.yaml
@@ -147,7 +147,7 @@ tests:
     stdout:
       contains: 'Foo.juvix'
     stderr: ''
-    exit-status: 1
+    exit-status: 0
 
   - name: format-project-containing-unformatted-and-unformatted
     command:
@@ -166,7 +166,7 @@ tests:
     stdout:
       contains: 'Foo.juvix'
     stderr: ''
-    exit-status: 1
+    exit-status: 0
 
   - name: format-project-package-dot-juvix
     command:
@@ -182,7 +182,7 @@ tests:
     stderr: ''
     stdout:
       contains: 'Package.juvix'
-    exit-status: 1
+    exit-status: 0
 
   - name: format-project-containing-unformatted-from-subdir
     command:
@@ -201,7 +201,7 @@ tests:
     stderr: ''
     stdout:
       contains: 'Foo.juvix'
-    exit-status: 1
+    exit-status: 0
 
   - name: format-ignore-subproject
     command:


### PR DESCRIPTION
The behaviour change happens when at least one file wasn't formatted in a project. The old version exited with 1. The new one exits with 1 if the `--check` flag is given. Otherwise exits with 0.

