### PR TITLE
Fix detection of mutual blocks for the positivity checker

### DIFF
--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -163,6 +163,15 @@ genFieldProjection kind _funDefName _funDefType _funDefBuiltin _funDefArgsInfo m
             _lambdaClauses = pure cl
           }
 
+flattenMutualBlocks :: [MutualBlock] -> [PreStatement]
+flattenMutualBlocks = concatMap (^.. mutualStatements . each . to toPreStatement)
+  where
+    toPreStatement :: MutualStatement -> PreStatement
+    toPreStatement = \case
+      StatementInductive i -> PreInductiveDef i
+      StatementFunction i -> PreFunctionDef i
+      StatementAxiom i -> PreAxiomDef i
+
 -- | Generates definitions for each variable in a given pattern.
 genPatternDefs ::
   forall r.
@@ -366,7 +375,7 @@ buildMutualBlocks ::
 buildMutualBlocks ss = do
   depInfo <- ask
   let scomponents :: [SCC Name] = buildSCCs depInfo
-      sccs = (boolHack (mapMaybe nameToPreStatement scomponents))
+      sccs = boolHack (mapMaybe nameToPreStatement scomponents)
   return (map goSCC sccs)
   where
     goSCC :: SCC PreStatement -> MutualBlock

--- a/src/Juvix/Compiler/Internal/Extra.hs
+++ b/src/Juvix/Compiler/Internal/Extra.hs
@@ -7,6 +7,7 @@ module Juvix.Compiler.Internal.Extra
 where
 
 import Data.HashMap.Strict qualified as HashMap
+import Juvix.Compiler.Internal.Data.NameDependencyInfo
 import Juvix.Compiler.Internal.Extra.Base
 import Juvix.Compiler.Internal.Extra.Clonable
 import Juvix.Compiler.Internal.Extra.DependencyBuilder
