### PR TITLE
Plain markdown support

### DIFF
--- a/app/Commands/Dev.hs
+++ b/app/Commands/Dev.hs
@@ -19,6 +19,7 @@ import Commands.Dev.MigrateJuvixYaml qualified as MigrateJuvixYaml
 import Commands.Dev.Nockma qualified as Nockma
 import Commands.Dev.Options
 import Commands.Dev.Parse qualified as Parse
+import Commands.Dev.PlainMarkdown qualified as PlainMarkdown
 import Commands.Dev.Reg qualified as Reg
 import Commands.Dev.Runtime qualified as Runtime
 import Commands.Dev.Scope qualified as Scope
@@ -47,3 +48,4 @@ runCommand = \case
   MigrateJuvixYaml opts -> runFilesIO $ MigrateJuvixYaml.runCommand opts
   Nockma opts -> Nockma.runCommand opts
   Anoma opts -> Anoma.runCommand opts
+  PlainMarkdown opts -> PlainMarkdown.runCommand opts

--- a/app/Commands/Dev/Options.hs
+++ b/app/Commands/Dev/Options.hs
@@ -25,6 +25,7 @@ import Commands.Dev.Latex.Options
 import Commands.Dev.MigrateJuvixYaml.Options
 import Commands.Dev.Nockma.Options
 import Commands.Dev.Parse.Options
+import Commands.Dev.PlainMarkdown.Options
 import Commands.Dev.Reg.Options
 import Commands.Dev.Repl.Options
 import Commands.Dev.Runtime.Options
@@ -45,6 +46,7 @@ data DevCommand
   | Asm AsmCommand
   | Reg RegCommand
   | Tree TreeCommand
+  | PlainMarkdown PlainMarkdownCommand
   | Casm CasmCommand
   | Runtime RuntimeCommand
   | Parse ParseOptions
@@ -78,9 +80,17 @@ parseDevCommand =
           commandMigrateJuvixYaml,
           commandLatex,
           commandAnoma,
-          commandNockma
+          commandNockma,
+          commandPlainMarkdown
         ]
     )
+
+commandPlainMarkdown :: Mod CommandFields DevCommand
+commandPlainMarkdown =
+  command "plain-markdown" $
+    info
+      (PlainMarkdown <$> parsePlainMarkdownCommand)
+      (progDesc "Subcommands related to Markdown (without Juvix)")
 
 commandLatex :: Mod CommandFields DevCommand
 commandLatex =

--- a/app/Commands/Dev/PlainMarkdown.hs
+++ b/app/Commands/Dev/PlainMarkdown.hs
@@ -1,0 +1,9 @@
+module Commands.Dev.PlainMarkdown where
+
+import Commands.Base
+import Commands.Dev.PlainMarkdown.Format qualified as Format
+import Commands.Dev.PlainMarkdown.Options
+
+runCommand :: forall r. (Members AppEffects r) => PlainMarkdownCommand -> Sem r ()
+runCommand = \case
+  Format opts -> Format.runCommand opts

--- a/app/Commands/Dev/PlainMarkdown/Format.hs
+++ b/app/Commands/Dev/PlainMarkdown/Format.hs
@@ -1,0 +1,17 @@
+module Commands.Dev.PlainMarkdown.Format where
+
+import Commands.Base
+import Commands.Dev.PlainMarkdown.Format.Options
+import Markdown.FromSource
+import Markdown.Print
+
+runCommand ::
+  forall r.
+  (Members AppEffects r) =>
+  FormatOptions ->
+  Sem r ()
+runCommand opts = do
+  afile <- fromAppPathFile (opts ^. formatFile)
+  mdBlock <- runAppError @SimpleError (fromFile afile)
+  print mdBlock
+  renderStdOutLn (ppOut mdBlock)

