### PR TITLE
Fix `parseFailure` in the parsers

### DIFF
--- a/app/Commands/Dev/Tree/Repl.hs
+++ b/app/Commands/Dev/Tree/Repl.hs
@@ -56,7 +56,7 @@ readProgram f = do
   bs <- State.gets (^. replStateBuilderState)
   txt <- readFile f
   case parseText' bs txt of
-    Left e -> error (show e)
+    Left e -> error (renderTextDefault e)
     Right bs' ->
       State.modify (set replStateBuilderState bs')
 
@@ -77,7 +77,7 @@ readNode :: String -> Repl Node
 readNode s = do
   bs <- State.gets (^. replStateBuilderState)
   case parseNodeText' bs replFile (strip (pack s)) of
-    Left e -> error (show e)
+    Left e -> error (renderTextDefault e)
     Right (bs', n) -> do
       State.modify (set replStateBuilderState bs')
       return n

--- a/src/Anoma/Client/Base.hs
+++ b/src/Anoma/Client/Base.hs
@@ -78,9 +78,9 @@ anomaClientCreateProcess launchMode = do
 setupAnomaClientProcess :: forall r. (Members '[EmbedIO, Logger, Error SimpleError] r) => Handle -> Sem r AnomaClientInfo
 setupAnomaClientProcess nodeOut = do
   ln <- hGetLine nodeOut
-  let parseError = throw (SimpleError (mkAnsiText ("Failed to parse the client grpc port when starting the anoma node and client.\nExpected a number but got " <> ln)))
+  let parsingError = throw (SimpleError (mkAnsiText ("Failed to parse the client grpc port when starting the anoma node and client.\nExpected a number but got " <> ln)))
   let parseInt :: Text -> Sem r Int
-      parseInt = either (const parseError) return . readEither . unpack
+      parseInt = either (const parsingError) return . readEither . unpack
   (grpcPort, nodeId) <- case T.words ln of
     [grpcPortStr, nodeIdStr] -> (,) <$> parseInt grpcPortStr <*> pure nodeIdStr
     _ -> throw (SimpleError (mkAnsiText ("Could not parse Anoma client output. Expected <grpcPort> <node_id>, got: " <> ln)))

--- a/src/Juvix/Compiler/Asm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Asm/Translation/FromSource.hs
@@ -140,7 +140,7 @@ command = do
     "tsave" ->
       parseSave loc True
     _ ->
-      parseFailure' i ("unknown instruction: " ++ fromText txt)
+      parsingError' i ("unknown instruction: " ++ fromText txt)
 
 parseSave ::
   (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>

--- a/src/Juvix/Compiler/Casm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Casm/Translation/FromSource.hs
@@ -62,7 +62,7 @@ label addr = P.try $ do
     Just sym -> do
       b <- lift $ hasOffset sym
       if
-          | b -> parseFailure' loc "duplicate label"
+          | b -> parsingError' loc "duplicate label"
           | otherwise -> do
               lift $ registerLabelAddress sym addr
               return $ Label $ LabelRef {_labelRefSymbol = sym, _labelRefName = Just txt}

--- a/src/Juvix/Compiler/Casm/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Casm/Translation/FromSource.hs
@@ -9,47 +9,48 @@ import Juvix.Extra.Paths
 import Juvix.Parser.Error
 import Text.Megaparsec qualified as P
 
-parseText :: Text -> Either MegaparsecError (LabelInfo, [Instruction])
+parseText :: Text -> Either ParserError (LabelInfo, [Instruction])
 parseText = runParser noFile
 
-runParser :: Path Abs File -> Text -> Either MegaparsecError (LabelInfo, [Instruction])
+runParser :: Path Abs File -> Text -> Either ParserError (LabelInfo, [Instruction])
 runParser fileName input_ =
-  case run . runLabelInfoBuilder $ runParser' 0 (toFilePath fileName) input_ of
-    (_, Left err) -> Left err
-    (li, Right instrs) -> Right (li, instrs)
+  case run . runLabelInfoBuilder . runError @SimpleParserError $ runParser' 0 (toFilePath fileName) input_ of
+    (_, Left err) -> Left (ErrSimpleParserError err)
+    (_, Right (Left err)) -> Left err
+    (li, Right (Right instrs)) -> Right (li, instrs)
 
-runParser' :: (Member LabelInfoBuilder r) => Address -> FilePath -> Text -> Sem r (Either MegaparsecError [Instruction])
+runParser' :: (Member LabelInfoBuilder r) => Address -> FilePath -> Text -> Sem r (Either ParserError [Instruction])
 runParser' addr fileName input_ = do
-  e <- P.runParserT (parseToplevel addr) fileName input_
+  e <- runError @SimpleParserError $ P.runParserT (parseToplevel addr) fileName input_
   return $ case e of
-    Left err -> Left (MegaparsecError err)
-    Right instrs -> Right instrs
+    Left err -> Left (ErrSimpleParserError err)
+    Right (Left err) -> Left (ErrMegaparsec (MegaparsecError err))
+    Right (Right instrs) -> Right instrs
 
-parseToplevel :: (Member LabelInfoBuilder r) => Address -> ParsecS r [Instruction]
+parseToplevel :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => Address -> ParsecS r [Instruction]
 parseToplevel addr = do
   instrs <- statements addr
   P.eof
   return instrs
 
-statements :: (Member LabelInfoBuilder r) => Address -> ParsecS r [Instruction]
+statements :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => Address -> ParsecS r [Instruction]
 statements addr = do
   space
   label' addr <|> statement' addr <|> return []
 
-statement' :: (Member LabelInfoBuilder r) => Address -> ParsecS r [Instruction]
+statement' :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => Address -> ParsecS r [Instruction]
 statement' addr = do
   i <- instruction
   (i :) <$> statements (addr + 1)
 
-label' :: (Member LabelInfoBuilder r) => Address -> ParsecS r [Instruction]
+label' :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => Address -> ParsecS r [Instruction]
 label' addr = do
   l <- label addr
   (l :) <$> statements (addr + 1)
 
-label :: (Member LabelInfoBuilder r) => Address -> ParsecS r Instruction
+label :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => Address -> ParsecS r Instruction
 label addr = P.try $ do
-  off' <- P.getOffset
-  txt <- identifier
+  (txt, loc) <- interval identifier
   kw kwColon
   msym <- lift $ getIdent txt
   case msym of
@@ -61,12 +62,12 @@ label addr = P.try $ do
     Just sym -> do
       b <- lift $ hasOffset sym
       if
-          | b -> parseFailure off' "duplicate label"
+          | b -> parseFailure' loc "duplicate label"
           | otherwise -> do
               lift $ registerLabelAddress sym addr
               return $ Label $ LabelRef {_labelRefSymbol = sym, _labelRefName = Just txt}
 
-instruction :: (Member LabelInfoBuilder r) => ParsecS r Instruction
+instruction :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r Instruction
 instruction =
   parseHint
     <|> parseNop
@@ -107,7 +108,7 @@ parseNop = do
   kw kwNop
   return Nop
 
-parseAlloc :: (Member LabelInfoBuilder r) => ParsecS r Instruction
+parseAlloc :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r Instruction
 parseAlloc = do
   kw kwAp
   kw kwPlusEq
@@ -118,7 +119,7 @@ parseAlloc = do
         { _instrAllocSize = i
         }
 
-parseRValue :: forall r. (Member LabelInfoBuilder r) => ParsecS r RValue
+parseRValue :: forall r. (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r RValue
 parseRValue = load <|> binop <|> val
   where
     load :: ParsecS r RValue
@@ -166,19 +167,19 @@ parseRValue = load <|> binop <|> val
     val :: ParsecS r RValue
     val = Val <$> parseValue
 
-parseValue :: (Member LabelInfoBuilder r) => ParsecS r Value
+parseValue :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r Value
 parseValue = (Imm <$> parseImm) <|> (Ref <$> parseMemRef) <|> (Lab <$> parseLabel)
 
 parseImm :: ParsecS r Immediate
 parseImm = (^. withLocParam) <$> integer
 
-parseOffset :: ParsecS r Offset
+parseOffset :: (Member (Error SimpleParserError) r) => ParsecS r Offset
 parseOffset =
   (kw kwPlus >> offset)
     <|> (kw kwMinus >> (negate <$> offset))
     <|> return 0
 
-parseMemRef :: ParsecS r MemRef
+parseMemRef :: (Member (Error SimpleParserError) r) => ParsecS r MemRef
 parseMemRef = do
   lbracket
   r <- register
@@ -186,7 +187,7 @@ parseMemRef = do
   rbracket
   return MemRef {_memRefReg = r, _memRefOff = off}
 
-parseLabel :: (Member LabelInfoBuilder r) => ParsecS r LabelRef
+parseLabel :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r LabelRef
 parseLabel = do
   txt <- identifier
   msym <- lift $ getIdent txt
@@ -204,7 +205,7 @@ parseIncAp = (kw delimSemicolon >> kw kwApPlusPlus >> return True) <|> return Fa
 parseRel :: ParsecS r Bool
 parseRel = (kw kwRel >> return True) <|> (kw kwAbs >> return False) <|> return True
 
-parseJump :: forall r. (Member LabelInfoBuilder r) => ParsecS r Instruction
+parseJump :: forall r. (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r Instruction
 parseJump = do
   kw kwJmp
   P.try jmpIf <|> jmp
@@ -240,7 +241,7 @@ parseJump = do
               _instrJumpComment = Nothing
             }
 
-parseCall :: (Member LabelInfoBuilder r) => ParsecS r Instruction
+parseCall :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r Instruction
 parseCall = do
   kw kwCall
   isRel <- parseRel
@@ -258,19 +259,19 @@ parseReturn = do
   kw kwRet
   return Return
 
-parseAssert :: ParsecS r Instruction
+parseAssert :: (Member (Error SimpleParserError) r) => ParsecS r Instruction
 parseAssert = do
   kw kwAssert
   r <- parseMemRef
   return $ Assert $ InstrAssert {_instrAssertValue = r}
 
-parseTrace :: (Member LabelInfoBuilder r) => ParsecS r Instruction
+parseTrace :: (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r Instruction
 parseTrace = do
   kw kwTrace
   v <- parseRValue
   return $ Trace $ InstrTrace {_instrTraceValue = v}
 
-parseAssign :: forall r. (Member LabelInfoBuilder r) => ParsecS r Instruction
+parseAssign :: forall r. (Members '[Error SimpleParserError, LabelInfoBuilder] r) => ParsecS r Instruction
 parseAssign = do
   res <- parseMemRef
   kw kwEq

--- a/src/Juvix/Compiler/Casm/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Casm/Translation/FromSource/Lexer.hs
@@ -7,13 +7,14 @@ where
 
 import Juvix.Compiler.Casm.Keywords
 import Juvix.Compiler.Tree.Translation.FromSource.Lexer.Base
+import Juvix.Parser.Error.Base
 import Juvix.Prelude
 
-offset :: ParsecS r Int16
-offset = fromIntegral . (^. withLocParam) <$> number (-(2 ^ (15 :: Int16))) (2 ^ (15 :: Int16))
+offset :: (Member (Error SimpleParserError) r) => ParsecS r Int16
+offset = fromIntegral . (^. withLocParam) <$> number @SimpleParserError (-(2 ^ (15 :: Int16))) (2 ^ (15 :: Int16))
 
-int :: ParsecS r Int
-int = (^. withLocParam) <$> number (-(2 ^ (31 :: Int))) (2 ^ (31 :: Int))
+int :: (Member (Error SimpleParserError) r) => ParsecS r Int
+int = (^. withLocParam) <$> number @SimpleParserError (-(2 ^ (31 :: Int))) (2 ^ (31 :: Int))
 
 identifier :: ParsecS r Text
 identifier = lexeme bareIdentifier

--- a/src/Juvix/Compiler/Core/Error.hs
+++ b/src/Juvix/Compiler/Core/Error.hs
@@ -2,6 +2,7 @@ module Juvix.Compiler.Core.Error where
 
 import Juvix.Compiler.Core.Language
 import Juvix.Compiler.Core.Pretty
+import Juvix.Parser.Error.Base
 
 data CoreError = CoreError
   { _coreErrorMsg :: AnsiText,
@@ -10,6 +11,9 @@ data CoreError = CoreError
   }
 
 makeLenses ''CoreError
+
+instance FromSimpleParserError CoreError where
+  fromSimpleParserError e = CoreError (mkAnsiText (e ^. simpleParserErrorMessage)) Nothing (getLoc e)
 
 instance ToGenericError CoreError where
   genericError e = ask >>= generr

--- a/src/Juvix/Compiler/Core/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource.hs
@@ -671,10 +671,10 @@ exprConstUInt8 = P.try $ do
   (n, i) <- uint8
   return $ mkConstant (Info.singleton (LocationInfo i)) (ConstUInt8 (fromIntegral n))
 
-exprUniverse :: ParsecS r Type
+exprUniverse :: (Member (Error CoreError) r) => ParsecS r Type
 exprUniverse = do
   kw kwType
-  level <- optional (number 0 128) -- TODO: global Limits.hs file
+  level <- optional (number @CoreError 0 128) -- TODO: global Limits.hs file
   return $ mkUniv' (maybe 0 (^. withLocParam) level)
 
 exprDynamic :: ParsecS r Type

--- a/src/Juvix/Compiler/Core/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Core/Translation/FromSource/Lexer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Juvix.Compiler.Core.Translation.FromSource.Lexer
   ( module Juvix.Compiler.Core.Translation.FromSource.Lexer,
     module Juvix.Parser.Lexer,
@@ -7,6 +9,7 @@ where
 
 import Juvix.Compiler.Core.Keywords
 import Juvix.Extra.Strings qualified as Str
+import Juvix.Parser.Error.Base
 import Juvix.Parser.Lexer
 import Juvix.Prelude
 import Text.Megaparsec as P hiding (sepBy1, sepEndBy1, some)
@@ -36,8 +39,8 @@ uint8 = lexemeInterval uint8'
 integer :: ParsecS r (WithLoc Integer)
 integer = lexeme integer'
 
-number :: Int -> Int -> ParsecS r (WithLoc Int)
-number = number' integer
+number :: forall e r. (FromSimpleParserError e, Member (Error e) r) => Int -> Int -> ParsecS r (WithLoc Int)
+number = number' @e integer
 
 string :: ParsecS r (Text, Interval)
 string = lexemeInterval string'

--- a/src/Juvix/Compiler/Reg/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromSource.hs
@@ -31,25 +31,25 @@ parseRegSig =
       _parserSigEmptyExtra = ()
     }
 
-parseText :: Text -> Either MegaparsecError Module
+parseText :: Text -> Either ParserError Module
 parseText = runParser noFile
 
-parseText' :: BuilderState -> Text -> Either MegaparsecError BuilderState
+parseText' :: BuilderState -> Text -> Either ParserError BuilderState
 parseText' bs = runParser' bs noFile
 
-runParser :: Path Abs File -> Text -> Either MegaparsecError Module
+runParser :: Path Abs File -> Text -> Either ParserError Module
 runParser = runParserS parseRegSig
 
-runParser' :: BuilderState -> Path Abs File -> Text -> Either MegaparsecError BuilderState
+runParser' :: BuilderState -> Path Abs File -> Text -> Either ParserError BuilderState
 runParser' = runParserS' parseRegSig
 
 parseCode ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r Code
 parseCode = P.sepEndBy instruction (kw delimSemicolon)
 
 instruction ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r Instruction
 instruction =
   (instrNop >> return Nop)
@@ -68,7 +68,7 @@ instruction =
     <|> instrWithResult
 
 instrWithResult ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r Instruction
 instrWithResult = do
   vref <- declVarRef
@@ -87,7 +87,7 @@ instrNop :: ParsecS r ()
 instrNop = kw kwNop
 
 instrBinop ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrBinop
 instrBinop vref =
@@ -106,7 +106,7 @@ instrBinop vref =
     <|> parseBinaryOp kwStrcat OpStrConcat vref
 
 parseBinaryOp ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   Keyword ->
   BinaryOp ->
   VarRef ->
@@ -124,7 +124,7 @@ parseBinaryOp kwd op vref = do
       }
 
 instrUnop ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrUnop
 instrUnop vref =
@@ -135,7 +135,7 @@ instrUnop vref =
     <|> parseUnaryOp kwArgsNum OpArgsNum vref
 
 parseUnaryOp ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   Keyword ->
   UnaryOp ->
   VarRef ->
@@ -151,7 +151,7 @@ parseUnaryOp kwd op vref = do
       }
 
 instrCairo ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrCairo
 instrCairo vref =
@@ -161,7 +161,7 @@ instrCairo vref =
     <|> parseCairoOp kwRangeCheck OpCairoRangeCheck vref
 
 parseCairoOp ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   Keyword ->
   CairoOp ->
   VarRef ->
@@ -177,7 +177,7 @@ parseCairoOp kwd op vref = do
       }
 
 instrAssign ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrAssign
 instrAssign vref = do
@@ -189,7 +189,7 @@ instrAssign vref = do
       }
 
 instrTrace ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrTrace
 instrTrace = do
   kw kwTrace
@@ -200,7 +200,7 @@ instrTrace = do
       }
 
 instrAssert ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrAssert
 instrAssert = do
   kw kwAssert
@@ -214,7 +214,7 @@ instrDump :: ParsecS r ()
 instrDump = kw kwDump
 
 instrFailure ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrFailure
 instrFailure = do
   kw kwFail
@@ -225,7 +225,7 @@ instrFailure = do
       }
 
 instrPrealloc ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrPrealloc
 instrPrealloc = do
   kw kwPrealloc
@@ -238,7 +238,7 @@ instrPrealloc = do
       }
 
 instrAlloc ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrAlloc
 instrAlloc vref = do
@@ -254,7 +254,7 @@ instrAlloc vref = do
       }
 
 instrAllocClosure ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrAllocClosure
 instrAllocClosure vref = do
