### PR TITLE
Noun-like type representation in Nockma

### DIFF
--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -374,25 +374,25 @@ supportsNounNockmaRep tab ci = fmap NockmaMemRepNoun . run . runFail $ do
       return NockmaMemRepAtom
     2 -> return NockmaMemRepCell
     _ -> impossible
-    where
-      -- Returns True if all elements of some type are representable with an
-      -- Atom. There may be false negatives. In that case, a less optimal
-      -- representation might be chosen, but it shouldn't effect correctness.
-      typeRepresentedAsAtom :: Tree.Type -> Bool
-      typeRepresentedAsAtom = \case
-        Tree.TyInteger {} -> True
-        Tree.TyBool {} -> True
-        Tree.TyString {} -> True
-        Tree.TyUnit {} -> True
-        --
-        Tree.TyField {} -> False
-        Tree.TyVoid {} -> False
-        Tree.TyInductive {} -> False
-        Tree.TyConstr {} -> False
-        Tree.TyFun {} -> False
-        Tree.TyByteArray {} -> False
-        Tree.TyDynamic -> False
-        Tree.TyRandomGenerator {} -> False
+  where
+    -- Returns True if all elements of some type are representable with an
+    -- Atom. There may be false negatives. In that case, a less optimal
+    -- representation might be chosen, but it shouldn't effect correctness.
+    typeRepresentedAsAtom :: Tree.Type -> Bool
+    typeRepresentedAsAtom = \case
+      Tree.TyInteger {} -> True
+      Tree.TyBool {} -> True
+      Tree.TyString {} -> True
+      Tree.TyUnit {} -> True
+      --
+      Tree.TyField {} -> False
+      Tree.TyVoid {} -> False
+      Tree.TyInductive {} -> False
+      Tree.TyConstr {} -> False
+      Tree.TyFun {} -> False
+      Tree.TyByteArray {} -> False
+      Tree.TyDynamic -> False
+      Tree.TyRandomGenerator {} -> False
 
 supportsMaybeNockmaRep :: Tree.InfoTable -> Tree.ConstructorInfo -> Maybe NockmaMemRep
 supportsMaybeNockmaRep tab ci =

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -363,23 +363,6 @@ supportsListNockmaRep tab ci =
       | otherwise -> Nothing
     _ -> Nothing
 
--- | false negatives are ok
-typeRepresentedAsAtom :: Tree.Type -> Bool
-typeRepresentedAsAtom = \case
-  Tree.TyInteger {} -> True
-  Tree.TyBool {} -> True
-  Tree.TyString {} -> True
-  Tree.TyUnit {} -> True
-  --
-  Tree.TyField {} -> False
-  Tree.TyVoid {} -> False
-  Tree.TyInductive {} -> False
-  Tree.TyConstr {} -> False
-  Tree.TyFun {} -> False
-  Tree.TyByteArray {} -> False
-  Tree.TyDynamic -> False
-  Tree.TyRandomGenerator {} -> False
-
 supportsNounNockmaRep :: Tree.InfoTable -> Tree.ConstructorInfo -> Maybe NockmaMemRep
 supportsNounNockmaRep tab ci = fmap NockmaMemRepNoun . run . runFail $ do
   c1 :| [c2] <- pure (allConstructors tab ci)
@@ -391,6 +374,25 @@ supportsNounNockmaRep tab ci = fmap NockmaMemRepNoun . run . runFail $ do
       return NockmaMemRepAtom
     2 -> return NockmaMemRepCell
     _ -> impossible
