### PR TITLE
Precompute nock hashes

### DIFF
--- a/src/Juvix/Compiler/Nockma/Encoding/Cue.hs
+++ b/src/Juvix/Compiler/Nockma/Encoding/Cue.hs
@@ -165,7 +165,8 @@ atomToBits a' = do
 -- | Transform a vector of bits to a decoded term
 cueFromBits ::
   forall a r.
-  ( NockNatural a,
+  ( Hashable a,
+    NockNatural a,
     Members
       '[ Error DecodingError,
          Error (ErrNockNatural' a)
@@ -191,7 +192,8 @@ cueFromByteStringNatural = cueFromByteString'
 
 cueFromByteString' ::
   forall a r.
-  ( NockNatural a,
+  ( Hashable a,
+    NockNatural a,
     Members
       '[ Error DecodingError,
          Error (ErrNockNatural' a)
@@ -204,7 +206,8 @@ cueFromByteString' = cueFromBits . cloneFromByteString
 
 cueFromBitsSem ::
   forall a r.
-  ( NockNatural a,
+  ( Hashable a,
+    NockNatural a,
     Members
       '[ BitReader,
          Error DecodingError,
@@ -236,9 +239,9 @@ cueFromBitsSem = registerElementStart $ do
 
     goCell :: Sem r (Term a)
     goCell = do
-      _cellLeft <- cueFromBitsSem
-      _cellRight <- cueFromBitsSem
-      let cell = TermCell (Cell' {_cellInfo = emptyCellInfo, ..})
+      l <- cueFromBitsSem
+      r <- cueFromBitsSem
+      let cell = TermCell (mkCell l r)
       cacheCueTerm cell
       return cell
 
@@ -266,7 +269,8 @@ cueFromBitsSem = registerElementStart $ do
 -- | Decode an nock Atom to a nock term
 cue ::
   forall a r.
-  ( NockNatural a,
+  ( Hashable a,
+    NockNatural a,
     Members
       '[ Error DecodingError,
          Error (ErrNockNatural a)
@@ -283,7 +287,8 @@ cue a' =
 -- | A variant of cue with `ErrNockNatural` wrapped in a newtype to disambiguate it from DecodingError
 cue' ::
   forall a r.
-  ( NockNatural a,
+  ( Hashable a,
+    NockNatural a,
     Members
       '[ Error DecodingError,
          Error (ErrNockNatural' a)
@@ -299,7 +304,8 @@ cueEither ::
   -- overlapping instances with `ErrNockNatural a` when errors are handled. See
   -- the comment above `ErrNockNatural' a` for more explanation.
   forall a r.
-  ( NockNatural a,
+  ( Hashable a,
+    NockNatural a,
     Member (Error (ErrNockNatural a)) r
   ) =>
   Atom a ->
@@ -314,7 +320,8 @@ cueFromByteString ::
   -- overlapping instances with `ErrNockNatural a` when errors are handled. See
   -- the comment above `ErrNockNatural' a` for more explanation.
   forall a r.
-  ( NockNatural a,
+  ( Hashable a,
+    NockNatural a,
     Member (Error (ErrNockNatural a)) r
   ) =>
   ByteString ->
@@ -326,7 +333,7 @@ cueFromByteString =
 
 cueFromByteString'' ::
   forall a.
-  (NockNatural a) =>
+  (Hashable a, NockNatural a) =>
   ByteString ->
   Either (ErrNockNatural a) (Either DecodingError (Term a))
 cueFromByteString'' = run . runErrorNoCallStack . cueFromByteString

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -302,7 +302,7 @@ evalProfile inistack initerm =
             goAnomaSetFromList :: Term a -> Term a
             goAnomaSetFromList arg =
               foldr
-                (\t acc -> TermCell (Cell' t acc emptyCellInfo))
+                (\t acc -> TermCell (mkCell t acc))
                 (TermAtom nockNil)
                 (nubHashable (checkTermToList arg))
 
@@ -480,7 +480,7 @@ evalProfile inistack initerm =
 
             goOpHint :: Sem r (Term a)
             goOpHint = do
-              Cell' l r _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
+              Cell' l r _ _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
               case l of
                 TAtom {} -> evalArg crumbEvalFirst stack r
                 TCell t1 t2 -> do
@@ -502,8 +502,8 @@ evalProfile inistack initerm =
 
             goOpReplace :: Sem r (Term a)
             goOpReplace = do
-              Cell' rot1 t2 _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
-              Cell' ro t1 _ <- withCrumb (crumb crumbDecodeSecond) (asCell rot1)
+              Cell' rot1 t2 _ _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
+              Cell' ro t1 _ _ <- withCrumb (crumb crumbDecodeSecond) (asCell rot1)
               r <- withCrumb (crumb crumbDecodeThird) (asPath ro)
               t1' <- evalArg crumbEvalFirst stack t1
               t2' <- evalArg crumbEvalSecond stack t2
@@ -520,7 +520,7 @@ evalProfile inistack initerm =
             goOpIf = do
               cellTerm <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
               let t0 = cellTerm ^. cellLeft
-              Cell' t1 t2 _ <- withCrumb (crumb crumbDecodeSecond) (asCell (cellTerm ^. cellRight))
+              Cell' t1 t2 _ _ <- withCrumb (crumb crumbDecodeSecond) (asCell (cellTerm ^. cellRight))
               cond <- evalArg crumbEvalFirst stack t0 >>= asBool
               if
                   | cond -> evalArg crumbTrueBranch stack t1
@@ -558,7 +558,7 @@ evalProfile inistack initerm =
 
             goOpScry :: Sem r (Term a)
             goOpScry = do
-              Cell' typeFormula subFormula _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
+              Cell' typeFormula subFormula _ _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
               void (evalArg crumbEvalFirst stack typeFormula)
               key <- evalArg crumbEvalSecond stack subFormula
               fromMaybeM (throwKeyNotInStorage key) (HashMap.lookup (StorageKey key) <$> asks (^. storageKeyValueData))

--- a/src/Juvix/Compiler/Nockma/Evaluator.hs
+++ b/src/Juvix/Compiler/Nockma/Evaluator.hs
@@ -480,7 +480,7 @@ evalProfile inistack initerm =
 
             goOpHint :: Sem r (Term a)
             goOpHint = do
-              Cell' l r _ _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
+              Cell' l r _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
               case l of
                 TAtom {} -> evalArg crumbEvalFirst stack r
                 TCell t1 t2 -> do
@@ -502,8 +502,8 @@ evalProfile inistack initerm =
 
             goOpReplace :: Sem r (Term a)
             goOpReplace = do
-              Cell' rot1 t2 _ _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
-              Cell' ro t1 _ _ <- withCrumb (crumb crumbDecodeSecond) (asCell rot1)
+              Cell' rot1 t2 _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
+              Cell' ro t1 _ <- withCrumb (crumb crumbDecodeSecond) (asCell rot1)
               r <- withCrumb (crumb crumbDecodeThird) (asPath ro)
               t1' <- evalArg crumbEvalFirst stack t1
               t2' <- evalArg crumbEvalSecond stack t2
@@ -520,7 +520,7 @@ evalProfile inistack initerm =
             goOpIf = do
               cellTerm <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
               let t0 = cellTerm ^. cellLeft
-              Cell' t1 t2 _ _ <- withCrumb (crumb crumbDecodeSecond) (asCell (cellTerm ^. cellRight))
+              Cell' t1 t2 _ <- withCrumb (crumb crumbDecodeSecond) (asCell (cellTerm ^. cellRight))
               cond <- evalArg crumbEvalFirst stack t0 >>= asBool
               if
                   | cond -> evalArg crumbTrueBranch stack t1
@@ -558,7 +558,7 @@ evalProfile inistack initerm =
 
             goOpScry :: Sem r (Term a)
             goOpScry = do
-              Cell' typeFormula subFormula _ _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
+              Cell' typeFormula subFormula _ <- withCrumb (crumb crumbDecodeFirst) (asCell (c ^. operatorCellTerm))
               void (evalArg crumbEvalFirst stack typeFormula)
               key <- evalArg crumbEvalSecond stack subFormula
               fromMaybeM (throwKeyNotInStorage key) (HashMap.lookup (StorageKey key) <$> asks (^. storageKeyValueData))

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -132,7 +132,7 @@ unfoldCell c = c ^. cellLeft :| reverse (go [] (c ^. cellRight))
     go :: [Term a] -> Term a -> [Term a]
     go acc t = case t of
       TermAtom {} -> t : acc
-      TermCell (Cell' l r i)
+      TermCell (Cell' l r i _)
         | isNothing (i ^. cellInfoCall) && isNothing (i ^. cellInfoTag) -> go (l : acc) r
         | otherwise -> t : acc
 

--- a/src/Juvix/Compiler/Nockma/Pretty/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Pretty/Base.hs
@@ -132,7 +132,7 @@ unfoldCell c = c ^. cellLeft :| reverse (go [] (c ^. cellRight))
     go :: [Term a] -> Term a -> [Term a]
     go acc t = case t of
       TermAtom {} -> t : acc
-      TermCell (Cell' l r i _)
+      TermCell (Cell' l r i)
         | isNothing (i ^. cellInfoCall) && isNothing (i ^. cellInfoTag) -> go (l : acc) r
         | otherwise -> t : acc
 

--- a/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromSource/Base.hs
@@ -312,7 +312,8 @@ cell = do
         CellInfo
           { _cellInfoCall = c,
             _cellInfoTag = lbl,
-            _cellInfoLoc = Irrelevant (Just (lloc <> rloc))
+            _cellInfoLoc = Irrelevant (Just (lloc <> rloc)),
+            _cellInfoHash = hash r
           }
   return (set cellInfo info r)
   where


### PR DESCRIPTION
* Closes #3383 
* Depends on: #3370 

### Benchmarks

- `juvix-old` - the version from https://github.com/anoma/juvix/pull/3370
- `juvix` - the version from this PR

Both compiled with optimizations.

```
$ hyperfine -w 1 -p 'rm -rf .juvix-build' 'juvix-old compile anoma test001.juvix --modular' 'juvix compile anoma test001.juvix --modular'

Benchmark 1: juvix-old compile anoma test001.juvix --modular
  Time (mean ± σ):      6.178 s ±  0.041 s    [User: 12.155 s, System: 0.879 s]
  Range (min … max):    6.101 s …  6.238 s    10 runs
 
Benchmark 2: juvix compile anoma test001.juvix --modular
  Time (mean ± σ):      5.775 s ±  0.018 s    [User: 11.636 s, System: 0.900 s]
  Range (min … max):    5.750 s …  5.794 s    10 runs
 
Summary
  'juvix compile anoma test001.juvix --modular' ran
    1.07 ± 0.01 times faster than 'juvix-old compile anoma test001.juvix --modular'
```

```
$ hyperfine -w 1 'juvix-old compile anoma test001.juvix --modular' 'juvix compile anoma test001.juvix --modular'

Benchmark 1: juvix-old compile anoma test001.juvix --modular
  Time (mean ± σ):      2.160 s ±  0.049 s    [User: 3.540 s, System: 0.829 s]
  Range (min … max):    2.092 s …  2.234 s    10 runs
 
Benchmark 2: juvix compile anoma test001.juvix --modular
  Time (mean ± σ):      1.811 s ±  0.031 s    [User: 3.209 s, System: 0.847 s]
  Range (min … max):    1.769 s …  1.856 s    10 runs
 
Summary
  'juvix compile anoma test001.juvix --modular' ran
    1.19 ± 0.03 times faster than 'juvix-old compile anoma test001.juvix --modular'
```

```
$ hyperfine -w 1 'juvix-old dev nockma run builtin-evaluator test001.nockma --storage test001.modules.nockma' 'juvix dev nockma run builtin-evaluator test001.nockma --storage test001.modules.nockma'

Benchmark 1: juvix-old dev nockma run builtin-evaluator test001.nockma --storage test001.modules.nockma
  Time (mean ± σ):      6.693 s ±  0.056 s    [User: 7.388 s, System: 1.212 s]
  Range (min … max):    6.614 s …  6.811 s    10 runs
 
Benchmark 2: juvix dev nockma run builtin-evaluator test001.nockma --storage test001.modules.nockma
  Time (mean ± σ):      6.933 s ±  0.060 s    [User: 7.650 s, System: 1.321 s]
  Range (min … max):    6.783 s …  6.997 s    10 runs
 
Summary
  'juvix-old dev nockma run builtin-evaluator test001.nockma --storage test001.modules.nockma' ran
    1.04 ± 0.01 times faster than 'juvix dev nockma run builtin-evaluator test001.nockma --storage test001.modules.nockma'
```

### Conclusion

- Precomputing the hashes increases the performance of jamming, which dominates the final stage of compilation to Nock.
- The additional field in the `CellInfo` datatype decreases evaluation performance, which is not compensated by the faster module load times. However, compilation is the main user-facing feature of the Juvix compiler.