@@ -271,7 +271,7 @@ instrAllocClosure vref = do
       }
 
 instrExtendClosure ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrExtendClosure
 instrExtendClosure vref = do
@@ -286,34 +286,34 @@ instrExtendClosure vref = do
       }
 
 liveVars ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r [VarRef]
 liveVars = do
   P.try (comma >> symbol "live:")
   parens (P.sepBy varRef comma)
 
 outVar ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r VarRef
 outVar = do
   P.try (comma >> symbol "out:")
   varRef
 
 parseArgs ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r [Value]
 parseArgs = do
   parens (P.sepBy value comma)
 
 parseCallType ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r CallType
 parseCallType =
   (CallFun <$> funSymbol @Code @() @VarRef)
     <|> (CallClosure <$> varRef)
 
 instrCall ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrCall
 instrCall vref = do
@@ -330,7 +330,7 @@ instrCall vref = do
       }
 
 instrCallClosures ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r InstrCallClosures
 instrCallClosures vref = do
@@ -347,7 +347,7 @@ instrCallClosures vref = do
       }
 
 instrTailCall ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrTailCall
 instrTailCall = do
   kw kwCallTail
@@ -360,7 +360,7 @@ instrTailCall = do
       }
 
 instrTailCallClosures ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrTailCallClosures
 instrTailCallClosures = do
   kw kwCCallTail