--- a/app/Commands/Dev/PlainMarkdown/Format/Options.hs
+++ b/app/Commands/Dev/PlainMarkdown/Format/Options.hs
@@ -1,0 +1,15 @@
+module Commands.Dev.PlainMarkdown.Format.Options where
+
+import CommonOptions
+
+newtype FormatOptions = FormatOptions
+  { _formatFile :: AppPath File
+  }
+  deriving stock (Data)
+
+makeLenses ''FormatOptions
+
+parseFormatOptions :: Parser FormatOptions
+parseFormatOptions = do
+  _formatFile <- parseInputFile FileExtMarkdown
+  pure FormatOptions {..}

--- a/app/Commands/Dev/PlainMarkdown/Options.hs
+++ b/app/Commands/Dev/PlainMarkdown/Options.hs
@@ -1,0 +1,24 @@
+module Commands.Dev.PlainMarkdown.Options where
+
+import Commands.Dev.PlainMarkdown.Format.Options
+import CommonOptions
+
+data PlainMarkdownCommand
+  = Format FormatOptions
+  deriving stock (Data)
+
+parsePlainMarkdownCommand :: Parser PlainMarkdownCommand
+parsePlainMarkdownCommand =
+  hsubparser $
+    mconcat
+      [ commandFormat
+      ]
+  where
+    commandFormat :: Mod CommandFields PlainMarkdownCommand
+    commandFormat = command "format" formatInfo
+      where
+        formatInfo :: ParserInfo PlainMarkdownCommand
+        formatInfo =
+          info
+            (Format <$> parseFormatOptions)
+            (progDesc "Format a plain markdown file (no Juvix involved)")

--- a/app/CommonOptions.hs
+++ b/app/CommonOptions.hs
@@ -47,7 +47,7 @@ instance Show (AppPath f) where
 
 parseInputFilesMod :: NonEmpty FileExt -> Mod ArgumentFields (Prepath File) -> Parser (AppPath File)
 parseInputFilesMod exts' mods = do
-  let exts = NonEmpty.toList exts'
+  let exts = toList exts'
       mvars = intercalate "|" (map toMetavar exts)
       dotExts = intercalate ", " (map show exts)
       helpMsg = "Path to a " <> dotExts <> " file"

--- a/app/TopCommand.hs
+++ b/app/TopCommand.hs
@@ -1,6 +1,6 @@
 module TopCommand where
 
-import Commands.Base hiding (Format)
+import Commands.Base
 import Commands.Clean qualified as Clean
 import Commands.Compile qualified as Compile
 import Commands.Dependencies qualified as Dependencies

--- a/src/Juvix/Compiler/Backend/Markdown/Data/Types.hs
+++ b/src/Juvix/Compiler/Backend/Markdown/Data/Types.hs
@@ -4,7 +4,7 @@ module Juvix.Compiler.Backend.Markdown.Data.Types
   )
 where
 
-import Commonmark qualified as MK
+import Commonmark qualified as CM
 import Data.Text qualified as T
 import Juvix.Compiler.Backend.Markdown.Data.MkJuvixBlockOptions
 import Juvix.Data.Loc
@@ -90,13 +90,13 @@ instance Monoid Mk where
 nl :: Text
 nl = "\n"
 
-instance MK.ToPlainText TextBlock where
+instance CM.ToPlainText TextBlock where
   toPlainText r = r ^. textBlock
 
-instance MK.ToPlainText JuvixCodeBlock where
+instance CM.ToPlainText JuvixCodeBlock where
   toPlainText = show
 
-instance MK.ToPlainText Mk where
+instance CM.ToPlainText Mk where
   toPlainText =
     trimText
       . mconcat
@@ -112,7 +112,7 @@ builder = \case
 flatten :: [Mk] -> Mk
 flatten = foldl' (<>) MkNull
 
-instance MK.Rangeable Mk where
+instance CM.Rangeable Mk where
   ranged _ x = x
 
 toTextBlock :: Text -> TextBlock
@@ -145,16 +145,16 @@ paren = wrap' "(" ")"
 brack :: TextBlock -> TextBlock
 brack = wrap' "[" "]"
 
