### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
@@ -47,7 +47,7 @@ jobs:
     env:
       STACK_RESOLVER: lts-21.25
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: extractions/setup-just@v2
 
       - name: Install hpack
@@ -117,13 +117,13 @@ jobs:
       - uses: extractions/setup-just@v2
 
       - name: Checkout our repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: main
           submodules: true
 
       - name: Checkout Anoma repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: anoma/anoma
           ref: ${{ env.ANOMA_VERSION }}
@@ -238,7 +238,7 @@ jobs:
           ~/.risc0/bin/rzup install r0vm 1.2.6
 
       - name: Checkout CairoVM
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         with:
           repository: anoma/juvix-cairo-vm
@@ -354,7 +354,7 @@ jobs:
       - uses: extractions/setup-just@v2
 
       - name: Checkout our repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: main
           submodules: true
@@ -408,7 +408,7 @@ jobs:
       # runner image as the smoke testing step to make sure that the icu4c
       # versions match.
       - name: Checkout smoke repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: jonaprieto/smoke
           ref: regex-icu
@@ -470,7 +470,7 @@ jobs:
           cargo risczero install
 
       - name: Checkout CairoVM
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: steps.cache-cairo-vm.outputs.cache-hit != 'true'
         with:
           repository: anoma/juvix-cairo-vm

--- a/.github/workflows/clean-up-cache.yaml
+++ b/.github/workflows/clean-up-cache.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Cleanup
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       tag: ${{ steps.tag.outputs.value }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: true
           repository: anoma/juvix
@@ -95,7 +95,7 @@ jobs:
     name: Build macOS x86_64 binary
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: true
           repository: anoma/juvix
@@ -147,7 +147,7 @@ jobs:
     name: Build macOS aarch64 binary
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: true
           repository: anoma/juvix


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0