### PR TITLE
Improve readability of dependency directories

### DIFF
--- a/src/Juvix/Compiler/Pipeline/Loader/PathResolver/DependencyResolver.hs
+++ b/src/Juvix/Compiler/Pipeline/Loader/PathResolver/DependencyResolver.hs
@@ -1,6 +1,6 @@
 module Juvix.Compiler.Pipeline.Loader.PathResolver.DependencyResolver where
 
-import Data.Text qualified as T
+import Data.Text qualified as Text
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Data
 import Juvix.Compiler.Pipeline.Loader.PathResolver.Error
 import Juvix.Compiler.Pipeline.Package.Dependency
@@ -75,7 +75,12 @@ runDependencyResolver = runProvider_ helper
                     }
 
               mkSafeDir :: Text -> Path Rel Dir
-              mkSafeDir = relDir . T.unpack . SHA256.digestText
+              mkSafeDir uid =
+                relDir
+                  . unpack
+                  $ Text.filter isSafeDirectoryChar (g ^. gitDependencyName)
+                    <> "-"
+                    <> SHA256.digestText uid
 
 resolveDependency ::
   (Members '[Reader ResolverEnv, DependencyResolver] r) =>

--- a/src/Juvix/Prelude/Base/Foundation.hs
+++ b/src/Juvix/Prelude/Base/Foundation.hs
@@ -341,9 +341,6 @@ freshName :: HashSet Text -> Text -> Text
 freshName names name | HashSet.member name names = freshName names (prime name)
 freshName _ name = name
 
-isValidIdentChar :: Char -> Bool
-isValidIdentChar c = c == '_' || ((isLetter c || isDigit c) && isAscii c)
-
 isFirstLetter :: String -> Bool
 isFirstLetter = \case
   h : _ -> isLetter h
@@ -694,6 +691,15 @@ infixr 2 .||.
 
 eqOn :: (Eq b) => (a -> b) -> a -> a -> Bool
 eqOn = ((==) `on`)
+
+-- | Valid Unix directory character that does not need to be escaped
+isSafeDirectoryChar :: Char -> Bool
+isSafeDirectoryChar =
+  ((isLetter .||. isDigit) .&&. isAscii)
+    .||. (`elem` ("_.-" :: [Char]))
+
+isValidIdentChar :: Char -> Bool
+isValidIdentChar = ((isLetter .||. isDigit) .&&. isAscii) .||. (`elem` ("_" :: [Char]))
 
 class CanonicalProjection a b where
   project :: a -> b


### PR DESCRIPTION
Git dependencies are stored under `.juvix-build/deps/<hash>`. To make it more readable, now we store it in `.juvix-build/deps/<name>-<hash>`.

Before:
```
 0.6.10-037865f367e05e65156cd2879cae22a795a54319
├──  deps
│   └──  4840c75d24c71a4510ee7338beea31f9f2a65ddc71eab3907b676813c23e321
```
After:
```
 0.6.10-bdd4c80fba097333a24a9afeef1b9d8cfb2722f8
├──  deps
│   └──  anoma_juvix-stdlib-4840c75d24c71a4510ee7338beea31f9f2a65ddc71eab3907b676813c23e321a
```