-instance MK.HasAttributes TextBlock where
+instance CM.HasAttributes TextBlock where
   addAttributes _ = id
 
-instance MK.Rangeable TextBlock where
+instance CM.Rangeable TextBlock where
   ranged _ r = r
 
-instance MK.HasAttributes Mk where
+instance CM.HasAttributes Mk where
   addAttributes _ = id
 
-instance MK.IsInline TextBlock where
+instance CM.IsInline TextBlock where
   lineBreak = toTextBlock nl
   softBreak = toTextBlock " "
   str = toTextBlock
@@ -168,7 +168,7 @@ instance MK.IsInline TextBlock where
     toTextBlock "!" <> brack desc <> paren (toTextBlock src)
   code = wrap "`" . toTextBlock
   rawInline f t
-    | f == MK.Format "html" =
+    | f == CM.Format "html" =
         toTextBlock t
     | otherwise = mempty
 
@@ -189,7 +189,7 @@ processCodeBlock info t loc =
       let b = "```" <> info <> t <> "```"
        in MkTextBlock TextBlock {_textBlock = b, _textBlockInterval = loc}
 
-instance MK.IsBlock TextBlock Mk where
+instance CM.IsBlock TextBlock Mk where
   paragraph a = MkTextBlock a
   plain a = MkTextBlock a
   thematicBreak = toMK "---"

--- a/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
+++ b/src/Juvix/Compiler/Concrete/Translation/FromSource.hs
@@ -161,11 +161,11 @@ runModuleParser fileName input_
       res <- P.runParserT juvixCodeBlockParser (toFilePath fileName) input_
       case res of
         Left err -> return . Left . ErrMegaparsec . MegaparsecError $ err
-        Right r
-          | MK.nullMk r ->
+        Right mk
+          | MK.nullMk mk ->
               return . Left . ErrMarkdownBackend $
                 ErrNoJuvixCodeBlocks NoJuvixCodeBlocksError {_noJuvixCodeBlocksErrorFilepath = fileName}
-          | otherwise -> runMarkdownModuleParser fileName r
+          | otherwise -> runMarkdownModuleParser fileName mk
   | otherwise = do
       m <-
         evalState (Nothing @ParsedPragmas)

--- a/src/Juvix/Prelude/Base/Foundation.hs
+++ b/src/Juvix/Prelude/Base/Foundation.hs
@@ -133,7 +133,7 @@ import Data.Bifunctor hiding (first, second)
 import Data.Bitraversable
 import Data.Bool
 import Data.ByteString (ByteString)
-import Data.Char
+import Data.Char hiding (Format)
 import Data.Char qualified as Char
 import Data.Data
 import Data.Either.Extra

--- a/src/Juvix/Prelude/Trace.hs
+++ b/src/Juvix/Prelude/Trace.hs
@@ -27,7 +27,8 @@ traceWith f a = trace (f a) a
 
 trace :: Text -> a -> a
 trace = traceLabel ""
