### PR TITLE
Temporarily disable RISC0 in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,12 +234,12 @@ jobs:
           toolchain: 1.81.0
           cache-on-failure: false
 
-      - name: Install RISC0 VM
-        shell: bash
-        run: |
-          curl -L https://risczero.com/install | bash
-          ~/.risc0/bin/rzup install
-          ~/.risc0/bin/rzup install r0vm 1.2.5
+      # - name: Install RISC0 VM
+      #   shell: bash
+      #   run: |
+      #     curl -L https://risczero.com/install | bash
+      #     ~/.risc0/bin/rzup install
+      #     ~/.risc0/bin/rzup install r0vm 1.2.4
 
       - name: Checkout CairoVM
         uses: actions/checkout@v4

--- a/test/Rust.hs
+++ b/test/Rust.hs
@@ -2,9 +2,8 @@ module Rust where
 
 import Base
 import Rust.Compilation qualified as Compilation
-import Rust.RiscZero qualified as RiscZero
 
 allTests :: IO TestTree
 allTests =
   sequentialTestGroup "Juvix to Rust tests" AllFinish
-    <$> sequence [Compilation.allTests, RiscZero.allTests]
+    <$> sequence [Compilation.allTests]


### PR DESCRIPTION
We will re-enable it once the RISC0 toolchain is more stable and we figure out how to reliably lock the versions.
