### PR TITLE
Quote constants in Nock increment optimization

### DIFF
--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -982,8 +982,9 @@ compile = \case
 
         goAdd :: [Term Natural] -> Sem r (Term Natural)
         goAdd = \case
-          [arg, TAtom 1] -> return $ OpInc # arg
-          [TAtom 1, arg] -> return $ OpInc # arg
+          -- remember that 1 is quoted: we match [quote 1]
+          [arg, TCell (TAtom 1) (TAtom 1)] -> return $ OpInc # arg
+          [TCell (TAtom 1) (TAtom 1), arg] -> return $ OpInc # arg
           args -> callStdlib StdlibAdd args
 
     goAllocClosure :: Tree.NodeAllocClosure -> Sem r (Term Natural)


### PR DESCRIPTION
* In #3395 I forgot to quote the atoms. This PR fixes the omission.