-{-# WARNING trace "Using trace" #-}
+
+-- {-# WARNING trace "Using trace" #-}
 
 traceM :: (Applicative f) => Text -> f ()
 traceM t = traceLabel "" t (pure ())

--- a/src/Markdown/FromSource.hs
+++ b/src/Markdown/FromSource.hs
@@ -4,10 +4,19 @@ module Markdown.FromSource where
 import Commonmark.Parser
 import Juvix.Prelude
 import Markdown.Language
+import Text.Show.Pretty
 
-fromFile :: (Members '[Files, Error SimpleError] r) => Path Abs File -> Sem r Block
+fromFile :: (Members '[Files, Error SimpleError] r) => Path Abs File -> Sem r Blocks
 fromFile inputFile = do
   txt <- readFile' inputFile
   case commonmark (toFilePath inputFile) txt of
-    Left err -> todo
+    Left _err -> error "parse error"
     Right block -> return block
+
+testFile :: Path Abs File -> IO ()
+testFile f = runM . runFilesIO . runSimpleErrorIO $ do
+  b <- fromFile f
+  print (ppShow (b ^. blocks))
+  putStrLn "================"
+  putStrLn "================\n"
+  print b

--- a/src/Markdown/FromSource.hs
+++ b/src/Markdown/FromSource.hs
@@ -1,0 +1,13 @@
+-- | Import this module qualified
+module Markdown.FromSource where
+
+import Commonmark.Parser
+import Juvix.Prelude
+import Markdown.Language
+
+fromFile :: (Members '[Files, Error SimpleError] r) => Path Abs File -> Sem r Block
+fromFile inputFile = do
+  txt <- readFile' inputFile
+  case commonmark (toFilePath inputFile) txt of
+    Left err -> todo
+    Right block -> return block

--- a/src/Markdown/Language.hs
+++ b/src/Markdown/Language.hs
@@ -1,0 +1,150 @@
+module Markdown.Language
+  ( module Markdown.Language,
+    Attribute,
+    Format,
+    ListSpacing,
+    ListType,
+  )
+where
+
+import Commonmark
+import Juvix.Prelude
+
+data Link = Link
+  { _linkDestination :: Text,
+    _linkTitle :: Text,
+    _linkDescription :: Inlines
+  }
+  deriving stock (Show)
+
+data Image = Image
+  { _imageSource :: Text,
+    _imageTitle :: Text,
+    _imageDescription :: Inlines
+  }
+  deriving stock (Show)
+
+data RawInline = RawInline
+  { _rawInlineFormat :: Format,
+    _rawInlineText :: Text
+  }
+  deriving stock (Show)
+
+data InlineElem
+  = InlineLineBreak
+  | InlineSoftBreak
+  | InlineString Text
+  | InlineEntity Text
+  | InlineEscapedChar Char
+  | InlineEmph Inlines
+  | InlineStrong Inlines
+  | InlineLink Link
+  | InlineImage Image
+  | InlineCode Text
+  | InlineRaw RawInline
+  deriving stock (Show)
+
+data CodeBlock = CodeBlock
+  { _codeBlockLanguage :: Text,
+    _codeBlock :: Text
+  }
+  deriving stock (Show)
+
+data Heading = Heading
+  { _headingLabel :: Text,
+    _headingText :: Inline
+  }
+  deriving stock (Show)
+
+data RawBlock = RawBlock
+  { _rawBlockFormat :: Format,
+    _rawBlockText :: Text
+  }
+  deriving stock (Show)
+
+data ReferenceLinkDefinition = ReferenceLinkDefinition
+  { _referenceLinkDefinitionLabel :: Text,
+    _referenceLinkDefinitionDestination :: Text,
+    _referenceLinkDefinitionTitle :: Text
+  }
+  deriving stock (Show)
+
+data List = List
+  { _listType :: ListType,
+    _listSpacing :: ListSpacing,
+    _listBlocks :: [Block]
+  }
+  deriving stock (Show)
+
+data Block
+  = BlockParagraph Inline
+  | BlockPlain Inline
+  | BlockThematicBreak Block
+  | BlockQuote Block
+  | BlockCodeBlock CodeBlock
+  | BlockRawBlock RawBlock
+  | BlockReferenceLinkDefinition ReferenceLinkDefinition
+  | BlockList List
+  deriving stock (Show)
+
+data Inline = Inline
+  { _inlineAttributes :: [Attribute],
+    _inlineElem :: InlineElem
+  }
+  deriving stock (Show)
+
+newtype Inlines = Inlines
+  { _inlines :: [Inline]
+  }
+  deriving stock (Show)
+  deriving newtype (Semigroup, Monoid)
+
+makeLenses ''Link
+makeLenses ''Inline
+makeLenses ''Inlines
+makeLenses ''Image
+makeLenses ''CodeBlock
+
+instance HasAttributes Inline where
+  addAttributes attr = (over inlineAttributes (attr ++))
+
+-- TODO
+instance Rangeable Inline where
+  ranged _ = error "todo"
+
+instance HasAttributes Inlines where
+  addAttributes attr = over inlines (map (addAttributes attr))
+
+-- TODO
+instance Rangeable Inlines where
+  ranged _ = error "todo"
+
+class IsInlines a where
+  toInlines :: a -> Inlines
+
+instance IsInlines Inlines where
+  toInlines = id
+
+instance IsInlines InlineElem where
+  toInlines e =
+    Inlines
+      { _inlines =
+          [ Inline
+              { _inlineAttributes = [],
+                _inlineElem = e
+              }
+          ]
+      }
+
+instance IsInline Inlines where
+  lineBreak = toInlines InlineLineBreak
+  softBreak = toInlines InlineSoftBreak
+  str a = toInlines (InlineString a)
+  entity a = toInlines (InlineEntity a)
+  escapedChar a = toInlines (InlineEscapedChar a)
+  emph a = toInlines (InlineEmph a)
+  strong a = toInlines (InlineStrong a)
+  link _linkDestination _linkTitle _linkDescription = toInlines (InlineLink Link {..})
+  image _imageSource _imageTitle _imageDescription = toInlines (InlineImage Image {..})
+  code a = toInlines (InlineCode a)
+  rawInline _rawInlineFormat _rawInlineText = toInlines (InlineRaw (RawInline {..}))

--- a/src/Markdown/Language.hs
+++ b/src/Markdown/Language.hs
@@ -9,31 +9,39 @@ where
 
 import Commonmark
 import Juvix.Prelude
+import Juvix.Prelude.Pretty
 
 data Link = Link
   { _linkDestination :: Text,
     _linkTitle :: Text,
     _linkDescription :: Inlines
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data Image = Image
   { _imageSource :: Text,
     _imageTitle :: Text,
     _imageDescription :: Inlines
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data RawInline = RawInline
   { _rawInlineFormat :: Format,
     _rawInlineText :: Text
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
-data InlineElem
+data Meta a = Meta
+  { _metaAttributes :: [Attribute],
+    _metaLoc :: Irrelevant SourceRange,
+    _metaArg :: a
+  }
+  deriving stock (Show, Eq, Generic)
+
+data Inline
   = InlineLineBreak
   | InlineSoftBreak
-  | InlineString Text
+  | InlineString (Meta Text)
   | InlineEntity Text
   | InlineEscapedChar Char
   | InlineEmph Inlines
@@ -42,82 +50,113 @@ data InlineElem
   | InlineImage Image
   | InlineCode Text
   | InlineRaw RawInline
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data CodeBlock = CodeBlock
   { _codeBlockLanguage :: Text,
     _codeBlock :: Text
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data Heading = Heading
-  { _headingLabel :: Text,
-    _headingText :: Inline
+  { _headingLevel :: Int,
+    _headingText :: Inlines
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data RawBlock = RawBlock
   { _rawBlockFormat :: Format,
     _rawBlockText :: Text
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data ReferenceLinkDefinition = ReferenceLinkDefinition
   { _referenceLinkDefinitionLabel :: Text,
     _referenceLinkDefinitionDestination :: Text,
     _referenceLinkDefinitionTitle :: Text
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data List = List
   { _listType :: ListType,
     _listSpacing :: ListSpacing,
     _listBlocks :: [Block]
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
 data Block
-  = BlockParagraph Inline
-  | BlockPlain Inline
+  = BlockParagraph (Meta Inlines)
+  | BlockPlain (Meta Inlines)
+  | BlockHeading (Meta Heading)
   | BlockThematicBreak Block
   | BlockQuote Block
-  | BlockCodeBlock CodeBlock
+  | BlockCodeBlock (Meta CodeBlock)
   | BlockRawBlock RawBlock
   | BlockReferenceLinkDefinition ReferenceLinkDefinition
   | BlockList List
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
 
-data Inline = Inline
-  { _inlineAttributes :: [Attribute],
-    _inlineElem :: InlineElem
+newtype Blocks = Blocks
+  { _blocks :: [Block]
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (Semigroup, Monoid)
+
+mkBlocks :: Block -> Blocks
+mkBlocks = Blocks . pure
 
 newtype Inlines = Inlines
   { _inlines :: [Inline]
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
   deriving newtype (Semigroup, Monoid)
 
 makeLenses ''Link
 makeLenses ''Inline
 makeLenses ''Inlines
+makeLenses ''Blocks
 makeLenses ''Image
 makeLenses ''CodeBlock
+makeLenses ''Meta
+
+mkMeta :: a -> Meta a
+mkMeta _metaArg =
+  Meta
+    { _metaArg,
+      _metaLoc = Irrelevant iniRange,
+      _metaAttributes = []
+    }
+
+instance HasAttributes (Meta a) where
+  addAttributes attr = over metaAttributes (attr ++)
+
+instance Rangeable (Meta a) where
+  ranged = set (metaLoc . unIrrelevant)
 
 instance HasAttributes Inline where
-  addAttributes attr = (over inlineAttributes (attr ++))
+  addAttributes _attr = error "todo"
 
 -- TODO
 instance Rangeable Inline where
-  ranged _ = error "todo"
+  ranged d =
+    \case
+      InlineString s -> InlineString (ranged d s)
+      x ->
+        trace
+          ("* rangeable inline: '" <> (show x) <> "' " <> show d)
+          x
+
+instance HasAttributes Blocks where
+  addAttributes attr = over blocks (map (addAttributes attr))
 
 instance HasAttributes Inlines where
   addAttributes attr = over inlines (map (addAttributes attr))
 
--- TODO
+instance Rangeable Blocks where
+  ranged d bs = trace ("rangeable blocks " <> show (length (bs ^. blocks)) <> " " <> show d) (over blocks (map (ranged d)) bs)
+
 instance Rangeable Inlines where
-  ranged _ = error "todo"
+  ranged d = trace ("rangeable inlines " <> show d) . over inlines (map (ranged d))
 
 class IsInlines a where
   toInlines :: a -> Inlines
@@ -125,21 +164,41 @@ class IsInlines a where
 instance IsInlines Inlines where
   toInlines = id
 
-instance IsInlines InlineElem where
+instance IsInlines Inline where
   toInlines e =
     Inlines
-      { _inlines =
-          [ Inline
-              { _inlineAttributes = [],
-                _inlineElem = e
-              }
-          ]
+      { _inlines = [e]
       }
+
+placeHolderInterval :: Interval
+placeHolderInterval = intervalFromFile $(mkAbsFile "/<temporary location>")
+
+iniLoc :: Interval
+iniLoc = placeHolderInterval
+
+iniRange :: SourceRange
+-- iniRange = impossibleError "The SourceRange should never be accessed. It should be replaced by 'ranged' during parsing"
+iniRange = mempty
+
+instance Rangeable Block where
+  ranged r b =
+    trace
+      ("rangeable block: " <> show b)
+      ( case b of
+          BlockParagraph a -> BlockParagraph (ranged r a)
+          BlockPlain a -> BlockPlain (ranged r a)
+          BlockCodeBlock a -> BlockCodeBlock (ranged r a)
+          BlockHeading a -> BlockHeading (ranged r a)
+          x -> error ("TODO: " <> show x)
+      )
+
+instance HasAttributes Block where
+  addAttributes _ = error "todo"
 
 instance IsInline Inlines where
   lineBreak = toInlines InlineLineBreak
   softBreak = toInlines InlineSoftBreak
-  str a = toInlines (InlineString a)
+  str a = toInlines (InlineString (mkMeta a))
   entity a = toInlines (InlineEntity a)
   escapedChar a = toInlines (InlineEscapedChar a)
   emph a = toInlines (InlineEmph a)
@@ -148,3 +207,17 @@ instance IsInline Inlines where
   image _imageSource _imageTitle _imageDescription = toInlines (InlineImage Image {..})
   code a = toInlines (InlineCode a)
   rawInline _rawInlineFormat _rawInlineText = toInlines (InlineRaw (RawInline {..}))
+
+instance IsBlock Inlines Blocks where
+  plain p = mkBlocks (BlockPlain (mkMeta p))
+  paragraph i = mkBlocks (BlockParagraph (mkMeta i))
+  thematicBreak = error "todo"
+  blockQuote = error "todo"
+  codeBlock _codeBlockLanguage _codeBlock = mkBlocks (BlockCodeBlock (mkMeta (CodeBlock {..})))
+  heading _headingLevel _headingText = mkBlocks (BlockHeading (mkMeta Heading {..}))
+  rawBlock = error "todo"
+  referenceLinkDefinition = error "todo"
+  list = error "todo"
+
+instance (Pretty a) => Pretty (Meta a) where
+  pretty = pretty . (^. metaArg)

--- a/src/Markdown/Print.hs
+++ b/src/Markdown/Print.hs
@@ -1,0 +1,69 @@
+module Markdown.Print
+  ( module Markdown.Print,
+    module Markdown.Print.Options,
+  )
+where
+
+import Data.Text qualified as Text
+import Juvix.Data.Effect.ExactPrint
+import Juvix.Data.PPOutput (AnsiText, mkAnsiText)
+import Juvix.Prelude
+import Juvix.Prelude.Pretty (pretty)
+import Markdown.Language
+import Markdown.Print.Options
+
+ppOut :: (PrettyPrint c) => c -> AnsiText
+ppOut =
+  mkAnsiText
+    . run
+    . execExactPrint Nothing
+    . runReader Options
+    . ppCode
+
+class PrettyPrint a where
+  ppCode :: (Members '[ExactPrint, Reader Options] r) => a -> Sem r ()
+
+instance (PrettyPrint a) => PrettyPrint (Meta a) where
+  ppCode = ppCode . (^. metaArg)
+
+instance PrettyPrint Inline where
+  ppCode = \case
+    InlineString txt -> noLoc (pretty txt)
+    InlineSoftBreak -> hardline
+    _ -> todo
+
+instance PrettyPrint Inlines where
+  ppCode = mapM_ ppCode . (^. inlines)
+
+instance PrettyPrint Blocks where
+  ppCode = concatWith (\a b -> a <> hardline <> hardline <> b) . map ppCode . (^. blocks)
+
+instance PrettyPrint Text where
+  ppCode = noLoc . pretty
+
+instance PrettyPrint CodeBlock where
+  ppCode :: forall r. (Members '[ExactPrint, Reader Options] r) => CodeBlock -> Sem r ()
+  ppCode CodeBlock {..} = do
+    codeSep
+    ppCode _codeBlockLanguage
+    hardline
+    ppCode _codeBlock
+    codeSep
+    where
+      codeSep :: Sem r ()
+      codeSep = ppCode @Text "```"
+
+instance PrettyPrint Heading where
+  ppCode Heading {..} = do
+    ppCode (Text.replicate _headingLevel "#")
+    if
+        | null (_headingText ^. inlines) -> return ()
+        | otherwise -> ppCode @Text " " >> ppCode _headingText
+
+instance PrettyPrint Block where
+  ppCode = \case
+    BlockParagraph p -> ppCode p
+    BlockPlain p -> ppCode p
+    BlockCodeBlock p -> ppCode p
+    BlockHeading p -> ppCode p
+    x -> error ("TODO: " <> show x)

--- a/src/Markdown/Print/Options.hs
+++ b/src/Markdown/Print/Options.hs
@@ -1,0 +1,6 @@
+module Markdown.Print.Options where
+
+data Options = Options
+
+defaultOptions :: Options
+defaultOptions = Options


### PR DESCRIPTION
This pr adds a markdown AST and a prettyprinter.
It also adds the command `dev plain-markdown format`, which takes a markdown file as an input and outputs the formatted version to stdout.