### PR TITLE
Fixes for shielded transaction submission

### DIFF
--- a/app/Commands/Dev/Anoma.hs
+++ b/app/Commands/Dev/Anoma.hs
@@ -31,7 +31,7 @@ runCommand g =
         (Prove.runCommand opts)
     AnomaCommandAddTransaction opts ->
       runAnomaWithHostConfig
-        (addTransaction (opts ^. addTransactionFile))
+        (addTransaction (opts ^. addTransactionShielded) (opts ^. addTransactionFile))
     AnomaCommandIndexer opts -> runAnomaWithHostConfig (Indexer.runCommand opts)
   where
     runAnomaWithHostConfig :: (Members (Error SimpleError ': AppEffects) x) => Sem (Anoma ': x) () -> Sem x ()

--- a/app/Commands/Dev/Anoma/AddTransaction/Options.hs
+++ b/app/Commands/Dev/Anoma/AddTransaction/Options.hs
@@ -2,8 +2,9 @@ module Commands.Dev.Anoma.AddTransaction.Options where
 
 import CommonOptions
 
-newtype AddTransactionOptions = AddTransactionOptions
-  { _addTransactionFile :: AppPath File
+data AddTransactionOptions = AddTransactionOptions
+  { _addTransactionFile :: AppPath File,
+    _addTransactionShielded :: Bool
   }
   deriving stock (Data)
 
@@ -12,4 +13,5 @@ makeLenses ''AddTransactionOptions
 parseAddTransactionOptions :: Parser AddTransactionOptions
 parseAddTransactionOptions = do
   _addTransactionFile <- parseInputFile FileExtNockma
+  _addTransactionShielded <- switch (long "shielded" <> help "Add a shielded transaction")
   pure AddTransactionOptions {..}

--- a/src/Anoma/Effect/AddTransaction.hs
+++ b/src/Anoma/Effect/AddTransaction.hs
@@ -10,8 +10,9 @@ import Juvix.Compiler.Nockma.Language qualified as Nockma
 import Juvix.Prelude
 import Juvix.Prelude.Aeson qualified as Aeson
 
-newtype AddTransactionInput = AddTransactionInput
-  { _addTransactionInputCandidate :: Nockma.Term Natural
+data AddTransactionInput = AddTransactionInput
+  { _addTransactionInputCandidate :: Nockma.Term Natural,
+    _addTransactionInputType :: TransactionType
   }
 
 makeLenses ''AddTransactionInput

--- a/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
+++ b/src/Juvix/Compiler/Nockma/Translation/FromTree.hs
@@ -1177,7 +1177,7 @@ goConstructor mr t args = assert (all isCell args) $
   case t of
     Tree.BuiltinTag b -> case nockmaBuiltinTag b of
       Just (NockmaBuiltinBool v) -> nockBoolLiteral v
-      Just (NockmaBuiltinJson s) -> nockStringLiteral s
+      Just (NockmaBuiltinJson s) -> foldTerms (nockStringLiteral s :| args)
       Nothing -> crash
     Tree.UserTag tag -> case mr of
       NockmaMemRepConstr ->

--- a/test/Anoma/Client/Positive.hs
+++ b/test/Anoma/Client/Positive.hs
@@ -2,6 +2,7 @@ module Anoma.Client.Positive where
 
 import Anoma.Client.Base
 import Anoma.Effect
+import Anoma.Http.AddTransaction (TransactionType (TransactionTransparent))
 import Base
 import Juvix.Compiler.Nockma.Language hiding (Path)
 import Juvix.Prelude.Pretty
@@ -54,7 +55,8 @@ proveAndSubmit program proveArgs = do
   step "Submitting transaction candidate"
   addTransaction
     AddTransactionInput
-      { _addTransactionInputCandidate = resProve ^. runNockmaResult
+      { _addTransactionInputCandidate = resProve ^. runNockmaResult,
+        _addTransactionInputType = TransactionTransparent
       }
   return (resProve ^. runNockmaTraces)
 


### PR DESCRIPTION
* Fixes JSON representation in Nock
* Adds the `--shielded` option for `juvix dev anoma add-transaction`