@@ -373,7 +373,7 @@ instrTailCallClosures = do
       }
 
 instrReturn ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrReturn
 instrReturn = do
   kw kwRet
@@ -390,7 +390,7 @@ parseBoolOp =
     <|> (kw kwEq_ >> return OpEq)
 
 instrIf ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrIf
 instrIf = do
   kw kwIf
@@ -417,7 +417,7 @@ instrIf = do
       }
 
 instrBranch ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrBranch
 instrBranch = do
   kw kwBr
@@ -440,7 +440,7 @@ instrBranch = do
       }
 
 instrCase ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrCase
 instrCase = do
   kw kwCase
@@ -462,7 +462,7 @@ instrCase = do
       }
 
 caseBranch ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r CaseBranch
 caseBranch = do
   tag <- P.try $ do
@@ -481,7 +481,7 @@ caseBranch = do
       }
 
 defaultBranch ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r Code
 defaultBranch = do
   symbol "default:"
@@ -490,22 +490,22 @@ defaultBranch = do
   return c
 
 instrBlock ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r InstrBlock
 instrBlock = InstrBlock <$> braces parseCode
 
 varRef ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r VarRef
 varRef = varArg <|> varTmp <|> namedRef @Code @() @VarRef
 
 declVarRef ::
   forall r.
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r VarRef
 declVarRef = varArg <|> varTmp <|> namedRef' @Code @() @VarRef decl
   where
-    decl :: Int -> Text -> ParsecS r VarRef
+    decl :: Interval -> Text -> ParsecS r VarRef
     decl _ txt = do
       idx <- lift $ gets @LocalParams (^. localParamsTempIndex)
       lift $ modify' @LocalParams (over localParamsTempIndex (+ 1))
@@ -513,7 +513,7 @@ declVarRef = varArg <|> varTmp <|> namedRef' @Code @() @VarRef decl
       lift $ modify' (over localParamsNameMap (HashMap.insert txt vref))
       return vref
 
-varArg :: ParsecS r VarRef
+varArg :: (Member (Error SimpleParserError) r) => ParsecS r VarRef
 varArg = do
   kw kwArg
   off <- brackets int
@@ -524,7 +524,7 @@ varArg = do
         _varRefName = Nothing
       }
 
-varTmp :: ParsecS r VarRef
+varTmp :: (Member (Error SimpleParserError) r) => ParsecS r VarRef
 varTmp = do
   kw kwTmp
   off <- brackets int
@@ -536,19 +536,19 @@ varTmp = do
       }
 
 value ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r Value
 value = (ValConst <$> constant) <|> varOrConstrRef
 
 varOrConstrRef ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   ParsecS r Value
 varOrConstrRef = do
   r <- varRef
   (CRef <$> constrField r) <|> return (VRef r)
 
 constrField ::
-  (Members '[Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
+  (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>
   VarRef ->
   ParsecS r ConstrField
 constrField ref = do

--- a/src/Juvix/Compiler/Reg/Translation/FromSource/Lexer.hs
+++ b/src/Juvix/Compiler/Reg/Translation/FromSource/Lexer.hs
@@ -7,13 +7,14 @@ where
 
 import Juvix.Compiler.Reg.Keywords
 import Juvix.Compiler.Tree.Translation.FromSource.Lexer.Base
+import Juvix.Parser.Error.Base
 import Juvix.Prelude
 
-int :: ParsecS r Int
-int = (^. withLocParam) <$> number (-(2 ^ (31 :: Int))) (2 ^ (31 :: Int))
+int :: (Member (Error SimpleParserError) r) => ParsecS r Int
+int = (^. withLocParam) <$> number @SimpleParserError (-(2 ^ (31 :: Int))) (2 ^ (31 :: Int))
 
-smallnat :: ParsecS r Int
-smallnat = (^. withLocParam) <$> number 0 256
+smallnat :: (Member (Error SimpleParserError) r) => ParsecS r Int
+smallnat = (^. withLocParam) <$> number @SimpleParserError 0 256
 
 identifier :: ParsecS r Text
 identifier = lexeme bareIdentifier

--- a/src/Juvix/Compiler/Tree/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource.hs
@@ -264,7 +264,7 @@ parseCExtend = do
             _nodeExtendClosureArgs = arg2 :| args'
           }
     _ ->
-      parseFailure' loc "expected at least two arguments"
+      parsingError' loc "expected at least two arguments"
 
 parseCall ::
   forall r.
@@ -299,7 +299,7 @@ parseCall = do
                 _nodeCallArgs = args'
               }
         [] ->