+    where
+      -- Returns True if all elements of some type are representable with an
+      -- Atom. There may be false negatives. In that case, a less optimal
+      -- representation might be chosen, but it shouldn't effect correctness.
+      typeRepresentedAsAtom :: Tree.Type -> Bool
+      typeRepresentedAsAtom = \case
+        Tree.TyInteger {} -> True
+        Tree.TyBool {} -> True
+        Tree.TyString {} -> True
+        Tree.TyUnit {} -> True
+        --
+        Tree.TyField {} -> False
+        Tree.TyVoid {} -> False
+        Tree.TyInductive {} -> False
+        Tree.TyConstr {} -> False
+        Tree.TyFun {} -> False
+        Tree.TyByteArray {} -> False
+        Tree.TyDynamic -> False
+        Tree.TyRandomGenerator {} -> False
 
 supportsMaybeNockmaRep :: Tree.InfoTable -> Tree.ConstructorInfo -> Maybe NockmaMemRep
 supportsMaybeNockmaRep tab ci =

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -75,9 +75,18 @@ data NockmaMemRepMaybeConstr
   | NockmaMemRepMaybeConstrJust
   deriving stock (Eq)
 
+-- | A type that has two constructors:
+-- 1st constructor has a single argument. This argument must be representable as an atom.
+-- 2nd constructor has *at least* two arguments
+data NockmaMemRepNounConstr
+  = NockmaMemRepAtom
+  | NockmaMemRepCell
+  deriving stock (Eq)
+
 data NockmaMemRep
   = NockmaMemRepConstr
   | NockmaMemRepTuple
+  | NockmaMemRepNoun NockmaMemRepNounConstr
   | NockmaMemRepList NockmaMemRepListConstr
   | NockmaMemRepMaybe NockmaMemRepMaybeConstr
 
@@ -469,38 +478,44 @@ compile = \case
             path :: Sem r Path
             path = do
               fr <- directRefPath _fieldRef
-              return $ case memrep of
-                NockmaMemRepConstr ->
-                  fr
-                    ++ constructorPath ConstructorArgs
-                    ++ indexStack argIx
-                NockmaMemRepTuple ->
-                  fr
-                    ++ indexTuple
-                      IndexTupleArgs
-                        { _indexTupleArgsLength = arity,
-                          _indexTupleArgsIndex = argIx
-                        }
-                NockmaMemRepList constr -> case constr of
-                  NockmaMemRepListConstrNil -> impossible
-                  NockmaMemRepListConstrCons ->
-                    fr
-                      ++ indexTuple
+              return $
+                fr
+                  ++ case memrep of
+                    NockmaMemRepConstr ->
+                      constructorPath ConstructorArgs
+                        ++ indexStack argIx
+                    NockmaMemRepTuple ->
+                      indexTuple
                         IndexTupleArgs