@@ -357,3 +358,73 @@ substituteIndParams = substitutionE . HashMap.fromList . map (first (^. inductiv
 getInductiveKind :: InductiveDef -> Expression
 getInductiveKind InductiveDef {..} =
   foldFunType (map inductiveToFunctionParam _inductiveParameters) _inductiveType
+
+buildMutualBlocks ::
+  (Members '[Reader NameDependencyInfo] r) =>
+  [PreStatement] ->
+  Sem r [MutualBlock]
+buildMutualBlocks ss = do
+  depInfo <- ask
+  let scomponents :: [SCC Name] = buildSCCs depInfo
+      sccs = (boolHack (mapMaybe nameToPreStatement scomponents))
+  return (map goSCC sccs)
+  where
+    goSCC :: SCC PreStatement -> MutualBlock
+    goSCC = \case
+      AcyclicSCC s -> goAcyclic s
+      CyclicSCC c -> goCyclic (nonEmpty' c)
+      where
+        goCyclic :: NonEmpty PreStatement -> MutualBlock
+        goCyclic c = MutualBlock (goMutual <$> c)
+          where
+            goMutual :: PreStatement -> MutualStatement
+            goMutual = \case
+              PreInductiveDef i -> StatementInductive i
+              PreFunctionDef i -> StatementFunction i
+              PreAxiomDef i -> StatementAxiom i
+
+        goAcyclic :: PreStatement -> MutualBlock
+        goAcyclic = \case
+          PreInductiveDef i -> one (StatementInductive i)
+          PreFunctionDef i -> one (StatementFunction i)
+          PreAxiomDef i -> one (StatementAxiom i)
+          where
+            one :: MutualStatement -> MutualBlock
+            one = MutualBlock . pure
+
+    -- If the builtin bool definition is found, it is moved at the front.
+    --
+    -- This is a hack needed to translate BuiltinStringToNat in
+    -- internal-to-core. BuiltinStringToNat is the only function that depends on
+    -- Bool implicitly (i.e. without mentioning it in its type). Eventually
+    -- BuiltinStringToNat needs to be removed and so this hack.
+    boolHack :: [SCC PreStatement] -> [SCC PreStatement]
+    boolHack s = case popFirstJust isBuiltinBool s of
+      (Nothing, _) -> s
+      (Just boolDef, rest) -> AcyclicSCC (PreInductiveDef boolDef) : rest
+      where
+        isBuiltinBool :: SCC PreStatement -> Maybe InductiveDef
+        isBuiltinBool = \case
+          CyclicSCC [PreInductiveDef b]
+            | Just BuiltinBool <- b ^. inductiveBuiltin -> Just b
+          _ -> Nothing
+
+    statementsByName :: HashMap Name PreStatement
+    statementsByName = HashMap.fromList (map mkAssoc ss)
+      where
+        mkAssoc :: PreStatement -> (Name, PreStatement)
+        mkAssoc s = case s of
+          PreInductiveDef i -> (i ^. inductiveName, s)
+          PreFunctionDef i -> (i ^. funDefName, s)
+          PreAxiomDef i -> (i ^. axiomName, s)
+
+    getStmt :: Name -> Maybe PreStatement
+    getStmt n = statementsByName ^. at n
+
+    nameToPreStatement :: SCC Name -> Maybe (SCC PreStatement)
+    nameToPreStatement = nonEmptySCC . fmap getStmt
+      where
+        nonEmptySCC :: SCC (Maybe a) -> Maybe (SCC a)
+        nonEmptySCC = \case
+          AcyclicSCC a -> AcyclicSCC <$> a
+          CyclicSCC p -> CyclicSCC . toList <$> nonEmpty (catMaybes p)

--- a/src/Juvix/Compiler/Internal/Extra/Base.hs
+++ b/src/Juvix/Compiler/Internal/Extra/Base.hs
@@ -285,6 +285,7 @@ instance HasExpressions ConstructorDef where
     pure
       ConstructorDef
         { _inductiveConstructorType = ty',
+          _inductiveConstructorNormalizedType,
           _inductiveConstructorName,
           _inductiveConstructorIsRecord,
           _inductiveConstructorPragmas,

--- a/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
+++ b/src/Juvix/Compiler/Internal/Extra/DependencyBuilder.hs
@@ -67,8 +67,8 @@ buildDependencyInfoPreModule :: forall r. (Members '[Reader DependencyParams] r)
 buildDependencyInfoPreModule ms =
   buildDependencyInfoHelper (goPreModule ms >> addCastEdges)
 
--- | Compute dependency info of a mutual block with `_dependencyParamsInstance`
--- set to `False`. Used for positivity checking
+-- | Compute dependency info with `_dependencyParamsInstance` set to `False`.
+-- Used for positivity checking
 positivityNameDependencyInfo :: [PreStatement] -> NameDependencyInfo
 positivityNameDependencyInfo m =
   run

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -90,11 +90,6 @@ data MutualStatement
   | StatementAxiom AxiomDef
   deriving stock (Generic, Data)
 
-newtype MutualBlockPositivity = MutualBlockPositivity
-  { _mutualBlockPositivity :: NonEmpty MutualStatement
-  }
-  deriving stock (Generic, Data)
-
 newtype MutualBlock = MutualBlock
   { _mutualStatements :: NonEmpty MutualStatement
   }
@@ -453,6 +448,8 @@ data InductiveDef = InductiveDef
 data ConstructorDef = ConstructorDef
   { _inductiveConstructorName :: ConstrName,
     _inductiveConstructorType :: Expression,
+    -- | Filled by the typechecker. Used in positivity
+    _inductiveConstructorNormalizedType :: Maybe NormalizedExpression,
     _inductiveConstructorIsRecord :: Bool,
     _inductiveConstructorPragmas :: Pragmas,
     _inductiveConstructorDocComment :: Maybe Text
@@ -513,6 +510,7 @@ data NormalizedExpression = NormalizedExpression
   { _normalizedExpression :: Expression,
     _normalizedExpressionOriginal :: Expression
   }
+  deriving stock (Data)
 
 makePrisms ''Expression
 makePrisms ''Iden
@@ -530,7 +528,6 @@ makeLenses ''Module'
 makeLenses ''Let
 makeLenses ''MutualBlockLet
 makeLenses ''MutualBlock
-makeLenses ''MutualBlockPositivity
 makeLenses ''PatternArg
 makeLenses ''Import
 makeLenses ''FunctionDef

--- a/src/Juvix/Compiler/Internal/Language.hs
+++ b/src/Juvix/Compiler/Internal/Language.hs
@@ -90,6 +90,11 @@ data MutualStatement
   | StatementAxiom AxiomDef
   deriving stock (Generic, Data)
 
+newtype MutualBlockPositivity = MutualBlockPositivity
+  { _mutualBlockPositivity :: NonEmpty MutualStatement
+  }
+  deriving stock (Generic, Data)
+
 newtype MutualBlock = MutualBlock
   { _mutualStatements :: NonEmpty MutualStatement
   }
@@ -525,6 +530,7 @@ makeLenses ''Module'
 makeLenses ''Let
 makeLenses ''MutualBlockLet
 makeLenses ''MutualBlock
+makeLenses ''MutualBlockPositivity
 makeLenses ''PatternArg
 makeLenses ''Import
 makeLenses ''FunctionDef

--- a/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
+++ b/src/Juvix/Compiler/Internal/Translation/FromConcrete.hs
@@ -1155,6 +1155,7 @@ goConstructorDef retTy ConstructorDef {..} = do
   return
     Internal.ConstructorDef
       { _inductiveConstructorType = ty',
+        _inductiveConstructorNormalizedType = Nothing,
         _inductiveConstructorName = goSymbol _constructorName,
         _inductiveConstructorIsRecord = isRhsRecord _constructorRhs,
         _inductiveConstructorPragmas = pragmas',

--- a/test/Typecheck/Positive.hs
+++ b/test/Typecheck/Positive.hs
@@ -345,6 +345,10 @@ tests =
       $(mkRelDir ".")
       $(mkRelFile "issue2994.juvix"),
     posTest
+      "Positivity (issue 3348)"
+      $(mkRelDir "Internal")
+      $(mkRelFile "Positivity.juvix"),
+    posTest
       "Termination crash because of empty permutation"
       $(mkRelDir ".")
       $(mkRelFile "issue3064.juvix"),

--- a/tests/positive/Internal/Positivity.juvix
+++ b/tests/positive/Internal/Positivity.juvix
@@ -1,0 +1,7 @@
+module Positivity;
+
+type T := mk;
+
+type Fun : Type := mk (Box -> T);
+
+type Box := mk T;


### PR DESCRIPTION
- Closes #3071 
- Closes #3348

When checking positivity, the mutual blocks are recomputed without the rule that all declarations depend on the previous one