-          parseFailure' loc "expected at least one argument"
+          parsingError' loc "expected at least one argument"
 
 parseCCall ::
   forall r.
@@ -310,7 +310,7 @@ parseCCall = do
   args <- parseArgs
   case args of
     [_] ->
-      parseFailure' loc "expected at least two arguments"
+      parsingError' loc "expected at least two arguments"
     arg : args' ->
       return
         NodeCallClosures
@@ -319,7 +319,7 @@ parseCCall = do
             _nodeCallClosuresArgs = nonEmpty' args'
           }
     [] ->
-      parseFailure' loc "expected at least two arguments"
+      parsingError' loc "expected at least two arguments"
 
 parseBranch ::
   (Members '[Error SimpleParserError, Reader ParserSig, InfoTableBuilder, State LocalParams] r) =>

--- a/src/Juvix/Compiler/Tree/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource/Base.hs
@@ -38,7 +38,7 @@ localS update a = do
   lift $ put s
   return a'
 
-runParserS :: ParserSig t e d -> Path Abs File -> Text -> Either MegaparsecError (Module'' t e)
+runParserS :: ParserSig t e d -> Path Abs File -> Text -> Either ParserError (Module'' t e)
 runParserS sig fileName input_ = (^. stateModule) <$> runParserS' sig (mkBuilderState (emptyModule mid)) fileName input_
   where
     mid =
@@ -51,27 +51,29 @@ runParserS sig fileName input_ = (^. stateModule) <$> runParserS' sig (mkBuilder
               }
         }
 