-                          { _indexTupleArgsLength = 2,
+                          { _indexTupleArgsLength = arity,
                             _indexTupleArgsIndex = argIx
                           }
-                NockmaMemRepMaybe constr -> case constr of
-                  NockmaMemRepMaybeConstrNothing -> impossible
-                  -- just x is represented as [nil x] so argument index is offset by 1.
-                  -- argIx will always be 0 because just has one argument
-                  NockmaMemRepMaybeConstrJust ->
-                    fr
-                      ++ indexTuple
-                        IndexTupleArgs
-                          { _indexTupleArgsLength = 2,
-                            _indexTupleArgsIndex = argIx + 1
-                          }
+                    NockmaMemRepList constr -> case constr of
+                      NockmaMemRepListConstrNil -> impossible
+                      NockmaMemRepListConstrCons ->
+                        indexTuple
+                          IndexTupleArgs
+                            { _indexTupleArgsLength = 2,
+                              _indexTupleArgsIndex = argIx
+                            }
+                    NockmaMemRepNoun n -> case n of
+                      NockmaMemRepAtom -> []
+                      NockmaMemRepCell ->
+                        indexTuple
+                          IndexTupleArgs
+                            { _indexTupleArgsLength = arity,
+                              _indexTupleArgsIndex = argIx
+                            }
+                    NockmaMemRepMaybe constr -> case constr of
+                      NockmaMemRepMaybeConstrNothing -> impossible
+                      -- just x is represented as [nil x] so argument index is offset by 1.
+                      -- argIx will always be 0 because just has one argument
+                      NockmaMemRepMaybeConstrJust ->
+                        indexTuple
+                          IndexTupleArgs
+                            { _indexTupleArgsLength = 2,
+                              _indexTupleArgsIndex = argIx + 1
+                            }
         (opAddress "constrRef") <$> path
       where
         goDirectRef :: Tree.DirectRef -> Sem r (Term Natural)
@@ -980,8 +995,7 @@ goConstructor mr t args = assert (all isCell args) $
         makeConstructor $ \case
           ConstructorTag -> OpQuote # (fromIntegral (tag ^. Tree.tagUserWord) :: Natural)
           ConstructorArgs -> remakeList args
-      NockmaMemRepTuple ->
-        foldTerms (nonEmpty' args)
+      NockmaMemRepTuple -> foldTerms (nonEmpty' args)
       NockmaMemRepList constr -> case constr of
         NockmaMemRepListConstrNil
           | null args -> remakeList []
@@ -989,6 +1003,11 @@ goConstructor mr t args = assert (all isCell args) $
         NockmaMemRepListConstrCons -> case args of
           [l, r] -> TCell l r
           _ -> impossible
+      NockmaMemRepNoun constr -> case constr of
+        NockmaMemRepAtom -> case args of
+          [arg@(TermAtom _)] -> arg
+          _ -> impossible
+        NockmaMemRepCell -> foldTerms (nonEmpty' args)
       NockmaMemRepMaybe constr -> case constr of
         NockmaMemRepMaybeConstrNothing
           | null args -> (OpQuote # nockNilTagged "maybe-constr-nothing")
@@ -1200,7 +1219,7 @@ constructorTagToTerm = \case
   Tree.UserTag t -> OpQuote # toNock (fromIntegral (t ^. Tree.tagUserWord) :: Natural)
   Tree.BuiltinTag b -> builtinTagToTerm (nockmaBuiltinTag b)
 
--- Creates a case command from the reference `ref` to the compiled value and the
+-- | Creates a case command from the reference `ref` to the compiled value and the
 -- compiled branches.
 caseCmd ::
   forall r.
@@ -1257,6 +1276,15 @@ caseCmd ref defaultBranch = \case
           _ -> impossible
       Tree.BuiltinTag {} -> impossible
 
+    asNockmaMemRepNounConstr :: Tree.Tag -> Sem r NockmaMemRepNounConstr
+    asNockmaMemRepNounConstr tag = case tag of
+      Tree.UserTag {} -> do
+        rep <- getConstructorMemRep tag
+        case rep of
+          NockmaMemRepNoun constr -> return constr
+          _ -> impossible
+      Tree.BuiltinTag {} -> impossible
+
     asNockmaMemRepMaybeConstr :: Tree.Tag -> Sem r NockmaMemRepMaybeConstr
     asNockmaMemRepMaybeConstr tag = case tag of
       Tree.UserTag {} -> do
@@ -1296,6 +1324,18 @@ caseCmd ref defaultBranch = \case
         NockmaMemRepListConstrNil -> branch cond otherBranch b
       where
         f :: (NockmaMemRepListConstr, Term Natural) -> Maybe (Term Natural)
+        f (c', br) = guard (c /= c') $> br
+
+    goRepNoun :: NonEmpty (NockmaMemRepNounConstr, Term Natural) -> Sem r (Term Natural)
+    goRepNoun ((c, b) :| bs) = do
+      arg <- addressTempRef ref
+      let cond = OpIsCell # arg
+          otherBranch = fromMaybe crash (firstJust f bs <|> defaultBranch)
+      return $ case c of
+        NockmaMemRepCell -> branch cond b otherBranch
+        NockmaMemRepAtom -> branch cond otherBranch b
+      where
+        f :: (NockmaMemRepNounConstr, Term Natural) -> Maybe (Term Natural)
         f (c', br) = guard (c /= c') $> br
 
     goRepMaybe :: NonEmpty (NockmaMemRepMaybeConstr, Term Natural) -> Sem r (Term Natural)

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -538,7 +538,7 @@ compile = \case
                               _indexTupleArgsIndex = argIx
                             }
                     NockmaMemRepNoun n -> case n of
-                      NockmaMemRepAtom -> []
+                      NockmaMemRepAtom -> emptyPath
                       NockmaMemRepCell ->
                         indexTuple
                           IndexTupleArgs

--- a/src/Juvix/Compiler/Tree/Language/Type.hs
+++ b/src/Juvix/Compiler/Tree/Language/Type.hs
@@ -17,19 +17,19 @@ data Type
     -- of an appropriate TyInductive.
     TyConstr TypeConstr
   | TyFun TypeFun
-  deriving stock (Eq, Generic)
+  deriving stock (Show, Eq, Generic)
 
 data TypeInteger = TypeInteger
   { _typeIntegerMinValue :: Maybe Integer,
     _typeIntegerMaxValue :: Maybe Integer
   }
-  deriving stock (Eq, Generic)
+  deriving stock (Show, Eq, Generic)
 
 data TypeBool = TypeBool
   { _typeBoolTrueTag :: Tag,
     _typeBoolFalseTag :: Tag
   }
-  deriving stock (Generic)
+  deriving stock (Show, Generic)
 
 instance Eq TypeBool where
   _ == _ = True
@@ -37,14 +37,14 @@ instance Eq TypeBool where
 newtype TypeInductive = TypeInductive
   { _typeInductiveSymbol :: Symbol
   }
-  deriving stock (Eq, Generic)
+  deriving stock (Show, Eq, Generic)
 
 data TypeConstr = TypeConstr
   { _typeConstrInductive :: Symbol,
     _typeConstrTag :: Tag,
     _typeConstrFields :: [Type]
   }
-  deriving stock (Generic)
+  deriving stock (Show, Generic)
 
 instance Eq TypeConstr where
   (TypeConstr _ tag1 _) == (TypeConstr _ tag2 _) = tag1 == tag2
@@ -53,7 +53,7 @@ data TypeFun = TypeFun
   { _typeFunArgs :: NonEmpty Type,
     _typeFunTarget :: Type
   }
-  deriving stock (Eq, Generic)
+  deriving stock (Show, Eq, Generic)
 
 instance Serialize TypeInteger
 

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -1056,13 +1056,12 @@ allTests =
               $(mkRelFile "test087.juvix")
               [testList]
               $ checkTracesAndOutput [expectedOutput],
-        let expectedOutput :: Term Natural = [nock| [2 1 nil] |]
-         in mkAnomaTest
-              88
-              AnomaTestModeFull
-              "Noun type representation"
-              $(mkRelDir ".")
-              $(mkRelFile "test088.juvix")
-              []
-              $ checkTracesAndOutput [[nock| [30 40 80] |], [nock| 80 |], [nock| [0 0] |]]
+        mkAnomaTest
+          88
+          AnomaTestModeFull
+          "Noun type representation"
+          $(mkRelDir ".")
+          $(mkRelFile "test088.juvix")
+          []
+          $ checkTracesAndOutput [[nock| [30 40 80] |], [nock| 80 |], [nock| [0 0] |]]
       ]

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -1055,5 +1055,14 @@ allTests =
               $(mkRelDir ".")
               $(mkRelFile "test087.juvix")
               [testList]
-              $ checkTracesAndOutput [expectedOutput]
+              $ checkTracesAndOutput [expectedOutput],
+        let expectedOutput :: Term Natural = [nock| [2 1 nil] |]
+         in mkAnomaTest
+              88
+              AnomaTestModeFull
+              "Noun type representation"
+              $(mkRelDir ".")
+              $(mkRelFile "test088.juvix")
+              []
+              $ checkTracesAndOutput [[nock| [30 40 80] |], [nock| 80 |], [nock| [0 0] |]]
       ]

--- a/test/Anoma/Compilation/Positive.hs
+++ b/test/Anoma/Compilation/Positive.hs
@@ -236,6 +236,7 @@ classify AnomaTest {..} = case _anomaTestNum of
   85 -> ClassWorking
   86 -> ClassExpectedFail
   87 -> ClassWorking
+  88 -> ClassWorking
   _ -> error "non-exhaustive test classification"
 
 allTests :: TestTree

--- a/tests/Anoma/Compilation/positive/test088.juvix
+++ b/tests/Anoma/Compilation/positive/test088.juvix
@@ -1,0 +1,39 @@
+module test088;
+
+import Juvix.Builtin.V1.Nat open;
+import Juvix.Builtin.V1.Bool open;
+import Juvix.Builtin.V1.List open;
+
+-- -- Internally, it would be the identity function
+-- -- derived instances
+-- trait
+-- type Reify (T : Type) :=
+--   mk@{
+--     reify : T -> Term;
+--   };
+
+-- -- TODO nonempty-list
+-- type NockmaTypeRep := NockmaTypeRep (List NockmaConstructorRep);
+
+-- type NockmaConstructorRep :=
+--   | atom
+--   | cell@{
+--       left : NockmaTypeRep;
+--       right : NockmaTypeRep;
+--     };
+
+-- trait
+-- type HasNockmaRep (T : Type) := mk NockmaTypeRep;
+
+-- -- checkShape {T} {{Reify T}} {{HasNockmaRep T}} (t : T) : Bool := todo;
+
+type Term :=
+  | atom Nat
+  | cell@{
+      left : Term;
+      right : Term;
+    };
+
+t : Term := Term.cell (Term.atom 3) (Term.cell (Term.atom 4) (Term.atom 8));
+
+main : Term := t;

--- a/tests/Anoma/Compilation/positive/test088.juvix
+++ b/tests/Anoma/Compilation/positive/test088.juvix
@@ -1,31 +1,19 @@
+-- Noun representation
 module test088;
 
+import Juvix.Builtin.V1.Fixity open;
 import Juvix.Builtin.V1.Nat open;
 import Juvix.Builtin.V1.Bool open;
 import Juvix.Builtin.V1.List open;
 
--- -- Internally, it would be the identity function
--- -- derived instances
--- trait
--- type Reify (T : Type) :=
---   mk@{
---     reify : T -> Term;
---   };
+builtin trace
+axiom trace : {A : Type} -> A -> A;
 
--- -- TODO nonempty-list
--- type NockmaTypeRep := NockmaTypeRep (List NockmaConstructorRep);
+syntax operator >-> seq;
 
--- type NockmaConstructorRep :=
---   | atom
---   | cell@{
---       left : NockmaTypeRep;
---       right : NockmaTypeRep;
---     };
-
--- trait
--- type HasNockmaRep (T : Type) := mk NockmaTypeRep;
-
--- -- checkShape {T} {{Reify T}} {{HasNockmaRep T}} (t : T) : Bool := todo;
+builtin seq
+>-> : {A B : Type} -> A -> B -> B
+  | x y := y;
 
 type Term :=
   | atom Nat
@@ -34,6 +22,15 @@ type Term :=
       right : Term;
     };
 
-t : Term := Term.cell (Term.atom 3) (Term.cell (Term.atom 4) (Term.atom 8));
+type T := mk;
 
-main : Term := t;
+type FakeTerm :=
+  | atom T
+  | cell@{
+      left : FakeTerm;
+      right : FakeTerm;
+    };
+
+t : Term := Term.cell (Term.atom 30) (Term.cell (Term.atom 40) (Term.atom 80));
+
+main : _ := trace t >-> trace (Term.atom 80) >-> FakeTerm.cell;


### PR DESCRIPTION
Adds a new type representation for types that can be directly encoded with either an atom or a cell without a tag.
E.g.
Consider this inductive type:
```
type Term :=
  | atom Nat
  | cell@{
      left : Term;
      right : Term;
    };
```
And terms:
```
x : Term := Term.cell (Term.atom 30) (Term.cell (Term.atom 40) (Term.atom 80));
y : Term := Term.atom 20
```
Then x and y will be represented unambiguously as
```
x ~ [30 40 80]
y ~ 20
```