### PR TITLE
Update RISC0 to 1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,8 @@ jobs:
         shell: bash
         run: |
           curl -L https://risczero.com/install | bash
-          bash -c "rzup install"
+          source ${{ env.HOME }}/.bashrc
+          rzup install
 
       - name: Checkout CairoVM
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
         shell: bash
         run: |
           curl -L https://risczero.com/install | bash
-          rzup install
+          bash -c "rzup install"
 
       - name: Checkout CairoVM
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         shell: bash
         run: |
           curl -L https://risczero.com/install | bash
-          source ${{ env.HOME }}/.bashrc && rzup install
+          ~/.risc0/bin/rzup install
 
       - name: Checkout CairoVM
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,8 +234,6 @@ jobs:
           toolchain: 1.81.0
           cache-on-failure: false
 
-      # cargo-risczero version needs to be updated to the latest version if the
-      # CI reports a version inconsistency error
       - name: Install RISC0 VM
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,8 +238,7 @@ jobs:
         shell: bash
         run: |
           curl -L https://risczero.com/install | bash
-          source ${{ env.HOME }}/.bashrc
-          rzup install
+          source ${{ env.HOME }}/.bashrc && rzup install
 
       - name: Checkout CairoVM
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,8 @@ jobs:
       - name: Install RISC0 VM
         shell: bash
         run: |
-          cargo install cargo-binstall@1.6.9 --force
-          cargo binstall cargo-risczero@1.2.0 --no-confirm --force
-          cargo risczero install
+          curl -L https://risczero.com/install | bash
+          rzup install
 
       - name: Checkout CairoVM
         uses: actions/checkout@v4

--- a/runtime/rust/risc0/host/Cargo.toml
+++ b/runtime/rust/risc0/host/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 methods = { path = "../methods" }
-risc0-zkvm = { version = "1.0.1" }
+risc0-zkvm = { version = "1.3.0" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"

--- a/runtime/rust/risc0/methods/Cargo.toml
+++ b/runtime/rust/risc0/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = { version = "1.0.1" }
+risc0-build = { version = "2.0.0" }
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/runtime/rust/risc0/methods/guest/Cargo.toml
+++ b/runtime/rust/risc0/methods/guest/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.0.1", default-features = false, features = [ "std" ] }
+risc0-zkvm = { version = "1.3.0", default-features = false, features = [ "std" ] }
 juvix = { path = "../../juvix" }

--- a/runtime/rust/risc0/rust-toolchain.toml
+++ b/runtime/rust/risc0/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.81.0"
 components = ["rustfmt", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
The CI broke again because of a new RISC0 version made available. This time, it took a bit longer to fix it. In the future, it should be enough to update the versions in the `*.toml` files.