-runParserS' :: forall t e d. ParserSig t e d -> BuilderState' t e -> Path Abs File -> Text -> Either MegaparsecError (BuilderState' t e)
+runParserS' :: forall t e d. ParserSig t e d -> BuilderState' t e -> Path Abs File -> Text -> Either ParserError (BuilderState' t e)
 runParserS' sig bs fileName input_ = case runParserS'' (parseToplevel @t @e @d) sig bs fileName input_ of
   Left e -> Left e
   Right (bs', ()) -> Right bs'
 
 runParserS'' ::
   forall t e d a.
-  ParsecS '[Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] a ->
+  ParsecS '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] a ->
   ParserSig t e d ->
   BuilderState' t e ->
   Path Abs File ->
   Text ->
-  Either MegaparsecError (BuilderState' t e, a)
+  Either ParserError (BuilderState' t e, a)
 runParserS'' parser sig bs fileName input_ =
   case run
     . evalState emptyLocalParams
     . runInfoTableBuilder' bs
     . runReader sig
+    . runError @SimpleParserError
     $ P.runParserT parser (toFilePath fileName) input_ of
-    (_, Left err) -> Left (MegaparsecError err)
-    (bs', Right x) -> Right (bs', x)
+    (_, Left err) -> Left (ErrSimpleParserError err)
+    (_, Right (Left err)) -> Left (ErrMegaparsec (MegaparsecError err))
+    (bs', Right (Right x)) -> Right (bs', x)
 
 createBuiltinConstr ::
   Symbol ->
@@ -121,7 +123,7 @@ declareBuiltins = do
 
 parseToplevel ::
   forall t e d.
-  ParsecS '[Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] ()
+  ParsecS '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] ()
 parseToplevel = do
   declareBuiltins @t @e
   space
@@ -130,23 +132,22 @@ parseToplevel = do
 
 statement ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) =>
   ParsecS r ()
 statement = statementFunction @t @e @d <|> statementInductive @t @e @d
 
 statementFunction ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) =>
   ParsecS r ()
 statementFunction = do
   kw kwFun
-  off <- P.getOffset
   (txt, i) <- identifierL @t @e @d
   idt <- lift $ getIdent' @t @e txt
   sym <- case idt of
     Nothing -> lift $ freshSymbol' @t @e
     Just (IdentFwd sym) -> return sym
-    _ -> parseFailure off ("duplicate identifier: " ++ fromText txt)
+    _ -> parseFailure' i ("duplicate identifier: " ++ fromText txt)
   when (txt == "main") $
     lift (registerMain' @t @e sym)
   args <- functionArguments @t @e @d
@@ -174,13 +175,13 @@ statementFunction = do
   case idt of
     Just (IdentFwd _) -> do
       when (isNothing mcode) $
-        parseFailure off ("duplicate forward declaration of " ++ fromText txt)
+        parseFailure' i ("duplicate forward declaration of " ++ fromText txt)
       fi' <- lift $ getFunctionInfo' @t @e sym
       unless
         ( fi' ^. functionArgsNum == fi ^. functionArgsNum
             && isSubtype (fi' ^. functionType) (fi ^. functionType)
         )
-        $ parseFailure off "function definition does not match earlier declaration"
+        $ parseFailure' i "function definition does not match earlier declaration"
       lift $ registerFunction' fi
     _ -> do
       lift $ registerFunction' fi
@@ -189,15 +190,14 @@ statementFunction = do
 
 statementInductive ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r ()
 statementInductive = do
   kw kwInductive
-  off <- P.getOffset
   (txt, i) <- identifierL @t @e @d
   idt <- lift $ getIdent' @t @e txt
   when (isJust idt) $
-    parseFailure off ("duplicate identifier: " ++ fromText txt)
+    parseFailure' i ("duplicate identifier: " ++ fromText txt)
   sym <- lift $ freshSymbol' @t @e
   let ii =
         InductiveInfo
@@ -214,7 +214,7 @@ statementInductive = do
 
 functionArguments ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r [(Maybe Text, Type)]
 functionArguments = do
   lparen
@@ -224,15 +224,14 @@ functionArguments = do
 
 constrDecl ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   Symbol ->
   ParsecS r ConstructorInfo
 constrDecl symInd = do
-  off <- P.getOffset
   (txt, i) <- identifierL @t @e @d
   idt <- lift $ getIdent' @t @e txt
   when (isJust idt) $
-    parseFailure off ("duplicate identifier: " ++ fromText txt)
+    parseFailure' i ("duplicate identifier: " ++ fromText txt)
   tag <- lift $ freshTag' @t @e
   ty <- typeAnnotation @t @e @d
   let ty' = uncurryType ty
@@ -254,7 +253,7 @@ constrDecl symInd = do
 
 typeAnnotation ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r Type
 typeAnnotation = do
   kw kwColon
@@ -262,7 +261,7 @@ typeAnnotation = do
 
 parseArgument ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r (Maybe Text, Type)
 parseArgument = do
   n <- optional $ P.try $ do
@@ -274,20 +273,19 @@ parseArgument = do
 
 parseType ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r Type
 parseType = do
-  tys <- typeArguments @t @e @d
-  off <- P.getOffset
+  (tys, loc) <- interval $ typeArguments @t @e @d
   typeFun' @t @e @d tys
     <|> do
       unless (null (NonEmpty.tail tys)) $
-        parseFailure off "expected \"->\""
+        parseFailure' loc "expected \"->\""
       return (head tys)
 
 typeFun' ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   NonEmpty Type ->
   ParsecS r Type
 typeFun' tyargs = do
@@ -296,7 +294,7 @@ typeFun' tyargs = do
 
 typeArguments ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r (NonEmpty Type)
 typeArguments = do
   parens (P.sepBy1 (parseType @t @e @d) comma <&> NonEmpty.fromList)
@@ -308,11 +306,10 @@ typeDynamic = kw kwStar $> TyDynamic
 
 typeNamed ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r Type
 typeNamed = do
-  off <- P.getOffset
-  txt <- identifier @t @e @d
+  (txt, loc) <- interval $ identifier @t @e @d
   case txt of
     "integer" -> return mkTypeInteger
     "field" -> return TyField
@@ -325,7 +322,7 @@ typeNamed = do
       idt <- lift $ getIdent' @t @e txt
       case idt of
         Just (IdentInd sym) -> return (mkTypeInductive sym)
-        _ -> parseFailure off ("not a type: " ++ fromText txt)
+        _ -> parseFailure' loc ("not a type: " ++ fromText txt)
 
 constant :: ParsecS r Constant
 constant = fieldValue <|> uint8Value <|> integerValue <|> boolValue <|> stringValue <|> unitValue <|> voidValue
@@ -381,13 +378,13 @@ functionBody parseCode' argnames = do
 
 memRef ::
   forall t e r.
-  (Members '[Reader (ParserSig t e DirectRef), InfoTableBuilder' t e, State (LocalParams' DirectRef)] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e DirectRef), InfoTableBuilder' t e, State (LocalParams' DirectRef)] r) =>
   ParsecS r MemRef
 memRef = do
   r <- directRef @t @e
   parseField @t @e @DirectRef r <|> return (DRef r)
 
-directRef :: forall t e r. (Members '[Reader (ParserSig t e DirectRef), State (LocalParams' DirectRef)] r) => ParsecS r DirectRef
+directRef :: forall t e r. (Members '[Error SimpleParserError, Reader (ParserSig t e DirectRef), State (LocalParams' DirectRef)] r) => ParsecS r DirectRef
 directRef = argRef <|> tempRef <|> namedRef @t @e
 
 argRef :: ParsecS r DirectRef
@@ -402,21 +399,20 @@ tempRef = do
   off <- (^. withLocParam) <$> brackets integer
   return $ mkTempRef (OffsetRef (fromInteger off) Nothing)
 
-namedRef' :: forall t e d r. (Members '[Reader (ParserSig t e d), State (LocalParams' d)] r) => (Int -> Text -> ParsecS r d) -> ParsecS r d
+namedRef' :: forall t e d r. (Members '[Reader (ParserSig t e d), State (LocalParams' d)] r) => (Interval -> Text -> ParsecS r d) -> ParsecS r d
 namedRef' f = do
-  off <- P.getOffset
-  txt <- identifier @t @e @d
+  (txt, loc) <- interval $ identifier @t @e @d
   mr <- lift $ gets (HashMap.lookup txt . (^. localParamsNameMap))
   case mr of
     Just r -> return r
-    Nothing -> f off txt
+    Nothing -> f loc txt
 
-namedRef :: forall t e d r. (Members '[Reader (ParserSig t e d), State (LocalParams' d)] r) => ParsecS r d
-namedRef = namedRef' @t @e @d (\off _ -> parseFailure off "undeclared identifier")
+namedRef :: forall t e d r. (Members '[Error SimpleParserError, Reader (ParserSig t e d), State (LocalParams' d)] r) => ParsecS r d
+namedRef = namedRef' @t @e @d (\loc _ -> parseFailure' loc "undeclared identifier")
 
 parseField ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   DirectRef ->
   ParsecS r MemRef
 parseField dref = do
@@ -427,37 +423,34 @@ parseField dref = do
 
 constrTag ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r Tag
 constrTag = do
-  off <- P.getOffset
-  txt <- identifier @t @e @d
+  (txt, loc) <- interval $ identifier @t @e @d
   idt <- lift $ getIdent' @t @e txt
   case idt of
     Just (IdentConstr tag) -> return tag
-    _ -> parseFailure off "expected a constructor"
+    _ -> parseFailure' loc "expected a constructor"
 
 indSymbol ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r Symbol
 indSymbol = do
-  off <- P.getOffset
-  txt <- identifier @t @e @d
+  (txt, loc) <- interval $ identifier @t @e @d
   idt <- lift $ getIdent' @t @e txt
   case idt of
     Just (IdentInd sym) -> return sym
-    _ -> parseFailure off "expected an inductive type"
+    _ -> parseFailure' loc "expected an inductive type"
 
 funSymbol ::
   forall t e d r.
-  (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
+  (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r Symbol
 funSymbol = do
-  off <- P.getOffset
-  txt <- identifier @t @e @d
+  (txt, loc) <- interval $ identifier @t @e @d
   idt <- lift $ getIdent' @t @e txt
   case idt of
     Just (IdentFwd sym) -> return sym
     Just (IdentFun sym) -> return sym
-    _ -> parseFailure off "expected a function"
+    _ -> parseFailure' loc "expected a function"

--- a/src/Juvix/Compiler/Tree/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource/Base.hs
@@ -426,11 +426,12 @@ constrTag ::
   (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e] r) =>
   ParsecS r Tag
 constrTag = do
-  (txt, loc) <- interval $ identifier @t @e @d
+  off <- P.getOffset
+  txt <- identifier @t @e @d
   idt <- lift $ getIdent' @t @e txt
   case idt of
     Just (IdentConstr tag) -> return tag
-    _ -> parsingError' loc "expected a constructor"
+    _ -> parseFailure off "expected a constructor"
 
 indSymbol ::
   forall t e d r.

--- a/src/Juvix/Compiler/Tree/Translation/FromSource/Lexer/Base.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource/Lexer/Base.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Juvix.Compiler.Tree.Translation.FromSource.Lexer.Base
   ( module Juvix.Compiler.Tree.Translation.FromSource.Lexer.Base,
     module Juvix.Parser.Lexer,
@@ -5,6 +7,7 @@ module Juvix.Compiler.Tree.Translation.FromSource.Lexer.Base
 where
 
 import Juvix.Data.Keyword
+import Juvix.Parser.Error.Base
 import Juvix.Parser.Lexer
 import Juvix.Prelude
 import Text.Megaparsec as P hiding (sepBy1, sepEndBy1, some)
@@ -25,8 +28,8 @@ symbol = void . L.symbol space
 integer :: ParsecS r (WithLoc Integer)
 integer = lexeme integer'
 
-number :: Int -> Int -> ParsecS r (WithLoc Int)
-number = number' integer
+number :: forall e r. (FromSimpleParserError e, Member (Error e) r) => Int -> Int -> ParsecS r (WithLoc Int)
+number = number' @e integer
 
 field :: ParsecS r (Integer, Interval)
 field = lexemeInterval field'

--- a/src/Juvix/Compiler/Tree/Translation/FromSource/Sig.hs
+++ b/src/Juvix/Compiler/Tree/Translation/FromSource/Sig.hs
@@ -9,6 +9,7 @@ import Control.Monad.Trans.Class (lift)
 import Juvix.Compiler.Tree.Data.InfoTableBuilder.Base
 import Juvix.Compiler.Tree.Language.Base
 import Juvix.Compiler.Tree.Translation.FromSource.Lexer.Base
+import Juvix.Parser.Error.Base
 
 type LocalNameMap d = HashMap Text d
 
@@ -26,7 +27,7 @@ emptyLocalParams =
 
 data ParserSig t e d = ParserSig
   { _parserSigBareIdentifier :: forall r. ParsecS r Text,
-    _parserSigParseCode :: forall r. (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) => ParsecS r t,
+    _parserSigParseCode :: forall r. (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) => ParsecS r t,
     _parserSigArgRef :: Index -> Maybe Text -> d,
     _parserSigEmptyCode :: t,
     _parserSigEmptyExtra :: e
@@ -45,7 +46,7 @@ identifierL = do
   sig <- lift $ ask @(ParserSig t e d)
   lexemeInterval (sig ^. parserSigBareIdentifier)
 
-parseCode :: forall t e d r. (Members '[Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) => ParsecS r t
+parseCode :: forall t e d r. (Members '[Error SimpleParserError, Reader (ParserSig t e d), InfoTableBuilder' t e, State (LocalParams' d)] r) => ParsecS r t
 parseCode = do
   sig <- lift $ ask @(ParserSig t e d)
   sig ^. parserSigParseCode

--- a/src/Juvix/Data/Error/GenericError.hs
+++ b/src/Juvix/Data/Error/GenericError.hs
@@ -114,6 +114,9 @@ renderText = render RenderText Nothing
 renderTextDefault :: (ToGenericError e) => e -> Text
 renderTextDefault = run . runReader defaultGenericOptions . renderText
 
+renderStringDefault :: (ToGenericError e) => e -> String
+renderStringDefault = unpack . renderTextDefault
+
 -- | Render the error with Ansi formatting (if any).
 renderAnsiText :: (ToGenericError e, Member (Reader GenericOptions) r) => e -> Sem r Text
 renderAnsiText = render RenderAnsi Nothing

--- a/src/Juvix/Parser/Error.hs
+++ b/src/Juvix/Parser/Error.hs
@@ -5,6 +5,7 @@ module Juvix.Parser.Error
 where
 
 import Commonmark qualified as MK
+import Data.Yaml qualified as Yaml
 import Juvix.Compiler.Backend.Markdown.Error
 import Juvix.Compiler.Concrete.Language
 import Juvix.Compiler.Concrete.Pretty.Options (fromGenericOptions)
@@ -27,6 +28,15 @@ data ParserError
   | ErrDanglingJudoc DanglingJudoc
   | ErrMarkdownBackend MarkdownBackendError
   | ErrFlatParseError FlatParseError
+  | ErrExpectedDerivingInstance ExpectedDerivingInstanceError
+  | ErrDerivingInstancePatterns DerivingInstancePatternsError
+  | ErrYamlParseError YamlParseError
+  | ErrCoercionNotAllowed CoercionNotAllowedError
+  | ErrInstanceNotAllowed InstanceNotAllowedError
+  | ErrExpectedInstance ExpectedInstanceError
+  | ErrExpectedFunctionName ExpectedFunctionNameError
+  | ErrExpectedResultType ExpectedResultTypeError
+  | ErrExpectedColonEquals ExpectedColonEqualsError
 
 instance ToGenericError ParserError where
   genericError = \case
@@ -39,6 +49,169 @@ instance ToGenericError ParserError where
     ErrMarkdownBackend e -> genericError e
     ErrFlatParseError e -> genericError e
     ErrNamedApplicationMissingAt e -> genericError e
+    ErrExpectedDerivingInstance e -> genericError e
+    ErrDerivingInstancePatterns e -> genericError e
+    ErrYamlParseError e -> genericError e
+    ErrCoercionNotAllowed e -> genericError e
+    ErrInstanceNotAllowed e -> genericError e
+    ErrExpectedInstance e -> genericError e
+    ErrExpectedFunctionName e -> genericError e
+    ErrExpectedResultType e -> genericError e
+    ErrExpectedColonEquals e -> genericError e
+
+newtype ExpectedColonEqualsError = ExpectedColonEqualsError
+  { _expectedColonEqualsErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc ExpectedColonEqualsError where
+  getLoc ExpectedColonEqualsError {..} = _expectedColonEqualsErrorLoc
+
+instance ToGenericError ExpectedColonEqualsError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("Expected ':=' instead of '='" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
+
+newtype ExpectedResultTypeError = ExpectedResultTypeError
+  { _expectedResultTypeErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc ExpectedResultTypeError where
+  getLoc ExpectedResultTypeError {..} = _expectedResultTypeErrorLoc
+
+instance ToGenericError ExpectedResultTypeError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("Expected result type" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
+
+newtype ExpectedFunctionNameError = ExpectedFunctionNameError
+  { _expectedFunctionNameErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc ExpectedFunctionNameError where
+  getLoc ExpectedFunctionNameError {..} = _expectedFunctionNameErrorLoc
+
+instance ToGenericError ExpectedFunctionNameError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("Expected function name" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
+
+newtype ExpectedInstanceError = ExpectedInstanceError
+  { _expectedInstanceErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc ExpectedInstanceError where
+  getLoc ExpectedInstanceError {..} = _expectedInstanceErrorLoc
+
+instance ToGenericError ExpectedInstanceError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("Expected 'instance'" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
+
+newtype InstanceNotAllowedError = InstanceNotAllowedError
+  { _instanceNotAllowedErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc InstanceNotAllowedError where
+  getLoc InstanceNotAllowedError {..} = _instanceNotAllowedErrorLoc
+
+instance ToGenericError InstanceNotAllowedError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("'instance' not allowed here" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
+
+newtype CoercionNotAllowedError = CoercionNotAllowedError
+  { _coercionNotAllowedErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc CoercionNotAllowedError where
+  getLoc CoercionNotAllowedError {..} = _coercionNotAllowedErrorLoc
+
+instance ToGenericError CoercionNotAllowedError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("'coercion' not allowed here" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
+
+data YamlParseError = YamlParseError
+  { _yamlParseError :: Yaml.ParseException,
+    _yamlParseErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc YamlParseError where
+  getLoc YamlParseError {..} = _yamlParseErrorLoc
+
+instance ToGenericError YamlParseError where
+  genericError e@YamlParseError {..} =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText $ Yaml.prettyPrintParseException _yamlParseError,
+          _genericErrorIntervals = [getLoc e]
+        }
+
+newtype DerivingInstancePatternsError = DerivingInstancePatternsError
+  { _derivingInstancePatternsErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc DerivingInstancePatternsError where
+  getLoc DerivingInstancePatternsError {..} = _derivingInstancePatternsErrorLoc
+
+instance ToGenericError DerivingInstancePatternsError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("Patterns not allowed for 'deriving instance'" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
+
+newtype ExpectedDerivingInstanceError = ExpectedDerivingInstanceError
+  { _expectedDerivingInstanceErrorLoc :: Interval
+  }
+  deriving stock (Show)
+
+instance HasLoc ExpectedDerivingInstanceError where
+  getLoc ExpectedDerivingInstanceError {..} = _expectedDerivingInstanceErrorLoc
+
+instance ToGenericError ExpectedDerivingInstanceError where
+  genericError e =
+    return
+      GenericError
+        { _genericErrorLoc = getLoc e,
+          _genericErrorMessage = mkAnsiText ("Expected 'deriving instance'" :: Text),
+          _genericErrorIntervals = [getLoc e]
+        }
 
 newtype FlatParseError = FlatParseError
   { _flatParseErrorLoc :: Interval

--- a/src/Juvix/Parser/Error.hs
+++ b/src/Juvix/Parser/Error.hs
@@ -20,6 +20,7 @@ import Text.Parsec.Pos qualified as P
 
 data ParserError
   = ErrMegaparsec MegaparsecError
+  | ErrSimpleParserError SimpleParserError
   | ErrCommonmark CommonmarkError
   | ErrWrongTopModuleName WrongTopModuleName
   | ErrWrongTopModuleNameOrphan WrongTopModuleNameOrphan
@@ -38,9 +39,13 @@ data ParserError
   | ErrExpectedResultType ExpectedResultTypeError
   | ErrExpectedColonEquals ExpectedColonEqualsError
 
+instance FromSimpleParserError ParserError where
+  fromSimpleParserError = ErrSimpleParserError
+
 instance ToGenericError ParserError where
   genericError = \case
     ErrMegaparsec e -> genericError e
+    ErrSimpleParserError e -> genericError e
     ErrCommonmark e -> genericError e
     ErrWrongTopModuleName e -> genericError e
     ErrWrongTopModuleNameOrphan e -> genericError e

--- a/src/Juvix/Parser/Error/Base.hs
+++ b/src/Juvix/Parser/Error/Base.hs
@@ -41,3 +41,29 @@ fromMegaParsecError :: Either MegaparsecError a -> a
 fromMegaParsecError = \case
   Left e -> error (prettyText e)
   Right a -> a
+
+data SimpleParserError = SimpleParserError
+  { _simpleParserErrorLoc :: Interval,
+    _simpleParserErrorMessage :: Text
+  }
+  deriving stock (Show)
+
+makeLenses ''SimpleParserError
+
+instance HasLoc SimpleParserError where
+  getLoc SimpleParserError {..} = _simpleParserErrorLoc
+
+instance ToGenericError SimpleParserError where
+  genericError SimpleParserError {..} =
+    return
+      GenericError
+        { _genericErrorLoc = _simpleParserErrorLoc,
+          _genericErrorMessage = mkAnsiText _simpleParserErrorMessage,
+          _genericErrorIntervals = [_simpleParserErrorLoc]
+        }
+
+class FromSimpleParserError a where
+  fromSimpleParserError :: SimpleParserError -> a
+
+instance FromSimpleParserError SimpleParserError where
+  fromSimpleParserError = id

--- a/src/Juvix/Parser/Lexer.hs
+++ b/src/Juvix/Parser/Lexer.hs
@@ -20,11 +20,14 @@ import Juvix.Prelude
 import Juvix.Prelude.Parsing as P hiding (hspace, space, space1)
 import Text.Megaparsec.Char.Lexer qualified as L
 
-parseFailure :: forall e r a. (FromSimpleParserError e, Member (Error e) r) => Interval -> String -> ParsecS r a
-parseFailure loc str = P.lift . throw @e . fromSimpleParserError $ SimpleParserError loc (Text.pack str)
+parseFailure :: Int -> String -> ParsecT Void Text m a
+parseFailure off str = P.parseError $ P.FancyError off (Set.singleton (P.ErrorFail str))
 
-parseFailure' :: forall r a. (Member (Error SimpleParserError) r) => Interval -> String -> ParsecS r a
-parseFailure' loc str = P.lift . throw $ SimpleParserError loc (Text.pack str)
+parsingError :: forall e r a. (FromSimpleParserError e, Member (Error e) r) => Interval -> String -> ParsecS r a
+parsingError loc str = P.lift . throw @e . fromSimpleParserError $ SimpleParserError loc (Text.pack str)
+
+parsingError' :: forall r a. (Member (Error SimpleParserError) r) => Interval -> String -> ParsecS r a
+parsingError' loc str = P.lift . throw $ SimpleParserError loc (Text.pack str)
 
 whiteSpace1 :: (MonadParsec e s m, Token s ~ Char) => m ()
 whiteSpace1 = void (takeWhile1P (Just spaceMsg) isWhiteSpace)
@@ -161,7 +164,7 @@ number' int mn mx = do
   let n = num ^. withLocParam
   when
     (n < fromIntegral mn || n > fromIntegral mx)
-    (parseFailure @e loc ("number out of bounds: " ++ show n))
+    (parsingError @e loc ("number out of bounds: " ++ show n))
   return (fromInteger <$> num)
 
 string' :: ParsecS r Text

--- a/src/Juvix/Prelude/Parsing.hs
+++ b/src/Juvix/Prelude/Parsing.hs
@@ -38,3 +38,5 @@ parseHelperS p t = mapLeft ppParseErrorBundle <$> runParserT p "<input>" t
 
 ppParseErrorBundle :: (TraversableStream txt, VisualStream txt, IsString err) => ParseErrorBundle txt Void -> err
 ppParseErrorBundle = prettyIsString . errorBundlePretty
+
+-- TODO: replace errorBundlePretty

--- a/src/Juvix/Prelude/Parsing.hs
+++ b/src/Juvix/Prelude/Parsing.hs
@@ -38,5 +38,3 @@ parseHelperS p t = mapLeft ppParseErrorBundle <$> runParserT p "<input>" t
 
 ppParseErrorBundle :: (TraversableStream txt, VisualStream txt, IsString err) => ParseErrorBundle txt Void -> err
 ppParseErrorBundle = prettyIsString . errorBundlePretty
-
--- TODO: replace errorBundlePretty

--- a/test/Anoma/Compilation/Negative.hs
+++ b/test/Anoma/Compilation/Negative.hs
@@ -39,7 +39,7 @@ checkCoreError :: CheckError
 checkCoreError e =
   unless
     (isJust (fromJuvixError @CoreError e))
-    (assertFailure ("Expected core error got: " <> unpack (renderTextDefault e)))
+    (assertFailure ("Expected core error got: " <> renderStringDefault e))
 
 allTests :: TestTree
 allTests =

--- a/test/Asm/Compile/Base.hs
+++ b/test/Asm/Compile/Base.hs
@@ -41,7 +41,7 @@ asmCompileAssertion root' mainFile expectedFile stdinText step = do
   step "Parse"
   s <- readFile mainFile
   case runParser mainFile s of
-    Left err -> assertFailure (show err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md -> do
       entryPoint <- testDefaultEntryPointIO root' mainFile
       asmCompileAssertion' entryPoint 3 md mainFile expectedFile stdinText step

--- a/test/Asm/Run/Base.hs
+++ b/test/Asm/Run/Base.hs
@@ -54,7 +54,7 @@ asmRunAssertionParam interpretFun mainFile expectedFile trans testTrans step = d
   step "Parse"
   r <- parseFile mainFile
   case r of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md -> do
       case trans md of
         Left err -> assertFailure (prettyString err)
@@ -88,7 +88,7 @@ asmRunErrorAssertion mainFile step = do
                 )
             Nothing -> assertBool "" True
 
-parseFile :: Path Abs File -> IO (Either MegaparsecError Module)
+parseFile :: Path Abs File -> IO (Either ParserError Module)
 parseFile f = do
   s <- readFile f
   return (runParser f s)

--- a/test/Asm/Validate/Base.hs
+++ b/test/Asm/Validate/Base.hs
@@ -17,7 +17,7 @@ asmValidateErrorAssertion mainFile step = do
         Just _ -> assertBool "" True
         Nothing -> assertFailure "no error"
 
-parseFile :: Path Abs File -> IO (Either MegaparsecError Module)
+parseFile :: Path Abs File -> IO (Either ParserError Module)
 parseFile f = do
   s <- readFile f
   return (runParser f s)

--- a/test/BackendMarkdown/Negative.hs
+++ b/test/BackendMarkdown/Negative.hs
@@ -63,7 +63,7 @@ root :: Path Abs Dir
 root = relToProject $(mkRelDir "tests/negative")
 
 wrongError :: JuvixError -> Maybe FailMsg
-wrongError e = Just ("unexpected error: " <> unpack (renderTextDefault e))
+wrongError e = Just ("unexpected error: " <> renderStringDefault e)
 
 tests :: [NegTest]
 tests =

--- a/test/Casm/Run/Base.hs
+++ b/test/Casm/Run/Base.hs
@@ -139,7 +139,7 @@ casmRunAssertion bInterp bRunVM root mainFile inputFile expectedFile step = do
   step "Parse"
   r <- parseFile mainFile
   case r of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right (labi, instrs) -> do
       entryPoint <- testDefaultEntryPointIO root mainFile
       casmRunAssertion' entryPoint bInterp bRunVM labi instrs [] 1 inputFile expectedFile step
@@ -161,7 +161,7 @@ casmRunErrorAssertion mainFile step = do
             Left _ -> assertBool "" True
             Right _ -> assertFailure "no error"
 
-parseFile :: Path Abs File -> IO (Either MegaparsecError (LabelInfo, Code))
+parseFile :: Path Abs File -> IO (Either ParserError (LabelInfo, Code))
 parseFile f = do
   s <- readFile f
   return (runParser f s)

--- a/test/Parsing/Negative.hs
+++ b/test/Parsing/Negative.hs
@@ -66,21 +66,21 @@ parserErrorTests =
       $(mkRelDir ".")
       $(mkRelFile "PragmasYAML.juvix")
       $ \case
-        ErrMegaparsec {} -> Nothing
+        ErrYamlParseError {} -> Nothing
         _ -> wrongError,
     negTest
       "Pragmas format error"
       $(mkRelDir ".")
       $(mkRelFile "PragmasFormat.juvix")
       $ \case
-        ErrMegaparsec {} -> Nothing
+        ErrYamlParseError {} -> Nothing
         _ -> wrongError,
     negTest
       "Pragmas duplicate keys error"
       $(mkRelDir ".")
       $(mkRelFile "PragmasDuplicateKeys.juvix")
       $ \case
-        ErrMegaparsec {} -> Nothing
+        ErrYamlParseError {} -> Nothing
         _ -> wrongError,
     negTest
       "Missing @ in named application"
@@ -94,7 +94,7 @@ parserErrorTests =
       $(mkRelDir ".")
       $(mkRelFile "ErrorOnLocalInstances.juvix")
       $ \case
-        ErrMegaparsec {} -> Nothing
+        ErrInstanceNotAllowed {} -> Nothing
         _ -> wrongError
   ]
 

--- a/test/Reg/Parse/Base.hs
+++ b/test/Reg/Parse/Base.hs
@@ -4,14 +4,13 @@ import Base
 import Juvix.Compiler.Reg.Data.Module
 import Juvix.Compiler.Reg.Pretty
 import Juvix.Compiler.Reg.Translation.FromSource
-import Juvix.Data.PPOutput
 
 regParseAssertion :: Path Abs File -> (String -> IO ()) -> Assertion
 regParseAssertion mainFile step = do
   step "Parse"
   r <- parseFile mainFile
   case r of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md -> do
       withTempDir'
         ( \dirPath -> do
@@ -21,14 +20,14 @@ regParseAssertion mainFile step = do
             step "Parse printed"
             r' <- parseFile outputFile
             case r' of
-              Left err -> assertFailure (prettyString err)
+              Left err -> assertFailure (renderStringDefault err)
               Right md' -> do
                 assertBool
                   ("Check: print . parse = print . parse . print . parse")
                   (ppPrint md (computeCombinedInfoTable md) == ppPrint md' (computeCombinedInfoTable md'))
         )
 
-parseFile :: Path Abs File -> IO (Either MegaparsecError Module)
+parseFile :: Path Abs File -> IO (Either ParserError Module)
 parseFile f = do
   s <- readFile f
   return (runParser f s)

--- a/test/Reg/Run/Base.hs
+++ b/test/Reg/Run/Base.hs
@@ -52,7 +52,7 @@ regRunAssertionParam interpretFun mainFile expectedFile trans testTrans step = d
   step "Parse"
   r <- parseFile mainFile
   case r of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md -> do
       unless (null trans) $
         step "Transform"
@@ -84,7 +84,7 @@ regRunErrorAssertion mainFile step = do
             )
         Nothing -> assertBool "" True
 
-parseFile :: Path Abs File -> IO (Either MegaparsecError Module)
+parseFile :: Path Abs File -> IO (Either ParserError Module)
 parseFile f = do
   s <- readFile f
   return (runParser f s)

--- a/test/Tree/Asm/Base.hs
+++ b/test/Tree/Asm/Base.hs
@@ -17,7 +17,7 @@ treeAsmAssertion root' mainFile expectedFile step = do
   step "Parse"
   s <- readFile mainFile
   case runParser mainFile s of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right tabIni -> do
       step "Translate"
       entryPoint <- testDefaultEntryPointIO root' mainFile

--- a/test/Tree/Compile/Base.hs
+++ b/test/Tree/Compile/Base.hs
@@ -62,7 +62,7 @@ treeCompileAssertion root' mainFile expectedFile stdinText step = do
   step "Parse"
   s <- readFile mainFile
   case runParser mainFile s of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md -> do
       entryPoint <-
         set entryPointPipeline (Just EntryPoint.PipelineExec)

--- a/test/Tree/Eval/Base.hs
+++ b/test/Tree/Eval/Base.hs
@@ -34,7 +34,7 @@ treeEvalAssertionParam evalParam mainFile expectedFile trans testTrans step = do
   step "Parse"
   s <- readFile mainFile
   case runParser mainFile s of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md0 -> do
       step "Validate"
       let opts = Tree.defaultOptions
@@ -99,7 +99,7 @@ treeEvalErrorAssertion mainFile step = do
   step "Parse"
   s <- readFile mainFile
   case runParser mainFile s of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md ->
       case md ^. moduleInfoTable . infoMainFunction of
         Just sym -> do

--- a/test/Tree/Parse/Base.hs
+++ b/test/Tree/Parse/Base.hs
@@ -4,14 +4,13 @@ import Base
 import Juvix.Compiler.Tree.Data.Module
 import Juvix.Compiler.Tree.Pretty
 import Juvix.Compiler.Tree.Translation.FromSource
-import Juvix.Data.PPOutput
 
 treeParseAssertion :: Path Abs File -> (String -> IO ()) -> Assertion
 treeParseAssertion mainFile step = do
   step "Parse"
   r <- parseFile mainFile
   case r of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right md -> do
       withTempDir'
         ( \dirPath -> do
@@ -21,14 +20,14 @@ treeParseAssertion mainFile step = do
             step "Parse printed"
             r' <- parseFile outputFile
             case r' of
-              Left err -> assertFailure (prettyString err)
+              Left err -> assertFailure (renderStringDefault err)
               Right md' -> do
                 assertBool
                   ("Check: print . parse = print . parse . print . parse")
                   (ppPrint md (computeCombinedInfoTable md) == ppPrint md' (computeCombinedInfoTable md'))
         )
 
-parseFile :: Path Abs File -> IO (Either MegaparsecError Module)
+parseFile :: Path Abs File -> IO (Either ParserError Module)
 parseFile f = do
   s <- readFile f
   return (runParser f s)

--- a/test/Tree/Transformation/CheckNoAnoma.hs
+++ b/test/Tree/Transformation/CheckNoAnoma.hs
@@ -27,7 +27,7 @@ treeEvalTransformationErrorAssertion mainFile trans checkError step = do
   step "Parse"
   s <- readFile mainFile
   case runParser mainFile s of
-    Left err -> assertFailure (prettyString err)
+    Left err -> assertFailure (renderStringDefault err)
     Right tab0 -> do
       step "Validate"
       case run $ runReader Tree.defaultOptions $ runError @JuvixError $ applyTransformations [Validate] tab0 of

--- a/tests/negative/PragmasFormat.juvix
+++ b/tests/negative/PragmasFormat.juvix
@@ -1,6 +1,6 @@
 module PragmasFormat;
 
-open import Stdlib.Prelude;
+import Stdlib.Prelude open;
 
 {-# inline: Tre #-}
 main : Nat := 0;


### PR DESCRIPTION
* Closes #3303 
* Removes `parseFailure` from the frontend parser.
* Replaces most remaining occurrences of `parseFailure` with `parsingError` which throws a parsing error instead of relying on the megaparsec error mechanism.
